### PR TITLE
[bug 790742 followup] Fix style issues for non-English locales

### DIFF
--- a/media/css/cannedresponses.css
+++ b/media/css/cannedresponses.css
@@ -93,6 +93,7 @@
     display: none;
     margin-top: 0.5em;
     overflow: auto;
+    width: 100%;
 }
 
 .response-preview-rendered .main-content {


### PR DESCRIPTION
I figured that non-English locales will have quite a problem because strings that are too long can shrink the editor.

Now the button just goes into the next line when the string is too long.
http://screencast.com/t/9Pj42n0jK
