### PR TITLE
Better positioning for the watch button 'eye' in the forums

### DIFF
--- a/media/css/forums.css
+++ b/media/css/forums.css
@@ -469,6 +469,12 @@ div.badges span {
     padding: 0 10px 2px 10px;
 }
 
+#watch-thread-toggle img {
+    position: relative;
+    top: 2px;
+    left: -4px;
+}
+
 span.sticky {
     background: #eaf4f8 url(../img/forums/type/sticky.png) no-repeat 8px center;
     color: #139ec4;


### PR DESCRIPTION
I found that the eye of the watch button is badly positioned. I centered it more. 

I hope that I don't need to file a bug for this trivial thing. ;-)
