### PR TITLE
[bug 889141] Fix get_doctype_stats

### DIFF
--- a/kitsune/search/es_utils.py
+++ b/kitsune/search/es_utils.py
@@ -122,7 +122,11 @@ def get_doctype_stats(index):
 
     from kitsune.search.models import get_mapping_types
     for cls in get_mapping_types():
-        stats[cls.get_mapping_type_name()] = cls.search().count()
+        # Note: Can't use cls.search() here since that returns a
+        # Sphilastic which is hard-coded to look only at the
+        # READ_INDEX.
+        s = S(cls).indexes(index)
+        stats[cls.get_mapping_type_name()] = s.count()
 
     return stats
 


### PR DESCRIPTION
It was looking at the hard-coded READ_INDEX when it should look at the
index it's told to look at.

This fixes the summary in `./manage.py esstatus` and in the search admin page.

It doesn't affect anything else.

Quick r?
