### PR TITLE
[bug 694941] Add UI to insert images in the contributor forums.

### DIFF
--- a/media/js/forums.js
+++ b/media/js/forums.js
@@ -7,7 +7,11 @@
 (function($){
 
     function init() {
-        Marky.createSimpleToolbar('.editor-tools', '#reply-content, #id_content');
+        Marky.createSimpleToolbar(
+            '.editor-tools',
+            '#reply-content, #id_content',
+            {mediaButton: true});
+
         new k.AjaxPreview($('#preview'));
 
         $('span.post-action a.reply').click(function() {
@@ -26,6 +30,8 @@
             return true;
         });
         watchDiscussion();
+
+        $('img.lazy').lazyload();
     }
     function watchDiscussion() {
         // For a thread on the all discussions for a locale.

--- a/media/js/markup.js
+++ b/media/js/markup.js
@@ -47,6 +47,9 @@ var Marky = {
             new SB(gettext('Bulleted List'), '* ', '',
                    gettext('Bulleted list item'), 'btn-ul', true)
         ];
+        if (settings.mediaButton) {
+            buttons.splice(4, 0, new Marky.MediaButton());
+        }
         if (settings.cannedResponses) {
             buttons.push(new Marky.Separator(),
                          new Marky.CannedResponsesButton());

--- a/media/less/forums.less
+++ b/media/less/forums.less
@@ -178,6 +178,10 @@
         margin: 1.5em;
         padding: 1em;
       }
+
+      img {
+        max-width: 100%;
+      }
     }
 
     .content-raw {
@@ -358,4 +362,11 @@
 
 .warning-box {
   margin-top: 0;
+}
+
+/* We don't support inserting videos in the forums */
+#media-modal {
+  li[data-type=video] {
+    display: none;
+  }
 }

--- a/settings.py
+++ b/settings.py
@@ -663,6 +663,7 @@ MINIFY_BUNDLES = {
             'js/search.js',
         ),
         'forums': (
+            'js/libs/jquery.lazyload.js',
             'js/markup.js',
             'js/ajaxpreview.js',
             'js/forums.js',


### PR DESCRIPTION
(/forums)

It turns out we were just missing the UI for easily inserting images in the forums. I add the Insert Media button to the editor toolbar for the forums, hide the link for videos since that isn't supported, tweak the img css and add the lazyload script to the forums.

That's about it! I'll revise the bug to 1pt.

r?
