### PR TITLE
[Bug 887017] Add GA tracking to related links.

### DIFF
--- a/kitsune/wiki/templates/wiki/includes/document_macros.html
+++ b/kitsune/wiki/templates/wiki/includes/document_macros.html
@@ -1,16 +1,34 @@
 {% macro related(related_things, header, title_field) -%}
-    {% if related_things %}
-      <aside id="doc-related" class="folding-section">
-        <header>{{ header }}</header>
-        <section>
-          <ul>
-            {% for thing in related_things %}
-              <li><a href="{{ thing['url'] }}">{{ thing[title_field] }}</a></li>
-            {% endfor %}
-          </ul>
-        </section>
-      </aside>
-    {% endif %}
+
+  {% if title_field == 'document_title' %}
+    {% set ga_type = 'Related Article' %}
+    {% set ga_field = 'document_slug' %}
+  {% elif title_field == 'question_title' %}
+    {% set ga_type = 'Related Thread' %}
+    {% set ga_field = 'id' %}
+  {% else %}
+    {% set ga_type = None %}
+  {% endif %}
+
+  {% if related_things %}
+    <aside id="doc-related" class="folding-section">
+      <header>{{ header }}</header>
+      <section>
+        <ul>
+          {% for thing in related_things %}
+            <li>
+              <a href="{{ thing['url'] }}" 
+                {% if ga_type %}
+                  data-ga-click="_trackEvent | {{ ga_type }} | {{ document.slug }} | {{ thing[ga_field] }}"
+                {% endif %}>
+                {{ thing[title_field] }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    </aside>
+  {% endif %}
 {%- endmacro %}
 
 {% macro contributor_list(contributors) -%}


### PR DESCRIPTION
This adds the declarative GA click tracking code to the related links on articles. It isn't precisely what Ibai asked for in the bug, because he asked for questions slugs, which don't exist. I've asked him in the bug to clarify that is correct.

Assuming that question ids are the right thing, r?
