### PR TITLE
[Bug 881210] Make product header flow right on RTL

### DIFF
--- a/kitsune/sumo/static/less/products.less
+++ b/kitsune/sumo/static/less/products.less
@@ -246,3 +246,15 @@
     padding: 30px;
   }
 }
+
+.html-rtl {
+  .download-firefox {
+    left: 20px;
+    right: auto;
+  }
+
+  h1.product-title .logo-sprite {
+    float: right;
+    margin: 0 0 0 8px;
+  }
+}


### PR DESCRIPTION
Before
![firefox help 2013-07-30 16-42-43](https://f.cloud.github.com/assets/305049/882985/d83ae7ba-f971-11e2-9b5f-022657c780d4.png)

After
![firefox help 2013-07-30 16-42-22](https://f.cloud.github.com/assets/305049/882983/d4b6279e-f971-11e2-9074-3fb0ee3cee18.png)

r?
