### PR TITLE
Removing unsuitable "Maybe you should ask some" when there are no questions

### DIFF
--- a/apps/questions/templates/questions/questions.html
+++ b/apps/questions/templates/questions/questions.html
@@ -136,7 +136,7 @@
     {{ questions|simple_paginator }}
   {% else %}
     {# Not localized because it's not worth localizers time. #}
-    <p>There are no questions. Maybe you should ask some!</p>
+    <p>There are no questions that match the current filter settings.</p>
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Some people in the contributor forum have complained about "Maybe you should ask some" being unsuitable in /questions. I changed the string to say something different.

r?

I hope I don't need to create a bug for this simple string change?
