### PR TITLE
Rollback highcharts to v1.0.2

### DIFF
--- a/apps/wiki/cron.py
+++ b/apps/wiki/cron.py
@@ -83,11 +83,11 @@ def rebuild_kb():
 
 @cronjobs.register
 def get_highcharts():
-    """Fetch highcharts."""
+    """Fetch highcharts, v1.0.2."""
     localfilename = os.path.join(settings.MEDIA_ROOT, 'js', 'libs',
                                  'highstock.src.js')
     u = urllib2.urlopen('https://raw.github.com/highslide-software/'
-                        'highcharts.com/e8bb83d2f332a2ed4e71fc307c4'
-                        '00906538cab24/js/highstock.src.js')
+                        'highcharts.com/7df98c2f1d7909edd212fea4519'
+                        'd0bb87adac164/js/highstock.src.js')
     with open(localfilename, 'w') as f:
         f.write(u.read())


### PR DESCRIPTION
r? rollback because v1.1.2 has some issues with large datasets and causes stackoverflows/unresponsive script errors.
