### PR TITLE
Cache total number of questions most of the time. [bug 661547]

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -533,6 +533,9 @@ QUESTIONS_MAX_SUGGESTIONS = 5
 # of things that could be deleted between indexer runs.
 QUESTIONS_SUGGESTION_SLOP = 3
 
+# How long do we cache the question counts (in seconds)?
+QUESTIONS_COUNT_TTL = 900  # 15 minutes.
+
 # Email
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 


### PR DESCRIPTION
Cache the count of visible questions for 15 minutes for most views. Not
caching for "my contributions" or tag filtering right now. Will want
to add both eventually, though maybe with shorter TTL.

Since only the filter affects the total, the cache key is based on the
filter only. It speeds up subsequent page loads, or switching the sort,
significantly.

Also, we were stomping on the built-in "filter", so I fixed that.
