### PR TITLE
[Bug 764821] Remove Firefox 3.5-3.6 from the help with dropdown menu

### DIFF
--- a/apps/wiki/config.py
+++ b/apps/wiki/config.py
@@ -50,7 +50,7 @@ GROUPED_FIREFOX_VERSIONS = (
         VersionMetadata(1, _lazy(u'Firefox 4'),
                         _lazy(u'Firefox 4'), 'fx4', 4.9999, False, False),
         VersionMetadata(2, _lazy(u'Firefox 3.5-3.6'),
-                        _lazy(u'Firefox 3.5-3.6'), 'fx35', 3.9999, True,
+                        _lazy(u'Firefox 3.5-3.6'), 'fx35', 3.9999, False,
                         False),
         VersionMetadata(3, _lazy(u'Firefox 3.0'),
                         _lazy(u'Firefox 3.0'), 'fx3', 3.4999, False, False))),


### PR DESCRIPTION
This removes Firefox 3.5-3.6 from the dropdown menu in articles.
