### PR TITLE
[bug 648258] Mark new threads read, at least.

### DIFF
--- a/apps/forums/models.py
+++ b/apps/forums/models.py
@@ -151,9 +151,15 @@ class Thread(NotificationsMixin, ModelBase):
         return self.post_set.create(author=author, content=content)
 
     def get_absolute_url(self):
-        return reverse('forums.posts',
-                       kwargs={'forum_slug': self.forum.slug,
-                               'thread_id': self.id})
+        return reverse('forums.posts', args=[self.forum.slug, self.id])
+
+    def get_last_post_url(self):
+        query = {'last': self.last_post_id}
+        page = self.last_page
+        if page > 1:
+            query['page'] = page
+        url = reverse('forums.posts', args=[self.forum.slug, self.id])
+        return urlparams(url, hash='post-%s' % self.last_post_id, **query)
 
     def save(self, *args, **kwargs):
         super(Thread, self).save(*args, **kwargs)

--- a/apps/forums/templates/forums/includes/forum_macros.html
+++ b/apps/forums/templates/forums/includes/forum_macros.html
@@ -20,7 +20,7 @@
       <div class="author"><a class="username" href="{{ profile_url(thread.creator) }}">{{ thread.creator.username }}</a></div>
       <div class="replies">{{ thread.replies }}</div>
       <div class="last-post">
-        <a href="{{ thread.last_post.get_absolute_url() }}">
+        <a href="{{ thread.get_last_post_url() }}">
           {{ datetimeformat(thread.last_post.created) }}
         </a><br/>
         {{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.author), username=thread.last_post.author.username) }}

--- a/apps/forums/tests/test_models.py
+++ b/apps/forums/tests/test_models.py
@@ -50,6 +50,17 @@ class ForumModelTestCase(ForumTestCase):
         p = Post.objects.get(pk=24)
         eq_(2, p.page)
 
+    def test_thread_last_post_url(self):
+        p = Post.objects.get(pk=24)
+        t = p.thread
+        lp = t.last_post
+        f = t.forum
+        url_ = t.get_last_post_url()
+        assert f.slug in url_
+        assert str(t.id) in url_
+        assert '#post-%s' % lp.id in url_
+        assert 'last=%s' % lp.id in url_
+
     def test_last_post_updated(self):
         """Adding/Deleting the last post in a thread and forum should
         update the last_post field

--- a/apps/forums/tests/test_views.py
+++ b/apps/forums/tests/test_views.py
@@ -159,6 +159,29 @@ class ThreadTests(ForumTestCase):
         edited_t = Thread.uncached.get(pk=2)
         eq_('new title', edited_t.title)
 
+    def test_new_thread_redirect(self):
+        """Posting a new thread should redirect."""
+        self.client.login(username='pcraciunoiu', password='testpass')
+        f = Forum.objects.get(pk=1)
+        url = reverse('forums.new_thread', args=[f.slug])
+        data = {'title': 'some title', 'content': 'some content'}
+        r = self.client.post(url, data, follow=False)
+        eq_(302, r.status_code)
+        assert f.slug in r['location']
+        assert 'last=' in r['location']
+
+    def test_reply_redirect(self):
+        """Posting a reply should redirect."""
+        self.client.login(username='pcraciunoiu', password='testpass')
+        t = Thread.objects.get(pk=2)
+        url = reverse('forums.reply', args=[t.forum.slug, t.id])
+        data = {'content': 'some content'}
+        r = self.client.post(url, data, follow=False)
+        eq_(302, r.status_code)
+        assert t.forum.slug in r['location']
+        assert str(t.id) in r['location']
+        assert 'last=' in r['location']
+
 
 class ThreadPermissionsTests(ForumTestCase):
 

--- a/apps/forums/views.py
+++ b/apps/forums/views.py
@@ -17,6 +17,7 @@ from forums.events import NewPostEvent, NewThreadEvent
 from forums.feeds import ThreadsFeed, PostsFeed
 from forums.forms import ReplyForm, NewThreadForm, EditThreadForm, EditPostForm
 from forums.models import Forum, Thread, Post
+from sumo.helpers import urlparams
 from sumo.urlresolvers import reverse
 from sumo.utils import paginate
 from users.models import Setting
@@ -169,7 +170,7 @@ def reply(request, forum_slug, thread_id):
                 # Send notifications to thread/forum watchers.
                 NewPostEvent(reply_).fire(exclude=reply_.author)
 
-                return HttpResponseRedirect(reply_.get_absolute_url())
+                return HttpResponseRedirect(thread.get_last_post_url())
 
     return posts(request, forum_slug, thread_id, form, post_preview,
                  is_reply=True)
@@ -216,8 +217,8 @@ def new_thread(request, forum_slug):
             if Setting.get_for_user(request.user, 'forums_watch_new_thread'):
                 NewPostEvent.notify(request.user, thread)
 
-            return HttpResponseRedirect(
-                reverse('forums.posts', args=[forum_slug, thread.id]))
+            url = reverse('forums.posts', args=[forum_slug, thread.id])
+            return HttpResponseRedirect(urlparams(url, last=post.id))
 
     return jingo.render(request, 'forums/new_thread.html',
                         {'form': form, 'forum': forum,

--- a/media/css/forums.css
+++ b/media/css/forums.css
@@ -75,7 +75,8 @@ ol.threads li div.title {
     width: 32%;
 }
 
-.title a:visited {
+.title a:visited,
+.last-post a:visited {
     color: #777;
 }
 


### PR DESCRIPTION
r?

Makes new threads automagically "read" in the list, if not replies, and makes the "last post" link reflect its own "read" status.
