### PR TITLE
[Bug 897096] Use a custom showfor header on mobile

### DIFF
--- a/kitsune/sumo/templates/mobile/base.html
+++ b/kitsune/sumo/templates/mobile/base.html
@@ -119,7 +119,10 @@
     {% block content %}{% endblock %}
 
     {% if include_showfor %}
-      {{ show_for() }}
+      <article>
+        <header>Get support for another platform:</header>
+        {{ show_for('') }}
+      </article>
     {% endif %}
   </section>
 


### PR DESCRIPTION
This was trying to use desktop styles that relied on desktop scripts, and so it was giant and ugly and the close button was just a big X. So I told it to stop that.

r?
