### PR TITLE
[bug 885309] Fix auto_lock_old_questions

### DIFF
--- a/kitsune/questions/cron.py
+++ b/kitsune/questions/cron.py
@@ -114,8 +114,7 @@ def auto_lock_old_questions():
                         doc[u'indexed_on'] = int(time.time())
                         documents.append(doc)
 
-                    QuestionMappingType.bulk_index(
-                        documents, id_field='document_id')
+                    QuestionMappingType.bulk_index(documents)
 
             except ES_EXCEPTIONS:
                 # Something happened with ES, so let's push index


### PR DESCRIPTION
It was using the wrong id_field when doing bulk_indexing. This fixes
it so that it's using the same one we use elsewhere and therefore
questions won't get indexed multiple times.

The default id_field is 'id' which is what Indexable passes bulk_index. So this switches this bulk_index call to use the default, too.

To test this, do:
1. `./manage.py esreindex` -- this gives you a fresh index
2. then do `./manage.py esstatus` and note the number of questions in the index
3. then `./manage.py cron auto_lock_old_questions`. assuming that does something, it'll update the index
4. then `./manage.py esreindex` and the number of questions should be the same

The problem with this is that auto_lock_old_questions changes the db, so it's hard to run twice in a row (i.e. with and without the patch). I'm not sure offhand what to do about that.

r?

Note: This is going to be hard-ish to deploy since we need to delete all the questions with bad ids from the index. We don't have any infrastructure for doing that easily. We should discuss how to push this after the review.
