### PR TITLE
[bug 710210] Stop redirecting from /favicon.ico to /<locale>/favicon.ico...

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -130,7 +130,7 @@ ADMIN_MEDIA_PREFIX = '/admin-media/'
 
 # Paths that don't require a locale prefix.
 SUPPORTED_NONLOCALES = ('media', 'admin', 'robots.txt', 'services', '1',
-                        'postcrash', 'wafflejs')
+                        'postcrash', 'wafflejs', 'favicon.ico')
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '#%tc(zja8j01!r#h_y)=hy!^k)9az74k+-ib&ij&+**s3-e^_z'


### PR DESCRIPTION
r?

I am not sure what causes browsers to request /favicon.ico in some cases. I couldn't repro locally at all. (Maybe it gets impatient on slow connections and tries to fetch it before parsing the `<head/>`?)

Anyway, this will kill the /favicon.ico -> /`<locale>`/favicon.ico redirect.
