### PR TITLE
[bug 779502] Fix ES_LIVE_INDEXING issues

### DIFF
--- a/apps/search/management/commands/esreindex.py
+++ b/apps/search/management/commands/esreindex.py
@@ -1,6 +1,7 @@
 from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
+from django.test.utils import override_settings
 
 from search.es_utils import es_reindex_cmd
 from search.utils import FakeLogger
@@ -19,6 +20,9 @@ class Command(BaseCommand):
                     help='Indexes a critical mass of things'),
         )
 
+    # We (ab)use override_settings to force ES_LIVE_INDEXING for the
+    # duration of this command so that it actually indexes stuff.
+    @override_settings(ES_LIVE_INDEXING=True)
     def handle(self, *args, **options):
         percent = options['percent']
         delete = options['delete']

--- a/apps/search/templates/search/admin/search.html
+++ b/apps/search/templates/search/admin/search.html
@@ -187,6 +187,13 @@
         indexing pass unless you really know you want to.
       </p>
     {% endif %}
+    {% if not settings.ES_LIVE_INDEXING %}
+      <p class="errornote">
+        WARNING! <tt>ES_LIVE_INDEXING</tt> is False so you can't
+        reindex via the admin. Either enable <tt>ES_LIVE_INDEXING</tt>
+        or use the command line <tt>./manage.py esreindex</tt>.
+      </p>
+    {% endif %}
     {% if doctype_write_stats != None %}
       <h2>Reindex into existing index</h2>
       <p>
@@ -202,7 +209,7 @@
         {% endfor %}
         <input type="submit" name="reindex"
                value="Reindex into {{ write_index }}"
-               {% if outstanding_chunks %}disabled{% endif %}>
+               {% if not settings.ES_LIVE_INDEXING or outstanding_chunks %}disabled{% endif %}>
       </form>
     {% endif %}
     <h2>DELETE existing index, recreate it and reindex</h2>
@@ -223,7 +230,7 @@
       <input type="hidden" name="delete_index" value="1">
       <input class="DANGER" type="submit" name="reindex"
              value="DELETE index and index into {{ write_index }}"
-             {% if outstanding_chunks %}disabled{% endif %}>
+             {% if not settings.ES_LIVE_INDEXING or outstanding_chunks %}disabled{% endif %}>
     </form>
 
     <h2>RESET scoreboard</h2>


### PR DESCRIPTION
- overrides the setting if you do ./manage.py esreindex figuring
  if you're running that on the command line you really mean it
  for realz srsly.
- puts a big warning note in the admin figuring it's hard to
  override it in the admin without fiddling with a lot of code, but
  a warning is helpful.

r?
