### PR TITLE
[bug 899507] Add image upload modal to media page

### DIFF
--- a/kitsune/sumo/static/js/gallery.js
+++ b/kitsune/sumo/static/js/gallery.js
@@ -470,4 +470,10 @@
 
     var kbox = $('#gallery-upload-modal').kbox({preClose: preClose});
 
+    // Open modal window from media page
+    if (document.location.hash === '#upload' ||
+        $('#gallery-upload-type').hasClass('draft')) {
+        $('#btn-upload').click();
+    }
+
 })(jQuery);


### PR DESCRIPTION
Clicking "Upload a New Media File" from a media page displays the gallery instead of the upload modal window.

As Ricky explained in the bug we are linking to the media gallery and open the modal window. This is just adding back the piece that was removed in https://github.com/mozilla/kitsune/commit/94fa5fec5935d8f4b96b5a65258acbac5c399ec2 
