### PR TITLE
[Bug 918002] Give feedback that Persona is working.

### DIFF
--- a/kitsune/sumo/static/js/browserid.js
+++ b/kitsune/sumo/static/js/browserid.js
@@ -40,9 +40,15 @@
             next = $this.data('next') || document.location.pathname + document.location.search;
             $form.find('input[name="next"]').val(next);
 
+            var originalText = $this.text();
+            $this.text(gettext('Signing you in...'));
+
             navigator.id.request({
                 returnTo: next,
-                siteName: gettext('Mozilla Support')/*,
+                siteName: gettext('Mozilla Support'),
+                onCancel: function() {
+                    $this.text(originalText);
+                }/*,
                 TODO: siteLogo: */
             });
         });


### PR DESCRIPTION
This helps the case where Persona takes a little while to do the assertion dance. It seems a little confusing for Persona to go away, and no more instructions be given to the user, but the button still says "Sign in with email". This fixes that by changing the text to something that implies something is happening. I chose this text because it is the same text that is shown on the Persona popup.

I'm not sure in what cases `onCancel` will be called, but it is mentioned in the docs, and I assume it will happen anytime a failure happens. The docs say `onCancel` is "A function that will be invoked if the user refuses to share an identity with the site."

r?
