### PR TITLE
[bug 720870] Survey WMP article visitors.

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -29,6 +29,12 @@
   <article id="wiki-doc" class="main">
     {{ related_articles(related, document) }}
     {{ document_title(document) }}
+    {# TODO: Remove this right after the test on Feb 29. #}
+    {% if document.slug == 'Using the Windows Media Player plugin with Firefox' %}
+      {% if waffle.flag('wmp-article-survey') %}
+        <script type="text/javascript">document.write('<script src="http' + ( ("https:" == document.location.protocol) ? "s" : "") + '://www.surveygizmo.com/s3/js/816956/4a06d820b568?__ref=' + escape(document.location) + '" type="text/javascript" ></scr'  + 'ipt>');</script><noscript>This survey is powered by SurveyGizmo's <a href="http://www.surveygizmo.com">online survey software</a>. <a href="http://www.surveygizmo.com/s3/jsfallback/816956/4a06d820b568">Please take my survey now</a></noscript>
+      {% endif %}
+    {% endif %}
     {{ document_messages(document, redirected_from) }}
     {{ document_content(document, fallback_reason, request, settings) }}
     {{ contributor_list(contributors) }}


### PR DESCRIPTION
Behind "wmp-article-survey" waffle flag. Enable it to see (only on http://localhost:8000/en-US/kb/Using%20the%20Windows%20Media%20Player%20plugin%20with%20Firefox) right below the article title. It will probably say "The survey is now closed." or something like that.

r?
