### PR TITLE
Fix locale path

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -14,8 +14,11 @@ STAGE = False
 LOG_LEVEL = logging.INFO
 SYSLOG_TAG = 'http_sumo_app'
 
+# ROOT is the Kitsune Django project directory
 ROOT = os.path.dirname(os.path.abspath(__file__))
-path = lambda *a: os.path.join(ROOT, *a)
+
+# path bases things off of ROOT
+path = lambda *a: os.path.abspath(os.path.join(ROOT, *a))
 
 ROOT_PACKAGE = os.path.basename(ROOT)
 
@@ -232,8 +235,10 @@ DB_LOCALIZE = {
     },
 }
 
+# locale is in the kitsune git repo project directory, so that's
+# up one directory from the ROOT
 LOCALE_PATHS = (
-    path('locale'),
+    path('..', 'locale'),
 )
 
 # Use the real robots.txt?


### PR DESCRIPTION
Pretty sure that fixes the locale path problem.

To test:
1. run the tests
2. make sure there is no kitsune/locale/ directory
3. do `./manage.py shell` then:

```
(kitsune) (locale-path-fix=4ec53) saturn ~/mozilla/kitsune> ./manage.py shell
Python 2.7.5 (default, May 29 2013, 22:31:19) 
[GCC 4.7.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from django.conf import settings
>>> settings.LOCALE_PATHS
('/home/willkg/mozilla/kitsune/locale',)
```

That should show up in the right place.

Tiny r?
