### PR TITLE
Auto Complete functionality for the article field in the support forums

### DIFF
--- a/media/js/markup.js
+++ b/media/js/markup.js
@@ -382,7 +382,7 @@ Marky.LinkButton.prototype = $.extend({}, Marky.SimpleButton.prototype, {
 
         var articleSearch = function(request, response) {
             $.ajax({
-                url: "/search",
+                url: "/en-US/search",
                 data: {
                     format: 'json',
                     q: request.term,
@@ -403,7 +403,9 @@ Marky.LinkButton.prototype = $.extend({}, Marky.SimpleButton.prototype, {
         var sectionSearch = function(request, response) {
             var articleName = request.term.split("#")[0]
                 articleName = articleName.toLowerCase().replace(/\s/g, "-");
-            var articleURL = "/kb/" + articleName;
+            
+            // Forcing en-US locale (as support forums are en-US only)
+            var articleURL = "/en-US/kb/" + articleName;
             
             $.ajax({
                 url: articleURL,


### PR DESCRIPTION
This adds an autocomplete functionality on the article level to the Support article field in Kitsune.

Therefore, it queries the article database in the background and returns a list of matching articles.

Do we want:
Some kind of progress indicator as it's already in the add-on?

Please suggest any changes to the code you want me to do.

(And sorry about the 5 insignificant commits prior to the last one)
