### PR TITLE
[bug 768457] Add e= back for CTR analysis

### DIFF
--- a/apps/search/templates/search/includes/macros.html
+++ b/apps/search/templates/search/includes/macros.html
@@ -2,6 +2,7 @@
 
 {% macro search_engine() -%}
   {# Must be imported with context #}
+  <input type="hidden" name="e" value="{% if waffle.flag('esunified') %}un{% else %}es{% endif %}" />
   {% if 'esunified' in request.GET and request.GET['esunified'] %}
     <input type="hidden" name="esunified" value="1" />
   {% endif %}

--- a/apps/search/templates/search/includes/result.html
+++ b/apps/search/templates/search/includes/result.html
@@ -1,6 +1,11 @@
 {% macro search_result(result, s=None, as='s', r=None) %}
   <div class="result {{ result.type }}">
-    {% set url =  result.url|urlparams(s=s, as=as, r=r) %}
+    {% if waffle.flag('esunified') %}
+      {% set engine = 'un' %}
+    {% else %}
+      {% set engine = 'es' %}
+    {% endif %}
+    {% set url =  result.url|urlparams(s=s, as=as, r=r, e=engine) %}
     <a class="title" href="{{ url }}">{{ result.title }}</a>
     <p><a tabindex="-1" href="{{ url }}">
       {{ result.search_summary|safe }}


### PR DESCRIPTION
This re-adds the e= querystring parameter for CTR stuff between
bucketed search (e=es) and unified search (e=un).

r?
