### PR TITLE
[bug 710279] Fix test_creator_nums_redis test

### DIFF
--- a/apps/sumo/tests/__init__.py
+++ b/apps/sumo/tests/__init__.py
@@ -67,9 +67,7 @@ class LocalizingClient(Client):
 
 
 class TestCase(test_utils.TestCase):
-    def setUp(self):
-        super(TestCase, self).setUp()
-        settings.REDIS_BACKENDS = settings.REDIS_TEST_BACKENDS
+    pass
 
 
 class ElasticTestMixin(object):

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -123,15 +123,18 @@ For local development you will want to add the following settings::
 Redis
 -----
 
-You need to copy the ``REDIS_BACKEND`` and ``REDIS_TEST_BACKEND``
-sections from ``settings.py`` into your ``settings_local.py``.  After
-doing that, uncomment the three lines in each section.
+You need to copy the ``REDIS_BACKEND`` section from ``settings.py``
+into your ``settings_local.py``.  After doing that, uncomment the
+three lines in each section.
 
-There are three ``.conf`` files in ``config/redis/`` each
-corresponding to a different redis server configuration.  You need to
-run all three redis servers.
+There are three ``.conf`` files in ``config/redis/``.  One is for
+testing and is used in ``settings_test.py``.  The other two are used
+for the sections in ``REDIS_BACKEND``.
 
-The three conf files need to match the settings in ``settings_local.py``.
+There are two ways to set this up.  First is to set it up like in
+``settings.py`` and run all three redis servers.  The second is to set
+it up differently, tweak the settings in ``settings_local.py``
+accordingly, and run Redis using just the test configuration.
 
 
 Database
@@ -197,7 +200,7 @@ package directory. To set this up, run this command to do the initial fetch::
 Running redis
 -------------
 
-You'll need to run three redis servers--one for each configuration.
+This script runs all three servers---one for each configuration.
 
 I (Will) put that in a script that creates the needed directories in
 ``/var/redis/`` and kicks off the three redis servers::

--- a/settings.py
+++ b/settings.py
@@ -767,13 +767,6 @@ REDIS_BACKENDS = {
     #'helpfulvotes': 'redis://localhost:6379?socket_timeout=0.5&db=1',
 }
 
-# Redis backends used for testing.
-REDIS_TEST_BACKENDS = {
-    #'default': 'redis://localhost:6383?socket_timeout=0.5&db=0',
-    #'karma': 'redis://localhost:6383?socket_timeout=0.5&db=1',
-    #'helpfulvotes': 'redis://localhost:6379?socket_timeout=0.5&db=1',
-}
-
 # Set this to enable Arecibo (http://www.areciboapp.com/) error reporting:
 ARECIBO_SERVER_URL = ''
 

--- a/settings_test.py
+++ b/settings_test.py
@@ -8,3 +8,11 @@ ES_INDEXES = {'default': 'sumo_test'}
 # This makes sure we only turn on ES stuff when we're testing ES
 # stuff.
 USE_ELASTIC = False
+
+# Make sure we use port 6383 db 2 redis for tests.  That's db 2 of the
+# redis test config.  That shouldn't collide with anything else.
+REDIS_BACKENDS = {
+    'default': 'redis://localhost:6383?socket_timeout=0.5&db=2',
+    'karma': 'redis://localhost:6383?socket_timeout=0.5&db=2',
+    'helpfulvotes': 'redis://localhost:6383?socket_timeout=0.5&db=2',
+}


### PR DESCRIPTION
KarmaManager() gets created before we stomp on the REDIS_BACKENDS settings
with REDIS_TEST_BACKENDS.  This switches all that testy stuff around to use
settings_test.py which stomps on everything before modules get imported.

r?
