### PR TITLE
[bug 896477] Add link from l10n dashboard to l10n team.

### DIFF
--- a/kitsune/dashboards/templates/dashboards/includes/macros.html
+++ b/kitsune/dashboards/templates/dashboards/includes/macros.html
@@ -173,7 +173,7 @@
   </div>
 {% endmacro %}
 
-{% macro sidebar_nav(locale, active) %}
+{% macro localization_sidebar_nav(locale, active) %}
   <ul class="sidebar-nav">
     <li {{ active|class_selected('dashboard') }}>
       <a href="{{ url('dashboards.localization', locale=locale) }}">{{ _('Localization Dashboard') }}</a>

--- a/kitsune/dashboards/templates/dashboards/localization.html
+++ b/kitsune/dashboards/templates/dashboards/localization.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "dashboards/includes/macros.html" import print_readout, overview_section, product_selector, print_subscription_menu with context %}
-{% from "dashboards/includes/macros.html" import sidebar_nav %}
+{% from "dashboards/includes/macros.html" import localization_sidebar_nav %}
 {% set title = _('[{locale}] Localization Dashboard')|f(locale=current_locale) %}
 {% set scripts = ('wiki', 'rickshaw', 'wiki.dashboard') %}
 {% set styles = ('rickshaw', 'kbdashboards') %}
@@ -104,5 +104,5 @@
 {% endblock %}
 
 {% block side_top %}
-  {{ sidebar_nav(current_locale, 'dashboard') }}
+  {{ localization_sidebar_nav(current_locale, 'dashboard') }}
 {% endblock %}

--- a/kitsune/wiki/templates/wiki/locale_details.html
+++ b/kitsune/wiki/templates/wiki/locale_details.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% from "layout/errorlist.html" import errorlist %}
-{% from "dashboards/includes/macros.html" import sidebar_nav %}
+{% from "dashboards/includes/macros.html" import localization_sidebar_nav %}
 {% set title = _('{locale} Localization Team | Knowledge Base')|f(locale=locale.locale) %}
 {% set crumbs = [(url('wiki.locales'), _('Locales')), (None, locale.locale)] %}
 
@@ -106,7 +106,7 @@
 {% endblock %}
 
 {% block side_top %}
-  {{ sidebar_nav(locale.locale, 'team')}}
+  {{ localization_sidebar_nav(locale.locale, 'team')}}
 {% endblock %}
 
 {% macro user_row(user) -%}


### PR DESCRIPTION
This was a little more work than I expected because I had to go fiddle with URLs and stuff.
- Added a sidebar nav to go back and forth.
- Added ability to go to l10n dashboard of locales other than the current request locale. To do this I had to fiddle with URLs a little bit.

r?

Test it here, for example: http://localhost:8000/es/localization
