### PR TITLE
Nix sphinx_locale

### DIFF
--- a/apps/search/utils.py
+++ b/apps/search/utils.py
@@ -61,8 +61,3 @@ def locale_or_default(locale):
     if locale not in LOCALES:
         locale = settings.LANGUAGE_CODE
     return locale
-
-
-def sphinx_locale(locale):
-    """Given a locale string like 'en-US', return a Sphinx-ready locale."""
-    return crc32(locale)


### PR DESCRIPTION
The switch to oedipus nixed all uses of this function, so we can make it
go away now.

This is a trivial change.

r?
