### PR TITLE
[826277] Fix deploys on dev.

### DIFF
--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -64,12 +64,14 @@ def checkin_changes(ctx):
 @hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def deploy_app(ctx):
     ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
-    ctx.remote("/bin/touch %s" % settings.REMOTE_WSGI)
+    ctx.remote('service httpd graceful')
+
 
 @hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def prime_app(ctx):
     for http_port in range(80, 82):
         ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:%s/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
+
 
 @hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def update_celery(ctx):


### PR DESCRIPTION
Freddo's environment variables leak into ours. It would be nice if Freddo didn't do this, but this was able to get around the problem for me.

We should test pushing this to stage, to make sure that it doesn't break that deployment process (it shouldn't).

I also added a thing jakem suggested, which is to explicitly restarting apache, instead of just touching the wsgi file, which was kind of unreliable in his experience.

r?
