### PR TITLE
Add Firefox 21, default to Firefox 19.

### DIFF
--- a/apps/wiki/config.py
+++ b/apps/wiki/config.py
@@ -26,12 +26,14 @@ VersionMetadata = namedtuple('VersionMetadata',
                              'id, name, long, slug, max_version, show_in_ui, '
                              'is_default')
 DESKTOP_FIREFOX_VERSIONS = (
+    VersionMetadata(37, _lazy(u'Firefox 21'),
+                    _lazy(u'Firefox 21'), 'fx21', 21.9999, True, False),
     VersionMetadata(35, _lazy(u'Firefox 20'),
                     _lazy(u'Firefox 20'), 'fx20', 20.9999, True, False),
     VersionMetadata(33, _lazy(u'Firefox 19'),
-                    _lazy(u'Firefox 19'), 'fx19', 19.9999, True, False),
+                    _lazy(u'Firefox 19'), 'fx19', 19.9999, True, True),
     VersionMetadata(31, _lazy(u'Firefox 18'),
-                    _lazy(u'Firefox 18'), 'fx18', 18.9999, True, True),
+                    _lazy(u'Firefox 18'), 'fx18', 18.9999, True, False),
     VersionMetadata(29, _lazy(u'Firefox 17'),
                     _lazy(u'Firefox 17'), 'fx17', 17.9999, True, False),
     VersionMetadata(27, _lazy(u'Firefox 16'),
@@ -66,12 +68,14 @@ DESKTOP_FIREFOX_VERSIONS = (
     VersionMetadata(3, _lazy(u'Firefox 3.0'),
                     _lazy(u'Firefox 3.0'), 'fx3', 3.4999, False, False))
 MOBILE_FIREFOX_VERSIONS = (
+    VersionMetadata(36, _lazy(u'Firefox 21'), _lazy(u'Firefox 21 for Mobile'),
+                    'm21', 21.9999, True, False),
     VersionMetadata(34, _lazy(u'Firefox 20'), _lazy(u'Firefox 20 for Mobile'),
                     'm20', 20.9999, True, False),
     VersionMetadata(32, _lazy(u'Firefox 19'), _lazy(u'Firefox 19 for Mobile'),
-                    'm19', 19.9999, True, False),
+                    'm19', 19.9999, True, True),
     VersionMetadata(30, _lazy(u'Firefox 18'), _lazy(u'Firefox 18 for Mobile'),
-                    'm18', 18.9999, True, True),
+                    'm18', 18.9999, True, False),
     VersionMetadata(28, _lazy(u'Firefox 17'), _lazy(u'Firefox 17 for Mobile'),
                     'm17', 17.9999, True, False),
     VersionMetadata(26, _lazy(u'Firefox 16'), _lazy(u'Firefox 16 for Mobile'),


### PR DESCRIPTION
Pretty sure this is right, but I've never done this before and I couldn't find any docs for it.

I'm basing the changes on commits b12b024 and b4c0f5e7 .

r?
