### PR TITLE
[bug 845582] Implement ReadOnlyBackend

### DIFF
--- a/apps/sumo/readonlyauth.py
+++ b/apps/sumo/readonlyauth.py
@@ -1,0 +1,26 @@
+class ReadOnlyBackend(object):
+    """Django auth backend for readonly mode
+
+    The whole purpose of this is to reject everything.  It should
+    implement all the methods that
+    django.contrib.auth.backends.ModelBackend has.
+
+    """
+
+    def authenticate(self, *args, **kwargs):
+        return None
+
+    def get_group_permissions(self, *args, **kwargs):
+        return set()
+
+    def get_all_permissions(self, *args, **kwargs):
+        return set()
+
+    def has_perm(self, *args, **kwargs):
+        return False
+
+    def has_module_perms(self, *args, **kwargs):
+        return False
+
+    def get_user(self, *args, **kwargs):
+        return None

--- a/settings.py
+++ b/settings.py
@@ -878,7 +878,7 @@ def read_only_mode(env):
     env['DATABASES']['default'] = env['DATABASES'][slave]
 
     # No sessions without the database, so disable auth.
-    env['AUTHENTICATION_BACKENDS'] = ()
+    env['AUTHENTICATION_BACKENDS'] = ('sumo.readonlyauth.ReadOnlyBackend',)
 
     # Add in the read-only middleware before csrf middleware.
     extra = 'sumo.middleware.ReadOnlyMiddleware'


### PR DESCRIPTION
Instead of wiping out all AUTHENTICATION_BACKENDS which kicks up tons
of errors, this changes read_only_mode to use the brand new
ReadOnlyBackend which categorically rejects everything.

How to test:
1. run kitsune locally and log in with a non-superuser account
2. shut down kitsune locally, then put it in read only mode by adding `read_only_mode(globals())` to the bottom of your `settings_local.py` file
3. run kitsune locally again (now in readonly mode) and try to use the site--ERRORZ!
4. apply this patch
5. run kitsune locally again (now in readonly mode with the patch) and try to use the site--AWESOME!

One note is that I had to nix the lines in the `read_only_mode` function regarding slave databases since I didn't have that set up on my machine and didn't feel like figuring it out right now.

One problem with this is if permissions get cached on user objects. So if we go into readonly mode and then come out, will those user objects in cache all have no permissions?

r?
