### PR TITLE
[bug 904883] Stop opening search results in new tab.

### DIFF
--- a/kitsune/questions/templates/questions/new_question.html
+++ b/kitsune/questions/templates/questions/new_question.html
@@ -52,7 +52,7 @@
         {% set button_text = _('None of these solve my problem') %}
         <div class="search-results">
           {% for result in results %}
-            {{ search_result(result, as='aaq') }}
+            {{ search_result(result, as='aaq', open_in_new_tab=True) }}
           {% endfor %}
         </div>{# .search-results #}
       </div>

--- a/kitsune/search/templates/search/includes/result.html
+++ b/kitsune/search/templates/search/includes/result.html
@@ -1,4 +1,4 @@
-{% macro search_result(result, s=None, as='s', r=None) %}
+{% macro search_result(result, s=None, as='s', r=None, open_in_new_tab=False) %}
   <div class="result {{ result.type }}">
     {% if waffle.flag('search-ab') %}
       {% set esab = 'a' %}
@@ -6,8 +6,8 @@
       {% set esab = 'b' %}
     {% endif %}
     {% set url =  result.url|urlparams(s=s, as=as, r=r, esab=esab) %}
-    <h3><a class="title" href="{{ url }}" target="_blank">{{ result.title }}</a></h3>
-    <a tabindex="-1" href="{{ url }}" target="_blank">{{ result.search_summary }}</a>
+    <h3><a class="title" href="{{ url }}"{% if open_in_new_tab %} target="_blank"{% endif %}>{{ result.title }}</a></h3>
+    <a tabindex="-1" href="{{ url }}"{% if open_in_new_tab %} target="_blank"{% endif %}>{{ result.search_summary }}</a>
     {% if result.type == 'question' %}
       <ul class="thread-meta cf">
         {% if result.is_solved %}


### PR DESCRIPTION
http://localhost:8000/en-US/search?esab=a&q=cookies shouldn't open a new tab

http://localhost:8000/en-US/questions/new/desktop/get-started?search=cookies#summarize-question should open a new tab

r?
