### PR TITLE
[bug 761320] Grab users and profiles in one query

### DIFF
--- a/apps/groups/views.py
+++ b/apps/groups/views.py
@@ -26,7 +26,7 @@ def list(request):
 
 def profile(request, group_slug, member_form=None, leader_form=None):
     prof = get_object_or_404(GroupProfile, slug=group_slug)
-    leaders = prof.leaders.all()
+    leaders = prof.leaders.all().select_related('profile')
     members = prof.group.user_set.all().select_related('profile')
     user_can_edit = _user_can_edit(request.user, prof)
     user_can_manage_leaders = _user_can_manage_leaders(request.user, prof)


### PR DESCRIPTION
(Instead of N + 1 queries where N is the number of users in the group)

You can verify this by enabling django debug toolbar and looking at the query counts with a cold cache.

r?
