### PR TITLE
[Bug 802578] do not allow votes on templates

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -37,7 +37,7 @@
       {{ document_messages(document, redirected_from) }}
       {{ document_content(document, fallback_reason, request, settings) }}
 
-      {% if not waffle.switch('hide-voting') %}
+      {% if not waffle.switch('hide-voting') and not hide_voting %}
         <div class="vote-wrap">
         {# this extra div is to make the js compatible with old theme. TODO: Remove and fix js. #}
           {{ vote_form(document, 'footer') }}

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -13,7 +13,7 @@ from sumo.tests import TestCase, LocalizingClient
 from sumo.urlresolvers import reverse
 from users.tests import user, add_permission
 from wiki.models import Document
-from wiki.config import VersionMetadata
+from wiki.config import VersionMetadata, TEMPLATES_CATEGORY
 from wiki.tests import (doc_rev, document, helpful_vote, new_document_data,
                         revision)
 from wiki.showfor import _version_groups
@@ -274,6 +274,14 @@ class VoteTests(TestCase):
         """Throw helpful_vote a POST without an ID and see if it 400s."""
         response = self.client.post(reverse('wiki.document_vote', args=['hi']),
                                     {})
+        eq_(400, response.status_code)
+
+    def test_vote_on_template(self):
+        """Throw helpful_vote a document that is a template and see if it 400s."""
+        d = document(save=True, slug="somedoc", category=TEMPLATES_CATEGORY)
+        r = revision(save=True, document=d)
+        response = self.client.post(reverse('wiki.document_vote', args=['hi']),
+                                    {'revision_id': r.id})
         eq_(400, response.status_code)
 
     def test_unhelpful_survey(self):


### PR DESCRIPTION
Here is a change to fix issue 802578 ( https://bugzilla.mozilla.org/show_bug.cgi?id=802578 ). It prevents users from voting on articles that are templates.

This is my first pull request to kitsune, so let me know if something looks off !

thanks
