### PR TITLE
[bug 836288] Add on_delete=SET_NULL to last_post FKs.

### DIFF
--- a/apps/forums/models.py
+++ b/apps/forums/models.py
@@ -40,7 +40,7 @@ class Forum(NotificationsMixin, ModelBase):
     slug = models.SlugField(unique=True)
     description = models.TextField(null=True)
     last_post = models.ForeignKey('Post', related_name='last_post_in_forum',
-                                  null=True)
+                                  null=True, on_delete=models.SET_NULL)
 
     # Dictates the order in which forums are displayed in the forum list.
     display_order = models.IntegerField(default=1, db_index=True)
@@ -105,7 +105,7 @@ class Thread(NotificationsMixin, ModelBase, SearchMixin):
                                    db_index=True)
     creator = models.ForeignKey(User)
     last_post = models.ForeignKey('Post', related_name='last_post_in',
-                                  null=True)
+                                  null=True, on_delete=models.SET_NULL)
     replies = models.IntegerField(default=0)
     is_locked = models.BooleanField(default=False)
     is_sticky = models.BooleanField(default=False, db_index=True)

--- a/apps/forums/tests/test_models.py
+++ b/apps/forums/tests/test_models.py
@@ -164,6 +164,18 @@ class ForumModelTestCase(ForumTestCase):
         f.delete()
         assert not NewThreadEvent.is_notifying('me@me.com', f)
 
+    def test_last_post_creator_deleted(self):
+        """Delete the creator of the last post and verify forum survives."""
+        # Create a post and verify it is the last one in the forum.
+        post_ = post(content="test", save=True)
+        forum_ = post_.thread.forum
+        eq_(forum_.last_post.id, post_.id)
+
+        # Delete the post creator, then check the forum still exists
+        post_.author.delete()
+        forum_ = Forum.objects.get(id=forum_.id)
+        eq_(forum_.last_post, None)
+
 
 class ThreadModelTestCase(ForumTestCase):
     def test_delete_thread_with_last_forum_post(self):


### PR DESCRIPTION
Otherwise, deleting a user that happens to be the author of last
post CASCADES to deleting the thread and/or forum.

r?
