### PR TITLE
Fix search fields on the results page

### DIFF
--- a/apps/search/templates/search/results.html
+++ b/apps/search/templates/search/results.html
@@ -24,7 +24,9 @@
 
     {{ pages|paginator }}
 
-    {{ basic_search_form() }}
+    {% if num_results > 3 %}
+      {{ basic_search_form() }}
+    {% endif %}
 
   </div>
 


### PR DESCRIPTION
Make sure that the bottom search field only appears when there are more
than three results.

r?
