### PR TITLE
[bug 732579] update elasticutils url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -129,7 +129,7 @@
 	url = git://github.com/erikrose/oedipus.git
 [submodule "vendor/src/elasticutils"]
 	path = vendor/src/elasticutils
-	url = git://github.com/davedash/elasticutils.git
+	url = git://github.com/mozilla/elasticutils.git
 [submodule "vendor/src/django-tastypie"]
 	path = vendor/src/django-tastypie
 	url = https://github.com/toastdriven/django-tastypie.git


### PR DESCRIPTION
We moved elasticutils from davedash/elasticutils to mozilla/elasticutils.
This commit updates the url.

r?
