### PR TITLE
[Bug 782854] Warning: Field 'upvotes' doesn't have a default value when ...

### DIFF
--- a/migrations/164-set-upvotes-default.sql
+++ b/migrations/164-set-upvotes-default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE questions_answer MODIFY upvotes INT(11) DEFAULT NULL;


### PR DESCRIPTION
...posting a new reply to a question

Modifies the column to use NULL as the default value.
