### PR TITLE
[Bug 908680] Fix typo in graph cutoff.

### DIFF
--- a/kitsune/sumo/static/js/rickshaw_utils.js
+++ b/kitsune/sumo/static/js/rickshaw_utils.js
@@ -166,7 +166,7 @@ k.Graph.prototype.rebucket = function() {
     chopLimit = new Date(now.getFullYear(), now.getMonth(), 1);
   } else {
     // Get midnight of today (ie, the boundary between today and yesterday)
-    chopLimit = new Date(now.getFullYear(), now.getMonth(), now.getDay());
+    chopLimit = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   }
   bucketed = _.filter(bucketed, function(d) {
     return d.date < chopLimit / 1000;


### PR DESCRIPTION
JS's `.getDay()` returns 0 through 6 to represent the days of the week. `.getDate()` return 1 through 31 to represent the days of the month. I used the wrong one.

r?

Also, I would like to push this change out today (even though it is Friday) because it is a small change, and this fixes a regression that went to production yesterday.
