### PR TITLE
[Bug 809449] Set the ES prefix based on build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -57,6 +57,7 @@ DATABASES['default']['TEST_CHARSET'] = 'utf8'
 DATABASES['default']['TEST_COLLATION'] = 'utf8_general_ci'
 CELERY_ALWAYS_EAGER = True
 CACHE_BACKEND = 'caching.backends.locmem://'
+ES_INDEX_PREFIX = 'sumo_$BUILD_NAME'
 SETTINGS
 
 echo "Starting tests..." `date`


### PR DESCRIPTION
Use the build name to generate a ES_INDEX_PREFIX value in build.sh, so
we can have multiple jobs on Jenkins without them colliding in ES.

The best way to test that this doesn't break things is to make this pull request and let Leeroy go about his business. Assuming that Leeroy shows that this works the way I expect, r?
