### PR TITLE
[bug 776014] Admin page for investigating issue

### DIFF
--- a/apps/search/templates/search/admin/troubleshooting.html
+++ b/apps/search/templates/search/admin/troubleshooting.html
@@ -1,0 +1,61 @@
+{% extends "kadmin/base.html" %}
+
+{% block content_title %}
+<h1>Elastic Search - Troubleshooting</h1>
+{% endblock %}
+
+{% block content %}
+<section>
+  <p>
+    What is this? Well, it shows the last 50 wiki documents indexed
+    and the last 50 revisions that were reviewed.
+
+  <table>
+    <tr>
+      <td>
+        <h2>INDEX</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>id</th>
+        <th>title</th>
+        <th>indexed on ({{ settings.TIME_ZONE }})</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for doc in last_50_indexed %}
+        <tr>
+          <td><a href="/admin/index?bucket=wiki_document&id={{ doc.id }}">{{ doc.id }}</a></td>
+          <td>{{ doc.document_title }}</td>
+          <td>{{ doc.indexed_on }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+      </td>
+
+      <td>
+        <h2>DB</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>id</th>
+        <th>title</th>
+        <th>reviewed on ({{ settings.TIME_ZONE }})</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for doc in last_50_reviewed %}
+        <tr>
+          <td><a href="{{ doc.get_absolute_url }}">{{ doc.id }}</a></td>
+          <td>{{ doc.title }}</td>
+          <td>{{ doc.current_revision.reviewed }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+    </tr>
+  </table>
+</section>
+{% endblock %}


### PR DESCRIPTION
This adds a thrown-together admin page to investigate the possibility
that live indexing isn't working correctly. It shows the last 50 wiki
documents indexed side by side with the last 50 wiki documents with
revisions that were approved. I think showing these side by side
would show whether there were things that weren't indexed that should
have been and may shed some more light on what's going on.

I literally threw this together. It's not pretty. It uses tables for layout.
But I need it in production sooner rather than later and it's solely an
admin page no one but me will probably use. If that turns out to be a
false assumption, we can fix it.

Mostly I need to know that the query isn't going to hose everything.
It works locally and I think it's probably fine, but a double-check is good.

r?
