### PR TITLE
[Bug 904123] Setup TravisCI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python: "2.6"
+node: "0.10"
+
+install: scripts/travis/install.sh
+before_script: scripts/travis/setup.sh
+script: scripts/travis/test.sh
+env:
+  - ES_VERSION=0.20.5 REDIS_VERSION=2.4.11
+
+branches:
+  only:
+    - travis-904123

--- a/kitsune/gallery/tests/test_templates.py
+++ b/kitsune/gallery/tests/test_templates.py
@@ -137,7 +137,7 @@ class GalleryUploadTestCase(TestCase):
 
     def test_invalid_messages(self):
         # TODO(paul) POSTing invalid data shows error messages and pre-fills
-        raise SkipTest
+        raise SkipTest('Not implemented')
 
 
 class MediaPageCase(TestCase):

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -588,7 +588,7 @@ class NewDocumentTests(TestCaseBase):
         # You shouldn't be able to make a new doc in a non-default locale
         # without marking it as non-localizable. Unskip this when the non-
         # localizable bool is implemented.
-        raise SkipTest
+        raise SkipTest('Not implemented')
 
         get_current.return_value.domain = 'testserver'
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "Kitsune",
+    "description": "Platform for Firefox Help",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/mozilla/kitsune.git"
+    },
+    "dependencies": {
+        "less": "1.4.1"
+    }
+}

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# pwd is the git repo.
+set -e
+uname -a
+date
+
+echo "Fixing path issues"
+sudo ln -s /usr/lib/`uname -i`-linux-gnu/libfreetype.so ~/virtualenv/python2.6/lib/
+sudo ln -s /usr/lib/`uname -i`-linux-gnu/libjpeg.so ~/virtualenv/python2.6/lib/
+sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.6/lib/
+
+echo "Install Python dependencies"
+pip install -r requirements/compiled.txt
+
+echo "Installing Node.js dependencies"
+npm install
+
+echo "Getting ElasticSearch"
+wget "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz"
+tar xzvf elasticsearch-${ES_VERSION}.tar.gz
+
+echo "Getting Redis"
+wget "http://redis.googlecode.com/files/redis-${REDIS_VERSION}.tar.gz"
+tar xzvf redis-${REDIS_VERSION}.tar.gz
+pushd redis-${REDIS_VERSION}
+  make
+popd

--- a/scripts/travis/setup.sh
+++ b/scripts/travis/setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# pwd is the git repo.
+set -e
+date
+
+echo "Making settings_local.py"
+cat > kitsune/settings_local.py <<SETTINGS
+from settings import *
+ROOT_URLCONF = '%s.urls' % PROJECT_MODULE
+LOG_LEVEL = logging.ERROR
+DATABASES['default']['NAME'] = 'kitsune'
+DATABASES['default']['HOST'] = 'localhost'
+DATABASES['default']['USER'] = 'travis'
+CELERY_ALWAYS_EAGER = True
+CACHE_BACKEND = 'caching.backends.locmem://'
+ES_INDEX_PREFIX = 'sumo'
+ES_URLS = ['http://localhost:9200']
+SETTINGS
+
+echo "Creating test database"
+mysql -e 'create database kitsune'
+
+echo "Updating product details"
+python manage.py update_product_details
+
+echo "Starting ElasticSearch"
+pushd elasticsearch-${ES_VERSION}
+  # This will daemonize
+  ./bin/elasticsearch
+popd
+
+echo "Starting Redis Servers"
+# This will daemonize
+sudo mkdir -p /var/redis/sumo-test/
+sudo chown `whoami` -R /var/redis/
+./redis-${REDIS_VERSION}/src/redis-server configs/redis/redis-test.conf
+
+echo "Starting XVFB for Selenium tests."
+/usr/bin/Xvfb :99 -ac -screen 0 1280x1024x16 >/dev/null &

--- a/scripts/travis/test.sh
+++ b/scripts/travis/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# pwd is the git repo.
+set -e
+date
+
+# For XVFB Selenium tests.
+export DISPLAY=:99.0
+
+python manage.py test -v 2 --noinput --logging-clear-handlers --with-xunit --with-fixture-bundling
+echo 'Booyahkasha!'


### PR DESCRIPTION
This runs all the tests, they all pass, and the only test that skip are tests that are skipped no matter where they are run. i.e. Tests that depend on Redis, ElasticSearch, or _Selenium_ all run and pass. \o/

This Travis set up is designed to happen in 3 phases. Each phase is a shell script in the repository that does the steps outline below. These scripts have `set -e` at the beginning, which means that if any of the sub steps exists with non-zero exit code, the script will exit with a non-zero exit code. This will cause Travis to abort the build and mark it as failed.

1 Install Phase
- Fixes path issues so libraries are available to PIL.
- Installs compiled python dependencies from requirements/compiled.txt.
- Installs node dependencies (currently just LESS).
- Downloads and untars ElasticSearch.
- Downloads, untars, and compiles Redis.

2 Setup Phase
- Makes settings_local.py.
- Creates a MySQL database.
- Updates product details.
- Starts ES.
- Starts Redis.
- Starts XVFB, for running Selenium tests.

3 Test Phase
- Sets environment variables for headless Firefox
- Runs the tests
- Celebrates.

r?
