### PR TITLE
[bug 720865] Remove race conditions that were causing mapping conflicts ...

### DIFF
--- a/apps/forums/models.py
+++ b/apps/forums/models.py
@@ -179,25 +179,21 @@ class Thread(NotificationsMixin, ModelBase, SearchMixin):
 
     @classmethod
     def get_mapping(cls):
-        mapping = {
-            'properties': {
-                'id': {'type': 'integer'},
-                'thread_id': {'type': 'integer'},
-                'forum_id': {'type': 'integer'},
-                'title': {'type': 'string', 'analyzer': 'snowball'},
-                'is_sticky': {'type': 'boolean'},
-                'is_locked': {'type': 'boolean'},
-                'author_id': {'type': 'integer'},
-                'author_ord': {'type': 'string'},
-                'content': {'type': 'string', 'analyzer': 'snowball',
-                            'store': 'yes',
-                            'term_vector': 'with_positions_offsets'},
-                'created': {'type': 'date'},
-                'updated': {'type': 'date'},
-                'replies': {'type': 'integer'}
-                }
-            }
-        return mapping
+        return {
+            'id': {'type': 'integer'},
+            'thread_id': {'type': 'integer'},
+            'forum_id': {'type': 'integer'},
+            'title': {'type': 'string', 'analyzer': 'snowball'},
+            'is_sticky': {'type': 'boolean'},
+            'is_locked': {'type': 'boolean'},
+            'author_id': {'type': 'integer'},
+            'author_ord': {'type': 'string'},
+            'content': {'type': 'string', 'analyzer': 'snowball',
+                        'store': 'yes',
+                        'term_vector': 'with_positions_offsets'},
+            'created': {'type': 'date'},
+            'updated': {'type': 'date'},
+            'replies': {'type': 'integer'}}
 
     def extract_document(self):
         """Extracts interesting thing from a Thread and its Posts"""

--- a/apps/questions/models.py
+++ b/apps/questions/models.py
@@ -283,34 +283,30 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
 
     @classmethod
     def get_mapping(cls):
-        mapping = {
-            'properties': {
-                'id': {'type': 'long'},
-                'question_id': {'type': 'long'},
-                'title': {'type': 'string', 'analyzer': 'snowball'},
-                'question_content':
-                    {'type': 'string', 'analyzer': 'snowball',
-                    # TODO: Stored because originally, this is the
-                    # only field we were excerpting on. Standardize
-                    # one way or the other.
-                     'store': 'yes', 'term_vector': 'with_positions_offsets'},
-                'answer_content':
-                    {'type': 'string', 'analyzer': 'snowball'},
-                'replies': {'type': 'integer'},
-                'is_solved': {'type': 'boolean'},
-                'is_locked': {'type': 'boolean'},
-                'has_answers': {'type': 'boolean'},
-                'has_helpful': {'type': 'boolean'},
-                'created': {'type': 'date'},
-                'updated': {'type': 'date'},
-                'question_creator': {'type': 'string'},
-                'answer_creator': {'type': 'string'},
-                'question_votes': {'type': 'integer'},
-                'answer_votes': {'type': 'integer'},
-                'tag': {'type': 'string'}
-                }
-            }
-        return mapping
+        return {
+            'id': {'type': 'long'},
+            'question_id': {'type': 'long'},
+            'title': {'type': 'string', 'analyzer': 'snowball'},
+            'question_content':
+                {'type': 'string', 'analyzer': 'snowball',
+                # TODO: Stored because originally, this is the
+                # only field we were excerpting on. Standardize
+                # one way or the other.
+                 'store': 'yes', 'term_vector': 'with_positions_offsets'},
+            'answer_content':
+                {'type': 'string', 'analyzer': 'snowball'},
+            'replies': {'type': 'integer'},
+            'is_solved': {'type': 'boolean'},
+            'is_locked': {'type': 'boolean'},
+            'has_answers': {'type': 'boolean'},
+            'has_helpful': {'type': 'boolean'},
+            'created': {'type': 'date'},
+            'updated': {'type': 'date'},
+            'question_creator': {'type': 'string'},
+            'answer_creator': {'type': 'string'},
+            'question_votes': {'type': 'integer'},
+            'answer_votes': {'type': 'integer'},
+            'tag': {'type': 'string'}}
 
     def extract_document(self):
         """Extracts indexable attributes from a Question and its answers."""

--- a/apps/search/management/commands/esreindex.py
+++ b/apps/search/management/commands/esreindex.py
@@ -1,6 +1,8 @@
 import logging
-from django.core.management.base import BaseCommand, CommandError
 from optparse import make_option
