### PR TITLE
Update readme.rst (bug 832766)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,18 @@
 Kitsune
 =======
 
-Kitsune is the platform that powers `Firefox Help`_.
+Kitsune is the platform that powers `SuMo (support.mozilla.org) <https://support.mozilla.org>`_
+
 
 It is a Django_ application. There is documentation_ online.
 
 .. _Firefox Help: https://support.mozilla.org/
 .. _Django: http://www.djangoproject.com/
 .. _documentation: http://kitsune.readthedocs.org/en/latest/
+
+
+
+**Stage site**
+``Please note stage site is the developer site``
+
+You can access stage Live on https://support.allizom.org/


### PR DESCRIPTION
Updated by adding stage and changed the name from firefox help to SuMo

the reason for the change was because it was a issue and we support other products more than firefox now on sumo such as browserid
