### PR TITLE
Add password requirements description to registration page

### DIFF
--- a/apps/users/templates/users/includes/macros.html
+++ b/apps/users/templates/users/includes/macros.html
@@ -51,7 +51,7 @@
       <li class="cf">{{ field|label_with_help }} {{ field }}
         {% if field.name == "password"  %}
           <br />
-          <div style="margin-left:170px;margin-top:5px;width:200px"><small>Password should be at least 8 characters long and contain at least 1 number.</small></div>
+          <div id="password-rules">{{ _("Password should be at least 8 characters long and contain at least 1 number.") }}</div>
         {% endif %}
       </li>
       {% endfor %}

--- a/media/less/users.less
+++ b/media/less/users.less
@@ -378,3 +378,10 @@ article {
   font-size: 2em;
   margin: 0 10px 20px;
 }
+
+#password-rules {
+  margin-left: 170px;
+  margin-top: 5px;
+  width: 240px;
+  font-size: 85%;
+}


### PR DESCRIPTION
Very small change to make the registration page more user friendly by letting the user know what type of password is required before they attempt to register.
