### PR TITLE
[bug 863528] Add sampling to redirecting inproduct to HTTPS.

### DIFF
--- a/migrations/208-add-inproduct-https-sample.sql
+++ b/migrations/208-add-inproduct-https-sample.sql
@@ -1,0 +1,2 @@
+INSERT IGNORE INTO `waffle_sample` (`name`, `percent`, `note`, `created`, `modified`)
+    VALUES ('inproduct-https', 0, 'Redirect inproduct links to HTTPS.', NOW(), NOW());


### PR DESCRIPTION
This adds a sampling waffle thingy so we can dial up redirects to HTTPS from inproduct links.

r?
