### PR TITLE
[bug 778753] Clean up register_for_indexing

### DIFF
--- a/apps/forums/models.py
+++ b/apps/forums/models.py
@@ -12,7 +12,8 @@ import forums
 from sumo.helpers import urlparams, wiki_to_html
 from sumo.urlresolvers import reverse
 from sumo.models import ModelBase
-from search.models import SearchMixin, register_for_indexing
+from search.models import (SearchMixin, register_for_indexing,
+                           register_for_unified_search)
 
 
 def _last_post_from(posts, exclude_post=None):
@@ -96,6 +97,7 @@ class Forum(NotificationsMixin, ModelBase):
         self.last_post = _last_post_from(posts, exclude_post=exclude_post)
 
 
+@register_for_unified_search
 class Thread(NotificationsMixin, ModelBase, SearchMixin):
     title = models.CharField(max_length=255)
     forum = models.ForeignKey('Forum')
@@ -257,7 +259,7 @@ class Thread(NotificationsMixin, ModelBase, SearchMixin):
         return super(Thread, cls).search().order_by('created')
 
 
-register_for_indexing(Thread, 'forums')
+register_for_indexing('forums', Thread)
 
 
 class Post(ActionMixin, ModelBase):
@@ -338,4 +340,4 @@ class Post(ActionMixin, ModelBase):
         return wiki_to_html(self.content)
 
 
-register_for_indexing(Post, 'forums', instance_to_indexee=lambda p: p.thread)
+register_for_indexing('forums', Post, instance_to_indexee=lambda p: p.thread)

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -17,7 +17,8 @@ from tower import ugettext_lazy as _lazy, ugettext as _
 
 from products.models import Product
 from search.es_utils import ESTimeoutError, ESMaxRetryError, ESException
-from search.models import SearchMixin, register_for_indexing
+from search.models import (SearchMixin, register_for_indexing,
+                           register_for_unified_search)
 from sumo import ProgrammingError
 from sumo.models import ModelBase, LocaleField
 from sumo.urlresolvers import reverse, split_path
@@ -42,6 +43,7 @@ class _NotDocumentView(Exception):
     """A URL not pointing to the document view was passed to from_url()."""
 
 
+@register_for_unified_search
 class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
                SearchMixin):
     """A localized knowledgebase document, not revision-specific."""
@@ -650,16 +652,14 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
         super(cls, cls).index(document, **kwargs)
 
 
-register_for_indexing(Document, 'wiki')
+register_for_indexing('wiki', Document)
 register_for_indexing(
-    Document.topics.through,
     'wiki',
-    instance_to_indexee=lambda i: i,
+    Document.topics.through,
     m2m=True)
 register_for_indexing(
-    Document.products.through,
     'wiki',
-    instance_to_indexee=lambda i: i,
+    Document.products.through,
     m2m=True)
 
 


### PR DESCRIPTION
This does some minor cleanup of register_for_indexing and related code.
It adds documentation, removes unneded lines, reorders the arguments
to be slightly more hierarchical, and also moves
register_for_unified_search to a separate class decorator so as to
reduce the complexity of register_for_indexing.

r?
