### PR TITLE
Increase delta to make test more likely to pass on ci

### DIFF
--- a/apps/kbforums/tests/test_models.py
+++ b/apps/kbforums/tests/test_models.py
@@ -61,14 +61,15 @@ class KBSaveDateTestCase(KBForumTestCase):
     and updated dates.
     """
 
-    delta = datetime.timedelta(milliseconds=300)
+    delta = datetime.timedelta(milliseconds=600)
 
     def setUp(self):
         super(KBSaveDateTestCase, self).setUp()
 
         self.user = user(save=True)
         self.doc = document(save=True)
-        self.thread = thread(save=True)
+        self.thread = thread(created=datetime.datetime(2010, 1, 12, 9, 48, 23),
+                             save=True)
 
     def assertDateTimeAlmostEqual(self, a, b, delta, msg=None):
         """


### PR DESCRIPTION
Jenkins semi-regularly fails these tests because the times end up just
outside the delta. The tests are for making sure that the fields get
auto updated. It doesn't really matter a whole lot if the delta
is minute or not.

This doesn't break any tests and I'm pretty sure it doesn't cause
any tests to be logically wrong, either.

r?
