### PR TITLE
[Bug 894686] Localized search

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -52,7 +52,8 @@ from kitsune.questions.marketplace import (
 from kitsune.questions.models import (
     Question, Answer, QuestionVote, AnswerVote, QuestionMappingType)
 from kitsune.questions.question_config import products
-from kitsune.search.es_utils import ES_EXCEPTIONS, Sphilastic, F
+from kitsune.search.es_utils import (ES_EXCEPTIONS, Sphilastic, F,
+                                     es_query_with_analyzer)
 from kitsune.search.utils import locale_or_default, clean_excerpt
 from kitsune.sumo.helpers import urlparams
 from kitsune.sumo.urlresolvers import reverse
@@ -1406,6 +1407,7 @@ def _search_suggestions(request, text, locale, product_slugs):
                       for field in DocumentMappingType.get_query_fields())
         query.update(dict(('%s__text_phrase' % field, text)
                       for field in DocumentMappingType.get_query_fields()))
+        query = es_query_with_analyzer(query, locale)
         filter = F()
         filter |= F(document_locale=locale)
         filter |= F(document_locale=settings.WIKI_DEFAULT_LANGUAGE)

--- a/kitsune/search/models.py
+++ b/kitsune/search/models.py
@@ -106,6 +106,10 @@ class SearchMappingType(MappingType, Indexable):
         raise NotImplementedError
 
     @classmethod
+    def get_localized_fields(cls):
+        return []
+
+    @classmethod
     def get_indexable(cls):
         # Some models have a gazillion instances. So we want to go
         # through them one at a time in a way that doesn't pull all

--- a/kitsune/search/tests/test_es.py
+++ b/kitsune/search/tests/test_es.py
@@ -1149,6 +1149,24 @@ class TestAnalyzers(ElasticTestCase):
             locale = doc['locale']
             eq_(doc['_analyzer'], self.locale_data[locale]['analyzer'])
 
+    def test_query_analyzer_upgrader(self):
+        analyzer = 'snowball-english'
+        before = {
+            'document_title__text': 'foo',
+            'document_locale__text': 'bar',
+            'document_title__text_phrase': 'baz',
+            'document_locale__text_phrase': 'qux'
+        }
+        expected = {
+            'document_title__text_analyzer': ('foo', analyzer),
+            'document_locale__text': 'bar',
+            'document_title__text_phrase_analyzer': ('baz', analyzer),
+            'document_locale__text_phrase': 'qux',
+        }
+        actual = es_utils.es_query_with_analyzer(before, 'en-US')
+        eq_(actual, expected)
+
+
     def _check_locale_tokenization(self, locale, expected_tokens, p_tag=True):
         """
         Check that a given locale's document was tokenized correctly.

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -585,10 +585,10 @@ SESSION_EXISTS_COOKIE = 'sumo_session'
 # Connection information for Elastic
 ES_URLS = ['http://127.0.0.1:9200']
 # Indexes for reading
-ES_INDEXES = {'default': 'sumo-20130701'}
+ES_INDEXES = {'default': 'sumo-20130723'}
 # Indexes for indexing--set this to ES_INDEXES if you want to read to
 # and write to the same index.
-ES_WRITE_INDEXES = {'default': 'sumo-20130723'}
+ES_WRITE_INDEXES = ES_INDEXES
 # This is prepended to index names to get the final read/write index
 # names used by kitsune. This is so that you can have multiple
 # environments pointed at the same ElasticSearch cluster and not have

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -675,6 +675,15 @@ class DocumentMappingType(SearchMappingType):
                 'document_keywords']
 
     @classmethod
+    def get_localized_fields(cls):
+        # This is the same list as `get_query_fields`, but it doesn't
+        # have to be, which is why it is typed twice.
+        return ['document_title',
+                'document_content',
+                'document_summary',
+                'document_keywords']
+
+    @classmethod
     def get_mapping(cls):
         return {
             'properties': {


### PR DESCRIPTION
This adds locale specific analyzer settings to the KB search.

This is a change to the ES indexes, so it is structured as a two step change. Step one updates ES_WRITE_INDEXES and makes the indexing changes, and step two updates ES_READ_INDEXES and updates the search code. For local testing, you can use take both commits as a single unit, though they should work and be tested separately as well.

To test: reindex the KB. (`./manage.py esreindex --delete --criticalmass` should work). Do searches. It should all work. Do searches in a language that isn't English and you should get stemming and stop word support. The easiest way I have found to see this is to search for "tienos" in spanish, and notice that documents that contains "tienes" are ranked highly (those words are conjucations of "to have", so should be stemmed together)

I'm currently writing tests for this, but they are a little involved, so I wasn't sure I would have them done today. I hoped I could get some review on this before the weekend.

f?
