### PR TITLE
Hide Firefox OS and point Apps to /marketplace

### DIFF
--- a/kitsune/questions/question_config.py
+++ b/kitsune/questions/question_config.py
@@ -124,31 +124,31 @@ products = SortedDict([
             }),
         ])
     }),
-    ('firefox-os', {
-        'name': _lazy(u'Firefox OS'),
-        'subtitle': '',
-        'extra_fields': [],
-        'tags': [],
-        'products': ['firefox-os'],
-        'categories': SortedDict([
-            # TODO: Just use the IA topics for this.
-            ('download-and-install', {
-                'name': _lazy(u'Download and install apps'),
-                'topic': 'download-and-install',
-                'tags': ['download-and-install'],
-            }),
-            ('customize', {
-                'name': _lazy(u'Customize controls, options, settings and preferences'),
-                'topic': 'customize',
-                'tags': ['customize'],
-            }),
-            ('fix-problems', {
-                'name': _lazy(u'Fix slowness, crashing, error messages and other problems'),
-                'topic': 'fix-problems',
-                'tags': ['fix-problems'],
-            }),
-        ])
-    }),
+#    ('firefox-os', {
+#        'name': _lazy(u'Firefox OS'),
+#        'subtitle': '',
+#        'extra_fields': [],
+#        'tags': [],
+#        'products': ['firefox-os'],
+#        'categories': SortedDict([
+#            # TODO: Just use the IA topics for this.
+#            ('download-and-install', {
+#                'name': _lazy(u'Download and install apps'),
+#                'topic': 'marketplace',
+#                'tags': ['marketplace'],
+#            }),
+#            ('customize', {
+#                'name': _lazy(u'Customize controls, options, settings and preferences'),
+#                'topic': 'customize',
+#                'tags': ['customize'],
+#            }),
+#            ('fix-problems', {
+#                'name': _lazy(u'Fix slowness, crashing, error messages and other problems'),
+#                'topic': 'fix-problems',
+#                'tags': ['fix-problems'],
+#            }),
+#        ])
+#    }),
     ('other', {
         'name': _lazy(u'Thunderbird'),
         'subtitle':  _lazy(u'or other Mozilla products'),


### PR DESCRIPTION
Hidding Firefox OS until launch and changing the slug for Download and Install apps so it shows articles related to the Marketplace topic.
