### PR TITLE
[bug 583789] JS error when clicking "I have this problem" twice

### DIFF
--- a/media/js/questions.js
+++ b/media/js/questions.js
@@ -96,6 +96,9 @@
     function initHaveThisProblemTooAjax() {
         var $container = $('#question div.me-too');
         initAjaxForm($container, 'form', '#vote-thanks');
+        $container.find('input').click(function() {
+            $(this).attr('disabled', 'disabled');
+        });
         $container.delegate('.kbox-close, .kbox-cancel', 'click', function(ev){
             ev.preventDefault();
             $container.unbind().remove();


### PR DESCRIPTION
If the person clicks the button twice, a JS parser error is returned. This still displays the alert if something else failed during the submission.

r?
