### PR TITLE
[bug 644859] Fix multi-word tag queries

### DIFF
--- a/apps/search/tests/test_es.py
+++ b/apps/search/tests/test_es.py
@@ -499,6 +499,23 @@ class ElasticSearchViewTests(ElasticTestCase):
         content = json.loads(response.content)
         eq_(content['total'], 0)
 
+    def test_multi_word_tag_search(self):
+        """Tests searching for tags with spaces in them"""
+        ques = question(title=u'audio', save=True)
+        ques.tags.add(u'Windows 7')
+
+        self.refresh()
+
+        response = self.client.get(reverse('search'), {
+            'q': 'audio', 'q_tags': 'Windows 7', 'w': '2', 'a': '1',
+            'sortby': '0', 'format': 'json'
+        })
+
+        eq_(200, response.status_code)
+
+        content = json.loads(response.content)
+        eq_(content['total'], 1)
+
 
 class ElasticSearchUnifiedViewTests(ElasticTestCase):
     client_class = LocalizingClient
@@ -807,6 +824,23 @@ class ElasticSearchUnifiedViewTests(ElasticTestCase):
 
         content = json.loads(response.content)
         eq_(content['total'], 0)
+
+    def test_multi_word_tag_search(self):
+        """Tests searching for tags with spaces in them"""
+        ques = question(title=u'audio', save=True)
+        ques.tags.add(u'Windows 7')
+
+        self.refresh()
+
+        response = self.client.get(reverse('search'), {
+            'q': 'audio', 'q_tags': 'Windows 7', 'w': '2', 'a': '1',
+            'sortby': '0', 'format': 'json'
+        })
+
+        eq_(200, response.status_code)
+
+        content = json.loads(response.content)
+        eq_(content['total'], 1)
 
     def test_category_invalid(self):
         """Tests passing an invalid category"""

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -185,9 +185,10 @@ def search_with_es_unified(request, template=None):
         if cleaned['answered_by']:
             question_f &= F(question_answer_creator=cleaned['answered_by'])
 
-        q_tags = [t.strip() for t in cleaned['q_tags'].split()]
+        q_tags = [t.strip() for t in cleaned['q_tags'].split(',')]
         for t in q_tags:
-            question_f &= F(question_tag=t)
+            if t:
+                question_f &= F(question_tag=t)
 
     # End - support questions filters
 
@@ -531,9 +532,10 @@ def search(request, template=None):
             question_s = question_s.filter(
                 question_answer_creator=cleaned['answered_by'])
 
-        q_tags = [t.strip() for t in cleaned['q_tags'].split()]
+        q_tags = [t.strip() for t in cleaned['q_tags'].split(',')]
         for t in q_tags:
-            question_s = question_s.filter(question_tag=t)
+            if t:
+                question_s = question_s.filter(question_tag=t)
 
     # Discussion forum specific filters
     if cleaned['w'] & constants.WHERE_DISCUSSION:


### PR DESCRIPTION
We were splitting on white space before, but the instructions in
the Advanced Search dialog say to separate tags with commas. So this
changes the splitting code and makes it moar korrect.

Now you can search for "Windows 7" as a tag.

r?
