### PR TITLE
[bug 665852] Add checkbox for subscribing to ready-for-l10n notifications

### DIFF
--- a/apps/dashboards/templates/dashboards/contributors.html
+++ b/apps/dashboards/templates/dashboards/contributors.html
@@ -33,6 +33,13 @@
 
 {% block side %}
   {% if not user.is_anonymous() %}
-    {{ print_subscription_menu(default_locale_name, request_locale_name, on_default_locale, is_watching_default_locale, is_watching_other_locale, is_watching_default_approved, is_watching_other_approved, settings.WIKI_DEFAULT_LANGUAGE) }}
+    {{ print_subscription_menu(default_locale_name,
+                               request_locale_name,
+                               on_default_locale,
+                               is_watching_default_locale,
+                               is_watching_other_locale,
+                               is_watching_default_approved,
+                               is_watching_other_approved,
+                               settings.WIKI_DEFAULT_LANGUAGE) }}
   {% endif %}
 {% endblock %}

--- a/apps/dashboards/templates/dashboards/includes/macros.html
+++ b/apps/dashboards/templates/dashboards/includes/macros.html
@@ -81,16 +81,26 @@
   </details>
 {% endmacro %}
 
-{% macro print_checkbox_row(label, on_default_locale, is_watching_default, is_watching_other, watch_view, unwatch_view, default_locale) %}
+{% macro print_checkbox_row(label,
+                            on_default_locale,
+                            is_watching_default,
+                            is_watching_other,
+                            watch_view,
+                            unwatch_view,
+                            default_locale,
+                            show_default=True,
+                            show_other=True) %}
   <tr>
     <th class="state">{{ label }}</th>
     <td>
-      <input data-action-watch="{{ url(watch_view, locale=default_locale) }}"
-             data-action-unwatch="{{ url(unwatch_view, locale=default_locale) }}"
-             type="checkbox"
-             {% if is_watching_default %}checked="checked"{% endif %} />
+      {% if show_default %}
+        <input data-action-watch="{{ url(watch_view, locale=default_locale) }}"
+               data-action-unwatch="{{ url(unwatch_view, locale=default_locale) }}"
+               type="checkbox"
+               {% if is_watching_default %}checked="checked"{% endif %} />
+      {% endif %}
     </td>
-    {% if not on_default_locale %}
+    {% if not on_default_locale and show_other %}
       <td>
         <input data-action-watch="{{ url(watch_view) }}"
                data-action-unwatch="{{ url(unwatch_view) }}"
@@ -101,7 +111,16 @@
   </tr>
 {% endmacro %}
 
-{% macro print_subscription_menu(default_locale_name, current_locale_name, on_default_locale, is_watching_default_locale, is_watching_other_locale, is_watching_default_approved, is_watching_other_approved, default_locale) %}
+{% macro print_subscription_menu(default_locale_name,
+                                 current_locale_name,
+                                 on_default_locale,
+                                 is_watching_default_locale,
+                                 is_watching_other_locale,
+                                 is_watching_default_approved,
+                                 is_watching_other_approved,
+                                 default_locale,
+                                 show_default_waiting=True,
+                                 show_default_approved=True) %}
   <div id="doc-watch">
     <div class="popup-trigger">{{ _('Email me when revisions are...') }}</div>
     <form class="popup-menu" action="" method="POST">
@@ -114,8 +133,9 @@
             <th>{{ current_locale_name }}</th>
           {% endif %}
         </tr>
-        {{ print_checkbox_row(_('Waiting'), on_default_locale, is_watching_default_locale, is_watching_other_locale, 'wiki.locale_watch', 'wiki.locale_unwatch', default_locale) }}
-        {{ print_checkbox_row(_('Approved'), on_default_locale, is_watching_default_approved, is_watching_other_approved, 'wiki.approved_watch', 'wiki.approved_unwatch', default_locale) }}
+        {{ print_checkbox_row(_('Waiting for review'), on_default_locale, is_watching_default_locale, is_watching_other_locale, 'wiki.locale_watch', 'wiki.locale_unwatch', default_locale, show_default=show_default_waiting) }}
+        {{ print_checkbox_row(_('Approved'), on_default_locale, is_watching_default_approved, is_watching_other_approved, 'wiki.approved_watch', 'wiki.approved_unwatch', default_locale, show_default=show_default_approved) }}
+        {{ print_checkbox_row(_('Ready for localization'), on_default_locale, is_watching_default_ready, False, 'wiki.ready_watch', 'wiki.ready_unwatch', default_locale, show_other=False) }}
       </table>
     </form>
   </div>

--- a/apps/dashboards/templates/dashboards/localization.html
+++ b/apps/dashboards/templates/dashboards/localization.html
@@ -36,6 +36,13 @@
 
 {% block side %}
   {% if not user.is_anonymous() %}
