### PR TITLE
[bug 782322] Nix longer retry times

### DIFF
--- a/apps/search/tasks.py
+++ b/apps/search/tasks.py
@@ -68,8 +68,6 @@ RETRY_TIMES = (
     10 * 60,      # 10 minutes
     30 * 60,      # 30 minutes
     60 * 60,      # 60 minutes
-    2 * 60 * 60,  # 2 hours
-    6 * 60 * 60   # 6 hours
     )
 MAX_RETRIES = len(RETRY_TIMES)
 


### PR DESCRIPTION
If ES is down for longer than an hour or two, we probably want to
just reindex everything. Given that, it's not helpful to have the
really long reindexing retries.

r?
