### PR TITLE
[bug 867655] Dont autofill browser info when editing question.

### DIFF
--- a/apps/questions/templates/questions/edit_question.html
+++ b/apps/questions/templates/questions/edit_question.html
@@ -5,6 +5,8 @@
                  (url('questions.answers', question.id), question.title),
                  (None, _('Edit the question'))] %}
 
+{% set classes = 'edit-question' %}
+
 {% block headline %}{{ _('Edit a Question') }}{% endblock %}
 
 {% block major_detail_instructions %}

--- a/apps/questions/templates/questions/includes/question_editing_frame.html
+++ b/apps/questions/templates/questions/includes/question_editing_frame.html
@@ -14,7 +14,6 @@ we can compute the edit-title URL.
 {% from "includes/common_macros.html" import content_editor with context %}
 {% from "questions/includes/aaq_macros.html" import selected_product, selected_category %}
 {% from "questions/includes/aaq_macros.html" import troubleshooting_instructions with context %}
-{% set classes = 'new-question' %}
 
 {% block content %}
   <div class="grid_12">

--- a/apps/questions/templates/questions/new_question.html
+++ b/apps/questions/templates/questions/new_question.html
@@ -8,6 +8,8 @@
 {% set can_edit_category = True %}
 {% set no_headline = True %}
 
+{% set classes = 'new-question' %}
+
 {% block breadcrumbs %}{% endblock %}
 
 {% block product %}

--- a/media/less/questions.less
+++ b/media/less/questions.less
@@ -1168,3 +1168,20 @@ div.ans-attachments {
     width:  200px;
   }
 }
+
+.edit-question {
+  #troubleshooting-install,
+  #troubleshooting-manual {
+    display: none;
+  }
+
+  li.system-details-info {
+    display: none;
+  }
+
+  #question-form {
+    li.details {
+      display: block;
+    }
+  }
+}


### PR DESCRIPTION
- Changed the edit page to have `body class="edit-question"`. This makes it skip all the AAQ js logic for guessing browser, os, prefilling troubleshooting info, etc.
- Changed the display of some things on the edit page so that it makes more sense in that context.

I think that was it.

r?