-    {{ print_subscription_menu(default_locale_name, current_locale_name, on_default_locale, is_watching_default_locale, is_watching_other_locale, is_watching_default_approved, is_watching_other_approved, settings.WIKI_DEFAULT_LANGUAGE) }}
+    {{ print_subscription_menu(default_locale_name,
+                               current_locale_name,
+                               on_default_locale,
+                               is_watching_default_locale,
+                               is_watching_other_locale,
+                               is_watching_default_approved,
+                               is_watching_other_approved,
+                               settings.WIKI_DEFAULT_LANGUAGE) }}
   {% endif %}
 {% endblock %}

--- a/apps/dashboards/utils.py
+++ b/apps/dashboards/utils.py
@@ -7,7 +7,7 @@ import jingo
 from dashboards import ACTIONS_PER_PAGE
 from sumo_locales import LOCALES
 from sumo.utils import paginate
-from wiki.events import (ApproveRevisionInLocaleEvent,
+from wiki.events import (ApproveRevisionInLocaleEvent, ReadyRevisionEvent,
                          ReviewableRevisionInLocaleEvent)
 
 
@@ -50,6 +50,8 @@ def render_readouts(request, readouts, template, locale=None, extra_data=None):
                 None if on_default_locale
                 else ReviewableRevisionInLocaleEvent.is_notifying(
                     request.user, locale=request.locale),
+            'is_watching_default_ready':
+                ReadyRevisionEvent.is_notifying(request.user),
              'on_default_locale': on_default_locale}
     if extra_data:
         data.update(extra_data)

--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -72,17 +72,23 @@ document_patterns = patterns('wiki.views',
 urlpatterns = patterns('wiki.views',
     url(r'^$', redirect_to, {'url': 'home'}, name='wiki.home'),
 
-    # Un/Subscribe to locale 'ready for review' notifications.
+    # (Un)subscribe to locale 'ready for review' notifications.
     url(r'^/watch-ready-for-review$', 'watch_locale',
         name='wiki.locale_watch'),
     url(r'^/unwatch-ready-for-review$', 'unwatch_locale',
         name='wiki.locale_unwatch'),
 
-    # Un/Subscribe to 'approved' notifications.
+    # (Un)subscribe to 'approved' notifications.
     url(r'^/watch-approved$', 'watch_approved',
         name='wiki.approved_watch'),
     url(r'^/unwatch-approved$', 'unwatch_approved',
         name='wiki.approved_unwatch'),
+
+    # (Un)subscribe to 'ready-for-l10n' notifications.
+    url(r'^/watch-ready$', 'watch_ready',
+        name='wiki.ready_watch'),
+    url(r'^/unwatch-ready$', 'unwatch_ready',
+        name='wiki.ready_unwatch'),
 
     url(r'^/json$', 'json_view', name='wiki.json'),
 

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -622,6 +622,27 @@ def unwatch_approved(request):
     return HttpResponse()
 
 
+@require_POST
+@login_required
+def watch_ready(request):
+    """Start watching ready-for-l10n revisions."""
+    if request.locale != settings.WIKI_DEFAULT_LANGUAGE:
+        raise Http404
+    ReadyRevisionEvent.notify(request.user)
+    statsd.incr('wiki.watches.ready')
+    return HttpResponse()
+
+
+@require_POST
+@login_required
+def unwatch_ready(request):
+    """Stop watching ready-for-l10n revisions."""
+    if request.locale != settings.WIKI_DEFAULT_LANGUAGE:
+        raise Http404
+    ReadyRevisionEvent.stop_notifying(request.user)
+    return HttpResponse()
+
+
 @require_GET
 def json_view(request):
     """Return some basic document info in a JSON blob."""

--- a/media/css/dashboards.css
+++ b/media/css/dashboards.css
@@ -327,10 +327,7 @@ div#doc-watch .popup-menu table {
     border-radius: 10px;
     -moz-border-radius: 10px;
     -webkit-border-radius: 10px;
-    border-top-left-radius: 0;
-    -moz-border-radius-topleft: 0;
-    -webkit-border-top-left-radius: 0;
-    left: 0;
+    left: -67px;
     padding: 10px;
     position: absolute;
     top: 10px;
@@ -348,7 +345,7 @@ div#doc-watch table:before {
 
     height: 15px;
     width: 15px;
-    left: -9px;
+    left: 58px;
     top: -18px;
     margin-bottom: -13px;
 }


### PR DESCRIPTION
r?

[bug 665852] Add checkbox for subscribing to ready-for-l10n notifications.
- Expand popup menu and make labels less abbreviated.
- All the macro params are here in case we decide 5 checkboxes is too much and want to hide less commonly used ones on one dashboard or the other.
