### PR TITLE
[Bug 843766] django.conf.urls.defaults is deprecated.

### DIFF
--- a/apps/announcements/urls.py
+++ b/apps/announcements/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns('announcements.views',

--- a/apps/chat/urls.py
+++ b/apps/chat/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('chat.views',
     url(r'^$', 'chat', name='chat.home'),

--- a/apps/customercare/urls.py
+++ b/apps/customercare/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('customercare.views',
     url(r'^/more_tweets$', 'more_tweets', name="customercare.more_tweets"),

--- a/apps/dashboards/urls.py
+++ b/apps/dashboards/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns('dashboards.views',

--- a/apps/flagit/urls.py
+++ b/apps/flagit/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('flagit.views',
     url(r'^$', 'queue', name='flagit.queue'),

--- a/apps/forums/urls.py
+++ b/apps/forums/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from forums.feeds import ThreadsFeed, PostsFeed
 
 urlpatterns = patterns('forums.views',

--- a/apps/gallery/urls.py
+++ b/apps/gallery/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from sumo.views import redirect_to
 

--- a/apps/groups/urls.py
+++ b/apps/groups/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 
 
 group_patterns = patterns('groups.views',

--- a/apps/inproduct/urls.py
+++ b/apps/inproduct/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from inproduct import views
 

--- a/apps/karma/urls.py
+++ b/apps/karma/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 
 
 api_patterns = patterns('karma.api',

--- a/apps/kbforums/urls.py
+++ b/apps/kbforums/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.contrib.contenttypes.models import ContentType
 
 from kbforums.feeds import ThreadsFeed, PostsFeed

--- a/apps/kpi/urls.py
+++ b/apps/kpi/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 
 from kpi.api import (QuestionsResource, VoteResource,
                      ActiveContributorsResource, ElasticClickthroughResource,

--- a/apps/landings/urls.py
+++ b/apps/landings/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from sumo.views import redirect_to
 

--- a/apps/messages/urls.py
+++ b/apps/messages/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from messages import views
 

--- a/apps/postcrash/urls.py
+++ b/apps/postcrash/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from postcrash import views
 

--- a/apps/products/urls.py
+++ b/apps/products/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('products.views',
     url(r'^$', 'product_list', name='products'),

--- a/apps/questions/urls.py
+++ b/apps/questions/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.contrib.contenttypes.models import ContentType
 
 from questions.feeds import QuestionsFeed, AnswersFeed, TaggedQuestionsFeed

--- a/apps/search/urls.py
+++ b/apps/search/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns('search.views',

--- a/apps/sumo/urls.py
+++ b/apps/sumo/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 from django.views.generic.base import RedirectView
 
 from sumo import views

--- a/apps/topics/urls.py
+++ b/apps/topics/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('topics.views',
     url(r'^/(?P<slug>[^/]+)$', 'topic_landing', name='topics.topic'),

--- a/apps/upload/urls.py
+++ b/apps/upload/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('upload.views',
     url(r'^/image/(?P<model_name>\w+\.\w+)/(?P<object_pk>\d+)$',

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 from django.contrib.contenttypes.models import ContentType
 
 from sumo.views import redirect_to

--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 
 from wiki import locale_views
 from wiki.locale_views import LEADER, REVIEWER, EDITOR

--- a/urls.py
+++ b/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import include, patterns, url
+from django.conf.urls import include, patterns, url
 from django.conf import settings
 from django.contrib import admin
 from django.views.i18n import javascript_catalog


### PR DESCRIPTION
Use django.conf.urls instead.

https://bugzilla.mozilla.org/show_bug.cgi?id=843766
