### PR TITLE
[bug 894932] Don't collect tweets for @firefox

### DIFF
--- a/kitsune/customercare/cron.py
+++ b/kitsune/customercare/cron.py
@@ -22,7 +22,7 @@ MENTION_REGEX = re.compile('(^|\W)@')
 RT_REGEX = re.compile('^rt\W', re.IGNORECASE)
 
 ALLOWED_USERS = [
-    {'id': 2142731, 'username': 'Firefox'},
+    # NIXING FOR NOWZ: {'id': 2142731, 'username': 'Firefox'},
     {'id': 150793437, 'username': 'FirefoxBrasil'},
     {'id': 107272435, 'username': 'firefox_es'},
 ]


### PR DESCRIPTION
This removes Firefox from the list of usernames we collect tweets from.

This creates the following test failures which I think proves it's correctness:

```
FAIL: kitsune.customercare.tests.test_cron:TwitterCronTestCase.test_firefox_mention
  vim +57 kitsune/customercare/tests/test_cron.py  # test_firefox_mention
    eq_(self.tweet, _filter_tweet(self.tweet))
  vim +31 vendor/packages/nose/nose/tools.py  # eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: {'iso_language_code': 'en', 'text': 'Hey @firefox!', 'created_at': 'Mon, 25 Oct 2010 18:12:20 +0000', 'profile_image_url': 'http://a3.twimg.com/profile_images/688562959/jspeis_gmail.com_852af0c8__1__normal.jpg', 'source': '&lt;a href=&quot;http://twitter.com/&quot;&gt;web&lt;/a&gt;', 'user': {'screen_name': 'jspeis'}, 'to_user_id': None, 'geo': None, 'id': 28713868836L, 'metadata': {'result_type': 'recent'}} != None

FAIL: kitsune.customercare.tests.test_cron:TwitterCronTestCase.test_firefox_replies
  vim +74 kitsune/customercare/tests/test_cron.py  # test_firefox_replies
    eq_(self.tweet, _filter_tweet(self.tweet))
  vim +31 vendor/packages/nose/nose/tools.py  # eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: {'iso_language_code': 'en', 'text': '@firefox Hello!', 'created_at': 'Mon, 25 Oct 2010 18:12:20 +0000', 'profile_image_url': 'http://a3.twimg.com/profile_images/688562959/jspeis_gmail.com_852af0c8__1__normal.jpg', 'source': '&lt;a href=&quot;http://twitter.com/&quot;&gt;web&lt;/a&gt;', 'user': {'screen_name': 'jspeis'}, 'to_user_id': 2142731, 'geo': None, 'id': 28713868836L, 'metadata': {'result_type': 'recent'}} != None
```

r?
