### PR TITLE
[bug 572856] Fix docstring lengths for tests

### DIFF
--- a/apps/access/tests/__init__.py
+++ b/apps/access/tests/__init__.py
@@ -59,8 +59,11 @@ class AccessTests(TestCase):
         assert not access.has_perm(user, perm, self.forum_2)
 
     def test_perm_is_defined_on(self):
-        """Test whether we check for permission relationship, independent of
-        whether the permission is actually assigned to anyone."""
+        """Test permission relationship
+
+        Test whether we check for permission relationship, independent
+        of whether the permission is actually assigned to anyone.
+        """
         perm = 'forums_forum.view_in_forum'
         assert access.perm_is_defined_on(perm, Forum.objects.get(pk=3))
         assert not access.perm_is_defined_on(perm, Forum.objects.get(pk=2))

--- a/apps/customercare/tests/__init__.py
+++ b/apps/customercare/tests/__init__.py
@@ -13,9 +13,8 @@ tweet_created = datetime.now().strftime('%a, %d %b %Y %H:%M:%S')
 def tweet(**kwargs):
     """Return a Tweet with valid default values or the ones passed in.
 
-    Args:
-        save: whether to save the Tweet before returning it
-        text: the `text` attribute of the Tweet's raw_json
+    :arg save: whether to save the Tweet before returning it
+    :arg text: the `text` attribute of the Tweet's raw_json
     """
     global next_tweet_id
     # TODO: Escape quotes and such

--- a/apps/customercare/tests/test_cron.py
+++ b/apps/customercare/tests/test_cron.py
@@ -220,8 +220,7 @@ class TopContributors(TestCase):
 
     @override_settings(CC_TOP_CONTRIB_SORT='1w')
     def test_week_range(self):
-        """
-        Test that data looks about right for the 'one week' date range.
+        """Data looks about right for the 'one week' date range.
 
         Test two date ranges to ensure that the code is paying attention to
         settings.py.

--- a/apps/customercare/tests/test_helpers.py
+++ b/apps/customercare/tests/test_helpers.py
@@ -46,6 +46,5 @@ class UTCTimesinceTests(TestCase):
             utctimesince(datetime(2000, 1, 2), now=datetime(2001, 2, 3)))
 
     def test_future(self):
-        """Test behavior when date is in the future and also when omitting the
-        `now` kwarg."""
+        """Test future date and omitting "now" kwarg"""
         eq_('', utctimesince(datetime(9999, 1, 2)))

--- a/apps/customercare/tests/test_templates.py
+++ b/apps/customercare/tests/test_templates.py
@@ -89,7 +89,8 @@ class CannedResponsesTestCase(TestCase):
         eq_(3, len(doc('#accordion a.reply-topic')))
 
     def test_list_canned_responses_nondefault_locale(self):
-        """Listing canned responses gives all snippets regardless of locale."""
+        """Listing canned responses gives all snippets regardless of locale.
+        """
         # Create the canned responses article.
         self._create_doc(CANNED_RESPONSES_WIKI)
 

--- a/apps/customercare/tests/test_views.py
+++ b/apps/customercare/tests/test_views.py
@@ -52,8 +52,8 @@ class TweetListTests(TestCase):
         tweets_2 = _get_tweets(max_id=max_id)
         assert tweets_2
 
-        # Make sure this id is not in the result, and all tweets are older than
-        # max_id.
+        # Make sure this id is not in the result, and all tweets are
+        # older than max_id.
         for tweet in tweets_2:
             assert tweet['id'] < max_id
 
@@ -144,8 +144,11 @@ class FilterTests(FilterTestCase):
     """Test tweet filtering"""
 
     def setUp(self):
-        """Make a tweet, an answer to it, an unanswered tweet, and a hidden
-        one."""
+        """Set up FilterTests
+
+        Make a tweet, an answer to it, an unanswered tweet, and a
+        hidden one.
+        """
         super(FilterTests, self).setUp()
 
         tweet(text='YO_UNANSWERED').save()
@@ -184,8 +187,7 @@ class FilterCachingTests(FilterTestCase):
     """Test interaction of caching with filters"""
 
     def test_caching(self):
-        """Ensure refiltering the list after replying shows the replied-to
-        tweet as such."""
+        """Refiltering list after replying shows replied-to tweet"""
         # We need at least one existing answer to get the list of answered
         # tweets to cache:
         question = tweet(save=True)

