### PR TITLE
[bug 723718] fix date and string indexing

### DIFF
--- a/apps/forums/models.py
+++ b/apps/forums/models.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 
 from django.db import models
 from django.contrib.auth.models import User
@@ -187,12 +188,12 @@ class Thread(NotificationsMixin, ModelBase, SearchMixin):
             'is_sticky': {'type': 'boolean'},
             'is_locked': {'type': 'boolean'},
             'author_id': {'type': 'integer'},
-            'author_ord': {'type': 'string'},
+            'author_ord': {'type': 'string', 'index': 'not_analyzed'},
             'content': {'type': 'string', 'analyzer': 'snowball',
                         'store': 'yes',
                         'term_vector': 'with_positions_offsets'},
-            'created': {'type': 'date'},
-            'updated': {'type': 'date'},
+            'created': {'type': 'integer'},
+            'updated': {'type': 'integer'},
             'replies': {'type': 'integer'}}
 
     def extract_document(self):
@@ -203,10 +204,16 @@ class Thread(NotificationsMixin, ModelBase, SearchMixin):
         d['title'] = self.title
         d['is_sticky'] = self.is_sticky
         d['is_locked'] = self.is_locked
-        d['created'] = self.created
+
+        # TODO: Sphinx stores created and updated as seconds since the
+        # epoch, so we convert them to that format here so that the
+        # search view works correctly. When we ditch Sphinx, we should
+        # see if it's faster to filter on ints or whether we should
+        # switch them to dates.
+        d['created'] = int(time.mktime(self.created.timetuple()))
 
         if self.last_post is not None:
-            d['updated'] = self.last_post.created
+            d['updated'] = int(time.mktime(self.last_post.created.timetuple()))
         else:
             d['updates'] = None
 

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from urlparse import urlparse
+import time
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -495,12 +496,12 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
             'parent_id': {'type': 'integer'},
             'content': {'type': 'string', 'analyzer': 'snowball'},
             'category': {'type': 'integer'},
-            'slug': {'type': 'string'},
+            'slug': {'type': 'string', 'index': 'not_analyzed'},
             'is_archived': {'type': 'boolean'},
             'summary': {'type': 'string', 'analyzer': 'snowball'},
             'keywords': {'type': 'string', 'analyzer': 'snowball'},
-            'updated': {'type': 'date'},
-            'tag': {'type': 'string'}}
+            'updated': {'type': 'integer'},
+            'tag': {'type': 'string', 'index': 'not_analyzed'}}
 
     def extract_document(self):
         d = {}
@@ -520,7 +521,8 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
         if self.current_revision:
             d['summary'] = self.current_revision.summary
             d['keywords'] = self.current_revision.keywords
-            d['updated'] = self.current_revision.created
+            d['updated'] = int(time.mktime(
+                    self.current_revision.created.timetuple()))
             d['current'] = self.current_revision.id
         else:
             d['summary'] = None


### PR DESCRIPTION
We index and query dates in Sphinx as an int. Prior to this commit, we were
indexing dates in ES as a date which doesn't compare correctly when we
query with an int. So that's fixed now.

Additionally, we were running analysis on tags and username fields--we
shouldn't do that since these should be matching exactly.

This change fixes both issues in 723718.

r?
