### PR TITLE
Cors media images

### DIFF
--- a/media/.htaccess
+++ b/media/.htaccess
@@ -28,6 +28,6 @@ FileETag MTime
     FileETag None
 </FilesMatch>
 
-<FileMatch ".(jpeg|png|jpg|gif)$">
+<FilesMatch ".(jpeg|png|jpg|gif)$">
 Header set Access-Control-Allow-Origin "*"
-</FileMatch>
+</FilesMatch>


### PR DESCRIPTION
Offline SUMO will need media images to be CORS'ed, so this is added and images are allowed to be gotten from anywhere.

Example (this is served from staging, which has this code):
http://jsfiddle.net/PN6KE/7/

Previously this is not possible as `.toDataURL()` will throw a security exception.
