### PR TITLE
[bug853100] CrashIDs don't get auto linked in certain situations

### DIFF
--- a/media/js/questions.js
+++ b/media/js/questions.js
@@ -204,15 +204,15 @@
         if(!container) {
             return;
         }
-        var crashIDRegex = new RegExp("([^{])(bp-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})([^}])", "g");
+        var crashIDRegex = new RegExp("(bp-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})", "g");
         var crashStatsBase = "https://crash-stats.mozilla.com/report/index/";
         var helpingWithCrashesArticle = "/kb/helping-crashes";
         var iconPath = "/media/img/questions/icon.questionmark.png";
         var crashReportContainer =
-            "$1<span class='crash-report'>" +
-            "<a href='" + crashStatsBase + "$2' target='_blank'>$2</a>" +
+            "<span class='crash-report'>" +
+            "<a href='" + crashStatsBase + "$1' target='_blank'>$1</a>" +
             "<a href='" + helpingWithCrashesArticle + "' target='_blank'>" +
-            "<img src='" + iconPath + "'></img></a></span>$3";
+            "<img src='" + iconPath + "'></img></a></span>";
 
         container.html(
             container.html().replace(crashIDRegex,


### PR DESCRIPTION
I think I had a reason for using that first and last regex group...Anyway, removing it now.

r?
