### PR TITLE
[Bug 827645] Filter link autocompletion by locale.

### DIFF
--- a/media/js/markup.js
+++ b/media/js/markup.js
@@ -451,7 +451,8 @@ Marky.LinkButton.prototype = $.extend({}, Marky.SimpleButton.prototype, {
                     format: 'json',
                     q: request.term,
                     a: 1,
-                    w: 1
+                    w: 1,
+                    language: $('html').attr('lang')
                 },
                 dataType: 'json',
                 success: function(data, textStatus) {


### PR DESCRIPTION
To test: in the KB editor and the forum editor, click on the chain link icon to insert a new link. Type the name of a KB article (or just type something super common like "firefox"). Observe that the suggestions are only in the current locale. Switch locales. Do it again. Approve this PR.

r?
