### PR TITLE
[bug 701386] fixes forum_id filter

### DIFF
--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -182,7 +182,7 @@ def search(request, template=None):
                 discussion_s = discussion_s.filter(is_locked=1)
 
         if cleaned['forum']:
-            discussion_s = discussion_s.filter(forum_id=cleaned['forum'])
+            discussion_s = discussion_s.filter(forum_id__in=cleaned['forum'])
 
     # Filters common to support and discussion forums
     # Created filter


### PR DESCRIPTION
If you filtered by forum in the contributor forum advanced search, it'd
kick up an error because forum_id is a list of ids and thus should be
added using filter__in= rather than just filter=.

r?