--- a/apps/dashboards/tests/test_cron.py
+++ b/apps/dashboards/tests/test_cron.py
@@ -34,15 +34,13 @@ class TopUnhelpfulArticlesTests(TestCase):
         eq_(0, len(result))
 
     def test_no_current_articles(self):
-        """Make sure _get_current_articles() returns nothing with no votes."""
+        """Make sure _get_current_articles() returns nothing with no votes.
+        """
         result = _get_current_unhelpful({})
         eq_(0, len(result))
 
     def test_old_articles(self):
-        """
-        Make sure _get_old_unhelpful() returns an unhelpful (no > yes) with
-        votes within time range.
-        """
+        """Returns unhelpful votes within time range"""
         r = _make_backdated_revision(90)
 
         # Add 4 no votes 1.5 months ago
@@ -58,10 +56,7 @@ class TopUnhelpfulArticlesTests(TestCase):
         eq_(5, result[r.id]['total'])
 
     def test_old_articles_helpful(self):
-        """
-        Make sure _get_old_unhelpful() doesn't return a helpful (no < yes)
-        with votes within time range.
-        """
+        """Doesn't return helpful votes within range"""
         r = _make_backdated_revision(90)
 
         for x in range(0, 4):
@@ -73,10 +68,7 @@ class TopUnhelpfulArticlesTests(TestCase):
         eq_(0, len(result))
 
     def test_current_articles(self):
-        """
-        Make sure _get_current_unhelpful() returns an unhelpful (no > yes) with
-        votes within time range.
-        """
+        """Returns unhelpful votes within time range"""
         r = _make_backdated_revision(90)
 
         for x in range(0, 3):
@@ -95,10 +87,7 @@ class TopUnhelpfulArticlesTests(TestCase):
         eq_(5, result[r.id]['total'])
 
     def test_current_articles_helpful(self):
-        """
-        Make sure _get_current_unhelpful() doesn't return a helpful (no < yes)
-        with votes within time range.
-        """
+        """Doesn't return helpful votes within time range"""
         r = _make_backdated_revision(90)
 
         for x in range(0, 3):
@@ -113,9 +102,7 @@ class TopUnhelpfulArticlesTests(TestCase):
         eq_(0, len(result))
 
     def test_current_articles_not_in_old(self):
-        """
-        Unhelpful articles in current but not in old shouldn't break stuff.
-        """
+        """Unhelpful articles in current but not in old works"""
         r = _make_backdated_revision(90)
 
         for x in range(0, 3):

--- a/apps/dashboards/tests/test_personal.py
+++ b/apps/dashboards/tests/test_personal.py
@@ -19,7 +19,7 @@ class DashboardsTests(TestCase):
                        'GROUP_DASHBOARDS',
                        {ATestDashboard.slug: ATestDashboard})
     def test_personal_dashboards(self):
-        """Just run through it to make sure there aren't obvious explosions."""
+        """Verify no obvious explosions"""
         g = group(name='winners', save=True)
         g2 = group(name='losers', save=True)
         u = user(save=True)

--- a/apps/dashboards/tests/test_readouts.py
+++ b/apps/dashboards/tests/test_readouts.py
@@ -49,7 +49,7 @@ class OverviewTests(TestCase):
     """Tests for Overview readout"""
 
     def test_counting_unready_templates(self):
