### PR TITLE
Fix duplicate key issue on migration 151

### DIFF
--- a/migrations/151-inproduct-redirect-permissions.sql
+++ b/migrations/151-inproduct-redirect-permissions.sql
@@ -1,4 +1,4 @@
-INSERT INTO `django_content_type` (`name`, `app_label`, `model`) VALUES ('redirect','inproduct','redirect');
+INSERT INTO `django_content_type` (`name`, `app_label`, `model`) VALUES ('redirect','inproduct','redirect') ON DUPLICATE KEY UPDATE `name`='redirect';
 
 SELECT (@id:=`id`) FROM `django_content_type` WHERE `name` = 'redirect';
 


### PR DESCRIPTION
Ran into an error with the first `INSERT` due to a key conflict on `app_label`. This will prevent that from happening where this key already exists.

r?
