### PR TITLE
[Bug 841161] Fix lightbox links.

### DIFF
--- a/media/js/upload.js
+++ b/media/js/upload.js
@@ -112,7 +112,7 @@ $(document).ready(function () {
 
     // hijack the click on the thumb and open modal kbox
     function initImageModal() {
-        $('article').delegate('.attachments-list a.image', 'click', function(ev) {
+        $('article').on('click', '.attachments-list a.image', function(ev) {
             ev.preventDefault();
             var imgUrl = $(this).attr('href');
                 image = new Image(),


### PR DESCRIPTION
Tobbi's crash report linker caused the dom to be rebuilt when the regex replaced content. This was breaking click event bindings on any element. I couldn't think of an easy way to do the crash better, so I moved the binding for the lightbox trigger a little farther up the dom.

@Tobbi helped find this, thanks!

r?
