### PR TITLE
Fix anonymization script

### DIFF
--- a/scripts/anonymize.sql
+++ b/scripts/anonymize.sql
@@ -3,11 +3,11 @@
 -- not be considered approval to distribute this SUMO database.
 -- Talk to jsocol if you have questions.
 
-SET SESSION FOREIGN_KEY_CHECKS = 0;
-
 UPDATE auth_user SET
     email = CONCAT('user',id,'@example.com'),
     password = 'sha256$f538347e82$5098e89186fd307d4bb6fe29ac476e72cf96175617fa933a9bd6b3d89a8b0946'; -- 'testpass'
+
+SET SESSION FOREIGN_KEY_CHECKS = 0;
 
 TRUNCATE tidings_watchfilter;
 
@@ -20,6 +20,8 @@ TRUNCATE messages_inboxmessage;
 TRUNCATE messages_outboxmessage_to;
 
 TRUNCATE messages_outboxmessage;
+
+SET SESSION FOREIGN_KEY_CHECKS = 1;
 
 UPDATE django_site SET
     domain = 'support-local.allizom.org',


### PR DESCRIPTION
Stop checking foreign keys when truncating tables to prevent foreign key constraint errors on MySQL >= 5.5
