### PR TITLE
Fix esdelete

### DIFF
--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -342,7 +342,7 @@ def es_reindex_cmd(percent=100, delete=False, models=None,
     log.info('done! (%s total)', format_time(delta_time))
 
 
-def es_delete_cmd(index, interactive=False, log=log):
+def es_delete_cmd(index, noinput=False, log=log):
     """Deletes an index"""
     try:
         indexes = [name for name, count in get_indexes()]
@@ -355,7 +355,7 @@ def es_delete_cmd(index, interactive=False, log=log):
         log.error('Index "%s" is not a valid index.', index)
         return
 
-    if index == READ_INDEX and interactive:
+    if index == READ_INDEX and not noinput:
         ret = raw_input('"%s" is a read index. Are you sure you want '
                         'to delete it? (yes/no) ' % index)
         if ret != 'yes':

--- a/apps/search/management/commands/esdelete.py
+++ b/apps/search/management/commands/esdelete.py
@@ -1,3 +1,5 @@
+from optparse import make_option
+
 from django.core.management.base import BaseCommand, CommandError
 
 from search.es_utils import es_delete_cmd
@@ -6,6 +8,10 @@ from search.utils import FakeLogger
 
 class Command(BaseCommand):
     help = 'Delete an index from elastic search.'
+    option_list = BaseCommand.option_list + (
+        make_option('--noinput', action='store_true', dest='noinput',
+                    help='Do not ask for input--just do it'),
+    )
 
     def handle(self, *args, **options):
         if not args:
@@ -13,5 +19,5 @@ class Command(BaseCommand):
 
         es_delete_cmd(
             args[0],
-            interactive=options['interactive'],
+            noinput=options['noinput'],
             log=FakeLogger(self.stdout))

--- a/apps/search/tests/test_cmds.py
+++ b/apps/search/tests/test_cmds.py
@@ -55,4 +55,4 @@ class ESCommandTests(ElasticTestCase):
         # have to do one.
         for index in [es_utils.READ_INDEX,
                       'cupcakerainbow_index']:
-            call_command('esdelete', index, interactive=False)
+            call_command('esdelete', index, noinput=True)


### PR DESCRIPTION
This fixes something I borked a few days ago. It's just used by devs and rarely,
so just a cursory look-over is good.

The backstory is that I thought I read in the django docs that 'interactive' was a
standard option like 'verbosity' that all commands had. Turns out that's not
true or it's not true of pre-1.5--I didn't look into it.

Anyhow, this fixes the bug caused by that misunderstanding.

tiny cursory r?
