### PR TITLE
Import document_tools with context for csrf.

### DIFF
--- a/apps/kbforums/templates/kbforums/base.html
+++ b/apps/kbforums/templates/kbforums/base.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% from 'includes/common_macros.html' import for_contributors_sidebar %}
 {% set styles = ('forums',) %}
 {% set scripts = ('forums',) %}

--- a/apps/wiki/templates/wiki/compare_revisions.html
+++ b/apps/wiki/templates/wiki/compare_revisions.html
@@ -1,7 +1,7 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
-{% from "wiki/includes/document_macros.html" import revision_diff, document_watch with context %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
+{% from "wiki/includes/document_macros.html" import revision_diff with context %}
 {% set title = _('Compare Revisions | {document}')|f(document=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  (None, _('Compare Revisions'))] %}

--- a/apps/wiki/templates/wiki/confirm_document_delete.html
+++ b/apps/wiki/templates/wiki/confirm_document_delete.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% if delete_confirmed %}
   {% set title = _('Document Deleted | {document}')|f(document=document.title) %}
 {% else %}

--- a/apps/wiki/templates/wiki/confirm_remove_contributor.html
+++ b/apps/wiki/templates/wiki/confirm_remove_contributor.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% set title = _('Remove contributor | {document}')|f(document=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  (None, _('Remove Contributor'))] %}

--- a/apps/wiki/templates/wiki/confirm_revision_delete.html
+++ b/apps/wiki/templates/wiki/confirm_revision_delete.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% set title = _('Delete Revision | {document}')|f(document=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  (None, _('Delete Revision'))] %}

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -3,7 +3,7 @@
 {% from "wiki/includes/sidebar_modules.html" import document_tools, document_notifications with context %}
 {% from 'topics/includes/topic_macros.html' import topic_sidebar %}
 {% from "wiki/includes/document_macros.html" import contributor_list, document_title, document_messages, document_content, topic_list %}
-{% from "wiki/includes/document_macros.html" import related_articles, show_for, vote_form, document_watch with context %}
+{% from "wiki/includes/document_macros.html" import related_articles, show_for, vote_form with context %}
 {% set classes = 'document' %}
 {% set canonical_url = document.get_absolute_url() %}
 {% set scripts = ('wiki', 'readtracker') %}

--- a/apps/wiki/templates/wiki/edit.html
+++ b/apps/wiki/templates/wiki/edit.html
@@ -1,10 +1,9 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
 {% from "layout/errorlist.html" import errorlist %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% from "includes/common_macros.html" import content_editor %}
 {% from "wiki/includes/document_macros.html" import edit_messages, submit_revision %}
-{% from "wiki/includes/document_macros.html" import document_watch with context %}
 {% from "wiki/includes/document_macros.html" import document_lock_warning with context %}
 {% set title = _('Edit Article | {document}')|f(document=document.title) %}
 {# TODO: Change KB url to landing page when we have one #}

--- a/apps/wiki/templates/wiki/history.html
+++ b/apps/wiki/templates/wiki/history.html
@@ -1,7 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
-{% from "wiki/includes/document_macros.html" import document_watch with context %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% from "layout/errorlist.html" import errorlist %}
 {% set scripts = ('wiki', 'libs/jqueryui', 'wiki.history', 'highcharts') %}
 {% set meta = (('robots', 'noindex'),) %}

--- a/apps/wiki/templates/wiki/includes/sidebar_modules.html
+++ b/apps/wiki/templates/wiki/includes/sidebar_modules.html
@@ -98,7 +98,7 @@
             <li{% if active == 'localize' %} class="selected"{% endif %}>
               <a href="{{ url('wiki.translate', parent.slug) }}">{{ _('Translate Article') }}</a>
             </li>
-          {% endif %}          
+          {% endif %}
           {% if document and parent and parent.is_localizable %}
             <li{% if active == 'show_translations' %} class="selected"{% endif %}> 
               <a href="{{ url('wiki.show_translations', parent.slug) }}">{{ _('Show Translations') }}</a>

--- a/apps/wiki/templates/wiki/review_revision.html
+++ b/apps/wiki/templates/wiki/review_revision.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% from "wiki/includes/document_macros.html" import show_for, revision_diff with context %}
 {% set title = _('Review Revision {id} | {document}')|f(document=document.title, id=revision.id) %}
 {% set crumbs = [(document.get_absolute_url(), document.title), (None, 'Review Revision')] %}

--- a/apps/wiki/templates/wiki/review_translation.html
+++ b/apps/wiki/templates/wiki/review_translation.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% from "wiki/includes/document_macros.html" import show_for, revision_diff with context %}
 {% set title = _('Review Translation {id} | {document}')|f(document=document.parent.title, id=revision.id) %}
 {% set crumbs = [(document.get_absolute_url(), document.title), (None, 'Review Translation')] %}

--- a/apps/wiki/templates/wiki/revision.html
+++ b/apps/wiki/templates/wiki/revision.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% from "wiki/includes/document_macros.html" import show_for with context %}
 {# L10n: {n} is the revision number, {t} is the title of the document. {c} is the category. #}
 {% set title = _('Revision {n} | {t} | {c}')|f(n=revision.id, t=document.title, c=document.get_category_display()) %}

--- a/apps/wiki/templates/wiki/select_locale.html
+++ b/apps/wiki/templates/wiki/select_locale.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% set title = _('Select language | {document}')|f(document=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  (None, _('Select language'))] %}

--- a/apps/wiki/templates/wiki/show_translations.html
+++ b/apps/wiki/templates/wiki/show_translations.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% set title = _('Show translations | {document}')|f(document=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  (None, _('Show translations'))] %}

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -1,7 +1,7 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
 {% from "layout/errorlist.html" import errorlist %}
-{% from "wiki/includes/sidebar_modules.html" import document_tools %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
 {% from "includes/common_macros.html" import content_editor %}
 {% from "wiki/includes/document_macros.html" import revision_diff, submit_revision, edit_messages with context %}
 {% from "wiki/includes/document_macros.html" import document_lock_warning with context %}


### PR DESCRIPTION
Discovered this missing CSRF token issue while testing willkgs pull 1177. We need to import `document_tools` with context for the csrf token to be rendered in the form.

r?
