### PR TITLE
Changing the pointer from 'customize' to 'settings'

### DIFF
--- a/kitsune/questions/question_config.py
+++ b/kitsune/questions/question_config.py
@@ -139,8 +139,8 @@ products = SortedDict([
            }),
            ('customize', {
                'name': _lazy(u'Customize controls, options, settings and preferences'),
-               'topic': 'customize',
-               'tags': ['customize'],
+               'topic': 'settings',
+               'tags': ['settings'],
            }),
            ('fix-problems', {
                'name': _lazy(u'Fix slowness, crashing, error messages and other problems'),


### PR DESCRIPTION
We have changed the category slug in Firefox OS. We need to point the AAQ to the new one.
