### PR TITLE
[Bug 827650] test mythmon's first commit independent of the pair of 'em

### DIFF
--- a/apps/questions/models.py
+++ b/apps/questions/models.py
@@ -339,7 +339,9 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
             'question_num_votes': {'type': 'integer'},
             'question_num_votes_past_week': {'type': 'integer'},
             'question_answer_votes': {'type': 'integer'},
-            'question_tag': {'type': 'string', 'index': 'not_analyzed'}}
+            'question_tag': {'type': 'string', 'index': 'not_analyzed'},
+            'question_locale': {'type': 'string', 'index': 'not_analyzed'},
+            }
 
     @classmethod
     def extract_document(cls, obj_id):
@@ -350,7 +352,7 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
         obj = cls.uncached.values(
             'id', 'title', 'content', 'num_answers', 'solution_id',
             'is_locked', 'created', 'updated', 'num_votes_past_week',
-            'creator__username').get(pk=obj_id)
+            'creator__username', 'locale').get(pk=obj_id)
 
         d = {}
         d['id'] = obj['id']
@@ -393,6 +395,8 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
 
         d['question_tag'] = list(TaggedItem.tags_for(
             Question, Question(pk=obj_id)).values_list('name', flat=True))
+
+        d['question_locale'] = obj['locale']
 
         answer_values = list(Answer.objects
                                    .filter(question=obj_id)

--- a/settings.py
+++ b/settings.py
@@ -782,7 +782,7 @@ ES_HOSTS = ['127.0.0.1:9200']
 ES_INDEXES = {'default': 'sumo-20121227'}
 # Indexes for indexing--set this to ES_INDEXES if you want to read to
 # and write to the same index.
-ES_WRITE_INDEXES = ES_INDEXES
+ES_WRITE_INDEXES = {'default': 'sumo-20130205'}
 # This is prepended to index names to get the final read/write index
 # names used by kitsune. This is so that you can have multiple
 # environments pointed at the same ElasticSearch cluster and not have


### PR DESCRIPTION
Mythmon wanted to test the first commit alone in addition to the second, but wanted a complicated solution instead of `git checkout -b some-other-branch`, rebase the top commit off, and open a new pull request just so leeroy can test.

If this is going to be a common occurrence there is a config flag to test every commit that can be changed on a per project basis. Let me know if you want it changed.
