### PR TITLE
[bug 851532] Make OS and Fx version selectors behave more like select boxes

### DIFF
--- a/media/less/wiki.less
+++ b/media/less/wiki.less
@@ -60,6 +60,11 @@ article {
   }
 }
 
+#os_input,
+#browser_input {
+  cursor: pointer;
+}
+
 .wait {
   display: none;
 }


### PR DESCRIPTION
I wasn't able to remove the caret from the field without sacrificing the actual dropdown menu.

r?
