### PR TITLE
Fix logarithmic retry code

### DIFF
--- a/apps/search/tasks.py
+++ b/apps/search/tasks.py
@@ -81,7 +81,10 @@ def index_task(cls, ids, **kw):
             cls.index(cls.extract_document(id), refresh=True)
     except Exception as exc:
         retries = index_task.request.retries
-        index_task.retry(exc=exc, max_retries=MAX_RETRIES - 1,
+        if retries >= MAX_RETRIES:
+            raise
+
+        index_task.retry(exc=exc, max_retries=MAX_RETRIES,
                          countdown=RETRY_TIMES[retries])
 
 
@@ -92,7 +95,9 @@ def unindex_task(cls, ids, **kw):
     try:
         for id in ids:
             cls.unindex(id)
-    except Exception, exc:
+    except Exception as exc:
         retries = unindex_task.request.retries
-        unindex_task.retry(exc=exc, max_retries=MAX_RETRIES - 1,
+        if retries >= MAX_RETRIES:
+            raise
+        unindex_task.retry(exc=exc, max_retries=MAX_RETRIES,
                            countdown=RETRY_TIMES[retries])


### PR DESCRIPTION
I bumped into this while fixing something else. The retry code used
to have an off-by-one and I must have fixed it in a way that it's now
essentially an off-by-two.

The gist of it is that prior to this fix, it wouldn't go through all
the retry attempts--it'd skip the last one. With this fix it now
goes through all the retry attempts.

Also, I fixed some syntax since we want to use the:

```
except Exception as exc:
```

syntax now.

Easiest thing is to look at the code and then run the tests, though none of the tests go through the logarithmic retry. In order to test that effectively, you have to tweak the code a bit. I'm positive this is correct (and more correct than the previous iteration), so if you want to skip the code tweaking, that'd be ok.

r?
