### PR TITLE
Yak-shaving: Fix setup_indexes so it does less

### DIFF
--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -157,7 +157,7 @@ def get_documents(cls, ids):
 
 
 def recreate_index(es=None):
-    """Deletes index if it's there and creates a new one"""
+    """Deletes WRITE_INDEX if it's there and creates a new one"""
     if es is None:
         es = get_es()
 

--- a/apps/search/tests/__init__.py
+++ b/apps/search/tests/__init__.py
@@ -73,20 +73,18 @@ class ElasticTestCase(TestCase):
         get_es().refresh(index)
         get_es().health(wait_for_status='yellow')
 
-    def setup_indexes(self, empty=False, wait=True):
-        """(Re-)create ES indexes."""
+    def reindex_and_refresh(self):
+        """Reindexes anything in the db"""
         from search.es_utils import es_reindex_cmd
+        es_reindex_cmd()
+        self.refresh(run_tasks=False)
 
-        if empty:
-            # Removes the index and creates a new one with
-            # nothing in it (by abusing the percent argument).
-            es_reindex_cmd(delete=True, percent=0)
-        else:
-            # Removes the previous round of indexes and creates new
-            # ones with mappings and all that.
-            es_reindex_cmd(delete=True)
-
+    def setup_indexes(self, empty=False, wait=True):
+        """(Re-)create WRITE_INDEX"""
+        from search.es_utils import recreate_index
+        recreate_index()
         self.refresh(run_tasks=False)
 
     def teardown_indexes(self):
-        es_utils.delete_index(es_utils.READ_INDEX)
+        """Tear down WRITE_INDEX"""
+        es_utils.delete_index(es_utils.WRITE_INDEX)

--- a/apps/search/tests/test_es.py
+++ b/apps/search/tests/test_es.py
@@ -261,9 +261,12 @@ class ElasticSearchUnifiedViewTests(ElasticTestCase):
         r2 = revision(is_approved=True, save=True)
         helpful_vote(revision=r2, helpful=True, save=True)
 
-        # r2.document should come first with 1 vote.
+        # Note: We have to wipe and rebuild the index because new
+        # helpful_votes don't update the index data.
         self.setup_indexes()
-        self.refresh()
+        self.reindex_and_refresh()
+
+        # r2.document should come first with 1 vote.
         response = self.client.get(reverse('search'), {
             'w': '1', 'a': '1', 'sortby_documents': 'helpful',
             'format': 'json'})
@@ -277,7 +280,8 @@ class ElasticSearchUnifiedViewTests(ElasticTestCase):
         helpful_vote(revision=r1, helpful=True, save=True)
 
         self.setup_indexes()
-        self.refresh()
+        self.reindex_and_refresh()
+
         response = self.client.get(reverse('search'), {
             'w': '1', 'a': '1', 'sortby_documents': 'helpful',
             'format': 'json'})


### PR DESCRIPTION
We're nixing fixtures and we're at a point where we don't have to
assume there's anything in the db that needs to get indexed at
test setUp time.

This is pretty benign. It probably reduces the time involved a tiny
bit, but not a ton.

Mostly this nixes some complexity in test setup which will make
some tweaks I'm doing in the search overhaul less of a big deal.

r?
