### PR TITLE
[bug 670024] Make login sessions expire only after a month.

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -39,7 +39,12 @@ def login(request):
 
     if request.user.is_authenticated():
         res = HttpResponseRedirect(next_url)
-        res.set_cookie(settings.SESSION_EXISTS_COOKIE, '1', secure=False)
+        max_age = (None if settings.SESSION_EXPIRE_AT_BROWSER_CLOSE
+                        else settings.SESSION_COOKIE_AGE)
+        res.set_cookie(settings.SESSION_EXISTS_COOKIE,
+                       '1',
+                       secure=False,
+                       max_age=max_age)
         return res
 
     return jingo.render(request, 'users/login.html',

--- a/settings.py
+++ b/settings.py
@@ -499,9 +499,10 @@ JAVA_BIN = '/usr/bin/java'
 
 #
 # Sessions
+SESSION_COOKIE_AGE = 4 * 7 * 24 * 60 * 60  # 4 weeks
 SESSION_COOKIE_SECURE = True
 SESSION_COOKIE_HTTPONLY = True
-SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 SESSION_EXISTS_COOKIE = 'sumo_session'
 


### PR DESCRIPTION
r?
- Give the has-a-session-cookie cookie the same expiry as the session cookie itself.
- Start using the LocalizingClient in SessionTests so we don't have to specify locales all the time.
