### PR TITLE
[bug 714064] Showfor selector missing.

### DIFF
--- a/apps/wiki/templates/wiki/review_revision.html
+++ b/apps/wiki/templates/wiki/review_revision.html
@@ -65,5 +65,11 @@
   {{ document_tabs(document, document.parent, user, '', settings) }}
 {% endblock %}
 
+{% block side_bottom %}
+  {% if not revision.reviewed and not document.current_revision %}
+    {{ show_for(header=_('Article is for:')) }}
+  {% endif %}
+{% endblock %}
+
 {% block side %}
 {% endblock %}

--- a/apps/wiki/templates/wiki/review_translation.html
+++ b/apps/wiki/templates/wiki/review_translation.html
@@ -110,5 +110,11 @@
   {{ document_tabs(document, document.parent, user, '', settings) }}
 {% endblock %}
 
+{% block side_bottom %}
+  {% if not revision.reviewed and not document.current_revision %}
+    {{ show_for(header=_('Article is for:')) }}
+  {% endif %}
+{% endblock %}
+
 {% block side %}
 {% endblock %}


### PR DESCRIPTION
r?
- The showfor selector was missing on review of new article/translation.
