### PR TITLE
[bug 745473] Fix typo

### DIFF
--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -166,7 +166,7 @@ def get_documents(cls, ids):
     doctype = cls._meta.db_table
     index = READ_INDEX
 
-    ret = es.search(pyes.query.IdsQuery(doctype, ids), indices=[index],
+    ret = es.search(pyes.query.IdsQuery(doctype, ids), indexes=[index],
                     doc_types=[doctype])
     return ret['hits']['hits']
 

--- a/apps/search/tests/test_es.py
+++ b/apps/search/tests/test_es.py
@@ -2,16 +2,16 @@ import json
 import datetime
 
 from nose.tools import eq_
+import mock
 
-from sumo.tests import LocalizingClient, ElasticTestCase
-from sumo.urlresolvers import reverse
-
-from search.models import generate_tasks
+from forums.tests import thread, post
 from questions.tests import question, answer, answervote
 from questions.models import Question
+from search.models import generate_tasks
+from search.es_utils import get_documents
+from sumo.tests import LocalizingClient, ElasticTestCase
+from sumo.urlresolvers import reverse
 from wiki.tests import document, revision
-from forums.tests import thread, post
-import mock
 
 
 class ElasticSearchTasksTests(ElasticTestCase):
@@ -317,3 +317,12 @@ class ElasticSearchViewTests(ElasticTestCase):
 
         content = json.loads(response.content)
         eq_(content['total'], 0)
+
+
+class ElasticSearchUtilsTests(ElasticTestCase):
+    def test_get_documents(self):
+        q = question(save=True)
+        self.refresh()
+        docs = get_documents(Question, [q.id])
+        docs = [int(mem[u'_id']) for mem in docs]
+        eq_(docs, [q.id])


### PR DESCRIPTION
pyes switched from indices to indexes (or vice versa--I can't remember).
Point being that we were using the wrong one the result of which being
that it used the default index created with the ES object which calculates
the index name differently. Ugh.

This fixes that by changing the argument from indices to indexes. Now it
uses the one calculated in get_documents and all is well.

This also adds a test for get_documents.

And while doing that, I tidied up the import statements.

r?
