### PR TITLE
[Bug 841851] Don't disable troubleshooting info.

### DIFF
--- a/media/js/aaq.js
+++ b/media/js/aaq.js
@@ -144,7 +144,7 @@ AAQSystemInfo.prototype = {
                 // This parse/stringify trick makes `json` pretty printed.
                 json = JSON.parse(json);
                 json = JSON.stringify(json, null, "  ");
-                $('#id_troubleshooting').val(json).prop('disabled', true);
+                $('#id_troubleshooting').val(json);
                 $('#troubleshooting-manual').remove();
                 $('#troubleshooting-explanation').show();
             });


### PR DESCRIPTION
Doing this makes it not get submitted. Maybe this is something we did, but either way this is a simple fix. It might even be better for the user, because maybe they will want to remove data from it.

I'm not sure if this is because I don't know how to internet anymore, or because we have some weird JS that only grabs enabled forms. I spend a while looking around for something, but didn't find anything.

Also this reveals that we **do** show troubleshooting data, but now that we have JSON blobs, it is really ugly. I will update [bug 836321](https://bugzilla.mozilla.org/show_bug.cgi?id=836321) accordingly.

r?
