### PR TITLE
[bug 687987] Add Question metadata to search.

### DIFF
--- a/apps/questions/templates/questions/new_question.html
+++ b/apps/questions/templates/questions/new_question.html
@@ -1,6 +1,7 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "questions/includes/question_editing_frame.html" %}
 {% from "questions/includes/aaq_macros.html" import select_product, select_category, current_articles_and_message, aaq_search_form, show_results %}
+{% from "search/includes/result.html" import search_result %}
 {% set title = _('Ask a Question') %}
 {% set crumbs = [(url('questions.questions'), _('Forum')),
                  (None, _('Ask a New Question'))] %}
@@ -60,41 +61,7 @@
       {% set button_text = _('None of these solve my problem') %}
       <div class="search-results">
         {% for result in results %}
-          <div class="result {{ result.type }}">
-            <a class="title" href="{{ result.object.get_absolute_url() }}">
-              {{ result.object.title }}
-            </a>
-            {% if result.type == 'document' %}
-              <p><a href="{{ result.object.get_absolute_url() }}">
-                {{ result.object.current_revision.summary }}
-              </a></p>
-            {% elif result.type == 'question' %}
-              <p><a href="{{ result.object.get_absolute_url() }}">
-                {{ result.object.content|truncate(500) }}
-              </a></p>
-              <div class="thread-meta">
-                {% if result.object.is_solved %}
-                  <span class="solved">{{ _('Solved') }}</span>
-                {% endif %}
-                <span class="replies">
-                  {% if result.object.num_answers > 0 %}
-                    {{ ngettext('1 reply', '{n} replies',
-                                result.object.num_answers)|f(n=result.object.num_answers) }}
-                  {% else %}
-                    {{ _('No replies') }}
-                  {% endif %}
-                </span>
-                <span class="votes">
-                  {{ ngettext('1 person has this problem', '{n} people have this problem',
-                              result.object.num_votes)|f(n=result.object.num_votes) }}
-                </span>
-                <span class="votes this-week">
-                  {{ ngettext('1 new this week', '{n} new this week',
-                              result.object.num_votes_past_week)|f(n=result.object.num_votes_past_week) }}
-                </span>
-              </div>{# .thread-meta #}
-            {% endif %}
-          </div>{# .result #}
+          {{ search_result(result, as='aaq') }}
         {% endfor %}
       </div>{# .search-results #}
     {% else %}{# No search results at all. #}

--- a/apps/questions/views.py
+++ b/apps/questions/views.py
@@ -818,6 +818,9 @@ def _search_suggestions(query, locale, category_tags):
     Items are dicts of:
         {
             'type':
+            'search_summary':
+            'title':
+            'url':
             'object':
         }
 
@@ -862,6 +865,9 @@ def _search_suggestions(query, locale, category_tags):
             doc = Document.objects.select_related('current_revision').\
                 get(pk=r['id'])
             results.append({
+                'search_summary': doc.current_revision.summary,
+                'url': doc.get_absolute_url(),
+                'title': doc.title,
                 'type': 'document',
                 'object': doc,
             })
@@ -876,6 +882,9 @@ def _search_suggestions(query, locale, category_tags):
         try:
             q = Question.objects.get(pk=r['attrs']['question_id'])
             results.append({
+                'search_summary': q.content[0:500],
+                'url': q.get_absolute_url(),
+                'title': q.title,
                 'type': 'question',
                 'object': q
             })

--- a/apps/search/templates/search/includes/result.html
+++ b/apps/search/templates/search/includes/result.html
@@ -1,0 +1,31 @@
+{% macro search_result(result, s=None, as='s', r=None) %}
+  <div class="result {{ result.type }}">
+    <a class="title" href="{{ result.url|urlparams(s=s, as=as, r=r) }}">{{ result.title }}</a>
+    <p><a href="{{ result.url|urlparams(s=s, as=as, r=r) }}">
+      {{ result.search_summary|safe }}
+    </a></p>
+    {% if result.type == 'question' %}
+      <div class="thread-meta">
+        {% if result.object.is_solved %}
+          <span class="solved">{{ _('Solved') }}</span>
+        {% endif %}
+        <span class="replies">
+          {% if result.object.num_answers > 0 %}
+            {{ ngettext('1 reply', '{n} replies',
+                        result.object.num_answers)|f(n=result.object.num_answers) }}
+          {% else %}
+            {{ _('No replies') }}
+          {% endif %}
+        </span>
+        <span class="votes">
+          {{ ngettext('1 person has this problem', '{n} people have this problem',
+                      result.object.num_votes)|f(n=result.object.num_votes) }}
+        </span>
+        <span class="votes this-week">
+          {{ ngettext('1 new this week', '{n} new this week',
+                      result.object.num_votes_past_week)|f(n=result.object.num_votes_past_week) }}
+        </span>
+      </div>{# .thread-meta #}
+    {% endif %}
+  </div>{# .result #}
+{% endmacro %}

--- a/apps/search/templates/search/results.html
+++ b/apps/search/templates/search/results.html
@@ -1,5 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "search/base.html" %}
+{% from "search/includes/result.html" import search_result %}
 {% set meta = (('WT.oss', q),
                ('WT.oss_r', num_results)) %}
 
@@ -29,14 +30,7 @@
   <div class="search-results">
 
     {% for doc in results %}
-      <div class="result {{ doc.type }}">
-        <a class="title" href="{{ doc.url|urlparams(s=q, as='s', r=doc.rank) }}">{{ doc.title }}</a>
-        <p>
-          <a href="{{ doc.url|urlparams(s=q, as='s', r=doc.rank) }}">
-            {{ doc.search_summary|safe }}
-          </a>
-        </p>
-      </div>
+      {{ search_result(doc, s=q, r=doc.rank) }}
     {% endfor %}
 
     {{ pages|paginator }}

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -303,11 +303,14 @@ def search(request, template=None):
                 wiki_page = Document.objects.get(pk=documents[i]['id'])
                 summary = wiki_page.current_revision.summary
 
-                result = {'search_summary': summary,
-                          'url': wiki_page.get_absolute_url(),
-                          'title': wiki_page.title,
-                          'type': 'document',
-                          'rank': i,}
+                result = {
+                    'search_summary': summary,
+                    'url': wiki_page.get_absolute_url(),
+                    'title': wiki_page.title,
+                    'type': 'document',
+                    'rank': i,
+                    'object': wiki_page,
+                }
                 results.append(result)
             elif documents[i]['attrs'].get('question_creator', False) != False:
                 question = Question.objects.get(
@@ -316,11 +319,14 @@ def search(request, template=None):
                 excerpt = qc.excerpt(question.content, cleaned['q'])
                 summary = jinja2.Markup(excerpt)
 
-                result = {'search_summary': summary,
-                          'url': question.get_absolute_url(),
-                          'title': question.title,
-                          'type': 'question',
-                          'rank': i,}
+                result = {
+                    'search_summary': summary,
+                    'url': question.get_absolute_url(),
+                    'title': question.title,
+                    'type': 'question',
+                    'rank': i,
+                    'object': question,
+                }
                 results.append(result)
             else:
                 thread = Thread.objects.get(
@@ -330,11 +336,14 @@ def search(request, template=None):
                 excerpt = dc.excerpt(post.content, cleaned['q'])
                 summary = jinja2.Markup(excerpt)
 
-                result = {'search_summary': summary,
-                          'url': thread.get_absolute_url(),
-                          'title': thread.title,
-                          'type': 'thread',
-                          'rank': i,}
+                result = {
+                    'search_summary': summary,
+                    'url': thread.get_absolute_url(),
+                    'title': thread.title,
+                    'type': 'thread',
+                    'rank': i,
+                    'object': thread,
+                }
                 results.append(result)
         except IndexError:
             break
@@ -348,6 +357,9 @@ def search(request, template=None):
     refine_query = u'?%s' % urlencode(items)
 
     if is_json:
+        # Models are not json serializable.
+        for r in results:
+            del r['object']
         data = {}
         data['results'] = results
         data['total'] = len(results)

--- a/media/css/questions-meta.css
+++ b/media/css/questions-meta.css
@@ -1,0 +1,37 @@
+div.thread-meta {
+    margin-right: 140px;
+    padding: 10px 15px;
+}
+
+div.thread-meta span {
+    border-right: 1px solid rgba(0, 0, 0, 0.25);
+    padding: 0 10px;
+}
+
+div.thread-meta span:first-child {
+    padding-left: 0;
+}
+
+div.thread-meta span.solved {
+    color: #00cc1a;
+    font-weight: bold;
+}
+
+div.thread-meta span.locked{
+    font-weight: bold;
+}
+
+div.thread-meta span.contributed {
+    color: #ff0000;
+    font-weight: bold;
+}
+
+div.thread-meta ul.tag-list {
+    display: inline;
+    line-height: 17px;
+    padding: 0 10px;
+}
+
+div.thread-meta ul.tag-list a {
+    color: inherit;
+}

--- a/media/css/questions.css
+++ b/media/css/questions.css
@@ -242,44 +242,6 @@ div.user-meta div.have-problem span.recent {
     margin: 4px 0 0;
 }
 
-div.thread-meta {
-    margin-right: 140px;
-    padding: 10px 15px;
-}
-
-div.thread-meta span {
-    border-right: 1px solid rgba(0, 0, 0, 0.25);
-    padding: 0 10px;
-}
-
-div.thread-meta span:first-child {
-    padding-left: 0;
-}
-
-div.thread-meta span.solved {
-    color: #00cc1a;
-    font-weight: bold;
-}
-
-div.thread-meta span.locked{
-    font-weight: bold;
-}
-
-div.thread-meta span.contributed {
-    color: #ff0000;
-    font-weight: bold;
-}
-
-div.thread-meta ul.tag-list {
-    display: inline;
-    line-height: 17px;
-    padding: 0 10px;
-}
-
-div.thread-meta ul.tag-list a {
-    color: inherit;
-}
-
 /* questions pagination tweak */
 body.questions ol.pagination {
     background: #E0EFFD;

--- a/media/css/search.css
+++ b/media/css/search.css
@@ -128,3 +128,8 @@ input.search-refine-submit:hover {
     background-color: #f90;
 }
 /* END Bug 527859 */
+
+/* High-specificity selector to fix question meta padding. */
+article#search-results div.thread-meta {
+    padding-left: 50px;
+}

--- a/settings.py
+++ b/settings.py
@@ -370,12 +370,14 @@ MINIFY_BUNDLES = {
         'questions': (
             'css/to-delete.css',
             'css/questions.css',
+            'css/questions-meta.css',
             'css/tags.css',
             'css/search.css',
         ),
         'search': (
             'css/search.css',
             'css/search-advanced.css',
+            'css/questions-meta.css',
         ),
         'wiki': (
             'css/users.autocomplete.css',


### PR DESCRIPTION
- Combine the search result code in one macro.
- Use the new macro in the AAQ and search results.
- Add 'object' to results from search (except in JSON).
- Add a few fields to results from AAQ.
- Factor out some CSS from questions.
