### PR TITLE
[bug 824935] Filter searches from product pages.

### DIFF
--- a/apps/products/tests/test_templates.py
+++ b/apps/products/tests/test_templates.py
@@ -58,6 +58,7 @@ class ProductViewsTestCase(ElasticTestCase):
         eq_(200, r.status_code)
         doc = pq(r.content)
         eq_(11, len(doc('#help-topics li')))
+        eq_(p.slug, doc('#support-search input[name=product]').attr['value'])
 
     @mock.patch.object(waffle, 'flag_is_active')
     def test_document_listing(self, flag_is_active):
@@ -87,6 +88,7 @@ class ProductViewsTestCase(ElasticTestCase):
         eq_(200, r.status_code)
         doc = pq(r.content)
         eq_(3, len(doc('#document-list > ul > li')))
+        eq_(p.slug, doc('#support-search input[name=product]').attr['value'])
 
         # GET the page with refine topic and verify the content.
         url = reverse('products.documents', args=[p.slug, t1.slug])
@@ -95,6 +97,7 @@ class ProductViewsTestCase(ElasticTestCase):
         eq_(200, r.status_code)
         doc = pq(r.content)
         eq_(1, len(doc('#document-list > ul > li')))
+        eq_(p.slug, doc('#support-search input[name=product]').attr['value'])
 
     @mock.patch.object(waffle, 'flag_is_active')
     def test_document_listing_order(self, flag_is_active):

--- a/apps/products/views.py
+++ b/apps/products/views.py
@@ -1,13 +1,9 @@
-from django.conf import settings
-from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 
 import jingo
 
-from landings.views import old_products
 from mobility.decorators import mobile_template
 from products.models import Product
-from sumo.urlresolvers import reverse
 from topics.models import Topic, HOT_TOPIC_SLUG
 from wiki.facets import topics_for, documents_for
 
@@ -39,7 +35,8 @@ def product_landing(request, template, slug):
         'products': Product.objects.filter(visible=True),
         'topics': topics_for(products=[product]),
         'hot_docs': hot_docs,
-        'fallback_hot_docs': fallback_hot_docs})
+        'fallback_hot_docs': fallback_hot_docs,
+        'search_params': {'product': slug}})
 
 
 @mobile_template('products/{mobile/}documents.html')
@@ -64,4 +61,5 @@ def document_listing(request, template, product_slug, topic_slug):
         'refine': refine,
         'refine_topics': topics_for(products=[product], topics=[topic]),
         'documents': documents,
-        'fallback_documents': fallback_documents})
+        'fallback_documents': fallback_documents,
+        'search_params': {'product': product_slug}})

--- a/templates/base.html
+++ b/templates/base.html
@@ -123,7 +123,7 @@
       </div>
       <div class="cf">
         {% if not hide_header_search %}
-          {{ search_box(settings, id='support-search') }}
+          {{ search_box(settings, id='support-search', params=search_params) }}
         {% endif %}
         <a href="{{ url('home') }}"><img class="logo" alt="mozilla support" src="{{ MEDIA_URL }}img/mozilla-support.png" /></a>
       </div>


### PR DESCRIPTION
smallish r?

Searching from product landing page (`/products/firefox` for example) and document listing page (`/products/firefox/get-started` for example) will now filter search results by the product selected.
