### PR TITLE
[bug 911846] Switch the repr to a unicode

### DIFF
--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -1095,8 +1095,8 @@ class DocumentLink(ModelBase):
     class Meta:
         unique_together = ('linked_from', 'linked_to')
 
-    def __repr__(self):
-        return ('<DocumentLink: %s from %r to %r>' %
+    def __unicode__(self):
+        return (u'<DocumentLink: %s from %r to %r>' %
                 (self.kind, self.linked_from, self.linked_to))
 
 


### PR DESCRIPTION
This fixes errors in production kicked up by the error handling
for whatever errors the error handling was handling.

In Django, you define a `__unicode__` and Model handles `__str__` and `__repr__` for you.
- https://docs.djangoproject.com/en/1.4/ref/models/instances/#unicode
- https://github.com/django/django/blob/1.4.6/django/db/models/base.py#L371

There's no test here because this is like defining a class without subclassing object (which makes it a new-style object)--it's not the sort of trivial thing you write tests for.

r?
