### PR TITLE
[bug 887050] Fix 404 on placeholder.gif

### DIFF
--- a/kitsune/sumo/parser.py
+++ b/kitsune/sumo/parser.py
@@ -295,7 +295,7 @@ class WikiParser(Parser):
 
         template = jingo.env.get_template(self.image_template)
         r_kwargs = {'image': image, 'params': params,
-                    'MEDIA_URL': settings.MEDIA_URL}
+                    'STATIC_URL': settings.STATIC_URL}
         return template.render(r_kwargs)
 
     # Videos are objects that can have one or more files attached to them


### PR DESCRIPTION
Note: I wasn't able to test this locally because I don't have `ace.js` and so when I try to edit an article I get a big error page. Could somebody make sure this works?

r?
