### PR TITLE
[bug 687996] Keep Related from covering warnings.

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -697,6 +697,7 @@ div.support-search button.img-submit {
     -moz-border-radius: 10px;
     -webkit-border-radius: 10px;
     margin: 35px 20px 0 0;
+    overflow: hidden;
     padding: .5em 2em .5em 2em;
 }
 

--- a/media/css/wiki_syntax.css
+++ b/media/css/wiki_syntax.css
@@ -17,6 +17,7 @@
 #home-content .note,
 #doc-content .note {
     margin: 1em 0;
+    overflow: hidden;
 }
 
 #doc-content p:first-child {


### PR DESCRIPTION
Add black-magic^W^W^W"overflow: hidden" to these classes:
- .warning-box
- .warning
- .note
