### PR TITLE
Add an error message when ES mappings aren't right

### DIFF
--- a/kitsune/search/admin.py
+++ b/kitsune/search/admin.py
@@ -12,7 +12,8 @@ from django.shortcuts import render
 
 from kitsune.search.es_utils import (
     get_doctype_stats, get_indexes, delete_index, ES_EXCEPTIONS,
-    get_indexable, CHUNK_SIZE, recreate_index, write_index, read_index)
+    get_indexable, CHUNK_SIZE, recreate_index, write_index, read_index,
+    es_mappings_are_correct)
 from kitsune.search.models import Record, get_mapping_types
 from kitsune.search.tasks import OUTSTANDING_INDEX_CHUNKS, index_chunk_task
 from kitsune.search.utils import chunked, create_batch_id
@@ -217,6 +218,7 @@ def search(request):
          'recent_records': recent_records,
          'outstanding_chunks': outstanding_chunks,
          'now': datetime.now(),
+         'mappings_correct': es_mappings_are_correct(write_index())[0][1],
          })
 
 

--- a/kitsune/search/management/commands/escheckmapping.py
+++ b/kitsune/search/management/commands/escheckmapping.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+
+from kitsune.search.es_utils import es_mappings_are_correct
+
+
+class Command(BaseCommand):
+    help = 'Checks if mappings are correct.'
+
+    def handle(self, *args, **options):
+        results = es_mappings_are_correct()
+
+        for index, result in results:
+            print '{0:<20} {1}'.format(index, 'Good' if result else 'Bad')

--- a/kitsune/search/templates/admin/search_maintenance.html
+++ b/kitsune/search/templates/admin/search_maintenance.html
@@ -202,6 +202,12 @@
         made mapping changes since this does not recreate the index with
         the new mappings.
       </p>
+      {% if not mappings_correct %}
+        <p class="errornote">
+          WARNING! The write index probably doesn't have a correct
+          mapping. You probabaly don't want to use this indexing button.
+        </p>
+      {% endif %}
       <form method="POST">
         {% csrf_token %}
         {% for stats_name, stats_count in doctype_write_stats.items %}


### PR DESCRIPTION
The breakage I caused yesterday was probably because I clicked the wrong button to do the re-indexing between steps one and two. Since the new index had only been created, but not set up, it had a default, ES-inferred mapping, which really screws up our stuff.

This adds a function to `es_utils.py` that tries to determine if the mappings for a given index (or all of them) lines up with what the code expects. I then used that to add a management command and a warning message to the ES management admin page.

Thoughts? r?
