### PR TITLE
[bug 834941] Ignore documents without a current_revision.

### DIFF
--- a/apps/wiki/facets.py
+++ b/apps/wiki/facets.py
@@ -22,6 +22,7 @@ def products_for(topics):
     docs = Document.objects.filter(
         locale=settings.WIKI_DEFAULT_LANGUAGE,
         is_archived=False,
+        current_revision__isnull=False,
         category__in=settings.IA_DEFAULT_CATEGORIES)
 
     for topic in topics:
@@ -41,6 +42,7 @@ def topics_for(products, topics=None):
     docs = Document.objects.filter(
         locale=settings.WIKI_DEFAULT_LANGUAGE,
         is_archived=False,
+        current_revision__isnull=False,
         category__in=settings.IA_DEFAULT_CATEGORIES)
 
     for product in products:
@@ -136,9 +138,11 @@ def _es_documents_for(locale, topics, products=None):
 
 def _db_documents_for(locale, topics, products=None):
     """DB implementation of topics_for."""
-    qs = (Document.objects
-        .filter(locale=locale, is_archived=False,
-                category__in=settings.IA_DEFAULT_CATEGORIES))
+    qs = Document.objects.filter(
+        locale=locale,
+        is_archived=False,
+        current_revision__isnull=False,
+        category__in=settings.IA_DEFAULT_CATEGORIES)
     for topic in topics:
         qs = qs.filter(topics=topic)
     for product in products or []:

--- a/apps/wiki/tests/test_facets.py
+++ b/apps/wiki/tests/test_facets.py
@@ -49,6 +49,15 @@ class TestFacetHelpersMixin(object):
         doc4.topics.add(self.bookmarks)
         doc4.products.add(self.desktop)
 
+        # An article without current revision should be "invisible"
+        # to everything.
+        doc5 = revision(is_approved=False, save=True).document
+        doc5.topics.add(self.general)
+        doc5.topics.add(self.bookmarks)
+        doc5.topics.add(self.sync)
+        doc5.products.add(self.desktop)
+        doc5.products.add(self.mobile)
+
 
 class TestFacetHelpers(TestCase, TestFacetHelpersMixin):
     def setUp(self):


### PR DESCRIPTION
When building products, topics and document lists.

r?
