### PR TITLE
[bug 682205] Add index to auth_user.is_active

### DIFF
--- a/migrations/128-index-user-isactive.sql
+++ b/migrations/128-index-user-isactive.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `auth_user_e01be369` ON `auth_user` (`is_active`);


### PR DESCRIPTION
I can't tell if this is helping the query on questions at all. The query times with cold and warm cache are pretty much the same for me locally. Maybe mysql isn't using the index for that query?
