### PR TITLE
[bug 895393] Remove deprecated selector interpolation

### DIFF
--- a/kitsune/sumo/static/less/grid.less
+++ b/kitsune/sumo/static/less/grid.less
@@ -104,7 +104,7 @@ body {
 
 #grid {
   .output () {
-    (~".html-ltr .container_@{gridColumns}") {
+    .html-ltr .container_@{gridColumns} {
       margin-left: auto;
       margin-right: auto;
       padding: 0 20px;
@@ -114,7 +114,7 @@ body {
       .fix(@gridColumns - 1);
     }
 
-    (~".html-rtl .container_@{gridColumns}") {
+    .html-rtl .container_@{gridColumns} {
       margin-left: auto;
       margin-right: auto;
       padding: 0 20px;
@@ -125,7 +125,7 @@ body {
     }
 
     .grids (@index) when (@index > 0) {
-      (~".grid_@{index}") { .grid(@index); }
+      .grid_@{index} { .grid(@index); }
       .grids(@index - 1);
     }
     .grids (0) {}
@@ -135,19 +135,19 @@ body {
     }
 
     .fix (@index) when (@index > 0) {
-      (~".prefix_@{index}") { .prefix(@index); }
-      (~".suffix_@{index}") { .suffix(@index); }
-      (~".push_@{index}") { .push(@index); }
-      (~".pull_@{index}") { .pull(@index); }
+      .prefix_@{index} { .prefix(@index); }
+      .suffix_@{index} { .suffix(@index); }
+      .push_@{index} { .push(@index); }
+      .pull_@{index} { .pull(@index); }
       .fix(@index - 1);
     }
     .fix (0) {}
 
     .fix-rtl (@index) when (@index > 0) {
-      (~".prefix_@{index}") { .suffix(@index); }
-      (~".suffix_@{index}") { .prefix(@index); }
-      (~".push_@{index}") { .push(@index); }
-      (~".pull_@{index}") { .pull(@index); }
+      .prefix_@{index} { .suffix(@index); }
+      .suffix_@{index} { .prefix(@index); }
+      .push_@{index} { .push(@index); }
+      .pull_@{index} { .pull(@index); }
       .fix-rtl(@index - 1);
     }
     .fix-rtl (0) {}


### PR DESCRIPTION
Selector interpolation was removed from less in 1.4.
grid.less wouldn't compile anymore, hence the removals.

https://github.com/less/less.js/blob/master/CHANGELOG.md
