### PR TITLE
Add outside-ascii range unicode to the fields of document and revision for tests

### DIFF
--- a/apps/wiki/tests/__init__.py
+++ b/apps/wiki/tests/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from datetime import datetime
 
 from django.template.defaultfilters import slugify
@@ -21,7 +22,7 @@ class TestCaseBase(TestCase):
 def document(**kwargs):
     """Return an empty document with enough stuff filled out that it can be
     saved."""
-    defaults = {'category': CATEGORIES[0][0], 'title': str(datetime.now())}
+    defaults = {'category': CATEGORIES[0][0], 'title': u'đ' + str(datetime.now())}
     defaults.update(kwargs)
     if 'slug' not in kwargs:
         defaults['slug'] = slugify(defaults['title'])
@@ -40,8 +41,8 @@ def revision(**kwargs):
     """
     d = kwargs.pop('document', None) or document(save=True)
 
-    defaults = {'summary': 'Some summary', 'content': 'Some content',
-                'significance': SIGNIFICANCES[0][0], 'comment': 'Some comment',
+    defaults = {'summary': 'đSome summary', 'content': u'đSome content',
+                'significance': SIGNIFICANCES[0][0], 'comment': 'đSome comment',
                 'creator': kwargs.get('creator', get_user()), 'document': d}
     defaults.update(kwargs)
 


### PR DESCRIPTION
r? 

useful for catching future errors that may be present with unicode only.
