### PR TITLE
Add pulse notifications for wiki revisions, forum posts, questions, and answers.

### DIFF
--- a/kitsune/forums/models.py
+++ b/kitsune/forums/models.py
@@ -11,9 +11,12 @@ from kitsune.access import has_perm, perm_is_defined_on
 from kitsune.sumo.helpers import urlparams, wiki_to_html
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.sumo.models import ModelBase
+from kitsune.sumo.utils import publish_message
 from kitsune.search.models import (
     SearchMappingType, SearchMixin, register_for_indexing,
     register_mapping_type)
+
+from mozillapulse.messages.sumo import SUMOForumPostMessage
 
 
 def _last_post_from(posts, exclude_post=None):
@@ -314,6 +317,17 @@ class Post(ModelBase):
 
             self.thread.forum.last_post = self
             self.thread.forum.save()
+
+        nowtuple = (self.created if new else self.updated).timetuple()
+        nowtimestamp = time.mktime(nowtuple)
+        pulsemsg = SUMOForumPostMessage(locale='en-US',
+                                        who=(self.creator if new else self.updated_by).email,
+                                        when=nowtimestamp,
+                                        slug=self.thread.forum.slug,
+                                        thread=self.thread.id,
+                                        id=self.id,
+                                        is_new=new)
+        publish_message(pulsemsg)
 
     def delete(self, *args, **kwargs):
         """Override delete method to update parent thread info."""

--- a/kitsune/questions/models.py
+++ b/kitsune/questions/models.py
@@ -37,10 +37,13 @@ from kitsune.sumo.models import ModelBase, LocaleField
 from kitsune.sumo.helpers import wiki_to_html
 from kitsune.sumo.redis_utils import RedisError
 from kitsune.sumo.urlresolvers import reverse, split_path
+from kitsune.sumo.utils import publish_message
 from kitsune.tags.models import BigVocabTaggableMixin
 from kitsune.tags.utils import add_existing_tag
 from kitsune.topics.models import Topic
 from kitsune.upload.models import ImageAttachment
+
+from mozillapulse.messages.sumo import SUMOAnswerMessage, SUMOQuestionMessage
 
 
 log = logging.getLogger('k.questions')
@@ -123,6 +126,16 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
             from kitsune.questions.events import QuestionReplyEvent
             # Authors should automatically watch their own questions.
             QuestionReplyEvent.notify(self.creator, self)
+
+            nowtuple = self.created.timetuple()
+            nowtimestamp = time.mktime(nowtuple)
+            pulsemsg = SUMOQuestionMessage(locale=str(self.locale),
+                                           who=self.creator.email,
+                                           when=nowtimestamp,
+                                           id=self.id,
+                                           product=unicode(self.product['name']),
+                                           category=self.category['topic'])
+            publish_message(pulsemsg)
 
     def add_metadata(self, **kwargs):
         """Add (save to db) the passed in metadata.
@@ -637,6 +650,18 @@ class Answer(ModelBase):
                 # Avoid circular import: events.py imports Question.
                 from kitsune.questions.events import QuestionReplyEvent
                 QuestionReplyEvent(self).fire(exclude=self.creator)
+
+        nowtuple = (self.created if new else self.updated).timetuple()
+        nowtimestamp = time.mktime(nowtuple)
+        pulsemsg = SUMOAnswerMessage(locale=self.question.locale,
+                                     who=(self.creator if new else self.updated_by).email,
+                                     when=nowtimestamp,
+                                     question=self.question.id,
+                                     id=self.id,
+                                     is_new=new,
+                                     product=unicode(self.question.product['name']),
+                                     category=self.question.category['topic'])
+        publish_message(pulsemsg)
 
     def delete(self, *args, **kwargs):
         """Override delete method to update parent question info."""

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import json
 
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models.signals import pre_delete
@@ -8,6 +9,8 @@ from django.utils import translation
 from django.utils.http import urlencode, is_safe_url
 
 import tower
+
+from mozillapulse.publishers import SUMOPublisher
 
 from kitsune.sumo import paginator
 
@@ -201,3 +204,18 @@ def uselocale(locale):
     tower.activate(locale)
     yield
     tower.activate(currlocale)
+
+
+def publish_message(message):
+    publisher = SUMOPublisher(host=settings.RABBIT_HOST,
+                              port=settings.RABBIT_PORT,
+                              vhost=settings.RABBIT_VHOST,
+                              user=settings.RABBIT_USER,
+                              password=settings.RABBIT_PASSWORD)
+    try:
+        publisher.publish(message)
+    except Exception as e:
+        import sys
+        print >>sys.stderr, 'error: ' + str(e)
+        #XXX handle stuff
+        pass


### PR DESCRIPTION
This is not meant to be merged at this time. This doesn't solve the problem of where the mozillapulse module lives (http://hg.mozilla.org/users/josh_joshmatthews.net/mozillapulse/), nor does it provide any error handling if publishing a message fails. This is designed to spur conversation about what kind of data to provide in the pulse messages, and clear up any further technical questions.
