### PR TITLE
[bug 904443] Fix highlighting

### DIFF
--- a/kitsune/search/views.py
+++ b/kitsune/search/views.py
@@ -295,16 +295,14 @@ def search(request, template=None):
     try:
         cleaned_q = cleaned['q']
 
-        # Set up the highlights
-        # First 500 characters of content in one big fragment
+        # Set up the highlights. Show the entire field highlighted.
         searcher = searcher.highlight(
             'question_content',  # support forum
-            'discussion_content', 'document_summary',  # kb
+            'document_summary',  # kb
             'post_content',  # contributor forum
             pre_tags=['<b>'],
             post_tags=['</b>'],
-            number_of_fragments=1,
-            fragment_size=500)
+            number_of_fragments=0)
 
         # Set up boosts
         searcher = searcher.boost(


### PR DESCRIPTION
This reinstates the "show the whole thing" highlighting.

Because we're showing the whole field highlighted, "fragment_size"
has no effect, so I nixed that.

Additionally, there's no "discussion_content" field so I nixed
that, too.

On top of that, to prevent me from trying to fix this again in the
future, I updated the comment so that it correctly represents
what should be happening in the code.

To test, do a search. You should see the entire document_summary and question_content now. No more half-sentences.

r?
