### PR TITLE
[Bug 799411] "1 replies" in the plural in discussions and forum threads 

### DIFF
--- a/apps/forums/templates/forums/posts.html
+++ b/apps/forums/templates/forums/posts.html
@@ -65,7 +65,7 @@
   <article id="posts" class="grid_9">
     <h1 class="nomargin">{{ thread.title }}</h1>
     <ul class="cf" id="thread-meta">
-      {% if count %}<li>{{ count - 1 }} {{ _('Replies') }}</li>{% endif %}
+      {% if count %}<li>{{ ngettext('{0} Reply','{0} Replies',(count-1))|f(count-1) }}</li>{% endif %}
       {% if last_post %}<li>{{ _('Last reply by') }} {{ last_post.author }}</li>{% endif %}
       {% if thread.is_sticky %}<li>{{ _('Sticky') }}</li>{% endif %}
       {% if thread.is_locked %}<li>{{ _('Locked') }}</li>{% endif %}


### PR DESCRIPTION
changed _('Replies') with ngettext('{0} Reply','{0} Replies',(count-1))|f(count-1)
