### PR TITLE
Add xx locale for testing

### DIFF
--- a/apps/sumo/tests/test_locale_middleware.py
+++ b/apps/sumo/tests/test_locale_middleware.py
@@ -19,9 +19,9 @@ class TestLocaleMiddleware(TestCase):
                                    HTTP_ACCEPT_LANGUAGE='fr-fr')
         self.assertRedirects(response, '/fr/search', status_code=302)
 
-        # User wants xx, we send en-US
+        # User wants xy (which doesn't exist), we send en-US
         response = self.client.get('/search', follow=True,
-                                   HTTP_ACCEPT_LANGUAGE='xx')
+                                   HTTP_ACCEPT_LANGUAGE='xy')
         self.assertRedirects(response, '/en-US/search', status_code=302)
 
         # User doesn't know what they want, we send en-US
@@ -77,7 +77,7 @@ class BestLanguageTests(TestCase):
         eq_('fr', best)
 
     def test_non_existent(self):
-        best = get_best_language('xx-YY, xx;q=0.8')
+        best = get_best_language('xy-YY, xy;q=0.8')
         eq_(False, best)
 
     def test_prefix_matching(self):
@@ -100,7 +100,7 @@ class NonSupportedTests(TestCase):
         eq_(None, get_non_supported('yy'))
 
     @mock.patch.object(settings._wrapped, 'NON_SUPPORTED_LOCALES',
-                       {'nn-NO': 'no', 'xx': None})
+                       {'nn-NO': 'no', 'xy': None})
     def test_middleware(self):
         response = self.client.get('/nn-NO/home', follow=True)
         self.assertRedirects(response, '/no/home', status_code=302)
@@ -108,5 +108,5 @@ class NonSupportedTests(TestCase):
         response = self.client.get('/nn-no/home', follow=True)
         self.assertRedirects(response, '/no/home', status_code=302)
 
-        response = self.client.get('/xx/home', follow=True)
+        response = self.client.get('/xy/home', follow=True)
         self.assertRedirects(response, '/en-US/home', status_code=302)

--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -301,10 +301,54 @@ By default, this will write all the strings to `apps/sumo/db_strings.py`
 and they will get picked up during the normal string extraction (see below).
 
 
+Testing localized strings
+=========================
+
+When we add strings that need to be localized, it can take a couple of
+weeks for us to get translations of those localized strings. This
+makes it difficult to find localization issues.
+
+Enter poxx.
+
+Requirements:
+
+1. Install polib - ``pip install polib``
+2. Get ``compile-mo.sh``. You can do this by getting the
+   localizations. See :ref:`getting-localizations`.
+
+After getting requirements::
+
+    $ ./scripts/test_locales.sh
+
+It'll extract all the strings, create a ``.pot`` file, then create a
+Pirate translation of all strings. The Pirate strings are available in
+the xx locale. After running the ``test_locales.sh`` script, you can
+access the xx locale with:
+
+    http://localhost:8000/xx/
+
+Strings in the Pirate translation have the following properties:
+
+1. they are longer than the English string: helps us find layout and
+   wrapping issues
+2. they have at least one unicode character: helps us find unicode
+   issues
+3. they are easily discernable from the English versions: helps us
+   find strings that aren't translated
+
+
+.. Note::
+
+   The xx locale is only available on your local machine. It is not
+   available on -dev, -stage, or -prod.
+
+
+.. _getting-localizations:
+
 Getting the Localizations
 =========================
 
-Localizations are not stored in this repository, but are in Mozilla's SVN::
+Localizations are not stored in this repository, but are in Mozilla's SVN:
 
     http://svn.mozilla.org/projects/sumo/locales
 

--- a/lib/languages.json
+++ b/lib/languages.json
@@ -548,5 +548,10 @@
         "iso639_1": null,
         "english": "Songhay",
         "native": "So\u014Bay"
+    },
+    "xx": {
+        "iso639_1": "xx",
+        "english": "Pirate",
+        "native": "Pirate ARrr!"
     }
 }

