### PR TITLE
[Bug 844933] Only accept troubleshooting dicts.

### DIFF
--- a/apps/questions/tests/test_templates.py
+++ b/apps/questions/tests/test_templates.py
@@ -638,7 +638,8 @@ class AnswersTemplateTestCase(TestCaseBase):
         eq_(200, response.status_code)
 
     def test_weird_list_troubleshooting_info(self):
-        """Test this corner case."""
+        """Test the corner case in which 'modifiedPReferences' is in a
+        list in troubleshooting data. This is weird, but caused a bug."""
         q = question(save=True)
         q.add_metadata(troubleshooting='["modifiedPreferences"]')
 

--- a/apps/questions/views.py
+++ b/apps/questions/views.py
@@ -215,7 +215,7 @@ def answers(request, template, question_id, form=None, watch_form=None,
     # Try to parse troubleshooting data as JSON.
     try:
         parsed = json.loads(question.metadata['troubleshooting'])
-        if type(parsed) != dict:
+        if not isinstance(parsed, dict):
             # If something not a dict comes out of JSON, it is probably
             # a list, and should not be treated like parsed data.
             raise TypeError


### PR DESCRIPTION
There is apparently some questions in SUMO that have this data as a list that contained the string 'modifedPreferenes', which caused errors. Being specific about the type will prevent this kind of error.

r?
