### PR TITLE
[bug 722697] Show contributor sidebar only one questions list page.

### DIFF
--- a/apps/questions/templates/questions/base.html
+++ b/apps/questions/templates/questions/base.html
@@ -44,7 +44,7 @@
           </section>
         {% endif %}
       {% endif %}
+      {{ for_contributors(request, user, settings.WIKI_DEFAULT_LANGUAGE) }}
     {% endblock %}
-    {{ for_contributors(request, user, settings.WIKI_DEFAULT_LANGUAGE) }}
   </div>
 {% endblock %}


### PR DESCRIPTION
small r?

Make sure the contributor sidebar only shows up on /questions. It shouldn't show up on /questions/new or at the bottom of the question/answers page.
