### PR TITLE
[bug 762894] Add ability to reset scoreboard

### DIFF
--- a/apps/search/templates/search/admin/search.html
+++ b/apps/search/templates/search/admin/search.html
@@ -237,9 +237,26 @@
     <form method="POST">
       {% csrf_token %}
       <input type="hidden" name="delete_index" value="1">
-      <input class="DANGER" type="submit" name="reindex"
+      <input class="DANGER" type="submit" name="delete"
              value="DELETE index and index into {{ write_index }}"
              {% if outstanding_chunks %}disabled{% endif %}>
+    </form>
+
+    <h2>RESET scoreboard</h2>
+    <p>
+      This resets the redis key which we use as a scoreboard for keeping
+      track of how many outstanding indexing tasks there are.
+    </p>
+    <p>
+      If you believe that the scoreboard is wrong and that it doesn't
+      represent the number of outstanding tasks and that there are no
+      outstanding tasks, then you should reset the scoreboard.
+    </p>
+    <form method="POST">
+      {% csrf_token %}
+      <input type="hidden" name="reset_scoreboard" value="1">
+      <input type="submit" name="reset"
+             value="Reset scoreboard">
     </form>
   </section>
 {% endblock %}


### PR DESCRIPTION
It's possible to end up in a state where there are no indexing tasks
but the outstanding-tasks scoreboard thinks there are. If you're in
this state, then you're kind of hosed.

This adds the ability to reset the scoreboard.

r?
