### PR TITLE
[Bug 878882] Generic way to do GA events on links.

### DIFF
--- a/kitsune/products/templates/products/product.html
+++ b/kitsune/products/templates/products/product.html
@@ -17,7 +17,9 @@
 
     {% if product.slug == 'firefox' %}
       <div class="download-firefox">
-        <a href="http://www.mozilla.org/firefox#desktop" class="download-button">
+        <a href="http://www.mozilla.org/firefox#desktop" class="download-button"
+         data-ga-click="_trackEvent | Download Click | {{ product.slug }}">
+
           <span class="download-content">
             <span class="download-title">{{ _('Firefox') }}</span>
             {{ _('Free Download') }}

--- a/kitsune/sumo/static/js/analytics.js
+++ b/kitsune/sumo/static/js/analytics.js
@@ -32,21 +32,20 @@ if (alternateUrl) {
 })();
 
 
-// Additional tracking:
-$(document).ready(function() {
-  // Track clicks to the product download button:
-  $(document).on('click', 'a.download-button', function(ev) {
-    ev.preventDefault();
+$('body').on('click', 'a[data-ga-click]', function(ev) {
+  ev.preventDefault();
 
-    var pathParts = document.location.pathname.split('/');
-    var productSlug = pathParts[pathParts.length - 1];
+  var $this = $(this);
+  // Split by '|', and allow for white space on either side.
+  var gaData = $this.data('ga-click').split(/\s*\|\s*/);
+  var href = $this.attr('href');
 
-    _gaq.push(['_trackEvent', 'Download Click', productSlug]);
+  _gaq.push(gaData);
 
-    // Delay the outbound click by 100ms to ensure the event is tracked.
-    var href = $(this).attr('href');
-    setTimeout(function() {
-      document.location.href = href;
-    }, 100);
-  });
+  // Delay the click navigation by 100ms to ensure the event is tracked.
+  setTimeout(function() {
+    document.location.href = href;
+  }, 100);
+
+  return false;
 });

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -110,7 +110,8 @@
     <span>
       {{ _('Your Firefox is out of date and may contain a security risk!') }}
     </span>
-    <a class="download-button" href="http://www.mozilla.org/firefox#desktop">
+    <a class="download-button" href="http://www.mozilla.org/firefox#desktop"
+     data-ga-click="_trackEvent | External Links | Top Banner - Firefox Upgrades">
       {{ _('Upgrade Firefox') }}
     </a>
   {% endcall %}


### PR DESCRIPTION
Adding `data-ga-click="_trackEvent | Some thing | Another thing"` will cause `_gaq.push(['_trackEvent', 'Some thing', 'Another thing'])` to happen, and then 100ms later, the page will navigate as normal.

I used this to add `data-ga-click="_trackEvent | External Links | Top Banner - Firefox Upgrades"` to the "Your firefox is out of date" banner.

To test: Trigger the out of date Firefox warning. I use Fx 12 on Windows' user agent for this, then click the download link. If you watch net traffic, there should be a request to Google Analytics. Also do the same thing with the download button on the Firefox product page.

r?
