### PR TITLE
Improve the tabflow

### DIFF
--- a/apps/search/templates/search/includes/result.html
+++ b/apps/search/templates/search/includes/result.html
@@ -7,7 +7,7 @@
     {% endif %}
     {% set url =  result.url|urlparams(s=s, as=as, r=r, e=engine) %}
     <a class="title" href="{{ url }}">{{ result.title }}</a>
-    <p><a tabIndex="-1" href="{{ url }}">
+    <p><a tabindex="-1" href="{{ url }}">
       {{ result.search_summary|safe }}
     </a></p>
     {% if result.type == 'question' %}


### PR DESCRIPTION
Keyboard users navigate between interactive elements via the Tab key. Every anchor element creates a tab stop, so redundant links within a module can create an inefficient overall tab flow, making navigating with the Tab key a real drag for keyboard users.

http://yaccessibilityblog.com/library/easy-fixes-to-common-accessibility-problems.html#dupe-links

This fixes Bug 748557 - improve tab flow [https://bugzilla.mozilla.org/show_bug.cgi?id=748557]
