### PR TITLE
[bug 769030] Fix IndexError in paging

### DIFF
--- a/apps/search/tests/test_es.py
+++ b/apps/search/tests/test_es.py
@@ -482,6 +482,19 @@ class ElasticSearchUnifiedViewTests(ElasticTestCase):
         assert cookie in response.cookies
         eq_(urlquote(data['q']), response.cookies[cookie].value)
 
+    def test_empty_pages(self):
+        """Tests requesting a page that has no results"""
+        ques = question(title=u'audio', save=True)
+        ques.tags.add(u'desktop')
+        ans = answer(question=ques, content=u'volume', save=True)
+        answervote(answer=ans, helpful=True, save=True)
+
+        self.refresh()
+
+        qs = {'q': 'audio', 'page': 81}
+        response = self.client.get(reverse('search'), qs)
+        eq_(200, response.status_code)
+
     def test_front_page_search_for_questions(self):
         """This tests whether doing a search from the front page returns
         question results.

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -311,8 +311,14 @@ def search_with_es_unified(request, template=None):
             # docs_for_page
             documents = documents[offset:offset + results_per_page]
 
-            bounds = documents[0][1]
-            searcher = searcher.values_dict()[bounds[0]:bounds[1]]
+            if len(documents) == 0:
+                # If the user requested a page that's beyond the
+                # pagination, then documents is an empty list and
+                # there are no results to show.
+                searcher = []
+            else:
+                bounds = documents[0][1]
+                searcher = searcher.values_dict()[bounds[0]:bounds[1]]
 
         results = []
         for i, doc in enumerate(searcher):


### PR DESCRIPTION
If there were 10 pages of search results, but the user requests page
11, then the search view code would throw an IndexError. This fixes
that.

r?
