### PR TITLE
Changing the link to the new Download pages

### DIFF
--- a/kitsune/products/templates/products/product.html
+++ b/kitsune/products/templates/products/product.html
@@ -17,7 +17,7 @@
 
     {% if product.slug == 'firefox' %}
       <div class="download-firefox">
-        <a href="http://www.mozilla.org/firefox#desktop" class="download-button"
+        <a href="http://www.mozilla.org/firefox/new/#download-fx" class="download-button"
          data-ga-click="_trackEvent | Download Click | {{ product.slug }}">
 
           <span class="download-content">
@@ -26,7 +26,7 @@
           </download>
         </a>
         <ul class="info">
-          <li><a href="http://www.mozilla.org/firefox/all.html">Systems and Languages</a></li>
+          <li><a href="http://www.mozilla.org/firefox/all/">Systems and Languages</a></li>
           <li><a href="http://www.mozilla.org/en-US/firefox/notes">What's New</a></li>
           <li><a href="http://www.mozilla.org/legal/privacy/firefox">Privacy</a></li>
         </ul>


### PR DESCRIPTION
I talked to Chris More and we were pointing these 2 links to old pages that were redirecting to the new ones. I'm changing the links to they point directly to the new page.
