### PR TITLE
[bug 775671] Fix migration 151

### DIFF
--- a/migrations/151-inproduct-redirect-permissions.sql
+++ b/migrations/151-inproduct-redirect-permissions.sql
@@ -1,3 +1,5 @@
+INSERT INTO `django_content_type` (`name`, `app_label`, `model`) VALUES ('redirect','inproduct','redirect');
+
 SELECT (@id:=`id`) FROM `django_content_type` WHERE `name` = 'redirect';
 
 INSERT INTO auth_permission (`name`, `content_type_id`, `codename`) VALUES


### PR DESCRIPTION
I'm not sure why this works on production databases, but doesn't
work on brand new databases, but this one line fixes it. The problem
is that a fresh database doesn't have a django_content_type for
redirect, yet.

r?
