### PR TITLE
706948 no replies

### DIFF
--- a/apps/questions/models.py
+++ b/apps/questions/models.py
@@ -33,7 +33,6 @@ from sumo.models import ModelBase
 from sumo.parser import wiki_to_html
 from sumo.redis_utils import RedisError
 from sumo.urlresolvers import reverse
-from taggit.models import TaggedItem
 from tags.models import BigVocabTaggableMixin
 from tags.utils import add_existing_tag
 from upload.models import ImageAttachment


### PR DESCRIPTION
This fixes the problem where num_answers gets out of sync with the actual number of answers for the question.

My steps to reproduce:
1. Go through all the shenanigans to create a question. Once you've created a question, you're on the answers page for that question.
2. On the answers page, reply with "first post" because that's the bestest reply ever.
3. Go to the questions listing page. The question lists as having "no replies".
4. Click on the question and go to the answers page. It'll show No Replies, but show replies.

With this fix, the "no replies" bits become correct.

Three things:
1. This fixes the issue I was seeing locally with the steps I was using to reproduce the issue.
2. I'm seeing some other weird caching behavior, so it's possible this doesn't fix it on -dev/-stage. It's possible there are other problems, too.
3. There is a test for this, but the test passed before and after my fix.

r?
