### PR TITLE
[Bug 889272] Fix z-index of contrib tools.

### DIFF
--- a/kitsune/sumo/static/less/main.less
+++ b/kitsune/sumo/static/less/main.less
@@ -1015,7 +1015,8 @@ input[type=button],
 
       > ul {
         background: #fff;
-        border-bottom: 1px solid #ccc;
+        .box-shadow(0 3px 3px rgba(0, 0, 0, 0.1));
+
         display: none;
         left: 0;
         list-style: none;

--- a/kitsune/sumo/static/less/wiki.less
+++ b/kitsune/sumo/static/less/wiki.less
@@ -33,7 +33,7 @@ article {
     > div {
       display: inline;
       position: relative;
-      z-index: 10;
+      z-index: 5;
 
       .selectbox-wrapper {
         background: #fff;
@@ -775,7 +775,7 @@ textarea[name="content"] {
     position: fixed;
     top: 50%;
     width: 165px;
-    z-index: 10;
+    z-index: 5;
 
     h1 {
       font-size: 20px;
@@ -788,7 +788,7 @@ textarea[name="content"] {
     position: absolute;
     right: 10px;
     top: 10px;
-    z-index: 11;
+    z-index: 6;
     &:hover {
       color: #999;
       cursor: pointer;
@@ -812,7 +812,7 @@ textarea[name="content"] {
     position: fixed;
     top: 50%;
     width: 165px;
-    z-index: 10;
+    z-index: 5;
   }
 
   .open {


### PR DESCRIPTION
The contributor tools and the showfor menu both had z-index of 10. I lowered all the showfor z-indexes by 5, which still keeps them above the content, but below the drop downs on the top.

Also, I noticed that the contrib tools and the showfor menu interacting didn't look good, because it was a white menu overlapping a white element with no border or shadow, so I added a shadow on the left, bottom, and right, and removed the hard border on the bottom.

r?
