### PR TITLE
Fix ES indexing timeout

### DIFF
--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -38,8 +38,8 @@ def get_doctype_stats():
     return stats
 
 
-def get_es(**kwargs):
-    """Returns a fresh ES instance
+def get_indexing_es(**kwargs):
+    """Returns a fresh ES instance for indexing
 
     Defaults for these arguments come from settings. Specifying them
     in the function call will override the default.

--- a/apps/search/models.py
+++ b/apps/search/models.py
@@ -107,7 +107,7 @@ class SearchMixin(object):
             100--e.g. all of them.
 
         """
-        es = es_utils.get_es()
+        es = es_utils.get_indexing_es()
 
         doc_type = cls._meta.db_table
         index = cls.get_es_index()
@@ -185,7 +185,9 @@ class SearchMixin(object):
             return
 
         if es is None:
-            es = elasticutils.get_es()
+            # Use the es_utils get_es because it uses
+            # ES_INDEXING_TIMEOUT.
+            es = es_utils.get_indexing_es()
 
         index = cls.get_es_index()
         doc_type = cls._meta.db_table


### PR DESCRIPTION
I missed a spot earlier when I changed indexing to use an ES with
timeout=settings.ES_INDEXING_TIMEOUT. This only affects incremental
indexing where it gets its own ES.

In the process of fixing that one line, I renamed es_utils.get_es
to es_utils.get_indexing_es so it's clearer what it's for.

r?