+
+from django.core.management.base import BaseCommand, CommandError
+
 from search.es_utils import es_reindex
 from search.models import get_search_models
 
@@ -14,17 +16,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         logging.basicConfig(level=logging.INFO)
         percent = options['percent']
-        if percent > 100 or percent < 1:
+        if not 1 <= percent <= 100:
             raise CommandError('percent should be between 1 and 100')
-
-        if args:
-            search_models = get_search_models()
-            possible_doctypes = dict((cls._meta.db_table, cls)
-                                     for cls in search_models)
-            for mem in args:
-                if mem not in possible_doctypes:
-                    raise CommandError('"%s" is not a valid doctype (%s)' %
-                                       (mem, possible_doctypes.keys()))
-
-        # args are the list of doctypes to index.
-        es_reindex(args, percent)
+        es_reindex(percent)

--- a/apps/sumo/tests/__init__.py
+++ b/apps/sumo/tests/__init__.py
@@ -78,7 +78,7 @@ class ElasticTestCase(TestCase):
         self.teardown_indexes()
         super(ElasticTestCase, self).tearDown()
 
-    def refresh(self, index='default'):
+    def refresh(self):
         # Any time we're doing a refresh, we're making sure that the
         # index is ready to be queried.  Given that, it's almost
         # always the case that we want to run all the generated tasks,
@@ -86,8 +86,7 @@ class ElasticTestCase(TestCase):
         from search.models import generate_tasks
         generate_tasks()
 
-        es = get_es()
-        es.refresh(settings.ES_INDEXES[index], timesleep=0)
+        get_es().refresh(settings.ES_INDEXES['default'], timesleep=0)
 
     def setup_indexes(self):
         """(Re-)create ES indexes."""
@@ -115,8 +114,7 @@ class ElasticTestCase(TestCase):
 
     def teardown_indexes(self):
         es = get_es()
-        for index in settings.ES_INDEXES.values():
-            es.delete_index_if_exists(index)
+        es.delete_index_if_exists(settings.ES_INDEXES['default'])
 
         settings.ES_LIVE_INDEXING = False
 

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -487,25 +487,20 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
 
     @classmethod
     def get_mapping(cls):
-        mapping = {
-            'properties': {
-                'id': {'type': 'integer'},
-                'title': {'type': 'string', 'analyzer': 'snowball'},
-                'locale': {'type': 'string', 'index': 'not_analyzed'},
-                'current': {'type': 'integer'},
-                'parent_id': {'type': 'integer'},
-                'content':
-                    {'type': 'string', 'analyzer': 'snowball'},
-                'category': {'type': 'integer'},
-                'slug': {'type': 'string'},
-                'is_archived': {'type': 'boolean'},
-                'summary': {'type': 'string', 'analyzer': 'snowball'},
-                'keywords': {'type': 'string', 'analyzer': 'snowball'},
-                'updated': {'type': 'date'},
-                'tag': {'type': 'string'}
-                }
-            }
-        return mapping
+        return {
+            'id': {'type': 'integer'},
+            'title': {'type': 'string', 'analyzer': 'snowball'},
+            'locale': {'type': 'string', 'index': 'not_analyzed'},
+            'current': {'type': 'integer'},
+            'parent_id': {'type': 'integer'},
+            'content': {'type': 'string', 'analyzer': 'snowball'},
+            'category': {'type': 'integer'},
+            'slug': {'type': 'string'},
+            'is_archived': {'type': 'boolean'},
+            'summary': {'type': 'string', 'analyzer': 'snowball'},
+            'keywords': {'type': 'string', 'analyzer': 'snowball'},
+            'updated': {'type': 'date'},
+            'tag': {'type': 'string'}}
 
     def extract_document(self):
         d = {}

--- a/settings.py
+++ b/settings.py
@@ -593,7 +593,7 @@ SESSION_EXISTS_COOKIE = 'sumo_session'
 #
 # Connection information for Elastic
 ES_HOSTS = ['127.0.0.1:9200']
-ES_INDEXES = {'default': 'sumo'}
+ES_INDEXES = {'default': 'sumo'}  # Doesn't support non-default indexes atm.
 ES_LIVE_INDEXING = False  # Keep indexes up to date as objects are made/deleted
 ES_TIMEOUT = 5  # 5 second timeouts for querying
 ES_INDEXING_TIMEOUT = 30  # 30 second timeouts for all things indexing


### PR DESCRIPTION
...in production.
- Remove support for putting different doctypes in different indices.
- Remove the ability to limit reindexing to given doctypes.
- Make get_mapping() return less boilerplate. Factor that up.

f? Anybody want to complain about this? I still have a test to add.
