### PR TITLE
[bug 683726] Require >1 tag in common for related.

### DIFF
--- a/apps/wiki/cron.py
+++ b/apps/wiki/cron.py
@@ -63,7 +63,9 @@ def calculate_related_documents():
             d2.is_archived = 0
         GROUP BY
             t1.object_id,
-            t2.object_id""")
+            t2.object_id
+        HAVING
+            common_tags > 1""")
     transaction.commit_unless_managed()
 
 

--- a/apps/wiki/tests/test_models.py
+++ b/apps/wiki/tests/test_models.py
@@ -591,7 +591,7 @@ class RelatedDocumentTests(TestCase):
         calculate_related_documents()
 
         d = Document.uncached.get(pk=1)
-        eq_(2, d.related_documents.count())
+        eq_(1, d.related_documents.count())
 
     def test_related_only_locale(self):
         calculate_related_documents()

--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -1896,7 +1896,7 @@ class RelatedDocumentTestCase(TestCaseBase):
 
         doc = pq(response.content)
         related = doc('section#related-articles li a')
-        eq_(2, len(related))
+        eq_(1, len(related))
 
         # If 'an article title 2' is first, the other must be second.
         eq_('an article title 2', related[0].text)


### PR DESCRIPTION
Only record related documents if they have at least 2 tags in common.
