### PR TITLE
[bug 897291] Tweak ES MLT error messages

### DIFF
--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -566,8 +566,7 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
             cache.add(key, documents)
         except ES_EXCEPTIONS as exc:
             statsd.incr('wiki.related_documents.esexception')
-            log.error('ES MLT {err} related_documents for {doc}'.format(
-                    doc=repr(self), err=str(exc)))
+            log.error('ES MLT {err} related_documents'.format(err=str(exc)))
             documents = []
 
         return documents
@@ -612,8 +611,7 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
             cache.add(key, questions)
         except ES_EXCEPTIONS as exc:
             statsd.incr('wiki.related_questions.esexception')
-            log.error('ES MLT {err} related_questions for {doc}'.format(
-                    doc=repr(self), err=str(exc)))
+            log.error('ES MLT {err} related_questions'.format(err=str(exc)))
             questions = []
 
         return questions


### PR DESCRIPTION
This should let them aggregate correctly in sentry so we can better
see what's going on.

The gist of it is to make the message string which Sentry is grouping on the same for all ES MLT errors. We don't really need the document the problem occurred on in the message since most/all of the issues are related to ES (timeouts, etc).

Tiny r?
