### PR TITLE
[bug 893944] Fix contributor tools link on mobile

### DIFF
--- a/kitsune/sumo/templates/includes/common_macros.html
+++ b/kitsune/sumo/templates/includes/common_macros.html
@@ -27,7 +27,7 @@
     <li><a href="{{ ask_url }}" class="ask">{{ _('Ask a question') }}</a></li>
     {% if user.is_authenticated() %}
       <li class="dropdown">
-        <span>{{ _('Contributor Tools') }}</span>
+        <a href="#">{{ _('Contributor Tools') }}</a>
         <ul class="double">
           {{ _for_contributor_links(user, settings.WIKI_DEFAULT_LANGUAGE) }}
         </ul>


### PR DESCRIPTION
Wow! I hated this one. I had tried the `<a>` approach but never gave it an href. Apparently without the href this doesn't work, which is why that didn't work.

tiny r?
