### PR TITLE
[bug 767650] Change timeout from 5s to 30s

### DIFF
--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -242,7 +242,7 @@ def get_indexing_es(**kwargs):
 
 
 def delete_index(index):
-    elasticutils.get_es().delete_index_if_exists(index)
+    get_indexing_es().delete_index_if_exists(index)
 
 
 def format_time(time_to_go):
@@ -265,7 +265,7 @@ def get_documents(cls, ids):
 def recreate_index(es=None):
     """Deletes index if it's there and creates a new one"""
     if es is None:
-        es = elasticutils.get_es()
+        es = get_indexing_es()
 
     from search.models import get_search_models
 


### PR DESCRIPTION
Deleting and recreating indexes was using an ES with a 5s timeout. This
fixes that to use a 30s timeout because 5s just isn't enough sometimes.

r?
