### PR TITLE
Update to the fixture-bundling versions of django-nose and test-utils.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,9 +61,9 @@ SETTINGS
 echo "Starting tests..." `date`
 export FORCE_DB=1
 if [ -z $COVERAGE ]; then
-    python manage.py test --noinput --logging-clear-handlers --with-xunit
+    python manage.py test --noinput --logging-clear-handlers --with-xunit --with-fixture-bundling
 else
-    coverage run manage.py test --noinput --logging-clear-handlers --with-xunit
+    coverage run manage.py test --noinput --logging-clear-handlers --with-xunit --with-fixture-bundling
     coverage xml $(find apps lib -name '*.py')
 fi
 


### PR DESCRIPTION
r? This should take another quarter to half off the test time.
