### PR TITLE
Ignore revision.is_ready_for_localization on non-localizable documents. [bug 668609]

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -530,7 +530,7 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin):
         # level fallback: first ready revisions, then approved ones, then
         # unapproved ones.
         rev = self.latest_localizable_revision
-        if not rev:
+        if not rev or not self.is_localizable:
             if reviewed_only:
                 exclusions = Q(is_approved=False, reviewed__isnull=False)
             else:

--- a/apps/wiki/tests/test_models.py
+++ b/apps/wiki/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from nose.exc import SkipTest
 from nose.tools import eq_
@@ -383,6 +383,19 @@ class LocalizableOrLatestRevisionTests(TestCase):
                             save=True)
         eq_(rejected, rejected.document.localizable_or_latest_revision())
 
+    def test_non_localizable(self):
+        """When document isn't localizable, ignore is_ready_for_l10n."""
+        r1 = revision(is_approved=True,
+                      is_ready_for_localization=True,
+                      save=True)
+        r2 = revision(document=r1.document,
+                      is_approved=True,
+                      is_ready_for_localization=False,
+                      save=True)
+        r1.document.is_localizable = False
+        r1.document.save()
+        eq_(r2, r2.document.localizable_or_latest_revision())
+
 
 class RedirectCreationTests(TestCase):
     """Tests for automatic creation of redirects when slug or title changes"""
@@ -560,8 +573,8 @@ class RevisionTests(TestCase):
         eq_(ready_2, ready_2.document.latest_localizable_revision)
 
         # Ready the older rev. It should not become the latest_localizable.
-        unready.is_ready_for_localization=True
-        unready.is_approved=True
+        unready.is_ready_for_localization = True
+        unready.is_approved = True
         unready.save()
         eq_(ready_2, ready_2.document.latest_localizable_revision)
 


### PR DESCRIPTION
r?
