### PR TITLE
[bug 697715] Don't delete Forums or Threads when the user who made their 

### DIFF
--- a/apps/forums/models.py
+++ b/apps/forums/models.py
@@ -37,8 +37,10 @@ class Forum(NotificationsMixin, ModelBase):
     name = models.CharField(max_length=50, unique=True)
     slug = models.SlugField(unique=True)
     description = models.TextField(null=True)
-    last_post = models.ForeignKey('Post', related_name='last_post_in_forum',
-                                  null=True)
+    last_post = models.ForeignKey('Post',
+                                  related_name='last_post_in_forum',
+                                  null=True,
+                                  on_delete=models.SET_NULL)
 
     class Meta(object):
         permissions = (
@@ -94,8 +96,10 @@ class Thread(NotificationsMixin, ModelBase):
     created = models.DateTimeField(default=datetime.datetime.now,
                                    db_index=True)
     creator = models.ForeignKey(User)
-    last_post = models.ForeignKey('Post', related_name='last_post_in',
-                                  null=True)
+    last_post = models.ForeignKey('Post',
+                                  related_name='last_post_in',
+                                  null=True,
+                                  on_delete=models.SET_NULL)
     replies = models.IntegerField(default=0)
     is_locked = models.BooleanField(default=False)
     is_sticky = models.BooleanField(default=False, db_index=True)

--- a/apps/forums/templates/forums/forums.html
+++ b/apps/forums/templates/forums/forums.html
@@ -31,9 +31,6 @@
                 {{ datetimeformat(forum.last_post.created) }}
             </a><br/>
             {{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(forum.last_post.author), username=forum.last_post.author.username) }}
-          {% else %}
-            {# Not localized because it's not worth localizers time. #}
-            No posts.
           {% endif %}
           </div>
           <hr/>

--- a/apps/forums/templates/forums/includes/forum_macros.html
+++ b/apps/forums/templates/forums/includes/forum_macros.html
@@ -16,15 +16,17 @@
           <img src="{{ MEDIA_URL }}img/forums/type/sticky.png" alt="{{ _('Sticky', 'thread_type') }}" title="{{ _('Sticky', 'thread_type') }}"/>
         {% endif %}
       </div>
-      <div class="title"><a href="{{ url('forums.posts', forum_slug=_forum.slug, thread_id=thread.id)|urlparams(last=thread.last_post.id) }}">{{ thread.title }}</a></div>
+      <div class="title"><a href="{{ url('forums.posts', forum_slug=_forum.slug, thread_id=thread.id)|urlparams(last=thread.last_post_id) }}">{{ thread.title }}</a></div>
       <div class="author"><a class="username" href="{{ profile_url(thread.creator) }}">{{ thread.creator.username }}</a></div>
       <div class="replies">{{ thread.replies }}</div>
-      <div class="last-post">
-        <a href="{{ thread.last_post.get_absolute_url() }}">
-          {{ datetimeformat(thread.last_post.created) }}
-        </a><br/>
-        {{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.author), username=thread.last_post.author.username) }}
-      </div>
+      {% if thread.last_post %}
+        <div class="last-post">
+          <a href="{{ thread.last_post.get_absolute_url() }}">
+            {{ datetimeformat(thread.last_post.created) }}
+          </a><br/>
+          {{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.author), username=thread.last_post.author.username) }}
+        </div>
+      {% endif %}
     <hr/>
     </li>
   {% endfor %}

--- a/apps/forums/tests/__init__.py
+++ b/apps/forums/tests/__init__.py
@@ -1,11 +1,56 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.template.defaultfilters import slugify
 
 from nose.tools import eq_
 
-from forums.models import Thread, Post, ThreadLockedError
+from forums.models import Forum, Thread, Post, ThreadLockedError
 from forums.views import sort_threads
-from sumo.tests import get, LocalizingClient, TestCase
+from sumo.tests import get, LocalizingClient, TestCase, with_save
+from users.tests import user
+
+
+@with_save
+def forum(**kwargs):
+    """Return an empty forum with enough data to make it saveable.
+
+    We assign a random slug and name by default so you can make more than one.
+
+    """
+    if 'name' not in kwargs:
+        kwargs['name'] = u'Förum %s' % datetime.now()
+    if 'slug' not in kwargs:
+        kwargs['slug'] = slugify(kwargs['name'])
+    return Forum(**kwargs)
+
+
+@with_save
+def thread(**kwargs):
+    """Return an empty thread with enough data to make it saveable.
+
+    We assign a random title so you can make more than one in a forum.
+
+    """
+    if 'title' not in kwargs:
+        kwargs['title'] = u'Thréåd %s' % datetime.now()
+    if 'forum' not in kwargs:
+        kwargs['forum'] = forum(save=True)
+    if 'creator' not in kwargs:
+        kwargs['creator'] = user(save=True)
+    return Thread(**kwargs)
+
+
+@with_save
+def post(**kwargs):
+    """Return an empty post with enough to make it saveable."""
+    if 'thread' not in kwargs:
+        kwargs['thread'] = thread(save=True)
+    if 'author' not in kwargs:
+        kwargs['author'] = user(save=True)
+    return Post(**kwargs)
 
 
 class ForumTestCase(TestCase):


### PR DESCRIPTION
f?

For now, we just set last_post to NULL. Django doesn't bring us what we need to set it properly, but it might be possible in the future with a custom on_delete value.

Stopped saying "No posts" when there's a null last_post, since it can also mean "We don't know what the last post was" now.

Added model makers for forums, because I wanted to use them.

To do:
- Add view tests to prove I fixed all the non-null assumers. Then this much can land. Then...
- Port all this to kbforums as well.
- Audit the rest of the ForeignKeys in the codebase.
