### PR TITLE
Discussion link stays link even when active 

### DIFF
--- a/apps/wiki/templates/wiki/includes/sidebar_modules.html
+++ b/apps/wiki/templates/wiki/includes/sidebar_modules.html
@@ -14,7 +14,7 @@
       </li>
       {% if document and document.allow_discussion %}
         <li{% if active == 'discussion' %} class="active"{% endif %}>
-            <a href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Discussion') }}</a>
+          <a href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Discussion') }}</a>
         </li>
       {% endif %}
       {% if document and not document.is_archived and (document.allows_revision_by(user) or document.allows_editing_by(user)) %}


### PR DESCRIPTION
First commit, it was low hanging fruit ;)
https://bugzilla.mozilla.org/show_bug.cgi?id=668018
