### PR TITLE
Make question tag filtering respect other filters.

### DIFF
--- a/apps/questions/templates/questions/questions.html
+++ b/apps/questions/templates/questions/questions.html
@@ -105,6 +105,9 @@
             <p>{{ _('Enter a tag. For example: "Firefox 14.0", "Windows 7", "crash"') }}</p>
             <form action="" method="get">
               <input type="hidden" class="current-tagged" value="{{ tagged }}"/>
+              {% for key, value in request.GET.items() %}
+                <input type="hidden" name="{{ key }}" value="{{ value }}"/>
+              {% endfor %}
               <input class="searchbox" type="text" name="tagged" value="" data-vocabulary="{{ tag_vocab() }}" required="required"/>
               <button type="submit" class="btn">{{ _('Filter Tag') }}</button>
             </form>

--- a/apps/questions/tests/test_templates.py
+++ b/apps/questions/tests/test_templates.py
@@ -1137,6 +1137,10 @@ class QuestionsTemplateTestCase(TestCaseBase):
         assert ('product=%s' % p1.slug) in doc('.sort-by >li > a')[0].attrib['href']
         assert ('product=%s' % p1.slug) in doc('.sort-by >li > a')[1].attrib['href']
 
+        product_input = doc('#tag-filter input[type=hidden][name=product]')
+        eq_(1, len(product_input))
+        eq_(p1.slug, product_input[0].attrib['value'])
+
 
 class QuestionsTemplateTestCaseNoFixtures(TestCase):
     client_class = LocalizingClient


### PR DESCRIPTION
I found this while I was testing adding the product switcher. Tag filtering was ignoring the current query string and discarding everything else.

r?
