### PR TITLE
[bug 613084] Use session to store twitter oauth token.

### DIFF
--- a/apps/twitter/__init__.py
+++ b/apps/twitter/__init__.py
@@ -1,5 +1,4 @@
 import logging
-from uuid import uuid4
 
 from django import http
 from django.conf import settings
@@ -30,7 +29,8 @@ def url(request, override=None):
 def auth_wanted(view_func):
     """Twitter sessions are SSL only, so redirect to SSL if needed.
 
-    Don't redirect if TWITTER_COOKIE_SECURE is False."""
+    Don't redirect if TWITTER_COOKIE_SECURE is False.
+    """
     def wrapper(request, *args, **kwargs):
         is_secure = settings.TWITTER_COOKIE_SECURE
         if (request.COOKIES.get(REDIRECT_NAME) and
@@ -56,17 +56,8 @@ def auth_required(view_func):
 
 
 class Session(object):
-    id = None
-    key = None
-    secret = None
-
-    @property
-    def key_key(self):
-        return 'twitter_oauth_key'
-
-    @property
-    def key_secret(self):
-        return 'twitter_oauth_secret'
+    key_key = 'twitter_oauth_key'
+    key_secret = 'twitter_oauth_secret'
 
     @property
     def authed(self):
@@ -89,7 +80,6 @@ class Session(object):
             del request.session[self.key_key]
         if self.key_secret in request.session:
             del request.session[self.key_secret]
-        self.id = None
         self.key = None
         self.secret = None
 

--- a/apps/twitter/middleware.py
+++ b/apps/twitter/middleware.py
@@ -4,8 +4,8 @@ import re
 from django import http
 from django.conf import settings
 
-from twitter import *
 import tweepy
+from twitter import url, Session, REQUEST_KEY_NAME, REQUEST_SECRET_NAME
 
 
 log = logging.getLogger('k')
@@ -21,13 +21,16 @@ class SessionMiddleware(object):
 
         request.twitter = Session.from_request(request)
 
+        # If is_secure is True (should always be true except for local dev),
+        # we will be redirected back to https and all cookies set will be
+        # secure only.
         is_secure = settings.TWITTER_COOKIE_SECURE
+
         ssl_url = url(request, {'scheme': 'https' if is_secure else 'http'})
         auth = tweepy.OAuthHandler(settings.TWITTER_CONSUMER_KEY,
                                    settings.TWITTER_CONSUMER_SECRET,
                                    ssl_url,
-                                   secure=is_secure)
-        #import pdb; pdb.set_trace()
+                                   secure=True)
 
         if request.REQUEST.get('twitter_delete_auth'):
             request.twitter = Session()

--- a/settings.py
+++ b/settings.py
@@ -838,6 +838,7 @@ CC_STATS_CACHE_TIMEOUT = 24 * 60 * 60  # 24 hours
 CC_STATS_WARNING = 30 * 60 * 60  # Warn if JSON data is older than 30 hours
 CC_IGNORE_USERS = ['fx4status']  # User names whose tweets to ignore.
 
+TWITTER_COOKIE_SECURE = True
 TWITTER_CONSUMER_KEY = ''
 TWITTER_CONSUMER_SECRET = ''
 


### PR DESCRIPTION
The first commit here is to get the AoA to work locally using the dev server. It was forcing SSL and secure cookies even if you had TWITTER_COOKIE_SECURE set to False in settings_local.

The rest of it is moving away from the cookies+cache approach to store twitter oauth creds and use the session instead. It simplifies things a little.

r?
