### PR TITLE
Fix for AAQ when clicking email confirmation link.

### DIFF
--- a/kitsune/sumo/static/js/browserid.js
+++ b/kitsune/sumo/static/js/browserid.js
@@ -9,8 +9,17 @@
 
         function submitAssertion(assertion) {
             if (assertion) {
-                var $e = $form.find('input[name="assertion"]');
-                $e.val(assertion.toString());
+                var $next = $form.find('input[name="next"]');
+                var next = $next.val();
+                var $assertion = $form.find('input[name="assertion"]');
+
+                // If there is no next set yet, make it the current URL.
+                if (!next) {
+                    $next.val(document.location.pathname + document.location.search);
+                }
+
+                $assertion.val(assertion.toString());
+
                 $form.submit();
             }
         }


### PR DESCRIPTION
OK, so when the `.watch()`automatically triggers `onlogin` without the user ever clicking a signin link, we were passing an empty `next`. This fixes that by defaulting `next` to the current url.

r?
