### PR TITLE
Changed ChoiceField to TypedChoiceField

### DIFF
--- a/apps/wiki/forms.py
+++ b/apps/wiki/forms.py
@@ -272,11 +272,12 @@ class ReviewForm(forms.Form):
                                 error_messages={'max_length': COMMENT_LONG})
 
     _widget = forms.RadioSelect(renderer=RadioFieldRendererWithHelpText)
-    significance = forms.ChoiceField(
+    significance = forms.TypedChoiceField(
                     label=_lazy(u'Significance:'),
                     choices=SIGNIFICANCES,
                     initial=SIGNIFICANCES[1][0],
-                    required=False, widget=_widget)
+                    required=False, widget=_widget,
+                    coerce=int, empty_value=SIGNIFICANCES[1][0])
 
     is_ready_for_localization = forms.BooleanField(
         initial=False,


### PR DESCRIPTION
Significance was an unicode string from the fields. `TypedChoiceField`
will force `significance` to be converted to an integer.

Without this, the value of `significance` will be wrong until it is
retrieved from the database, as I have encountered when trying to
compare the value of `signficance` in `wiki.review_revision`
