### PR TITLE
[Bug 818222] Don't escape html in wiki emails.

### DIFF
--- a/apps/wiki/templates/wiki/email/approved.ltxt
+++ b/apps/wiki/templates/wiki/email/approved.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{% load unsubscribe_instructions %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}{{ reviewer }} has approved the revision to the document {{ document_title }}.
+{% autoescape off %}{% load i18n %}{% load unsubscribe_instructions %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}{{ reviewer }} has approved the revision to the document {{ document_title }}.
 
 To view the updated document, click the following link, or paste it into your browser's location bar:
 {% endblocktrans %}
@@ -11,4 +11,4 @@ https://{{ host }}{{ url }}
 --
 {% blocktrans %}Changes:{% endblocktrans %}
 {{ diff|safe }}
-{% unsubscribe_instructions watch %}
+{% unsubscribe_instructions watch %}{% endautoescape %}

--- a/apps/wiki/templates/wiki/email/edited.ltxt
+++ b/apps/wiki/templates/wiki/email/edited.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{% load unsubscribe_instructions %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}{{ creator }} created a new revision to the document
+{% autoescape off %}{% load i18n %}{% load unsubscribe_instructions %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}{{ creator }} created a new revision to the document
 {{ document_title }}.
 
 To view this document's history, click the following
@@ -13,4 +13,4 @@ https://{{ host }}{{ url }}
 --
 {% trans "Changes:" %}
 {{ diff|safe }}
-{% unsubscribe_instructions watch %}
+{% unsubscribe_instructions watch %}{% endautoescape %}

--- a/apps/wiki/templates/wiki/email/ready_for_l10n.ltxt
+++ b/apps/wiki/templates/wiki/email/ready_for_l10n.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{% load unsubscribe_instructions %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}The document {{ document_title }} has a new revision
+{% autoescape off %}{% load i18n %}{% load unsubscribe_instructions %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}The document {{ document_title }} has a new revision
 that is ready for localization.
 
 To localize the document, click the following link, or paste it into
@@ -14,4 +14,4 @@ https://{{ host }}{{ url }}
 --
 {% blocktrans %}Text of the new revision:{% endblocktrans %}
 {{ fulltext|safe }}
-{% unsubscribe_instructions watch %}
+{% unsubscribe_instructions watch %}{% endautoescape %}

--- a/apps/wiki/templates/wiki/email/ready_for_review.ltxt
+++ b/apps/wiki/templates/wiki/email/ready_for_review.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{% load unsubscribe_instructions %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}{{ creator }} submitted a new revision to the document
+{% autoescape off %}{% load i18n %}{% load unsubscribe_instructions %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}{{ creator }} submitted a new revision to the document
 {{ document_title }}.
 
 To review this revision, click the following
@@ -13,4 +13,4 @@ https://{{ host }}{{ url }}
 --
 {% trans "Changes:" %}
 {{ diff|safe }}
-{% unsubscribe_instructions watch %}
+{% unsubscribe_instructions watch %}{% endautoescape %}

--- a/apps/wiki/templates/wiki/email/reviewed.ltxt
+++ b/apps/wiki/templates/wiki/email/reviewed.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}Your revision has been reviewed.{% endblocktrans %}
+{% autoescape off %}{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}Your revision has been reviewed.{% endblocktrans %}
 {% if approved %}
 {% blocktrans %}{{ reviewer }} has approved your revision to the document
 {{ document_title }}.{% endblocktrans %}
@@ -13,4 +13,4 @@
 To view the history of this document, click the following
 link, or paste it into your browser's location bar:
 {% endblocktrans %}
-https://{{ host }}{{ url }}
+https://{{ host }}{{ url }}{% endautoescape %}

--- a/apps/wiki/templates/wiki/email/reviewed_contributors.ltxt
+++ b/apps/wiki/templates/wiki/email/reviewed_contributors.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% if approved %}
+{% autoescape off %}{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% if approved %}
 {% blocktrans %}A revision you contributed to has been approved.
 {{ reviewer }} has approved a revision to the document {{ document_title }}.{% endblocktrans %}
 {% else %}
@@ -13,4 +13,4 @@
 To view the history of this document, click the following
 link, or paste it into your browser's location bar:
 {% endblocktrans %}
-https://{{ host }}{{ url }}
+https://{{ host }}{{ url }}{% endautoescape %}

--- a/apps/wiki/tests/test_tasks.py
+++ b/apps/wiki/tests/test_tasks.py
@@ -31,7 +31,8 @@ Message from the reviewer:
 To view the history of this document, click the following
 link, or paste it into your browser's location bar:
 
-https://testserver/en-US/kb/%s/history"""
+https://testserver/en-US/kb/%s/history
+"""
 
 
 class RebuildTestCase(TestCase):
@@ -162,3 +163,5 @@ class ReviewMailTestCase(TestCaseBase):
         eq_('Your revision has been approved: %s' % doc.title,
             mail.outbox[0].subject)
         assert '&quot;' not in mail.outbox[0].body
+        assert '"All about quotes"' in mail.outbox[0].body
+        assert 'foo & "bar"' in mail.outbox[0].body


### PR DESCRIPTION
All the wiki emails are Django, and were escaping html characters like
quotes. This commit removes all escaping, by surrounding the templates
with {% autoescape off %}. This is safe to do, because the emails are
sent as content-type: text/plain, so even if a user inserted malicious
text into the message, mail clients shouldn't treat them as HTML.

r?