-        """Templates without a ready-for-l10n rev shouldn't count in total."""
+        """Templates without a ready-for-l10n rev don't count"""
         # Make a template with an approved but not-ready-for-l10n rev:
         r = revision(document=document(title='Template:smoo',
                                        is_localizable=True,
@@ -67,10 +67,7 @@ class OverviewTests(TestCase):
         eq_(1, overview_rows('de')['templates']['denominator'])
 
     def test_counting_unready_navigation(self):
-        """Navigation articles without ready-for-l10n rev shouldn't count in
-        total.
-
-        """
+        """Navigation articles without ready-for-l10n rev don't count"""
         # Make a navigation doc with an approved but not-ready-for-l10n rev:
         r = revision(document=document(title='smoo',
                                        category=50,
@@ -106,10 +103,10 @@ class OverviewTests(TestCase):
         eq_(1, overview_rows('de')['all']['denominator'])
 
     def test_counting_unready_parents(self):
-        """Translations whose parents have no ready-to-localize revisions
-        should not count in the numerator.
+        """Translations with no ready revs don't count in numerator
 
-        By dint of factoring, this also tests that templates whose parents....
+        By dint of factoring, this also tests that templates whose
+        parents....
 
         """
         parent_rev = revision(document=document(is_localizable=True,
@@ -206,7 +203,8 @@ class OverviewTests(TestCase):
         eq_(0, overview['most-visited']['numerator'])
 
     def test_not_counting_untranslated(self):
-        """Translations with no approved revisions shouldn't count as done."""
+        """Translations with no approved revisions shouldn't count as done.
+        """
         t = translated_revision(is_approved=False, save=True)
         overview = overview_rows('de')
         eq_(0, overview['most-visited']['numerator'])
@@ -254,8 +252,8 @@ class UnreviewedChangesTests(ReadoutTestCase):
     readout = UnreviewedReadout
 
     def test_unrevieweds_after_current(self):
-        """Show the unreviewed revisions with later creation dates than the
-        current"""
+        """Show unreviewed revisions with later creation dates than current
+        """
         current = translated_revision(is_approved=True, save=True,
                                       created=datetime(2000, 1, 1))
         unreviewed = revision(document=current.document, save=True,
@@ -268,8 +266,7 @@ class UnreviewedChangesTests(ReadoutTestCase):
         assert unreviewed.document.title in self.titles()
 
     def test_rejected_newer_than_current(self):
-        """If there are reviewed but unapproved (i.e. rejected) revisions newer
-        than the current_revision, don't show them."""
+        """Don't show reviewed but unapproved revs newer than current rev"""
         rejected = translated_revision(reviewed=datetime.now(), save=True)
         assert rejected.document.title not in self.titles()
 
@@ -433,8 +430,12 @@ class MostVisitedTranslationsTests(ReadoutTestCase):
         self.assertRaises(IndexError, self.row)
 
     def _test_significance(self, significance, status):
-        """Assert that a translation out of date due to a `significance`-level
-        update to the original article shows status `status`."""
+        """
+        Assert that a translation out of date due to a
+        `significance`-level update to the original article shows
+        status `status`.
+
+        """
         translation = translated_revision(is_approved=True, save=True)
         revision(document=translation.document.parent,
                  is_approved=True,
@@ -463,7 +464,8 @@ class MostVisitedTranslationsTests(ReadoutTestCase):
         eq_(unicode(row['status']), 'Translation Needed')
 
     def test_up_to_date(self):
-        """Show up-to-date translations have no status, just a happy class."""
+        """Show up-to-date translations have no status, just a happy class.
+        """
         translation = translated_revision(is_approved=True, save=True)
         row = self.row()
         eq_(row['title'], translation.document.title)
@@ -471,10 +473,7 @@ class MostVisitedTranslationsTests(ReadoutTestCase):
         eq_(row['status_class'], 'ok')
 
     def test_one_rejected_revision(self):
-        """A translation with only 1 revision, which is rejected, should show
-        as "Needs Translation".
-
-        """
+        """Translation with 1 rejected rev shows as Needs Translation"""
         translated_revision(is_approved=False,
                             reviewed=datetime.now(),
                             save=True)
@@ -488,9 +487,12 @@ class MostVisitedTranslationsTests(ReadoutTestCase):
         eq_([], MostVisitedTranslationsReadout(MockRequest()).rows())
 
     def test_consider_max_significance(self):
-        """When determining how significantly an article has changed since
-        translation, use the max significance of the approved revisions, not
-        just that of the latest ready-to-localize one."""
+        """Use max significance for determining change significance
+
+        When determining how significantly an article has changed
+        since translation, use the max significance of the approved
+        revisions, not just that of the latest ready-to-localize one.
+        """
         translation = translated_revision(is_approved=True, save=True)
         revision(document=translation.document.parent,
                  is_approved=True,
@@ -546,9 +548,12 @@ class OutOfDateTests(ReadoutTestCase):
     readout = OutOfDateReadout
 
     def test_consider_max_significance(self):
-        """When determining how significantly an article has changed since
-        translation, use the max significance of the approved revisions, not
-        just that of the latest ready-to-localize one."""
+        """Use max significance of approved revs for changed significance
+
+        When determining how significantly an article has changed
+        since translation, use the max significance of the approved
+        revisions, not just that of the latest ready-to-localize one.
+        """
         translation = translated_revision(is_approved=True, save=True)
         revision(document=translation.document.parent,
                  is_approved=True,
@@ -591,7 +596,8 @@ class TemplateTranslationsTests(ReadoutTestCase):
     readout = TemplateTranslationsReadout
 
     def test_not_template(self):
-        """Documents that are not templates shouldn't show up in the list."""
+        """Documents that are not templates shouldn't show up in the list.
+        """
         translated_revision(is_approved=False, save=True)
         self.assertRaises(IndexError, self.row)
 
@@ -694,8 +700,8 @@ class UnreadyTests(ReadoutTestCase):
         eq_([], self.titles())
 
     def test_unapproved_revs(self):
-        """Articles with only unreviewed or rejected revs after the latest
-        ready one should not appear."""
+        """Don't show articles with unreviewed or rejected revs after latest
+        """
         d = document(save=True)
         ready = revision(document=d,
                          is_approved=True,
@@ -728,8 +734,9 @@ class UnreadyTests(ReadoutTestCase):
         eq_([r.document.title], self.titles())
 
     def test_insignificant_revs(self):
-        """Articles with approved, unready, but insignificant revisions newer
-        than their latest ready-for-l10n ones should not appear."""
+        # Articles with approved, unready, but insignificant revisions
+        # newer than their latest ready-for-l10n ones should not
+        # appear.
         ready = revision(is_approved=True,
                          is_ready_for_localization=True,
                          save=True)
@@ -741,8 +748,8 @@ class UnreadyTests(ReadoutTestCase):
         eq_([], self.titles())
 
     def test_significant_revs(self):
-        """Articles with approved, significant, but unready revisions newer
-        than their latest ready-for-l10n ones should appear."""
+        # Articles with approved, significant, but unready revisions
+        # newer than their latest ready-for-l10n ones should appear.
         ready = revision(is_approved=True,
                          is_ready_for_localization=True,
                          save=True)
@@ -905,8 +912,6 @@ class CannedResponsesTests(ReadoutTestCase):
                  save=True)
 
         eq_('out-of-date', self.row()['status_class'])
-
-
 
     def test_by_product(self):
         """Test the product filtering of the readout."""

--- a/apps/dashboards/tests/test_templates.py
+++ b/apps/dashboards/tests/test_templates.py
@@ -16,9 +16,10 @@ from wiki.tests import revision, translated_revision
 class LocalizationDashTests(TestCase):
     """Tests for the Localization Dashboard.
 
-    The L10n Dash shares a lot of code with the Contributor Dash, so this also
-    covers much of the latter, such as the readout template, most of the view
-    mechanics, and the Unreviewed Changes readout itself.
+    The L10n Dash shares a lot of code with the Contributor Dash, so
+    this also covers much of the latter, such as the readout template,
+    most of the view mechanics, and the Unreviewed Changes readout
+    itself.
 
     """
 
@@ -30,7 +31,7 @@ class LocalizationDashTests(TestCase):
             "'" + contents + "' is not in the following: " + html
 
     def test_render(self):
-        """Assert the main dash and all the readouts render and don't crash."""
+        """Assert main dash and all the readouts render and don't crash."""
         # Put some stuff in the DB so at least one row renders for each
         # readout:
         untranslated = revision(is_approved=True,
@@ -74,11 +75,12 @@ class LocalizationDashTests(TestCase):
 
     def test_untranslated_detail(self):
         """Assert the whole-page Untranslated Articles view works."""
-        # We don't need to test every whole-page view: just one, to make sure
-        # the localization_detail template and the view work. All the readouts'
-        # querying and formatting methods, including the various template
-        # parameters for each individual readout, are exercised by rendering
-        # the main, multi-readout page.
+        # We don't need to test every whole-page view: just one, to
+        # make sure the localization_detail template and the view
+        # work. All the readouts' querying and formatting methods,
+        # including the various template parameters for each
+        # individual readout, are exercised by rendering the main,
+        # multi-readout page.
 
         # Put something in the DB so something shows up:
         untranslated = revision(is_approved=True,
@@ -116,7 +118,8 @@ class GroupLocaleDashTests(TestCase):
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_for_user_active(self, get_current):
-        """Checks the locale dashboard loads for a user associated with it."""
+        """Checks the locale dashboard loads for a user associated with it.
+        """
         get_current.return_value.domain = 'testserver'
         # Create user/group and add user to group.
         u = user(username='test', save=True)

--- a/apps/dashboards/tests/test_views.py
+++ b/apps/dashboards/tests/test_views.py
@@ -1,25 +1,20 @@
 from datetime import timedelta, datetime
-import json
 
-from django.conf import settings
-
-from nose import SkipTest
 from nose.tools import eq_
 
 from announcements.tests import announcement
-from dashboards.cron import cache_most_unhelpful_kb_articles
 from dashboards.readouts import CONTRIBUTOR_READOUTS
 from sumo.tests import TestCase
 from sumo.urlresolvers import reverse
-from sumo.redis_utils import redis_client, RedisError
-from users.tests import user, group
+from users.tests import user
 from wiki.models import HelpfulVote
-from wiki.tests import revision, locale
+from wiki.tests import locale
 
 
 class LocalizationDashTests(TestCase):
     def test_redirect_to_contributor_dash(self):
-        """Should redirect to Contributor Dash if the locale is the default"""
+        """Should redirect to Contributor Dash if the locale is the default
+        """
         response = self.client.get(reverse('dashboards.localization',
                                            locale='en-US'),
                                    follow=True)
@@ -28,7 +23,6 @@ class LocalizationDashTests(TestCase):
 
 
 def LocalizationDashAnnouncementsTests(TestCase):
-
     def setUp(self):
         self.locale1 = locale(save=True, locale='es')
 
@@ -74,7 +68,8 @@ class ContributorDashTests(TestCase):
         eq_(200, response.status_code)
 
     def test_detail_view(self):
-        """Assert the detail page of the contributor dash resolves, renders."""
+        """Assert the detail page of the contributor dash resolves, renders.
+        """
         response = self.client.get(reverse('dashboards.contributors_detail',
             args=[CONTRIBUTOR_READOUTS[CONTRIBUTOR_READOUTS.keys()[0]].slug],
             locale='en-US'))

--- a/apps/forums/tests/test_models.py
+++ b/apps/forums/tests/test_models.py
@@ -76,9 +76,8 @@ class ForumModelTestCase(ForumTestCase):
         assert 'last=%s' % lp.id in url
 
     def test_last_post_updated(self):
-        """Adding/Deleting the last post in a thread and forum should
-        update the last_post field
-        """
+        # Adding/Deleting the last post in a thread and forum should
+        # update the last_post field
         orig_post = post(created=YESTERDAY, save=True)
         t = orig_post.thread
 
@@ -97,8 +96,9 @@ class ForumModelTestCase(ForumTestCase):
         eq_(t.last_post.id, orig_post.id)
 
     def test_public_access(self):
-        """Assert Forums think they're publicly viewable and postable at
-        appropriate times."""
+        # Assert Forums think they're publicly viewable and postable
+        # at appropriate times.
+
         # By default, users have access to forums that aren't restricted.
         u = user(save=True)
         f = forum(save=True)
@@ -122,9 +122,11 @@ class ForumModelTestCase(ForumTestCase):
         assert not f.allows_posting_by(unprivileged_user)
 
     def test_move_updates_last_posts(self):
-        """Moving the thread containing a forum's last post to a new forum
-        should update the last_post of both forums. Consequently, deleting
-        the last post shouldn't delete the old forum. [bug 588994]"""
+        # Moving the thread containing a forum's last post to a new
+        # forum should update the last_post of both
+        # forums. Consequently, deleting the last post shouldn't
+        # delete the old forum. [bug 588994]
+
         # Setup forum to move latest thread from.
         old_forum = forum(save=True)
         t1 = thread(forum=old_forum, save=True)
@@ -179,9 +181,8 @@ class ForumModelTestCase(ForumTestCase):
 
 class ThreadModelTestCase(ForumTestCase):
     def test_delete_thread_with_last_forum_post(self):
-        """Deleting the thread with a forum's last post should
-        update the last_post field on the forum
-        """
+        # Deleting the thread with a forum's last post should update
+        # the last_post field on the forum
         t = thread(save=True)
         post(thread=t, save=True)
         f = t.forum
@@ -232,8 +233,7 @@ class SaveDateTestCase(ForumTestCase):
         self.forum = self.thread.forum
 
     def assertDateTimeAlmostEqual(self, a, b, delta, msg=None):
-        """
-        Assert that two datetime objects are within `range` (a timedelta).
+        """Assert that two datetime objects are within `range` (a timedelta).
         """
         diff = abs(a - b)
         assert diff < abs(delta), msg or '%s ~= %s' % (a, b)
@@ -247,10 +247,8 @@ class SaveDateTestCase(ForumTestCase):
         self.assertDateTimeAlmostEqual(now, t.created, self.delta)
 
     def test_save_thread_created(self):
-        """
-        Saving a new thread that already has a created date should respect
-        that created date.
-        """
+        # Saving a new thread that already has a created date should
+        # respect that created date.
         created = datetime(1992, 1, 12, 9, 48, 23)
         t = thread(forum=self.forum, title='foo', creator=self.user,
                    created=created, save=True)
@@ -271,10 +269,8 @@ class SaveDateTestCase(ForumTestCase):
         eq_(created, t.created)
 
     def test_save_new_post_no_timestamps(self):
-        """
-        Saving a new post should behave as if auto_add_now was set on
-        created and auto_now set on updated.
-        """
+        # Saving a new post should behave as if auto_add_now was set on
+        # created and auto_now set on updated.
         p = post(thread=self.thread, content='bar', author=self.user,
                  save=True)
         now = datetime.now()
@@ -282,9 +278,7 @@ class SaveDateTestCase(ForumTestCase):
         self.assertDateTimeAlmostEqual(now, p.updated, self.delta)
 
     def test_save_old_post_no_timestamps(self):
-        """
-        Saving an existing post should update the updated date.
-        """
+        """Saving an existing post should update the updated date."""
         created = datetime(2010, 5, 4, 14, 4, 22)
         updated = datetime(2010, 5, 4, 14, 4, 31)
         p = post(thread=self.thread, created=created, updated=updated,
@@ -301,10 +295,8 @@ class SaveDateTestCase(ForumTestCase):
         eq_(created, p.created)
 
     def test_save_new_post_timestamps(self):
-        """
-        Saving a new post should allow you to override auto_add_now- and
-        auto_now-like functionality.
-        """
+        # Saving a new post should allow you to override auto_add_now-
+        # and auto_now-like functionality.
         created_ = datetime(1992, 1, 12, 10, 12, 32)
         p = Post(thread=self.thread, content='bar', author=self.user,
                  created=created_, updated=created_)

--- a/apps/forums/tests/test_notifications.py
+++ b/apps/forums/tests/test_notifications.py
@@ -17,9 +17,10 @@ from users.models import Setting
 from users.tests import user
 
 
-# Some of these contain a locale prefix on included links, while others don't.
-# This depends on whether the tests use them inside or outside the scope of a
-# request. See the long explanation in questions.tests.test_notifications.
+# Some of these contain a locale prefix on included links, while
+# others don't.  This depends on whether the tests use them inside or
+# outside the scope of a request. See the long explanation in
+# questions.tests.test_notifications.
 REPLY_EMAIL = u"""Reply to thread: {thread}
 
 User {username} has replied to a thread you're watching. Here is their reply:
@@ -138,8 +139,8 @@ class NotificationsTests(ForumTestCase):
         starts_with(mail.outbox[0].body, body)
 
     def test_watch_other_thread_then_reply(self):
-        """Watching a different thread than the one we're replying to shouldn't
-        notify."""
+        # Watching a different thread than the one we're replying to
+        # shouldn't notify.
         t1 = thread(save=True)
         t2 = thread(save=True)
         poster = user(save=True)
@@ -178,8 +179,8 @@ class NotificationsTests(ForumTestCase):
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_watch_forum_then_new_thread_as_self(self, get_current):
-        """Watching a forum and creating a new thread as myself should not
-        send email."""
+        # Watching a forum and creating a new thread as myself should
+        # not send email.
         get_current.return_value.domain = 'testserver'
 
         f = forum(save=True)

--- a/apps/forums/tests/test_permissions.py
+++ b/apps/forums/tests/test_permissions.py
@@ -74,10 +74,8 @@ class ForumTestPermissions(ForumTestCase):
                             self.forum_2)
 
     def test_has_perm_thread_sticky(self):
-        """
-        User in group can change sticky status of thread in forum_1, but not
-        in forum_2.
-        """
+        # User in group can change sticky status of thread in forum_1,
+        # but not in forum_2.
         u = user(save=True)
         self.group.user_set.add(u)
 
@@ -88,10 +86,8 @@ class ForumTestPermissions(ForumTestCase):
                             self.forum_2)
 
     def test_has_perm_thread_locked(self):
-        """
-        Sanity check: user in group has no permission to change locked
-        status in forum_1.
-        """
+        # Sanity check: user in group has no permission to change
+        # locked status in forum_1.
         u = user(save=True)
         self.group.user_set.add(u)
 
@@ -122,9 +118,7 @@ class ForumTestPermissions(ForumTestCase):
                             self.forum_2)
 
     def test_no_perm_thread_delete(self):
-        """
-        User not in group cannot delete thread in any forum.
-        """
+        """User not in group cannot delete thread in any forum."""
         self.context['request'].user = user(save=True)
         assert not has_perm(self.context, 'forums_forum.thread_delete_forum',
                             self.forum_1)

--- a/apps/forums/tests/test_posts.py
+++ b/apps/forums/tests/test_posts.py
@@ -14,8 +14,8 @@ from users.tests import user
 class PostTestCase(ForumTestCase):
 
     def test_new_post_updates_thread(self):
-        """Saving a new post in a thread should update the last_post key in
-        that thread to point to the new post."""
+        # Saving a new post in a thread should update the last_post
+        # key in that thread to point to the new post.
         t = thread(save=True)
         post(thread=t, save=True)
         p = t.new_post(author=t.creator, content='an update')
@@ -24,8 +24,8 @@ class PostTestCase(ForumTestCase):
         eq_(p.id, t.last_post_id)
 
     def test_new_post_updates_forum(self):
-        """Saving a new post should update the last_post key in the forum to
-        point to the new post."""
+        # Saving a new post should update the last_post key in the
+        # forum to point to the new post.
         t = thread(save=True)
         post(thread=t, save=True)
         p = t.new_post(author=t.creator, content='another update')
@@ -34,8 +34,8 @@ class PostTestCase(ForumTestCase):
         eq_(p.id, f.last_post_id)
 
     def test_update_post_does_not_update_thread(self):
-        """Updating/saving an old post in a thread should _not_ update the
-        last_post key in that thread."""
+        # Updating/saving an old post in a thread should _not_ update
+        # the last_post key in that thread.
         t = thread(save=True)
         old = post(thread=t, save=True)
         last = post(thread=t, save=True)
@@ -44,8 +44,8 @@ class PostTestCase(ForumTestCase):
         eq_(last.id, old.thread.last_post_id)
 
     def test_update_forum_does_not_update_thread(self):
-        """Updating/saving an old post in a forum should _not_ update the
-        last_post key in that forum."""
+        # Updating/saving an old post in a forum should _not_ update
+        # the last_post key in that forum.
         t = thread(save=True)
         old = post(thread=t, save=True)
         last = post(thread=t, save=True)
@@ -54,8 +54,8 @@ class PostTestCase(ForumTestCase):
         eq_(last.id, t.forum.last_post_id)
 
     def test_replies_count(self):
-        """The Thread.replies value should remain one less than the number of
-        posts in the thread."""
+        # The Thread.replies value should remain one less than the
+        # number of posts in the thread.
         t = thread(save=True)
         post(thread=t, save=True)
         post(thread=t, save=True)
@@ -66,7 +66,7 @@ class PostTestCase(ForumTestCase):
         eq_(old + 1, t.replies)
 
     def test_sticky_threads_first(self):
-        """Sticky threads should come before non-sticky threads."""
+        # Sticky threads should come before non-sticky threads.
         t = post(save=True).thread
         sticky = thread(forum=t.forum, is_sticky=True, save=True)
         yesterday = datetime.now() - timedelta(days=1)
@@ -76,8 +76,9 @@ class PostTestCase(ForumTestCase):
         eq_(sticky.id, Thread.objects.all()[0].id)
 
     def test_thread_sorting(self):
-        """After the sticky threads, threads should be sorted by the created
-        date of the last post."""
+        # After the sticky threads, threads should be sorted by the
+        # created date of the last post.
+
         # Make sure the datetimes are different.
         post(created=datetime.now() - timedelta(days=1), save=True)
         post(save=True)

--- a/apps/forums/tests/test_templates.py
+++ b/apps/forums/tests/test_templates.py
@@ -209,7 +209,8 @@ class PostsTemplateTests(ForumTestCase):
 class ThreadsTemplateTests(ForumTestCase):
 
     def test_last_thread_post_link_has_post_id(self):
-        """Make sure the last post url links to the last post (#post-<id>)."""
+        """Make sure the last post url links to the last post (#post-<id>).
+        """
         t = forum_post(save=True).thread
         last = forum_post(thread=t, save=True)
 
@@ -310,7 +311,8 @@ class ThreadsTemplateTests(ForumTestCase):
         self.assertContains(response, 'Post a new thread')
 
     def test_restricted_hide_new_thread(self):
-        """'Post new thread' doesn't show if user has no permission to post."""
+        """'Post new thread' doesn't show if user has no permission to post.
+        """
         f = forum(save=True)
         ct = ContentType.objects.get_for_model(f)
         # If the forum has the permission and the user isn't assigned said
@@ -327,7 +329,8 @@ class ThreadsTemplateTests(ForumTestCase):
 class ForumsTemplateTests(ForumTestCase):
 
     def test_last_post_link_has_post_id(self):
-        """Make sure the last post url links to the last post (#post-<id>)."""
+        """Make sure the last post url links to the last post (#post-<id>).
+        """
         p = forum_post(save=True)
 
         response = get(self.client, 'forums.forums')
@@ -395,7 +398,6 @@ class ForumsTemplateTests(ForumTestCase):
 
 
 class NewThreadTemplateTests(ForumTestCase):
-
     def test_preview(self):
         """Preview the thread post."""
         f = forum(save=True)

--- a/apps/forums/tests/test_urls.py
+++ b/apps/forums/tests/test_urls.py
@@ -101,10 +101,8 @@ class BelongsTestCase(ForumTestCase):
         eq_(404, r.status_code)
 
     def test_edit_post_belongs_to_thread_and_forum(self):
-        """
-        Edit post action - post belongs to thread and thread belongs to
-        forum.
-        """
+        # Edit post action - post belongs to thread and thread belongs
+        # to forum.
         f = forum(save=True)
         t = thread(forum=f, save=True)
         # Post belongs to a different forum and thread.
@@ -124,10 +122,8 @@ class BelongsTestCase(ForumTestCase):
         eq_(404, r.status_code)
 
     def test_delete_post_belongs_to_thread_and_forum(self):
-        """
-        Delete post action - post belongs to thread and thread belongs to
-        forum.
-        """
+        # Delete post action - post belongs to thread and thread
+        # belongs to forum.
         f = forum(save=True)
         t = thread(forum=f, save=True)
         # Post belongs to a different forum and thread.

--- a/apps/forums/tests/test_views.py
+++ b/apps/forums/tests/test_views.py
@@ -96,7 +96,8 @@ class ThreadAuthorityPermissionsTests(ForumTestCase):
         eq_(405, response.status_code)
 
     def test_watch_forum_without_permission(self):
-        """Watching forums without the view_in_forum permission should 404."""
+        """Watching forums without the view_in_forum permission should 404.
+        """
         restricted_forum = _restricted_forum()
         u = user(save=True)
 
@@ -107,7 +108,8 @@ class ThreadAuthorityPermissionsTests(ForumTestCase):
         eq_(404, response.status_code)
 
     def test_watch_thread_without_permission(self):
-        """Watching threads without the view_in_forum permission should 404."""
+        """Watching threads without the view_in_forum permission should 404.
+        """
         restricted_forum = _restricted_forum()
         t = thread(forum=restricted_forum, save=True)
         u = user(save=True)
@@ -119,7 +121,8 @@ class ThreadAuthorityPermissionsTests(ForumTestCase):
         eq_(404, response.status_code)
 
     def test_read_without_permission(self):
-        """Listing threads without the view_in_forum permission should 404."""
+        """Listing threads without the view_in_forum permission should 404.
+        """
         restricted_forum = _restricted_forum()
 
         response = get(self.client, 'forums.threads',
@@ -223,7 +226,6 @@ class ThreadTests(ForumTestCase):
 
 
 class ThreadPermissionsTests(ForumTestCase):
-
     def test_edit_thread_403(self):
         """Editing a thread without permissions returns 403."""
         t = forum_post(save=True).thread


### PR DESCRIPTION
This covers the following apps:
- access
- activity
- announcements
- customercare
- dashboards
- flagit
- forums

This is kind of tedious work, so I think I'm going to stop there for now. However, it's a pretty interesting excuse for going through our test code. We've got some funky looking test code that could probably use some cleaning up.

Cosmetic. Tiny r?
