### PR TITLE
[bug 765207] Fix update_question_vote_chunk

### DIFF
--- a/apps/questions/tasks.py
+++ b/apps/questions/tasks.py
@@ -10,6 +10,8 @@ from statsd import statsd
 from activity.models import Action
 from questions import ANSWERS_PER_PAGE
 from questions.karma_actions import AnswerAction, FirstAnswerAction
+from search.es_utils import ESTimeoutError, ESMaxRetryError, ESException
+from search.tasks import index_task
 
 
 log = logging.getLogger('k.task')
@@ -73,19 +75,26 @@ def update_question_vote_chunk(data):
         # convert that directly to a dict.
         id_to_num = dict(cursor.fetchall())
 
-        # Fetch all the documents we need to update.
-        from questions.models import Question
-        from search import es_utils
-        es_docs = es_utils.get_documents(Question, data)
+        try:
+            # Fetch all the documents we need to update.
+            from questions.models import Question
+            from search import es_utils
+            es_docs = es_utils.get_documents(Question, data)
 
-        # For each document, update the data and stick it back in the
-        # index.
-        for doc in es_docs:
-            # Note: Need to keep this in sync with
-            # Question.extract_document.
-            doc[u'question_num_votes_past_week'] = id_to_num[int(doc[u'id'])]
+            # For each document, update the data and stick it back in the
+            # index.
+            for doc in es_docs:
+                # Note: Need to keep this in sync with
+                # Question.extract_document.
+                num = id_to_num[int(doc[u'id'])]
+                doc[u'question_num_votes_past_week'] = num
 
-            Question.index(doc, refresh=True)
+                Question.index(doc, refresh=True)
+        except (ESTimeoutError, ESMaxRetryError, ESException):
+            # Something happened with ES, so let's push index updating
+            # into an index_task which retries when it fails because
+            # of ES issues.
+            index_task.delay(Question, id_to_num.keys())
 
 
 @task(rate_limit='4/m')


### PR DESCRIPTION
This task would do some ES index updating. The problem is when ES was
down, it'd send a flurry of emails to us plus it wouldn't update
the index.

This fixes that. If ES is down, it'll toss all the questions that
need to be updated into an index_task which retries when it fails.
Now we won't get more emails and the question data won't get
stale.

This is hard to test. Basically, I tweaked the code to raise ESTimeoutError, ran celeryd, and kicked off the cron job. Then verified that index_task items were kicked off. Then I removed the ESTimeoutError and hard-coded the cron job to create a single chunk with a bunch of question ids in it. Then I ran celeryd, kicked off the cron job and verified that it updated the index when everything was fine.

Could do that in a test, but since it generates a bunch of tasks, I wasn't wildly excited about it. I think we'd have to tweak the API for things to make it more testable.

r?
