### PR TITLE
Fix admin login page

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls.defaults import include, patterns, url
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth.decorators import login_required
 from django.views.i18n import javascript_catalog
 from django.views.decorators.cache import cache_page
 
@@ -11,6 +12,7 @@ from waffle.views import wafflejs
 
 admin.site = AdminSitePlus()
 admin.autodiscover()
+admin.site.login = login_required(admin.site.login)
 authority.autodiscover()
 
 urlpatterns = patterns('',


### PR DESCRIPTION
This fixes the admin login page so we never ever see it and/or get stuck
there and have to manually type in a url into the urlbar.

To test
1. `./manage.py runserver`
2. make sure you're not signed in
3. go to `/admin`
4. notice how it redirects you to the CORRECT login page -- rejoice!
5. login and notice how it bumps you to the admin immediately -- rejoice!
6. logout and notice how you go back to the CORRECT login page -- rejoice!
7. do a happy dance

r?
