### PR TITLE
[Bug 719909] Fix Safari sometimes not lazyloading images until scroll

### DIFF
--- a/media/js/libs/jquery.lazyload.js
+++ b/media/js/libs/jquery.lazyload.js
@@ -18,6 +18,9 @@
 
         loadAboveTheFoldImages(elements, opts);
 
+        // Safari doesn't load images until scroll, sometimes
+        $(window).trigger('scroll');
+
         if(window.location.hash) {
             // Reset scroll to anchor position if it exists
             window.location.hash = window.location.hash;


### PR DESCRIPTION
We were unable to find STR, seems like a true heisenbug. The one thing we noticed was that the images always loaded after even a single scroll event was fired, so hopefully by doing this it'll fix it. With this patch, I was unable to see the bug happen anymore. r?
