### PR TITLE
[Bug 876912] Only show complete timeframe on chart

### DIFF
--- a/kitsune/sumo/static/js/rickshaw_utils.js
+++ b/kitsune/sumo/static/js/rickshaw_utils.js
@@ -129,6 +129,16 @@ k.Graph.prototype.rebucket = function() {
     bucketed = this.data.datums.slice();
   }
 
+
+  /* Data points that are too near the present represent a UX problem.
+   * The data in them is not representative of a full time period, so
+   * they appear to be downward trending. `chopLimit` represents the
+   * boundary of what is considered to be "too new".  Bug #876912. */
+  var chopLimit = +new Date() / 1000 - (this.data.bucketSize || (24 * 60 * 60));
+  bucketed = _.filter(bucketed, function(d) {
+    return d.date < chopLimit;
+  });
+
   this.data.series = this.makeSeries(bucketed, this.data.seriesSpec);
 
   // Scale data based on axis groups


### PR DESCRIPTION
This excludes data that didn't happen within the last $WINDOW time, where $WINDOW is a day, a week, a month, or whatever else the bucketing is set to. It's a little finicky to test locally, since I don't have people constantly creating data, and I have a couple of weeks of no data since my last db dump, but I'm pretty sure this works. I tested it by adding some data of my own, and it seemed right.

To test: Make some votes on an article, then go that article's history graph at http://localhost:8080/en-US/kb/get-community-support/history. Before this change, your votes would appear on the graph as a sharp downward and/or upward trend at the end of the graph, depending on how the rest of your data looked. After this change, the new votes don't appear at all, since they were made in the last 1/7/30 days (depending on bucket settings).

r?
