### PR TITLE
in docs: correct mysql sentence and add same convention for db password

### DIFF
--- a/docs/hacking_howto.rst
+++ b/docs/hacking_howto.rst
@@ -261,7 +261,7 @@ database settings. For example, using the settings above::
 To load the latest database schema, use ``scripts/schema.sql`` and
 ``schematic``::
 
-    $ mysql -u kitsune -p <YOUR_PASSWORD> < scripts/schema.sql
+    $ mysql -u kitsune -p kitsune < scripts/schema.sql
     $ ./vendor/src/schematic/schematic migrations/
 
 You'll now have an empty but up-to-date database!

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -153,7 +153,7 @@ For local development you will want to add the following settings::
             'ENGINE': 'django.db.backends.mysql',
             'HOST': 'localhost',
             'USER': 'kitsune',
-            'PASSWORD': 'password',
+            'PASSWORD': '<YOUR_PASSWORD>',
             'OPTIONS': {'init_command': 'SET storage_engine=InnoDB'},
             'TEST_CHARSET': 'utf8',
             'TEST_COLLATION': 'utf8_unicode_ci',
@@ -234,7 +234,7 @@ settings. For example, using the settings above::
 To load the latest database schema, use ``scripts/schema.sql`` and
 ``schematic``::
 
-    $ mysql -u kitsune -p <YOUR_PASSWORD> < scripts/schema.sql
+    $ mysql -u kitsune -p kitsune < scripts/schema.sql
     $ ./vendor/src/schematic/schematic migrations/
 
 You'll now have an empty but up-to-date database!


### PR DESCRIPTION
This sentence is wrong

```
mysql -u kitsune -p <YOUR_PASSWORD> < scripts/schema.sql
```

because don't specify db name and white space before YOUR_PASSWORD is unnecessary. The correct sentence is:

```
mysql -u kitsune -p<YOUR_PASSWORD> kitsune < scripts/schema.sql
```

But I prefer as it was before.

```
mysql -u kitsune -p kitsune < scripts/schema.sql
```

In this way, mysql asked for password later
