### PR TITLE
Show top 10 topics in article sidebar.

### DIFF
--- a/apps/wiki/templates/wiki/document-new.html
+++ b/apps/wiki/templates/wiki/document-new.html
@@ -60,7 +60,7 @@
   {% endif %}
   {{ document_tools(doc, parent, user, 'article', settings) }}
   {{ related_articles(related, document) }}
-  {{ topic_sidebar(topics, product) }}
+  {{ topic_sidebar(topics[:10], product) }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -164,7 +164,7 @@ def document(request, document_slug, template=None):
     else:
         product = products[0]
 
-    topics = doc.get_topics()
+    topics = Topic.objects.filter(visible=True)
 
     data = {'document': doc, 'redirected_from': redirected_from,
             'related': related, 'contributors': contributors,


### PR DESCRIPTION
Instead of the topics assigned to the article.

@rehandalal : I think you had this right originally and I made you change it. r?