--- a/scripts/poxx.py
+++ b/scripts/poxx.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Munge a .po file so we English-bound can see what strings aren't
+marked for translation yet.
+
+Run this with a .po file as an argument.  It will set the translated
+strings to be the same as the English, but with vowels in the wrong
+case:
+
+    ./poxx.py locale/xx/LC_MESSAGES/messages.po
+
+This code is in the public domain.
+
+Contributors:
+
+* Ned Batchelder
+* Will Kahn-Greene
+
+"""
+
+import HTMLParser
+import re
+import string
+import sys
+
+try:
+    import polib  # from http://bitbucket.org/izi/polib
+except ImportError:
+    print "You need to install polib.  Do:"
+    print ""
+    print "   pip install polib"
+    sys.exit()
+
+
+DEBUG = False
+
+
+INTERP_RE = re.compile(
+    r'(%(?:[(].+?[)])?[#0 +-]?[.\d*]*[hlL]?[diouxXeEfFgGcrs%])')
+
+
+COLOR = [
+    u'{0} arr!',
+    u'{0}, matey!',
+    u'Ahoy! {0}',
+    u'Aye, {0}',
+    u'Aye, {0} ye scalleywag.',
+    u'Cap\'n, {0}',
+    u'Yo-ho-ho--{0}',
+
+    u'{0}',
+    u'{0}',
+    u'{0}',
+    ]
+
+
+def debug(*args):
+    if DEBUG:
+        print ' '.join([str(arg) for arg in args])
+
+
+def wc(c):
+    return c == "'" or c in string.letters
+
+
+def nwc(c):
+    return not wc(c)
+
+
+# List of transform rules. The tuples have:
+#
+# * in word
+# * not in word
+# * match string
+# * word character
+# * not word character
+# * replacement string
+#
+# See the transform code for details.
+TRANSFORM = (
+    # INW?, NIW?, match, WC?, NW?, replacement
+    # Replace entire words
+    (False, True, "add-on", False, True, "bilge rat"),
+    (False, True, "add-ons", False, True, "bilge rats"),
+    (False, True, "are", False, True, "bee"),
+    (False, True, "browser", False, True, "corsair"),
+    (False, True, "my", False, True, "me"),
+    (False, True, "no", False, True, "nay"),
+    (False, True, "of", False, True, "o'"),
+    (False, True, "over", False, True, "o'er"),
+    (False, True, "plugin", False, True, "mug o' grog"),
+    (False, True, "plugins", False, True, "mugs o' grog"),
+    (False, True, "program", False, True, "Jolly Roger"),
+    (False, True, "the", False, True, "th'"),
+    (False, True, "there", False, True, "tharr"),
+    (False, True, "want", False, True, "wants"),
+    (False, True, "where", False, True, "'erre"),
+    (False, True, "with", False, True, "wit'"),
+    (False, True, "yes", False, True, "aye"),
+    (False, True, "you", False, True, "ye'"),
+    (False, True, "You", False, True, "Ye'"),
+    (False, True, "your", False, True, "yer'"),
+    (False, True, "Your", False, True, "Yer'"),
+
+    # Prefixes
+    (False, True, "hel", True, False, "'el"),
+    (False, True, "Hel", True, False, "'el"),
+
+    # Mid-word
+    (True, False, "er", True, False, "ar"),
+
+    # Suffixes
+    (True, False, "a", False, True, "ar"),
+    (True, False, "ed", False, True, "'d"),
+    (True, False, "ing", False, True, "in'"),
+    (True, False, "ort", False, True, "art"),
+)
+
+
+def pirate_transform(s):
+    old_s = s
+    out = []
+
+    in_word = False  # in a word?
+
+    # TODO: This is awful--better to do a real lexer
+    while s:
+        if s.startswith((".", "!", "?")):
+            in_word = False
+            out.append(s[0])
+            s = s[1:]
+            continue
+
+        debug(s, in_word)
+
+        for mem in TRANSFORM:
+            # Match inside a word? (Not a prefix.)
+            if in_word and not mem[0]:
+                debug(mem, "not in word")
+                continue
+
+            # Not match inside a word? (Prefix.)
+            if not in_word and not mem[1]:
+                debug(mem, "in word")
+                continue
+
+            if not s.startswith(mem[2]):
+                debug(mem, "not match")
+                continue
+
+            # Check the character after the match to see if it's a
+            # word character and whether this match covers that.
+            try:
+                 # WC: word character
+                if mem[3] and not wc(s[len(mem[2])]):
+                    debug(mem, "not wc")
+                    continue
+            except IndexError:
+                # We don't count EOS as a word character.
+                if mem[3]:
+                    debug(mem, "not wc")
+                    continue
+
+            # Check the character after the match to see if it's not a
+            # word character and whether this match covers that.
+            try:
+                # NW: not word character
+                if mem[4] and not nwc(s[len(mem[2])]):
+                    debug(mem, "wc")
+                    continue
+            except IndexError:
+                # We count EOS as a non-word character.
+                if not mem[4]:
+                    debug(mem, "wc")
+                    continue
+
+            out.append(mem[5])
+            s = s[len(mem[2]):]
+            in_word = True
+            break
+
+        else:
+            in_word = wc(s[0])
+            out.append(s[0])
+            s = s[1:]
+
+    # print old_s, "->", out
+    new_s = u"".join(out)
+
+    # This guarantees every translated string has changed and is
+    # longer than the previous string.
+    if old_s == new_s or len(old_s) == len(new_s):
+        new_s = new_s + u"'"
+    return new_s
+
+
+class HtmlAwareMessageMunger(HTMLParser.HTMLParser):
+    def __init__(self):
+        HTMLParser.HTMLParser.__init__(self)
+        self.s = ""
+
+    def result(self):
+        return self.s
+
+    def xform(self, s):
+        return pirate_transform(s)
+
+    def handle_starttag(self, tag, attrs, closed=False):
+        self.s += "<" + tag
+        for name, val in attrs:
+            self.s += " "
+            self.s += name
+            self.s += '="'
+            if name in ['alt', 'title']:
+                self.s += self.xform(val)
+            else:
+                self.s += val
+            self.s += '"'
+        if closed:
+            self.s += " /"
+        self.s += ">"
+
+    def handle_startendtag(self, tag, attrs):
+        self.handle_starttag(tag, attrs, closed=True)
+
+    def handle_endtag(self, tag):
+        self.s += "</" + tag + ">"
+
+    def handle_data(self, data):
+        # We don't want to munge placeholders, so split on them,
+        # keeping them in the list, then xform every other token.
+        toks = INTERP_RE.split(data)
+        for i, tok in enumerate(toks):
+            if i % 2:
+                self.s += tok
+            else:
+                self.s += self.xform(tok)
+
+    def handle_charref(self, name):
+        self.s += "&#" + name + ";"
+
+    def handle_entityref(self, name):
+        self.s += "&" + name + ";"
+
+
+def translate_string(s):
+    hamm = HtmlAwareMessageMunger()
+    hamm.feed(s)
+    out = hamm.result()
+
+    if out.endswith(" >"):
+        out = out[:-2] + u" arr! >"
+    elif out.endswith("\n"):
+        out = out[:-2] + u" arrRRRrrr!\n"
+    else:
+        out = COLOR[len(out) % len(COLOR)].format(out)
+
+    # This guarantees that every string has at least one
+    # unicode charater
+    if "'" not in out:
+        out = out + u"'"
+
+    # Replace all ' with related unicode character.
+    out = out.replace(u"'", u"\u2019")
+    return out
+
+
+def munge_one_file(fname):
+    po = polib.pofile(fname)
+    po.metadata["Language"] = "Pirate"
+    po.metadata["Plural-Forms"] = "nplurals=2; plural= n != 1"
+    po.metadata["Content-Type"] = "text/plain; charset=UTF-8"
+    count = 0
+    for entry in po:
+        if entry.msgid_plural:
+            entry.msgstr_plural["0"] = translate_string(entry.msgid)
+            entry.msgstr_plural["1"] = translate_string(entry.msgid_plural)
+        else:
+            entry.msgstr = translate_string(entry.msgid)
+
+        if 'fuzzy' in entry.flags:
+            entry.flags.remove('fuzzy')  # clear the fuzzy flag
+        count += 1
+    print "Munged %d messages in %s" % (count, fname)
+    po.save()
+
+
+def run_tests():
+    for mem in [
+        "Products and Services",
+        "Get community support",
+        "Your input helps make Mozilla better.",
+        "Super browsing",
+        ]:
+        print repr(mem), '->', repr(pirate_transform(mem))
+
+    return 0
+
+
+if __name__ == "__main__":
+    if '--test' in sys.argv:
+        sys.exit(run_tests())
+
+    for fname in sys.argv[1:]:
+        munge_one_file(fname)

--- a/scripts/test_locales.sh
+++ b/scripts/test_locales.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This creates a faux Pirate locale under xx and transforms all the
+# strings such that every resulting string has four properties:
+#
+# 1. it's longer than the English equivalent (tests layout issues)
+# 2. it's different than the English equivalent (tests missing gettext calls)
+# 3, every string ends up with a non-ascii character (tests unicode)
+# 4. looks close enough to the English equivalent that you can quickly
+#    figure out what's wrong
+#
+# Run this from the project root directory like this:
+#
+# $ scripts/test_locales.sh
+
+echo "create required directories..."
+mkdir -p locale/templates/LC_MESSAGES
+
+echo "extract and merge...."
+./manage.py extract
+./manage.py merge
+
+echo "creating dir...."
+mkdir -p locale/xx/LC_MESSAGES
+
+echo "copying messages.pot file...."
+cp locale/templates/LC_MESSAGES/messages.pot locale/xx/LC_MESSAGES/messages.po
+
+echo "poxx messages.po file...."
+scripts/poxx.py locale/xx/LC_MESSAGES/messages.po
+locale/compile-mo.sh locale/xx/

--- a/settings.py
+++ b/settings.py
@@ -156,12 +156,16 @@ SUMO_LANGUAGES = (
     'tr',
     'uk',
     'vi',
+    'xx',  # This is a test locale
     'zh-CN',
     'zh-TW',
     'zu',
 )
 
-LANGUAGE_CHOICES = tuple([(i, LOCALES[i].native) for i in SUMO_LANGUAGES])
+# Languages that should show up in language switcher.
+LANGUAGE_CHOICES = tuple(
+    [(lang, LOCALES[lang].native) for lang in SUMO_LANGUAGES
+     if lang != 'xx'])
 LANGUAGES = dict([(i.lower(), LOCALES[i].native) for i in SUMO_LANGUAGES])
 
 LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in SUMO_LANGUAGES])

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,9 @@
 {% if request.locale == settings.WIKI_DEFAULT_LANGUAGE and waffle.flag('surveygizmo') %}
   {% set SURVEY_GIZMOS = (SURVEY_GIZMOS or []) + ['site_survey'] %}
 {% endif %}
+{% if request.locale == 'xx' %}
+  {% set meta = [('robots', 'noindex')] %}
+{% endif %}
 <!DOCTYPE html>
 <html class="no-js" lang="{{ request.locale }}" {% if DIR %}dir="{{ DIR }}"{% endif %}>
 <head>


### PR DESCRIPTION
This adds:
1. xx locale which is Pirate
2. scripts/poxx.py which translates a .po file into Pirate
3. scripts/test_locale.sh which extracts strings and runs poxx.py

The xx locale is set up so that it doesn't show up in the language
chooser lists, but you can explicitly specify it in the url:

```
http://localhost:8000/xx/home
```

The locale is only available translated locally--it will show up
as English on -dev, -stage, and -prod. It'll show up as English
if you don't run scripts/test_locale.sh.

This is similar to what I did in Fjord. The Pirate-speak could
use some tweaking, but it's probably good enough for now.

r?
