### PR TITLE
[bug 678507] Migration to add "desktop" tag to articles relevant to desktop fx and os

### DIFF
--- a/migrations/125-desktop-tag-for-documents.py
+++ b/migrations/125-desktop-tag-for-documents.py
@@ -1,7 +1,7 @@
 SET @ct = (SELECT id from django_content_type WHERE name='document' AND app_label='wiki');
 SET @tag = (SELECT id FROM taggit_tag WHERE name = 'desktop');
 
-INSERT INTO taggit_taggeditem (tag_id, object_id, content_type_id)
+INSERT IGNORE INTO taggit_taggeditem (tag_id, object_id, content_type_id)
     SELECT DISTINCT @tag, document_id, @ct FROM wiki_firefoxversion WHERE item_id IN (1,2,3,5,6,9)
     UNION
     SELECT DISTINCT @tag, document_id, @ct FROM wiki_operatingsystem WHERE item_id IN (1,2,3);


### PR DESCRIPTION
r? 

I feel like I leveled up my mysql skills for this. I kept trying to write a loop. And I am not sure if this is even the best way.
