### PR TITLE
 [bug 859361] Display article category on article history page

### DIFF
--- a/apps/wiki/templates/wiki/history.html
+++ b/apps/wiki/templates/wiki/history.html
@@ -13,21 +13,20 @@
   <div class="grid_9">
     <article id="revision-history">
       <h1 class="title">{{ _('History of {title}')|fe(title=document.title) }}</h1>
-
       <div class="grid_2">
-          {{ _('Category:') }}
+        {{ _('Category:') }}
       </div>
       <div class="grid_6">
-          <a href="{{ url('wiki.category', document.category) }}">{{ document.get_category_display() }}</a>
+        <a href="{{ url('wiki.category', document.category) }}">{{ document.get_category_display() }}</a>
       </div>
       <div class="grid_2">
-          {{ _('Revision history for:') }}
+        {{ _('Revision history for:') }}
       </div>
       <div class="grid_6">
-          {% if document.parent %}
-                <a href="{{ url('wiki.document_revisions', document.parent.slug, locale=document.parent.locale) }}">{{ document.parent.language }}</a>,
-          {% endif %}
-          {{ document.language }}
+        {% if document.parent %}
+          <a href="{{ url('wiki.document_revisions', document.parent.slug, locale=document.parent.locale) }}">{{ document.parent.language }}</a>,
+        {% endif %}
+        {{ document.language }}
       </div>
 
       <div id="helpful-graph" data-url="{{ url('wiki.get_helpful_votes_async', document.slug) }}">

--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -28,7 +28,7 @@ from wiki.events import (EditDocumentEvent, ReadyRevisionEvent,
 from wiki.models import Document, Revision, HelpfulVote, HelpfulVoteMetadata
 from wiki.config import (SIGNIFICANCES, MEDIUM_SIGNIFICANCE,
                          ADMINISTRATION_CATEGORY, TROUBLESHOOTING_CATEGORY,
-                         TEMPLATES_CATEGORY)
+                         TEMPLATES_CATEGORY, CATEGORIES)
 from wiki.tasks import send_reviewed_notification
 from wiki.tests import (TestCaseBase, document, revision, new_document_data,
                         translated_revision)
@@ -904,6 +904,16 @@ class HistoryTests(TestCaseBase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_('noindex', doc('meta[name=robots]')[0].attrib['content'])
+
+    def test_history_category_appears(self):
+        """Document history should have a category on page"""
+        category = CATEGORIES[1]
+        r = revision(save=True, content='Some text.', is_approved=True,
+                     document=document(category=category[0], save=True))
+        response = get(self.client, 'wiki.document_revisions',
+                       args=[r.document.slug])
+        eq_(200, response.status_code)
+        self.assertContains(response, category[1])
 
 
 class DocumentEditTests(TestCaseBase):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=859361
