### PR TITLE
[Bug 750247] dictConfig logging config done better

### DIFF
--- a/log_settings.py
+++ b/log_settings.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import setttings
 from django.conf import settings
 
 import celery.conf
@@ -51,4 +50,4 @@ else:
     celery.conf.CELERYD_LOG_FILE = task_proxy
     celery.conf.CELERYD_LOG_COLOR = False
 
-dictconfig.dictConfig(config)
+logging.config.dictConfig(config)


### PR DESCRIPTION
Now the dictConfig setting happens in manage.py, after settings.py and local_settings.py have been processed, so they can both set things like LOG_LEVEL or SYSLOG_TAG.

I don't really understand the reasoning behind this bug, so maybe this isn't right either.
