### PR TITLE
[Bug 823049] Add visual cue for blockquoted parts

### DIFF
--- a/media/less/forums.less
+++ b/media/less/forums.less
@@ -165,6 +165,19 @@
           margin-bottom: 0;
         }
       }
+
+      blockquote {
+        background-color: #e6eaec;
+        .border-radius(0.3em);
+        margin: 1.5em;
+        padding: 1em;
+      }
+      blockquote blockquote {
+        background-color: #ffffff;
+        .border-radius(0.3em);
+        margin: 1.5em;
+        padding: 1em;
+      }
     }
 
     .content-raw {


### PR DESCRIPTION
Adds the visual cue and a simple hack to add one more level of nesting. Arbitrary nesting should be possible by adding odd/even classes to block-quotes, but that seems like overkill. 

r?
