### PR TITLE
[Bug 901575] Add query params to questions feed.

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -139,7 +139,8 @@ def questions(request, template):
     else:
         filter_ = None
 
-    feed_urls = ((reverse('questions.feed'),
+    feed_urls = ((urlparams(reverse('questions.feed'),
+                            product=product_slug, topic=topic_slug),
                   QuestionsFeed().title()),)
 
     if tagged:


### PR DESCRIPTION
The bug was to allow filtering the RSS feed by product. I decided to simply support the same querystring parameters that the questions page does, and so I added topics too.

Check it out at localhost:8080/questions/feeds?product=firefox&topic=tips

That link also shows up as a meta tag in the questions page, just like it did before.

r?
