### PR TITLE
[bug 892610] Patch TestWikiVideo with mediocrity

### DIFF
--- a/kitsune/wiki/tests/test_parser.py
+++ b/kitsune/wiki/tests/test_parser.py
@@ -440,10 +440,28 @@ class TestWikiVideo(TestCase):
         d, _, p = doc_rev_parser('[[V:Some title]]')
         doc = pq(d.html)
         eq_('video', doc('div.video').attr('class'))
-        eq_(u'<source src="{0}" '
-            u'type="video/webm"><source src="{1}" type="video/ogg"/>'
-            u'</source>'.format(v.webm.url, v.ogv.url),
-            doc('video').html())
+
+        # This test and the code it tests hasn't changed in
+        # months. However, this test started failing for Mike and I
+        # early July 2013. We think we picked up libxml2 2.9.1 and
+        # that causes the output to be different.  I contend that the
+        # output and expected output are both "wrong" in that they're
+        # invalid html5 and the output I'm getting isn't really any
+        # worse. Ergo, I have changed the test to accept either output
+        # because I got stuff to do. Having said that, this is kind of
+        # ridiculous and should be fixed. See bug #829610.
+        assert doc('video').html() in [
+            # This was the original expected test output.
+            (u'<source src="{0}" '
+             u'type="video/webm"><source src="{1}" type="video/ogg"/>'
+             u'</source>'.format(v.webm.url, v.ogv.url)),
+
+            # This is the version that Mike and I get.
+            (u'\n          <source src="{0}" type="video/webm">'
+             u'\n          <source src="{1}" type="video/ogg">'
+             u'\n      </source></source>'.format(v.webm.url, v.ogv.url))
+            ]
+
         eq_(1, len(doc('video')))
         eq_(2, len(doc('source')))
         data_fallback = doc('video').attr('data-fallback')


### PR DESCRIPTION
This changes the test so it accepts the previous output I was getting
and the new output I'm getting now. I suspect the difference in my
system is that I updated from libxml2 2.8 to 2.9.1 and in doing that
I get slightly different output.

This is goofy, but I think both outputs are "good enough" and I think
Ricky said the video stuff in the wiki isn't long for this world anyhow.

r?
