### PR TITLE
[bug 690610] Fixes faux fine translation

### DIFF
--- a/apps/dashboards/readouts.py
+++ b/apps/dashboards/readouts.py
@@ -30,11 +30,23 @@ MOST_RECENT = 2
 
 
 # FROM clause for selecting most-visited translations:
+#
+# The "... EXISTS" bit in the transdoc left join prevents transdocs
+# for which there are only translated revisions that were reviewed and
+# rejected. In this case, we want it to show up as untranslated since
+# that's the most "correct" status.
 most_visited_translation_from = (
     'FROM wiki_document engdoc '
     'LEFT JOIN wiki_document transdoc ON '
         'transdoc.parent_id=engdoc.id '
         'AND transdoc.locale=%s '
+        'AND EXISTS ('
+            'SELECT * '
+            'FROM wiki_revision transrev_inner '
+            'WHERE transrev_inner.document_id=transdoc.id '
+            'AND NOT (NOT transrev_inner.is_approved '
+                     'AND transrev_inner.reviewed IS NOT NULL) '
+        ') '
     'LEFT JOIN dashboards_wikidocumentvisits ON engdoc.id='
         'dashboards_wikidocumentvisits.document_id '
         'AND dashboards_wikidocumentvisits.period=%s '

--- a/apps/dashboards/tests/test_readouts.py
+++ b/apps/dashboards/tests/test_readouts.py
@@ -290,6 +290,18 @@ class MostVisitedTranslationsTests(ReadoutTestCase):
         eq_(unicode(row['status']), '')
         eq_(row['status_class'], 'ok')
 
+    def test_one_rejected_revision(self):
+        """A translation with only 1 revision, which is rejected, should show
+        as "Needs Translation".
+
+        """
+        translated_revision(is_approved=False,
+                            reviewed=datetime.now(),
+                            save=True)
+
+        row = self.row()
+        eq_(row['status_class'], 'untranslated')
+
     def test_spam(self):
         """Don't offer unapproved (often spam) articles for translation."""
         r = revision(is_approved=False, save=True)


### PR DESCRIPTION
This fixes the edge case where a translated document only has revisions
that were reviewed and rejected. Previously, that translated document
would show up as the "hey--everything's super!" green circle. Now it
shows up as the daunting "yo! i'm untranslated!" red triangle.

r?
