### PR TITLE
Bug 700714 - Remove `delete_selected` action from the admin.

### DIFF
--- a/kitsune/users/admin.py
+++ b/kitsune/users/admin.py
@@ -14,6 +14,7 @@ class ProfileAdminForm(forms.ModelForm):
 
 
 class ProfileAdmin(admin.ModelAdmin):
+    actions = None
     fieldsets = (
         (None, {
             'fields': ['user', 'name', 'public_email',


### PR DESCRIPTION
There is one more way to do this:

``` py
def get_actions(self, request):
    actions = super(ProfileAdmin, self).get_actions(request)
    if 'delete_selected' in actions:
        del actions['delete_selected']
    return actions
```

https://bugzilla.mozilla.org/show_bug.cgi?id=700714
