### PR TITLE
[bug 683643] Show Ethnio on home page or anywhere.

### DIFF
--- a/apps/landings/templates/landings/home.html
+++ b/apps/landings/templates/landings/home.html
@@ -17,7 +17,7 @@
 
 {% block footer_script %}
   {# Ethnio tracking - see bugs 683643 and 673544 #}
-  {% if waffle.flag('ethnio') %}
+  {% if waffle.flag('ethnio-home') %}
     <script type="text/javascript" language="javascript" src="//ethn.io/remotes/24561" async="true"></script>
   {% endif %}
   {# End Ethnio #}

--- a/templates/base.html
+++ b/templates/base.html
@@ -184,6 +184,13 @@
 </noscript>
 {# End Webtrends #}
 
+{# Ethnio tracking - see bugs 683643 and 673544 #}
+{% if waffle.flag('ethnio-all') %}
+  <script type="text/javascript" language="javascript" src="//ethn.io/remotes/24561" async="true"></script>
+{% endif %}
+{# End Ethnio #}
+
+
 {% block footer_script %}
 {% endblock %}
 </body>


### PR DESCRIPTION
Restore the ability to include Ethnio JS anywhere, but break it into
two flags:
- ethnio-home -- Show Ethnio JS on home page.
- ethnio-all -- Show Ethnio JS on every page.
