### PR TITLE
[bug 889833] Fix excerpts for contributor forum searches

### DIFF
--- a/kitsune/search/views.py
+++ b/kitsune/search/views.py
@@ -299,10 +299,12 @@ def search(request, template=None):
         # Set up the highlights
         # First 500 characters of content in one big fragment
         searcher = searcher.highlight(
-            'question_content', 'discussion_content', 'document_summary',
+            'question_content',  # support forum
+            'discussion_content', 'document_summary',  # kb
+            'post_content',  # contributor forum
             pre_tags=['<b>'],
             post_tags=['</b>'],
-            number_of_fragments=0,
+            number_of_fragments=1,
             fragment_size=500)
 
         # Set up boosts


### PR DESCRIPTION
This re-adds excerpts for contributor forum searches.

Further, it fixes a bug where we were setting number_of_fragments to 0
which causes ES to highlight the entire content and ignore fragment_size.
If we set it to 1, then it picks one fragment and limits it to the
fragment_size.

That might cause other issues, but it's the right thing to do otherwise
excerpts can get huge especially for support and contributor forum results.

r?
