### PR TITLE
[bug 825031] Change chunk size

### DIFF
--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -34,7 +34,7 @@ SUMO_DOCTYPE = u'sumodoc'
 
 # The number of things in a chunk. This is for parallel indexing via
 # the admin.
-CHUNK_SIZE = 50000
+CHUNK_SIZE = 20000
 
 
 log = logging.getLogger('k.search.es')


### PR DESCRIPTION
This drops the chunk size from 50k to 20k. This will increase
the number of indexing chunks that get created and spread the load
across more workers. This will increase the load on ES (more things
being indexed at the same time), but probably shouldn't affect
mysql at all.

As a side note, since we set the chunk size at 50k, mysql got some
upgrades and shifts and is better now and we updated ES to 0.19.11
and it's doing better now, too.

r?
