### PR TITLE
[bug 798449] Fix media gallery modal.

### DIFF
--- a/media/less/includes/editor-tools.less
+++ b/media/less/includes/editor-tools.less
@@ -175,7 +175,7 @@ section.marky {
 
   div.placeholder {
     height: 65%;
-    height: -moz-calc(100% - 150px);
+    height:  -moz-calc(~"100% - 200px");
     left: 15px;
     position: absolute;
     top: 100px;
@@ -193,7 +193,7 @@ section.marky {
 
   #media-list {
     height: 80%;
-    height: -moz-calc(100% - 50px);
+    height: -moz-calc(~"100% - 50px");
     overflow: auto;
 
     li {
@@ -246,6 +246,7 @@ section.marky {
       ol {
         float: left;
         list-style-type: none;
+        margin: 0;
 
         li {
           border-left: 2px solid #929292;


### PR DESCRIPTION
LESS was converting `-moz-calc(100% - 150px);` to `-moz-calc(-50%);` Fixed with `~""`.

r? @rehandalal
