### PR TITLE
[bug 712069] Add logarithmic retry to indexing

### DIFF
--- a/apps/search/tasks.py
+++ b/apps/search/tasks.py
@@ -84,5 +84,5 @@ def unindex_task(cls, ids, **kw):
             cls.unindex(id)
     except Exception, exc:
         retries = unindex_task.request.retries
-        unindex_task.retry(exc=exc, max_retries=MAX_RETRIES,
-                           countdown=RETRY_TIMES[retries - 1])
+        unindex_task.retry(exc=exc, max_retries=MAX_RETRIES - 1,
+                           countdown=RETRY_TIMES[retries])


### PR DESCRIPTION
This adds logarithmic retry decorator to index/unindex_task. If they
fail, they'll get retried periodically rather than just fail and die
like they do now.

r?
