### PR TITLE
[bug 761573] Add esunified waffle flag

### DIFF
--- a/migrations/147-elasticsearch-unified-waffle.sql
+++ b/migrations/147-elasticsearch-unified-waffle.sql
@@ -1,0 +1,2 @@
+INSERT INTO waffle_flag (name, superusers, staff, authenticated, rollout, created, modified)
+VALUES ('esunified', FALSE, FALSE, FALSE, FALSE, NOW(), NOW());


### PR DESCRIPTION
This waffle flag will waffle between the ES bucketed search results
view that we have now and the new ES unified search results view of
the glorious future.
- off: bucketed search results (i.e. wiki, then questions, then forums)
- on: unified search results (i.e. everything sorted by score)

This is like migration 135, but accounts for the upgrade to waffle since then.

r?
