### PR TITLE
Skip the migration if Redis is not installed.

### DIFF
--- a/migrations/192-remove-old-aoa-stats.py
+++ b/migrations/192-remove-old-aoa-stats.py
@@ -1,14 +1,16 @@
 from django.conf import settings
 
-from sumo.redis_utils import redis_client
+from sumo.redis_utils import redis_client, RedisError
 from customercare.cron import get_customercare_stats
 
+try:
+    print "Removing old data"
+    redis = redis_client(name='default')
+    redis.delete(settings.CC_TOP_CONTRIB_CACHE_KEY)
 
-print "Removing old data"
-redis = redis_client(name='default')
-redis.delete(settings.CC_TOP_CONTRIB_CACHE_KEY)
+    print "Collecting new data."
+    get_customercare_stats()
 
-print "Collecting new data."
-get_customercare_stats()
-
-print "Done"
+    print "Done"
+except RedisError:
+    print "This migration needs Redis to be done."


### PR DESCRIPTION
Hacking HOWTO says that Redis is optional, but
192-remove-old-aoa-stats.py needs Redis to be done.
