### PR TITLE
[bug 889271] Fix migration 226

### DIFF
--- a/migrations/156-add-products.sql
+++ b/migrations/156-add-products.sql
@@ -1,4 +1,5 @@
 -- Add initial products for SUMO
 INSERT INTO products_product (`title`, `description`, `display_order`, `visible`, `slug`) VALUES
 ('Firefox', 'Web browser for Windows, Mac and Linux', 1, TRUE, 'firefox'),
-('Firefox for mobile', 'Web browser for Android smartphones and tablets', 2, TRUE, 'mobile');
+('Firefox for mobile', 'Web browser for Android smartphones and tablets', 2, TRUE, 'mobile'),
+('Firefox OS', 'Firefox OS', 3, TRUE, 'firefox-os');

--- a/migrations/226-retopic-questions.py
+++ b/migrations/226-retopic-questions.py
@@ -11,6 +11,8 @@ def run():
     # Make sure all topics listed in kitsune.questions.question_config exist.
     for prod_desc in question_config.products.values():
         for product_slug in prod_desc.get('products', []):
+            # Note: If this fails, add the missing product to
+            # migration 156.
             product = Product.objects.get(slug=product_slug)
             for topic_desc in prod_desc['categories'].values():
                 _, created = Topic.objects.get_or_create(


### PR DESCRIPTION
This adds the missing product that migration 226 balks at plus
adds a note to migration 226 about how to add products in the future if
it dies again.

To test:
1. change the database name in your settings_local.py to something like "kitsuneblank"
2. run: `mysql kitsuneblank < scripts/schema.sql`
3. run: `./vendor/src/schematic/schematic migrations/`

It should go through all the migrations.

I wrote a fab rule so I can trivially test migrations on a blank db. I'll try to do that for new migrations so we don't bump into this again.

r?
