### PR TITLE
[bug 682730] Add ability to edit a translation w/o making it up to date. 

### DIFF
--- a/apps/wiki/forms.py
+++ b/apps/wiki/forms.py
@@ -232,7 +232,7 @@ class RevisionForm(forms.ModelForm):
         super(RevisionForm, self).__init__(*args, **kwargs)
         self.fields['based_on'].widget = forms.HiddenInput()
 
-    def save(self, creator, document, **kwargs):
+    def save(self, creator, document, based_on_id=None, **kwargs):
         """Persist me, and return the saved Revision.
 
         Take several other necessary pieces of data that aren't from the
@@ -244,6 +244,8 @@ class RevisionForm(forms.ModelForm):
 
         new_rev.document = document
         new_rev.creator = creator
+        if based_on_id:
+            new_rev.based_on_id = based_on_id
         new_rev.save()
         return new_rev
 

--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -182,7 +182,7 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro submit_revision(form, buttons_only=False) -%}
+{% macro submit_revision(form, buttons_only=False, show_no_update_checkbox=False) -%}
   <div class="submit">
     <button class="btn btn-important btn-submit" type="submit">{{ _('Submit for Review') }}</button>
     <input class="btn-preview" data-preview-url="{{ url('wiki.preview') }}" type="button" value="{{ _('Preview Content') }}" disabled="disabled" />
@@ -198,6 +198,14 @@
           <label for="id_comment">{{ _('Briefly describe your changes:') }}</label>
           {{ form.comment|safe }}
         </div>
+        {% if show_no_update_checkbox %}
+          <div class="no-update">
+            <label>
+              <input type="checkbox" name="no-update" value="Yes" />
+              {{ _('This edit does not make this article up to date. The English differences should not change on the next edit.') }}
+            </label>
+          </div>
+        {% endif %}
         <div class="notifications">
           <label>
             <input type="checkbox" name="notify-future-changes" value="Yes" />

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -145,7 +145,10 @@
           </div>
           {{ revision_form.hidden_fields()|join|safe }}
           <div class="buttons-and-preview">
-            {{ submit_revision(revision_form) }}
+            {# If the document has been created and has a current revision,
+               we allow the localizer to keep the translation out of date
+               with this new revision. #}
+            {{ submit_revision(revision_form, show_no_update_checkbox=(document and document.current_revision)) }}
             <div id="preview"></div>
             <div class="submit" id="preview-bottom">
               {{ submit_revision(revision_form, buttons_only=True) }}

--- a/media/less/wiki.less
+++ b/media/less/wiki.less
@@ -734,6 +734,14 @@ form {
     padding: 0 0 0 10px;
 }
 
+#submit-modal {
+  .comment,
+  .notifications,
+  .no-update {
+    margin: 10px 0;
+  }
+}
+
 textarea[name="content"] {
     height: 500px;
 }


### PR DESCRIPTION
This adds a checkbox to the submit new l10n revision modal. When it is
checked, the new revision keeps the based_on of the previous revistion
being edited instead of updating it to the latest approved and ready for
l10n en-US revision.

This allows edits on translations to be made without marking them as
up to date.

r?
