### PR TITLE
[bug 765376] Fix AS ES questions sortby

### DIFF
--- a/apps/search/__init__.py
+++ b/apps/search/__init__.py
@@ -71,6 +71,13 @@ SORT_QUESTIONS = (
     ('-replies',)
 )
 
+SORT_QUESTIONS_ES = (
+    ('-@rank', '-updated'),  # default
+    ('-updated',),
+    ('-created',),
+    ('-question_num_answers',)
+)
+
 SORTBY_QUESTIONS = (
     (0, _lazy(u'Relevance')),
     (1, _lazy(u'Last answer date')),

--- a/apps/search/tests/test_es.py
+++ b/apps/search/tests/test_es.py
@@ -311,6 +311,24 @@ class ElasticSearchViewTests(ElasticTestCase):
         content = json.loads(response.content)
         eq_(content['total'], 1)
 
+    def test_advanced_search_questions_sortby(self):
+        """Tests advanced search for questions with a sortby"""
+        question(title=u'tags tags tags', save=True)
+
+        self.refresh()
+
+        # Advanced search for questions with sortby set to 3 which is
+        # '-replies' which is different between Sphinx and ES.
+        response = self.client.get(reverse('search'), {
+            'q': '', 'tags': 'desktop', 'w': '2', 'a': '1', 'sortby': '3',
+            'format': 'json'
+        })
+
+        eq_(200, response.status_code)
+
+        content = json.loads(response.content)
+        eq_(content['total'], 1)
+
     def test_forums_search(self):
         """This tests whether forum posts show up in searches."""
         thread1 = thread(

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -255,7 +255,7 @@ def search_with_es(request, template=None):
             # Sort results by
             try:
                 question_s = question_s.order_by(
-                    *constants.SORT_QUESTIONS[sortby])
+                    *constants.SORT_QUESTIONS_ES[sortby])
             except IndexError:
                 pass
 


### PR DESCRIPTION
That's Advanced Search questions sortby in ES. The problem is that
ES index doesn't have a "replies" field--it's called
"question_num_answers". So if someone used this sort then it would kick
up an error and die.

As a side note, this has been broken for months and no one mentioned
it. So maybe this is something we can remove since no one uses it?

Anyhow, without the code, the test fails miserably. With the code the test passes!

r?
