### PR TITLE
Fix tests to use correct get_es

### DIFF
--- a/apps/search/tests/test_es.py
+++ b/apps/search/tests/test_es.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.http import QueryDict
 from django.utils.http import urlquote
-from elasticutils import get_es
+from elasticutils.contrib.django import get_es
 from nose import SkipTest
 from nose.tools import eq_
 from pyquery import PyQuery as pq


### PR DESCRIPTION
The get_es it was using doesn't take into account Django settings. I
think it's kind of a fluke it was working before.

This fixes that.

r?
