### PR TITLE
[bug 694263] Missing author_post_count on post preview.

### DIFF
--- a/apps/forums/views.py
+++ b/apps/forums/views.py
@@ -463,6 +463,6 @@ def post_preview_async(request):
     """Ajax preview of posts."""
     statsd.incr('forums.preview')
     post = Post(author=request.user, content=request.POST.get('content', ''))
-    post.author_post_count = post.author.post_set.count()
+    post.author_post_count = 1
     return jingo.render(request, 'forums/includes/post_preview.html',
                         {'post_preview': post})


### PR DESCRIPTION
I can't reproduce the actual stack trace (the preview loads for me, but with an empty post count). It is obvious that it was missing the author_post_count attribute so I added that. I don't get why it would only fail in some locales either :-/.

r?
