### PR TITLE
[8293247] fix broken karma graph due to 500 error on API call

### DIFF
--- a/apps/karma/api.py
+++ b/apps/karma/api.py
@@ -106,6 +106,7 @@ def details(request):
     daterange = form.cleaned_data.get('daterange') or '1y'
     counts = {}
     count_func = mgr.monthly_counts
+    form.cleaned_data.pop('daterange')
     if daterange == '1w':
         count_func = mgr.daily_counts
     for t in KarmaManager.action_types.keys():


### PR DESCRIPTION
The Karma details API call was throwing a 500 error because of multiple arguments to countfunc() named daterange. So, I removed the 'daterange' value from the form data before we call countfunc() to prevent this.

Once this is done, the karma graph shows up
