### PR TITLE
[bug 845165] Allow email changes if you're not logged in

### DIFF
--- a/apps/users/templates/users/change_email_complete.html
+++ b/apps/users/templates/users/change_email_complete.html
@@ -6,8 +6,12 @@
   {% set title = _('Email changed for user {username}')|f(username=username) %}
 {% endif %}
 {% set classes = 'register' %}
-{% set crumbs = [(profile_url(user), user.username),
-                 (None, title)] %}
+{% if user.is_authenticated() %}
+  {% set crumbs = [(profile_url(user), user.username),
+                   (None, title)] %}
+{% else %}
+  {% set crumbs = [] %}
+{% endif %}
 
 {% block content %}
   <div class="grid_9">


### PR DESCRIPTION
The template errored out if you weren't logged in, but when you're
changing your email address, you request the change, then wait for
the email with the link, then click on the link--there's no guarantee
that the user is logged in.

This nixes the crumbs if the user is not logged in thus alleviating
the error.

To test:
1. log in with some account
2. in Edit Profile, opt to change your email address
3. change it to something really clever like "ou812@example.com"
4. that'll print the confirm email link in the console
5. open up either a private window or a new instance of the browser with a different profile so you're guaranteed not to be logged in
6. copy and paste the confirm email link into the new window substituting appropriate things so it works locally

Without the fix, that fails epically. Oops!

With the fix, you get the "yo dawg! yer email change is confirmed!" page.

r?
