### PR TITLE
[bug 719840] Call gettext on default locale name (English).

### DIFF
--- a/apps/dashboards/templates/dashboards/includes/macros.html
+++ b/apps/dashboards/templates/dashboards/includes/macros.html
@@ -130,7 +130,7 @@
       <table>
         <tr>
           <th />
-          <th>{{ default_locale_name }}</th>
+          <th>{{ _(default_locale_name) }}</th>
           {% if not on_default_locale %}
             <th>{{ current_locale_name }}</th>
           {% endif %}


### PR DESCRIPTION
tiiiiiiiiny r?
