### PR TITLE
[bug 729697] Add index browsing admin page of awesome

### DIFF
--- a/apps/forums/models.py
+++ b/apps/forums/models.py
@@ -195,7 +195,8 @@ class Thread(NotificationsMixin, ModelBase, SearchMixin):
             'created': {'type': 'integer'},
             'updated': {'type': 'integer'},
             'replies': {'type': 'integer'},
-            'url': {'type': 'string', 'index': 'not_analyzed'}}
+            'url': {'type': 'string', 'index': 'not_analyzed'},
+            'indexed_on': {'type': 'integer'}}
 
     @classmethod
     def extract_document(cls, obj_id):
@@ -237,6 +238,7 @@ class Thread(NotificationsMixin, ModelBase, SearchMixin):
         d['author_ord'] = list(author_ords)
         d['content'] = content
 
+        d['indexed_on'] = int(time.time())
         return d
 
 

--- a/apps/questions/models.py
+++ b/apps/questions/models.py
@@ -314,7 +314,8 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
             'num_votes_past_week': {'type': 'integer'},
             'answer_votes': {'type': 'integer'},
             'tag': {'type': 'string', 'index': 'not_analyzed'},
-            'url': {'type': 'string', 'index': 'not_analyzed'}}
+            'url': {'type': 'string', 'index': 'not_analyzed'},
+            'indexed_on': {'type': 'integer'}}
 
     @classmethod
     def extract_document(cls, obj_id):
@@ -371,6 +372,7 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
             d['has_helpful'] = Answer.objects.filter(
                 question=obj_id).filter(votes__helpful=True).exists()
 
+        d['indexed_on'] = int(time.time())
         return d
 
 

--- a/apps/search/templates/search/admin/index.html
+++ b/apps/search/templates/search/admin/index.html
@@ -1,0 +1,67 @@
+{% extends "kadmin/base.html" %}
+
+{% block content_title %}
+<h1>Elastic Search - Index Browser of Doom</h1>
+{% endblock %}
+
+{% block content %}
+  <section>
+    <h1>Find a specific item</h1>
+    <form method="GET">
+      <select name="bucket">
+        {% for bucket in buckets %}
+          <option value="{{ bucket }}"{% if requested_bucket == bucket %} checked{% endif %}>{{ bucket }}</option>
+        {% endfor %}
+      </select>
+      <input type="text" name="id" value="{{ requested_id }}">
+      <input type="Submit">
+    </form>
+  </section>
+
+  {% if requested_data %}
+    <section>
+      <h1>Item {{ requested_data.id }} from {{ requested_bucket }}</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>key</th>
+            <th>value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for key, val in requested_data.items %}
+            <tr>
+              <th>{{ key }}</th>
+              <td>{{ val }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+  {% else %}
+    <section>
+      <h1>Most recently indexed items per bucket</h1>
+      {% for cls_name, items in last_20_by_bucket %}
+        <h2>{{ cls_name }}</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>id</th>
+              <th>title</th>
+              <th>indexed on ({{ settings.TIME_ZONE }})</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in items %}
+              <tr>
+                <td><a href="?bucket={{ cls_name }}&id={{ item.id }}">{{ item.id }}</a></td>
+                <td>{{ item.title }}</td>
+                <td>{{ item.indexed_on }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endfor %}
+    </section>
+  {% endif %}
+{% endblock %}

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -502,7 +502,8 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
             'keywords': {'type': 'string', 'analyzer': 'snowball'},
             'updated': {'type': 'integer'},
             'tag': {'type': 'string', 'index': 'not_analyzed'},
-            'url': {'type': 'string', 'index': 'not_analyzed'}}
+            'url': {'type': 'string', 'index': 'not_analyzed'},
+            'indexed_on': {'type': 'integer'}}
 
     @classmethod
     def extract_document(cls, obj_id):
@@ -536,6 +537,8 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
             d['keywords'] = None
             d['updated'] = None
             d['current'] = None
+
+        d['indexed_on'] = int(time.time())
         return d
 
     @classmethod


### PR DESCRIPTION
This adds an elasticsearch index browser to the admin. This will make it
**way** easier to debug certain classes of problems that require answers
to questions such as:
- "Did xyz get updated in the index?"
- "What the hell did we put in the index and does it bite?"

This does require us to reindex. It makes it much easier to see what's going on in the index, but I'm on the fence as to whether the utility outweighs the requirement to reindex.

Anyhow, it's pretty cool.

r?
