### PR TITLE
[Bug 887962] Related in mobile view is not a blob

### DIFF
--- a/kitsune/sumo/static/less/wiki.less
+++ b/kitsune/sumo/static/less/wiki.less
@@ -299,8 +299,9 @@ article {
 
   > section {
     > ul {
+      list-style: none;
       margin: 0;
-      padding: 0 0 0 1em;
+      padding: 0;
 
       > li {
         padding: 10px 0;


### PR DESCRIPTION
There is a bullet point again.

I can't actually test on my machine.. the related stuff is not showing. I did the modification in web inspector. 

r?
