### PR TITLE
[Bug 876912] Fix document summary highlighting.

### DIFF
--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -687,6 +687,7 @@ class DocumentMappingType(SearchMappingType):
     def get_mapping(cls):
         return {
             'properties': {
+                # General fields
                 'id': {'type': 'long'},
                 'model': {'type': 'string', 'index': 'not_analyzed'},
                 'url': {'type': 'string', 'index': 'not_analyzed'},
@@ -696,17 +697,21 @@ class DocumentMappingType(SearchMappingType):
                 'product': {'type': 'string', 'index': 'not_analyzed'},
                 'topic': {'type': 'string', 'index': 'not_analyzed'},
 
+                # Document specific fields (locale aware)
                 'document_title': {'type': 'string'},
+                'document_keywords': {'type': 'string'},
+                'document_content': {'type': 'string', 'store': 'yes',
+                                     'term_vector': 'with_positions_offsets'},
+                'document_summary': {'type': 'string', 'store': 'yes',
+                                     'term_vector': 'with_positions_offsets'},
+
+                # Document specific fields (locale naive)
                 'document_locale': {'type': 'string', 'index': 'not_analyzed'},
                 'document_current_id': {'type': 'integer'},
                 'document_parent_id': {'type': 'integer'},
-                'document_content': {'type': 'string', 'store': 'yes',
-                                     'term_vector': 'with_positions_offsets'},
                 'document_category': {'type': 'integer'},
                 'document_slug': {'type': 'string', 'index': 'not_analyzed'},
                 'document_is_archived': {'type': 'boolean'},
-                'document_summary': {'type': 'string'},
-                'document_keywords': {'type': 'string'},
                 'document_recent_helpful_votes': {'type': 'integer'}
             }
         }


### PR DESCRIPTION
This fixes problems with highlighting in non-English languages. The problem is that if `'term_vector': 'with_positions_offsets'` is not set, the field is reanalyzed for highlighting ,and that reanalysis (apparently) did not take into account the locale specific analyzer. Using position offsets skips the reanalysis of the field, so it keeps the correct information from stemming and stop words.

This is technically a mapping change, but the code will work equally well with both the new and the old mapping, so a step1/step2 is not strictly needed, I think. Do we re-index documents occasionally when we re-parse the wiki? If so, the changes will be picked up then. Otherwise we might have to do a mapping switcheroo, which would be annoying.

r?
