### PR TITLE
[bug 721568] Keep green search arrows from wrapping.

### DIFF
--- a/media/css/home.css
+++ b/media/css/home.css
@@ -67,7 +67,7 @@ html[lang=ja] body div#featured {
 }
 
 #support-search input.text {
-    width: 329px;
+    width: 326px;
 }
 
 .html-rtl #support-search input.text {

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -755,7 +755,7 @@ div.support-search input.text {
     height: 26px;
     margin: 0 1px 0 0;
     padding: 2px 0 2px 34px;
-    width: 218px;
+    width: 215px;
 }
 
 .html-rtl div.support-search input.text {


### PR DESCRIPTION
...at least until _really_ illegibly small zoom sizes. Is something wrong with FF's scaling algorithm?

I'd have liked to make all this stuff use percents, but there's that dratted magnifying glass that has a hard-set pixel size.

r?
