### PR TITLE
[bug 685111] Search assumes tags inherit.

### DIFF
--- a/apps/search/tests/test_search.py
+++ b/apps/search/tests/test_search.py
@@ -315,6 +315,12 @@ class SearchTest(SphinxTestCase):
             response = self.client.get(reverse('search'), qs)
             eq_(total, json.loads(response.content)['total'])
 
+    def test_tags_inherit(self):
+        """Translations inherit tags from their parents."""
+        qs = {'a': 1, 'w': 1, 'format': 'json', 'tags': 'extant'}
+        response = self.client.get(reverse('search', locale='es'), qs)
+        eq_(1, json.loads(response.content)['total'])
+
     def test_products(self):
         """Search for products."""
         qs = {'a': 1, 'w': 1, 'format': 'json'}
@@ -329,6 +335,12 @@ class SearchTest(SphinxTestCase):
             qs.update({'product': prod})
             response = self.client.get(reverse('search'), qs)
             eq_(total, json.loads(response.content)['total'])
+
+    def test_products_inherit(self):
+        """Translations inherit products from their parents."""
+        qs = {'a': 1, 'w': 1, 'format': 'json', 'product': 'desktop'}
+        response = self.client.get(reverse('search', locale='fr'), qs)
+        eq_(1, json.loads(response.content)['total'])
 
     def test_unicode_excerpt(self):
         """Unicode characters in the excerpt should not be a problem."""

--- a/configs/sphinx/sphinx.conf
+++ b/configs/sphinx/sphinx.conf
@@ -290,13 +290,18 @@ source wiki_pages
     sql_attr_bool = is_archived
 
     sql_attr_multi = uint tag from query; SELECT \
-        d.id, \
+        d1.id, \
         CRC32(t.name) \
-    FROM \
-        wiki_document d \
+    FROM ( \
+        SELECT \
+            d.id AS id, \
+            IF(d.parent_id, d.parent_id, d.id) AS joiner \
+        FROM \
+            wiki_document d \
+    ) d1 \
     INNER JOIN \
         taggit_taggeditem ti \
-            ON d.id = ti.object_id AND \
+            ON joiner = ti.object_id AND \
                 ti.content_type_id = (\
                     SELECT \
                         id \


### PR DESCRIPTION
Update the Sphinx config so it pulls tags off the _parent_ document,
if it exists, so that translations inherit their parents' tags.
