### PR TITLE
[bug 742437] Tweak search results

### DIFF
--- a/apps/search/tests/test_es.py
+++ b/apps/search/tests/test_es.py
@@ -50,6 +50,45 @@ class ElasticSearchTasksTests(ElasticTestCase):
         eq_(index_fun.call_count, 1)
 
 
+class ElasticSearchViewPagingTests(ElasticTestCase):
+    client_class = LocalizingClient
+
+    def test_front_age_search_paging(self):
+        # Create 30 documents
+        for i in range(30):
+            doc = document(
+                title=u'How to fix your audio %d' % i,
+                locale=u'en-US',
+                category=10,
+                save=True)
+            doc.tags.add(u'desktop')
+            rev = revision(document=doc, is_approved=True, save=True)
+
+        # Create 20 questions
+        for i in range(20):
+            ques = question(title=u'audio',  content=u'audio bad.', save=True)
+            ques.tags.add(u'desktop')
+            ans = answer(question=ques, save=True)
+            ansvote = answervote(answer=ans, helpful=True, save=True)
+
+        self.refresh()
+
+        response = self.client.get(reverse('search'), {
+            'q_tags': 'desktop', 'product': 'desktop', 'q': 'audio',
+            'format': 'json'
+        })
+        eq_(200, response.status_code)
+        content = json.loads(response.content)
+
+        # Make sure there are 20 results.
+        eq_(content['total'], 20)
+
+        # Make sure only 10 of them are kb.
+        docs = [mem for mem in content['results']
+                if mem['type'] == 'document']
+        eq_(len(docs), 10)
+
+
 class ElasticSearchViewTests(ElasticTestCase):
     client_class = LocalizingClient
 

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -90,8 +90,8 @@ def search_with_es(request, template=None):
         r['language'] = language
         r['a'] = '1'
 
-    # TODO: Rewrite so SearchForm is unbound initially and we can use `initial`
-    # on the form fields.
+    # TODO: Rewrite so SearchForm is unbound initially and we can use
+    # `initial` on the form fields.
     if 'include_archived' not in r:
         r['include_archived'] = False
 
@@ -234,8 +234,15 @@ def search_with_es(request, template=None):
         if cleaned['w'] & constants.WHERE_WIKI:
             if cleaned_q:
                 wiki_s = wiki_s.query(cleaned_q)
+
+            # For a front-page non-advanced search, we want to cap the kb
+            # at 10 results.
+            if a == '0':
+                wiki_max_results = 10
+            else:
+                wiki_max_results = max_results
             documents.set_count(('wiki', wiki_s),
-                                min(wiki_s.count(), max_results))
+                                min(wiki_s.count(), wiki_max_results))
 
         if cleaned['w'] & constants.WHERE_SUPPORT:
             # Sort results by

--- a/settings.py
+++ b/settings.py
@@ -624,7 +624,7 @@ TEST_SPHINX_PORT = 3416
 TEST_SPHINXQL_PORT = 3418
 
 SEARCH_MAX_RESULTS = 1000
-SEARCH_RESULTS_PER_PAGE = 10
+SEARCH_RESULTS_PER_PAGE = 20
 
 # Search default settings
 # comma-separated tuple of included category IDs. Negative IDs are excluded.


### PR DESCRIPTION
For an Elastic Search-based front-page search, this caps the number
of kb articles to 10 and increases the number of results per page to
20.

r?
