### PR TITLE
Hidding Firefox OS until launch date

### DIFF
--- a/kitsune/questions/question_config.py
+++ b/kitsune/questions/question_config.py
@@ -124,7 +124,7 @@ products = SortedDict([
             }),
         ])
     }),
-    ('firefox-os', {
+   """ ('firefox-os', {
         'name': _lazy(u'Firefox OS'),
         'subtitle': '',
         'extra_fields': [],
@@ -148,7 +148,7 @@ products = SortedDict([
                 'tags': ['fix-problems'],
             }),
         ])
-    }),
+    }), """
     ('other', {
         'name': _lazy(u'Thunderbird'),
         'subtitle':  _lazy(u'or other Mozilla products'),


### PR DESCRIPTION
To avoid confusions in the time being, Michelle has asked me to remove FxOS from the AAQ flow
