### PR TITLE
[Bug 765490] Escaped ampersands in Army of Awesome responses not shown correctly

### DIFF
--- a/apps/customercare/views.py
+++ b/apps/customercare/views.py
@@ -41,10 +41,10 @@ CANNED_RESPONSES = [
                          "but part of a community that's 400M strong "
                          "http://mzl.la/e8xdv5")
         },
-        {'title': _lazy("Tips &amp; tricks"),
+        {'title': _lazy("Tips & tricks"),
         # L10n: This is a reply tweet, so it must fit in 140 characters.
          'response': _lazy("getting started with Firefox? Here are some tips "
-                           "&amp; tricks for getting the most out of it "
+                           "& tricks for getting the most out of it "
                            "http://mzl.la/c0B9P2")
         },
         {'title': _lazy("We're a non-profit organization"),
@@ -65,7 +65,7 @@ CANNED_RESPONSES = [
      [{'title': _lazy("Add-on reviews"),
         # L10n: This is a reply tweet, so it must fit in 140 characters.
        'response': _lazy("getting started with Firefox? Add-ons personalize it"
-                         " w cool features &amp; function. Some faves "
+                         " w cool features & function. Some faves "
                          "http://mzl.la/cGypVI")
         },
         {'title': _lazy("Customize Firefox with add-ons"),
@@ -83,7 +83,7 @@ CANNED_RESPONSES = [
         {'title': _lazy("Firefox Sync"),
          # L10n: This is a reply tweet, so it must fit in 140 characters.
          'response': _lazy("tried Firefox Sync? It's awesome! Switch computers"
-                           " &amp; it saves open tabs, pwords, history. Try it"
+                           " & it saves open tabs, pwords, history. Try it"
                            " http://mzl.la/aHHUYA")
         },
         {'title': _lazy("Update plugins and add-ons"),
@@ -162,7 +162,7 @@ CANNED_RESPONSES = [
         {'title': _lazy("Mozilla Developer Network"),
          # L10n: This is a reply tweet, so it must fit in 140 characters.
          'response': _lazy("help make the web better! Build web pages, apps "
-                           "&amp; add-ons here: Mozilla Developer Network "
+                           "& add-ons here: Mozilla Developer Network "
                            "http://mzl.la/9gQfrn")
         },
         {'title': _lazy("Report a bug"),


### PR DESCRIPTION
Some ampersands will be escaped automatically, thus escaping them as '&amp;' will lead us to a raw &amp; in the resulting HTML.

I fixed this with this pull request.
