### PR TITLE
[bug 714171] add statsd calls for "search unavailable"

### DIFF
--- a/apps/search/admin.py
+++ b/apps/search/admin.py
@@ -9,8 +9,9 @@ from search.es_utils import get_doctype_stats
 from search.tasks import (ES_REINDEX_PROGRESS, ES_WAFFLE_WHEN_DONE,
                           reindex_with_progress)
 from sumo.urlresolvers import reverse
-from pyes.urllib3 import MaxRetryError
-from pyes.exceptions import IndexMissingException
+
+from search.es_utils import (ESTimeoutError, ESMaxRetryError,
+                             ESIndexMissingException)
 
 
 def search(request):
@@ -36,12 +37,15 @@ def search(request):
         # This gets index stats, but also tells us whether ES is in
         # a bad state.
         stats = get_doctype_stats()
-    except MaxRetryError:
+    except ESMaxRetryError:
         es_error_message = ('Elastic Search is not set up on this machine '
-                            'or is not responding.  (MaxRetryError)')
-    except IndexMissingException:
-        es_error_message = ('Index is missing.  Press the reindex button '
-                            'below.  (IndexMissingException)')
+                            'or is not responding. (MaxRetryError)')
+    except ESIndexMissingException:
+        es_error_message = ('Index is missing. Press the reindex button '
+                            'below. (IndexMissingException)')
+    except ESTimeoutError:
+        es_error_message = ('Connection to Elastic Search timed out. '
+                            '(TimeoutError)')
 
     return render_to_response(
         'search/admin/search.html',

--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -13,6 +13,8 @@ from wiki.models import Document
 
 
 ESTimeoutError = pyes.urllib3.TimeoutError
+ESMaxRetryError = pyes.urllib3.MaxRetryError
+ESIndexMissingException = pyes.exceptions.IndexMissingException
 
 
 TYPE = 'type'

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -26,7 +26,7 @@ from forums.models import Thread, discussion_searcher
 from questions.models import question_searcher
 import search as constants
 from search.forms import SearchForm
-from search.es_utils import ESTimeoutError
+from search.es_utils import ESTimeoutError, ESMaxRetryError
 from search.tasks import ES_REINDEX_PROGRESS
 from sumo.utils import paginate, smart_int
 from wiki.models import wiki_searcher
@@ -398,13 +398,20 @@ def search(request, template=None):
             except ObjectDoesNotExist:
                 continue
 
-    except (SearchError, ESTimeoutError):
+    except (SearchError, ESTimeoutError, ESMaxRetryError), exc:
         # Handle timeout and all those other transient errors with a
         # "Search Unavailable" rather than a Django error page.
         if is_json:
             return HttpResponse(json.dumps({'error':
                                              _('Search Unavailable')}),
                                 mimetype=mimetype, status=503)
+
+        if isinstance(exc, SearchError):
+            statsd.incr('search.%s.searcherror' % engine)
+        elif isinstance(exc, ESTimeoutError):
+            statsd.incr('search.%s.timeouterror' % engine)
+        elif isinstance(exc, ESMaxRetryError):
+            statsd.incr('search.%s.maxretryerror' % engine)
 
         t = 'search/mobile/down.html' if request.MOBILE else 'search/down.html'
         return jingo.render(request, t, {'q': cleaned['q']}, status=503)


### PR DESCRIPTION
- adds statsd.incr calls for the various things that cause a
  "search unavailable" page so we can track them
- moves some ES-related names to es_utils
- cleans up double-space-after-period i did in a previous commit

(Sorry for bundling some minor clean-up with this one.)

r?
