### PR TITLE
Fixed a typo in test for user locale

### DIFF
--- a/apps/users/tests/__init__.py
+++ b/apps/users/tests/__init__.py
@@ -19,7 +19,7 @@ def profile(**kwargs):
     defaults = {'name': 'Test K. User', 'bio': 'Some bio.',
                 'website': 'http://support.mozilla.com',
                 'timezone': None, 'country': 'US', 'city': 'Mountain View',
-                'locale': 'en_US'}
+                'locale': 'en-US'}
     if 'user' not in kwargs:
         u = user(save=True)
         defaults['user'] = u


### PR DESCRIPTION
en_US is not how we store it in the database or anywhere else. en-US is used instead.
