### PR TITLE
[bug 658769] Include locale in kbforum URLs.

### DIFF
--- a/apps/kbforums/models.py
+++ b/apps/kbforums/models.py
@@ -67,6 +67,7 @@ class Thread(NotificationsMixin, ModelBase):
 
     def get_absolute_url(self):
         return reverse('wiki.discuss.posts',
+                       locale=self.document.locale,
                        kwargs={'document_slug': self.document.slug,
                                'thread_id': self.id})
 
@@ -143,6 +144,7 @@ class Post(ModelBase):
             query['page'] = self.page
 
         url_ = reverse('wiki.discuss.posts',
+                       locale=self.thread.document.locale,
                        kwargs={'document_slug': self.thread.document.slug,
                                'thread_id': self.thread.id})
         return urlparams(url_, hash='post-%s' % self.id, **query)

--- a/apps/kbforums/tests/test_models.py
+++ b/apps/kbforums/tests/test_models.py
@@ -16,18 +16,21 @@ class KBForumModelTestCase(KBForumTestCase):
 
     def test_thread_absolute_url(self):
         t = Thread.objects.get(pk=1)
-        exp_ = reverse('wiki.discuss.posts', args=[t.document.slug, t.id])
+        exp_ = reverse('wiki.discuss.posts', locale=t.document.locale,
+                       args=[t.document.slug, t.id])
         eq_(exp_, t.get_absolute_url())
 
     def test_post_absolute_url(self):
         p = Post.objects.get(pk=1)
         url_ = reverse('wiki.discuss.posts',
+                       locale=p.thread.document.locale,
                        args=[p.thread.document.slug, p.thread.id])
         exp_ = urlparams(url_, hash='post-%s' % p.id)
         eq_(exp_, p.get_absolute_url())
 
         p = Post.objects.get(pk=24)
         url_ = reverse('wiki.discuss.posts',
+                       locale=p.thread.document.locale,
                        args=[p.thread.document.slug, p.thread.id])
         exp_ = urlparams(url_, hash='post-%s' % p.id, page=2)
         eq_(exp_, p.get_absolute_url())


### PR DESCRIPTION
KBForum URLs are locale-specific so we need to include the locale in the URL always.

r?
