### PR TITLE
[bug 819755] Track zero search results as Google Analytics event.

### DIFF
--- a/apps/search/templates/search/mobile/results.html
+++ b/apps/search/templates/search/mobile/results.html
@@ -1,11 +1,14 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "mobile/base.html" %}
+{% from "search/basic-form.html" import mobile_results_form with context %}
 {% set title = _('Search') %}
 {% set headline = title %}
 {% set classes = 'results' %}
 {% set styles = ('mobile/search',) %}
 
-{% from "search/basic-form.html" import mobile_results_form with context %}
+{% if num_results == 0 %}
+  {% set ga_push = [['_trackEvent', 'Zero Search Results', q]] %}
+{% endif %}
 
 {% block after_header %}
   <div class="search-bar">

--- a/apps/search/templates/search/results.html
+++ b/apps/search/templates/search/results.html
@@ -5,6 +5,10 @@
 {% from "search/includes/macros.html" import basic_search_form with context %}
 {% set meta = (('WT.oss', q), ('WT.oss_r', num_results)) %}
 
+{% if num_results == 0 %}
+  {% set ga_push = [['_trackEvent', 'Zero Search Results', q]] %}
+{% endif %}
+
 {% block content %}
   <div id="search-results">
     <div class="grid_12">


### PR DESCRIPTION
This was pretty easy after doing the work for custom variables.

r?
