### PR TITLE
[Bug 808151] Send review comments to reviewer too.

### DIFF
--- a/apps/wiki/tasks.py
+++ b/apps/wiki/tasks.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.core.mail import send_mail, mail_admins
+from django.core.mail import send_mail, mail_admins, send_mass_mail
 from django.db import transaction
 from django.template import Context, loader
 
@@ -48,8 +48,9 @@ def send_reviewed_notification(revision, document, message):
                                 'message': message,
                                 'url': url,
                                 'host': Site.objects.get_current().domain}))
-    send_mail(subject, content, settings.TIDINGS_FROM_ADDRESS,
-              [revision.creator.email, revision.reviewer.email])
+    send_mass_mail(
+        ((subject, content, settings.TIDINGS_FROM_ADDRESS, [who.email])
+                    for who in [revision.creator, revision.reviewer]))
 
 
 @task

--- a/apps/wiki/tests/test_notifications.py
+++ b/apps/wiki/tests/test_notifications.py
@@ -68,7 +68,8 @@ class ReviewTests(TestCaseBase):
         notification and Approved watchers an Approved one."""
         _set_up_ready_watcher()
         self._review_revision(is_ready=True)
-        eq_(3, len(mail.outbox))  # 1 mail to each watcher, + 1 to creator
+        # 1 mail to each watcher, 1 to the creator, and one to the reviewer
+        eq_(4, len(mail.outbox))
         _assert_ready_mail(mail.outbox[0])
         _assert_approved_mail(mail.outbox[1])
         _assert_creator_mail(mail.outbox[2])
@@ -78,7 +79,8 @@ class ReviewTests(TestCaseBase):
         watchers an Approved notification."""
         _set_up_ready_watcher()
         self._review_revision(is_ready=False)
-        eq_(2, len(mail.outbox))  # 1 mail to Approved watcher, 1 to creator
+        # 1 mail to Approved watcher, 1 to creator, 1 for reviewer
+        eq_(3, len(mail.outbox))
         assert 'new approved revision' in mail.outbox[0].subject
         assert 'Your revision has been approved' in mail.outbox[1].subject
 
@@ -97,17 +99,19 @@ class ReviewTests(TestCaseBase):
                      save=True)
         eq_(0, len(mail.outbox))
         self._review_revision(r=r2)
-        eq_(3, len(mail.outbox))
+        # 1 mail for each watcher, 1 for creator, and one for reviewer.
+        eq_(4, len(mail.outbox))
         assert 'has a new approved revision' in mail.outbox[0].subject
         assert 'Your revision has been approved' in mail.outbox[1].subject
-        assert 'A revision you contributed to has' in mail.outbox[2].subject
+        assert 'Your revision has been approved' in mail.outbox[2].subject
+        assert 'A revision you contributed to has' in mail.outbox[3].subject
 
     def test_neither(self):
         """Show that neither an Approved nor a Ready mail is sent if a rev is
         rejected."""
         _set_up_ready_watcher()
         self._review_revision(is_approved=False)
-        eq_(1, len(mail.outbox))  # 1 mail to creator
+        eq_(2, len(mail.outbox))  # 1 mail to creator, one to the reviewer.
         assert mail.outbox[0].subject.startswith(
             'Your revision has been reviewed')
 
@@ -119,7 +123,8 @@ class ReviewTests(TestCaseBase):
         ReadyRevisionEvent.notify(self.approved_watcher)
 
         self._review_revision(is_ready=True)
-        eq_(2, len(mail.outbox))  # 1 mail to watcher, 1 to creator
+        # 1 mail to watcher, 1 to creator, 1 to reviewer
+        eq_(3, len(mail.outbox))
         _assert_ready_mail(mail.outbox[0])
         _assert_creator_mail(mail.outbox[1])
 

--- a/apps/wiki/tests/test_tasks.py
+++ b/apps/wiki/tests/test_tasks.py
@@ -113,7 +113,8 @@ class ReviewMailTestCase(TestCaseBase):
         msg = 'great work!'
         self._approve_and_send(rev, User.objects.get(username='admin'), msg)
 
-        eq_(1, len(mail.outbox))
+        # Two emails will be sent, one each for the reviewer and the reviewed.
+        eq_(2, len(mail.outbox))
         eq_('Your revision has been approved: %s' % doc.title,
             mail.outbox[0].subject)
         eq_([rev.creator.email], mail.outbox[0].to)
@@ -141,6 +142,7 @@ class ReviewMailTestCase(TestCaseBase):
         msg = 'foo'
         self._approve_and_send(rev, User.objects.get(username='admin'), msg)
 
-        eq_(1, len(mail.outbox))
+        # Two emails will be sent, one each for the reviewer and the reviewed.
+        eq_(2, len(mail.outbox))
         eq_('Your revision has been approved: %s' % doc.title,
             mail.outbox[0].subject)


### PR DESCRIPTION
This adds the reviewer to the list of recipients when a notification
gets sent for a revision being reviewed. This might be confusing for the
reviewer, as the email is targeted at the person who wrote the revision.
It will also reveal the email address of both parties to eachother, and
allow an email conversation to happen. All of this might be undesired,
but is what was requested.

Small code change, but needs thought as to if this is actually how we want it handled.

r?
