### PR TITLE
[bug 743261] Fix color of close button on modal windows

### DIFF
--- a/media/css/kbox.css
+++ b/media/css/kbox.css
@@ -39,6 +39,14 @@
     right: auto;
 }
 
+.kbox-close:link,
+.kbox-close:visited,
+.kbox-close:active
+.kbox-close:hover {
+    color: #fff;
+    text-decoration: none;
+}
+
 .kbox-title {
     background: #2d488d;
     border-bottom: solid 2px #22366a;


### PR DESCRIPTION
Changes the color of the close button on modal windows to white

The bug also mentions that the ESC key doesn't work to close the modal window, but I didn't find this to be true.

r?
