### PR TITLE
[bug 767967] Auto-refresh page when reindexing

### DIFF
--- a/apps/search/admin.py
+++ b/apps/search/admin.py
@@ -211,6 +211,7 @@ def search(request):
          'error_messages': error_messages,
          'recent_records': recent_records,
          'outstanding_chunks': outstanding_chunks,
+         'now': datetime.now(),
          },
         RequestContext(request, {}))
 

--- a/apps/search/templates/search/admin/search.html
+++ b/apps/search/templates/search/admin/search.html
@@ -1,5 +1,4 @@
 {% extends "kadmin/base.html" %}
-
 {% block content_title %}
 <h1>Elastic Search</h1>
 {% endblock %}
@@ -27,6 +26,14 @@
 {% endblock %}
 
 {% block content %}
+  <p>
+    Page last rendered: {{ now }} {{ settings.TIME_ZONE }}
+    {% if outstanding_chunks %}
+      (Auto-refreshing every 30 seconds)
+      <script>setTimeout("window.location.reload(true);", 30000);</script>
+    {% endif %}
+  </p>
+
   {% if error_messages %}
     <section>
       <h1>Errors</h1>


### PR DESCRIPTION
This just fixes an issue I've had with the indexing page for a while.

One thing I wasn't sure about was whether there was a better way to reload the page in 30 seconds than what I did here. We're sort of constrained by it being django templates (admin site uses django templates) and I can't add meta elements to the head.

r?
