### PR TITLE
[bug 821050] Add LOCALE_PATHS settings.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -210,6 +210,10 @@ DB_LOCALIZE = {
     },
 }
 
+LOCALE_PATHS = (
+    path('locale'),
+)
+
 # Use the real robots.txt?
 ENGAGE_ROBOTS = False
 


### PR DESCRIPTION
I can't trigger the warning locally

```
/data/support-dev/www/support-dev.allizom.org/kitsune/vendor/src/django/django/utils/translation/__init__.py:63: DeprecationWarning: Translations in the project directory aren't supported anymore. Use the LOCALE_PATHS setting instead.
  DeprecationWarning
```

but I am pretty sure this will silence it.

r?
