### PR TITLE
[Bug 827651] Localize questions list.

### DIFF
--- a/apps/questions/views.py
+++ b/apps/questions/views.py
@@ -149,6 +149,14 @@ def questions(request, template):
         # correct id.
         question_qs = question_qs.filter(products__id__exact=product.id)
 
+    # Filter by locale for AAQ locales, and by locale + default for others.
+    if request.LANGUAGE_CODE in settings.AAQ_LANGUAGES:
+        question_qs = question_qs.filter(locale=request.LANGUAGE_CODE)
+    else:
+        locale_query = Q(locale=request.LANGUAGE_CODE)
+        locale_query |= Q(locale=settings.WIKI_DEFAULT_LANGUAGE)
+        question_qs = question_qs.filter(locale_query)
+
     # Set the order.
     question_qs = question_qs.order_by(*order)
 


### PR DESCRIPTION
This filters questions to only the current language for locales that have opted-in to AAQ localization. For languages that have not opted in, it filters by English and by the current Locale, so they don't see questions specifically marked for other locales.

I chose this because it most closely duplicates the current behavior of the question list for non-AAQ locales. Before AAQ localization, questions in the question list would show only English, because that was the only available locale. This duplicates that behavior.

I'm not 100% sure if this is the right thing to do, or if non-AAQ locales should be shown an unfiltered question list.

r?
