### PR TITLE
CSS fix to radio buttons on article history page.

### DIFF
--- a/media/less/wiki.less
+++ b/media/less/wiki.less
@@ -365,7 +365,12 @@ article {
 
   .radio {
     text-align: center;
+    padding: 0 0 0 2px;
     width: 15px;
+
+    input {
+      margin: 0;
+    }
   }
 
   .date {


### PR DESCRIPTION
One of our recent style changes screwed up the radio buttons and they sort became slightly hidden from click events. See http://people.mozilla.org/~mverdi/screenshots/radiobutton-20130405-111446.jpg

This fixes that.

r?
