### PR TITLE
added fx8, m8 to {for} Bug 677569

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -102,10 +102,10 @@ GROUPED_FIREFOX_VERSIONS = (
                         _lazy(u'Firefox 3.0'), 'fx3', 3.4999, False, False))),
     ((_lazy(u'Mobile:'), 'mobile'), (
         VersionMetadata(12, _lazy(u'Firefox 8'),
-                        _lazy(u'Firefox 8 for Mobile'), 'm8', 8.9999, False,
+                        _lazy(u'Firefox 8 for Mobile'), 'm8', 8.9999, True,
                         False),
         VersionMetadata(10, _lazy(u'Firefox 7'),
-                        _lazy(u'Firefox 7 for Mobile'), 'm7', 7.9999, False,
+                        _lazy(u'Firefox 7 for Mobile'), 'm7', 7.9999, True,
                         False),
         VersionMetadata(8, _lazy(u'Firefox 6'),
                         _lazy(u'Firefox 6 for Mobile'), 'm6', 6.9999, True,


### PR DESCRIPTION
Should the "default" (the last boolean in VersionMetaData) should be changed?

https://bugzilla.mozilla.org/show_bug.cgi?id=677569
