### PR TITLE
Nix category exclude for wiki documents

### DIFF
--- a/apps/search/tests/test_search.py
+++ b/apps/search/tests/test_search.py
@@ -124,29 +124,6 @@ class SearchTest(SphinxTestCase):
         results = wiki_search.filter(category__in=[30])
         eq_(1, len(results))
 
-    def test_category_exclude_nothing(self):
-        """Excluding no categories should return results."""
-        # Note: We keep the query('') here to force a new S and thus
-        # not inadvertently test with an S that's not in an original
-        # state.
-        results = wiki_search.query('')
-        self.assertNotEquals(0, len(results))
-
-        results = question_search.query('')
-        self.assertNotEquals(0, len(results))
-
-        results = discussion_search.query('')
-        self.assertNotEquals(0, len(results))
-
-    def test_category_exclude(self):
-        q = {'q': 'audio', 'format': 'json', 'w': 1}
-        response = self.client.get(reverse('search'), q)
-        eq_(2, json.loads(response.content)['total'])
-
-        q = {'q': 'audio', 'category': -10, 'format': 'json', 'w': 1}
-        response = self.client.get(reverse('search'), q)
-        eq_(0, json.loads(response.content)['total'])
-
     def test_category_invalid(self):
         qs = {'a': 1, 'w': 3, 'format': 'json', 'category': 'invalid'}
         response = self.client.get(reverse('search'), qs)

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -60,8 +60,7 @@ def search(request, template=None):
                    settings.SEARCH_DEFAULT_CATEGORIES
     except ValueError:
         category = settings.SEARCH_DEFAULT_CATEGORIES
-    r.setlist('category', [x for x in category if x > 0])
-    exclude_category = [abs(x) for x in category if x < 0]
+    r.setlist('category', category)
 
     # Basic form
     if a == '0':
@@ -119,9 +118,6 @@ def search(request, template=None):
     # Category filter
     if cleaned['category']:
         wiki_s = wiki_s.filter(category__in=cleaned['category'])
-
-    if exclude_category:
-        wiki_s = wiki_s.exclude(category__in=exclude_category)
 
     # Locale filter
     wiki_s = wiki_s.filter(locale=language)


### PR DESCRIPTION
There's nothing in the ui that allows for category exclude, so this code
wasn't doing anything interesting.

Per yesterday's conversation, I thought I'd remove it.  It's dead code and now we don't have to fiddle with getting exclude working in elasticutils (though Erik said it's so easy he could do it upside-down with his hands behind his back).

r?
