### PR TITLE
[bug 775231] Migrate tags to products

### DIFF
--- a/apps/products/tests/__init__.py
+++ b/apps/products/tests/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+from django.template.defaultfilters import slugify
+
+from sumo.tests import with_save
+from products.models import Product
+
+
+@with_save
+def product(**kwargs):
+    """Create and return a product."""
+    defaults = {'title': u'đ' + str(datetime.now()),
+                'display_order': 1,
+                'visible': True}
+    defaults.update(kwargs)
+    if 'slug' not in kwargs:
+        defaults['slug'] = slugify(defaults['title'])
+    return Product(**defaults)

--- a/apps/search/forms.py
+++ b/apps/search/forms.py
@@ -6,8 +6,8 @@ from django.forms.util import ValidationError
 
 from tower import ugettext_lazy as _lazy
 
-from forums.models import Forum as DiscussionForum
 import search as constants
+from forums.models import Forum as DiscussionForum
 from sumo.form_fields import TypedMultipleChoiceField
 from sumo_locales import LOCALES
 from wiki.config import CATEGORIES, PRODUCTS
@@ -19,6 +19,13 @@ SEARCH_LANGUAGES = [(k, LOCALES[k].native) for
 
 class SearchForm(forms.Form):
     """Django form for handling display and validation"""
+    # TODO: Wrote this, but can't use it until we switch to product
+    # field in the index.
+    # def __init__(self, *args, **kwargs):
+    #     super(SearchForm, self).__init__(*args, **kwargs)
+
+    #     product_field = self.fields['product']
+    #     product_field.choices = Product.objects.values_list('id', 'title')
 
     def clean(self):
         """Clean up data and set defaults"""

--- a/apps/search/tests/test_es.py
+++ b/apps/search/tests/test_es.py
@@ -1,5 +1,5 @@
-import json
 import datetime
+import json
 
 import mock
 from django.conf import settings
@@ -12,10 +12,10 @@ from nose.tools import eq_
 from pyquery import PyQuery as pq
 from test_utils import TestCase
 
+import search as constants
 from forums.tests import forum, thread, post
 from questions.tests import question, answer, answervote, questionvote
 from questions.models import Question
-import search as constants
 from search import es_utils
 from search.models import generate_tasks
 from sumo.tests import LocalizingClient

--- a/apps/wiki/config.py
+++ b/apps/wiki/config.py
@@ -114,6 +114,7 @@ OPERATING_SYSTEMS = tuple(chain(*[options for label, options in
                                   GROUPED_OPERATING_SYSTEMS]))
 
 # Products supported
+# TODO: We can nix this once we finish the product changes in search.
 Product = namedtuple('Product', 'slug, name')  # slug is used for tag/topic
 PRODUCTS = (
     Product('desktop', _lazy(u'Desktop')),

--- a/apps/wiki/tests/__init__.py
+++ b/apps/wiki/tests/__init__.py
@@ -85,12 +85,12 @@ def doc_rev(content=''):
 # End model makers.
 
 
-def new_document_data(topic_ids=None):
+def new_document_data(topic_ids=None, product_ids=None):
     return {
         'title': 'A Test Article',
         'slug': 'a-test-article',
         'topics': topic_ids or [],
-        'product_tags': ['desktop'],
+        'products': product_ids or [],
         'category': CATEGORIES[0][0],
         'keywords': 'key1, key2',
         'summary': 'lipsum',

--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -13,7 +13,6 @@ import mock
 from nose import SkipTest
 from nose.tools import eq_
 from pyquery import PyQuery as pq
-from taggit.models import Tag
 from wikimarkup.parser import ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 
 from sumo.helpers import urlparams
@@ -458,7 +457,10 @@ class NewDocumentTests(TestCaseBase):
         self.client.login(username='admin', password='testpass')
         response = self.client.get(reverse('wiki.new_document'))
         doc = pq(response.content)
-        eq_(1, len(doc('input[name="product_tags"][checked=checked]')))
+        # TODO: Do we want to re-implement the initial product
+        # checked? Maybe add a column to the table and use that to
+        # figure out which are initial?
+        # eq_(1, len(doc('input[name="products"][checked=checked]')))
         eq_(None, doc('input[name="tags"]').attr('required'))
         eq_('checked', doc('input#id_allow_discussion').attr('checked'))
         eq_(None, doc('input#id_allow_discussion').attr('required'))
@@ -560,13 +562,13 @@ class NewDocumentTests(TestCaseBase):
         """Try to create a new document with an invalid product."""
         self.client.login(username='admin', password='testpass')
         data = new_document_data()
-        data['product_tags'] = [1337]
+        data['products'] = ['l337']
         response = self.client.post(reverse('wiki.new_document'), data,
                                     follow=True)
         doc = pq(response.content)
         ul = doc('#document-form > ul.errorlist')
         eq_(1, len(ul))
-        eq_('Select a valid choice. 1337 is not one of the available choices.',
+        eq_('Select a valid choice. l337 is not one of the available choices.',
             ul('li').text())
 
     def test_slug_collision_validation(self):

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -19,11 +19,11 @@ from django.views.decorators.http import (require_GET, require_POST,
 import jingo
 from mobility.decorators import mobile_template
 from statsd import statsd
-from taggit.models import Tag
 from tower import ugettext_lazy as _lazy
 from tower import ugettext as _
 
 from access.decorators import permission_required, login_required
+from products.models import Product
 from sumo.helpers import urlparams
 from sumo.urlresolvers import reverse
 from sumo.utils import paginate, smart_int, get_next_url, truncated_json_dumps
@@ -37,7 +37,7 @@ from wiki.forms import (AddContributorForm, DocumentForm, RevisionForm,
 from wiki.models import Document, Revision, HelpfulVote, ImportantDate
 from wiki.config import (CATEGORIES, OPERATING_SYSTEMS,
                          GROUPED_OPERATING_SYSTEMS, FIREFOX_VERSIONS,
-                         GROUPED_FIREFOX_VERSIONS, PRODUCT_TAGS)
+                         GROUPED_FIREFOX_VERSIONS)
 from wiki.parser import wiki_to_html
 from wiki.tasks import (send_reviewed_notification, schedule_rebuild_kb,
                         send_contributor_notification)
@@ -1019,8 +1019,8 @@ def _document_form_initial(document):
             'is_archived': document.is_archived,
             'topics': Topic.uncached.filter(
                 document=document).values_list('id', flat=True),
-            'product_tags': [t.name for t in document.tags.all()
-                         if t.name in PRODUCT_TAGS],
+            'products': Product.uncached.filter(
+                document=document).values_list('id', flat=True),
             'allow_discussion': document.allow_discussion,
             'needs_change': document.needs_change,
             'needs_change_comment': document.needs_change_comment}

--- a/migrations/160-products-migration.py
+++ b/migrations/160-products-migration.py
@@ -1,0 +1,49 @@
+from django.utils.encoding import smart_str
+
+from products.models import Product
+from taggit.models import Tag
+from wiki.models import Document
+
+tags_to_migrate = {
+    # source tag -> product
+    'firefox': ['firefox'],
+    'sync': ['firefox', 'mobile'],
+    'persona': ['firefox'],
+    'desktop': ['firefox'],
+    'fxhome': ['firefox', 'mobile'],
+    'firefox-10': ['firefox'],
+    'firefox-602': ['firefox'],
+    'firefox-50': ['firefox'],
+    'android': ['mobile'],
+    'mobile': ['mobile']
+}
+
+
+def assert_equals(a, b):
+    assert a == b, '%s != %s' % (a, b)
+
+
+def run():
+    # Get all the tags to migrate.
+    tags = list(Tag.objects.filter(slug__in=tags_to_migrate.keys()))
+
+    # Make sure I didn't typo anything.
+    assert_equals(len(tags), len(tags_to_migrate))
+
+    total_affected = 0
+
+    # For each tag, get the document and add a topic for it.
+    for tag in tags:
+        for product_slug in tags_to_migrate[tag.slug]:
+            product = Product.objects.get(slug=product_slug)
+
+            # Assign the topic to all the documents tagged with tag.
+            for doc in Document.objects.filter(tags__slug=tag.slug):
+
+                doc.products.add(product)
+
+                print 'Added product "%s" to document "%s"' % (
+                    smart_str(product.slug), smart_str(doc.title))
+                total_affected += 1
+
+    print 'Done! (%d)' % total_affected


### PR DESCRIPTION
- migration for connecting documents with appropriate products from the
  new products table
- updated kb forms so they work with the new products stuff
- updated tests

Pretty sure this covers everything. I'm a little fuzzy on the "if the doc has a parent, then don't save the products" bit. I'm not entirely sure I understand that requirement or that it's correctly coded in the new system.

Everything else should be ok for now, though.

r?
