### PR TITLE
Fix create_index

### DIFF
--- a/apps/search/es_utils.py
+++ b/apps/search/es_utils.py
@@ -168,8 +168,10 @@ def recreate_index(es=None):
     # indexing doesn't get a chance to index anything between the two
     # and infer a bogus mapping (which ES then freaks out over when we
     # try to lay in an incompatible explicit mapping).
-
     es.create_index(index, settings={'mappings': mappings})
+
+    # Wait until the index is there.
+    es.health(wait_for_status='yellow')
 
 
 def get_index_settings(index):


### PR DESCRIPTION
After creating the index, it's good to wait until it's created before
moving on. This worked before because the code did other things and
that allowed it to work, but we should make it explicit.

Easy to test by just running the tests.

Tiny r?
