### PR TITLE
[bug 720893] Fix empty queries in advanced search

### DIFF
--- a/apps/search/tests/test_es.py
+++ b/apps/search/tests/test_es.py
@@ -178,6 +178,40 @@ class ElasticSearchViewTests(ElasticTestCase):
         content = json.loads(response.content)
         eq_(content['total'], 1)
 
+    def test_advanced_search_for_wiki_no_query(self):
+        """Tests advanced search with no query"""
+        doc = document(
+            title=u'How to fix your audio',
+            locale=u'en-US',
+            category=10)
+        doc.save()
+
+        doc.tags.add(u'desktop')
+
+        rev = revision(
+            document=doc,
+            summary=u'Volume.',
+            content=u'Turn up the volume.',
+            is_approved=True)
+        rev.save()
+
+        self.refresh()
+
+        # This is the search that you get when you start on the sumo
+        # homepage and do a search from the box with two differences:
+        # first, we do it in json since it's easier to deal with
+        # testing-wise and second, we search for 'audio' since we have
+        # data for that.
+        response = self.localizing_client.get(reverse('search'), {
+            'q': '', 'tags': 'desktop', 'w': '1', 'a': '1',
+            'format': 'json'
+        })
+
+        eq_(200, response.status_code)
+
+        content = json.loads(response.content)
+        eq_(content['total'], 1)
+
     def test_forums_search(self):
         """This tests whether forum posts show up in searches."""
         thread1 = thread(

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -227,7 +227,9 @@ def search(request, template=None):
         cleaned_q = cleaned['q']
 
         if cleaned['w'] & constants.WHERE_WIKI:
-            wiki_s = wiki_s.query(cleaned_q)[:max_results]
+            if cleaned_q:
+                wiki_s = wiki_s.query(cleaned_q)
+            wiki_s = wiki_s[:max_results]
             # Execute the query and append to documents
             documents += [('wiki', (pair[0], pair[1]))
                           for pair in enumerate(wiki_s.object_ids())]
@@ -252,7 +254,9 @@ def search(request, template=None):
                 after_match='</b>',
                 limit=settings.SEARCH_SUMMARY_LENGTH)
 
-            question_s = question_s.query(cleaned_q)[:max_results]
+            if cleaned_q:
+                question_s = question_s.query(cleaned_q)
+            question_s = question_s[:max_results]
             documents += [('question', (pair[0], pair[1]))
                           for pair in enumerate(question_s.object_ids())]
 
@@ -272,7 +276,9 @@ def search(request, template=None):
                 after_match='</b>',
                 limit=settings.SEARCH_SUMMARY_LENGTH)
 
-            discussion_s = discussion_s.query(cleaned_q)[:max_results]
+            if cleaned_q:
+                discussion_s = discussion_s.query(cleaned_q)
+            discussion_s = discussion_s[:max_results]
             documents += [('discussion', (pair[0], pair[1]))
                           for pair in enumerate(discussion_s.object_ids())]
 


### PR DESCRIPTION
The theory here is that if the query is '', then ignore it. This adds code for that and a test that's wiki-specific.

r?
