### PR TITLE
Add Redis backends to /services/monitor [bug 659518]

### DIFF
--- a/apps/sumo/templates/services/monitor.html
+++ b/apps/sumo/templates/services/monitor.html
@@ -84,6 +84,20 @@
   </div>
   #}
 
+  <div class="notification-box {{ status(status_summary.redis) }}">
+    <h2>[Redis] Redis Servers</h2>
+    {% if redis_results %}
+      <dl>
+        {% for backend in redis_results %}
+          <dt>{{ backend }}</dt>
+          <dd>{% if redis_results[backend] %}OK{% else %}<strong>Connection Failed</strong>{% endif %}</dd>
+        {% endfor %}
+      </dl>
+    {% else %}
+      <strong>Warning!</strong> No Redis connections defined!
+    {% endif %}
+  </div>
+
 </article>
 
 {% endblock content %}


### PR DESCRIPTION
I didn't include the fix for `sumo.utils.redis_client` because Ricky has it on another branch, but reviewers should know about the bug: right now `redis_client` _always_ connects to `localhost:6379`, so killing that `redis-server` process will make all backends appear offline.
