### PR TITLE
Print error if elasticsearch isn't running

### DIFF
--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -82,7 +82,12 @@ def es_whazzup():
 
     es = elasticutils.get_es()
 
-    pprint.pprint(es.cluster_stats())
+    try:
+        pprint.pprint(es.cluster_stats())
+    except pyes.urllib3.connectionpool.MaxRetryError:
+        print ('ERROR: Your elasticsearch process is not running or '
+               'ES_HOSTS is set wrong in your settings_local.py file.')
+        return
 
     print 'Totals:'
     try:


### PR DESCRIPTION
If elasticsearch process isn't running, print an error to the console
that's more informative than the pyes exception and a traceback.

This is purely to make developers' lives easier.

r?
