### PR TITLE
[bug 695553] Add tests and fix PEP8 violation.

### DIFF
--- a/apps/search/tests/test_search.py
+++ b/apps/search/tests/test_search.py
@@ -567,6 +567,14 @@ class SearchTest(SphinxTestCase):
         results = wc.query('ghosts')
         eq_(1, len(results))
 
+    def test_search_cookie(self):
+        """Set a cookie with the latest search term."""
+        data = {'q': u'pagap\xf3 banco'}
+        cookie = settings.LAST_SEARCH_COOKIE
+        response = self.client.get(reverse('search', locale='fr'), data)
+        assert cookie in response.cookies
+        eq_(data['q'], response.cookies[cookie].value.decode('utf-8'))
+
     @mock.patch.object(Site.objects, 'get_current')
     def test_suggestions(self, get_current):
         """Suggestions API is well-formatted."""

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -380,7 +380,8 @@ def search(request, template=None):
     results_['Expires'] = (datetime.utcnow() +
                            timedelta(minutes=settings.SEARCH_CACHE_PERIOD)) \
                            .strftime(expires_fmt)
-    results_.set_cookie(settings.LAST_SEARCH_COOKIE, cleaned['q'].encode('utf-8'),
+    results_.set_cookie(settings.LAST_SEARCH_COOKIE,
+                        cleaned['q'].encode('utf-8'),
                         max_age=3600, secure=False, httponly=False)
     return results_
 


### PR DESCRIPTION
r?

Adds a test for setting cookies from search (including Unicode-ness) and fixes a minor PEP8 violation (line length) I just introduced.
