### PR TITLE
[Bug 850323] Stop hyphenating cards.

### DIFF
--- a/kitsune/sumo/static/less/main.less
+++ b/kitsune/sumo/static/less/main.less
@@ -398,12 +398,12 @@ input[type=button],
     .gradient(#ccc, #ddd, #bbb);
     .border-radius(6px);
     .box-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
-    .hyphens(auto);
     float: left;
     margin: 0 10px 20px 10px;
     padding: 1px;
     position: relative;
     width: 298px;
+    word-wrap: break-word;
     z-index: 1;
 
     &:before {


### PR DESCRIPTION
I did this to help out long-winded languages. It turns out it makes most languages unhappy. So instead I am enabling breaking words longer than the card width at arbitrary place, which will only affect languages with very long words.
