### PR TITLE
[bug 820010] Override S.__repr__ in Sphilastic

### DIFF
--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -59,6 +59,9 @@ class Sphilastic(S):
         # SUMO uses a unified doctype, so this always returns that.
         return [SUMO_DOCTYPE]
 
+    def __repr__(self):
+        return '<S %s>' % self._build_query()
+
 
 class MappingMergeError(Exception):
     """Represents a mapping merge error"""


### PR DESCRIPTION
This nixes those pesky ValueErrors that get kicked up when calling
repr() on a Sphilastic.

Easy way to test this is by opening `./manage.py shell` and doing this:

```
from questions.models import Question
repr(Question.search())
```

Before the fix, you get a traceback and a ValueError. After the fix, you get this:

```
In [1]: from questions.models import Question

In [2]: repr(Question.search())
Out[2]: "<S {'filter': {'term': {'model': 'questions_question'}}, 'fields': ['id']}>"

In [3]: 
```

r?
