### PR TITLE
[bug 904554] Add boosts for document queries

### DIFF
--- a/kitsune/search/es_utils.py
+++ b/kitsune/search/es_utils.py
@@ -58,7 +58,7 @@ class AnalyzerMixin(object):
             text_phrase
         """
         query, analyzer = val
-        return {
+        clause = {
             action: {
                 key: {
                     'query': query,
@@ -66,6 +66,12 @@ class AnalyzerMixin(object):
                 }
             }
         }
+
+        boost = self.field_boosts.get(key)
+        if boost is not None:
+            clause[action][key]['boost'] = boost
+
+        return clause
 
     def process_query_text_phrase_analyzer(self, key, val, action):
         """A text phrase query that includes an analyzer."""


### PR DESCRIPTION
This re-adds the boosts for document queries (document_summary, document_content, ...).

You can verify the boosts are there by adding:

```
import logging
logging.getLogger('pyelasticsearch').setLevel(logging.DEBUG)
```

to the top of the `search` view in `kitsune/search/views.py`. The output will show the complete ES search as well as the results. The ES search will show all the clauses and you can verify that the document ones have boosts.

r?
