### PR TITLE
Bug 713890 - let people who click on 'me too' know that helpers are volunteers

### DIFF
--- a/apps/questions/templates/questions/email/solution.ltxt
+++ b/apps/questions/templates/questions/email/solution.ltxt
@@ -15,4 +15,10 @@ helpful? Let other Firefox users know by voting next to the
 answer.
 
 https://{{ host }}{{ solution_url }}
+
+Did you know that {{ answerer }} is a Firefox user
+just like you? Get started helping other Firefox users by
+browsing questions at
+https://{{ host }}/questions?filter=unsolved -- you
+might just make someone's day!
 {% endblocktrans %}{% endautoescape %}{% unsubscribe_instructions watch %}


### PR DESCRIPTION
r? and land this, please.

fyi: I couldn't really test this, as I haven't gone through the trouble of setting up email on my local box.
