### PR TITLE
[bug 711119] L10n: redirect 'lij' to 'it'

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -98,6 +98,7 @@ NON_SUPPORTED_LOCALES = {
     'nn-NO': 'no',
     'oc': 'fr',
     'sr': 'sr-CYRL',  # Override the tendency to go sr->sr-LATN.
+    'lij': 'it',
 }
 
 TEXT_DOMAIN = 'messages'


### PR DESCRIPTION
r?
