### PR TITLE
[bug 917272] Mobile version of Persona signup page

### DIFF
--- a/kitsune/sumo/static/less/mobile/main.less
+++ b/kitsune/sumo/static/less/mobile/main.less
@@ -210,7 +210,7 @@ textarea {
   .border-radius(3px);
   .box-shadow(0 1px 2px 0 rgba(0, 0, 0, 0.1) inset);
   .box-sizing(border-box);
-  display: block;
+  display: inline-block;
   font-family: @Moz;
   font-size: 14px;
   margin: 0 0 12px 0;

--- a/kitsune/users/templates/users/mobile/browserid_signup.html
+++ b/kitsune/users/templates/users/mobile/browserid_signup.html
@@ -1,0 +1,28 @@
+{% extends 'mobile/base.html' %}
+
+{% set styles = ('mobile/users',) %}
+{% set classes = 'register' %}
+{% set headline = _("You're almost there!") %}
+{% set title = headline %}
+
+{% block content %}
+  <div class="top-section">
+    <h2>{{ _('Create a support account.') }}</h2>
+    <p>
+      {% trans %}
+        Please select a username and click continue to proceed with sign up.
+      {% endtrans %}
+    </p>
+  </div>
+
+
+  <form method="post" action="{{ url('users.browserid_signup') }}">
+    <input type="hidden" name="next" value="{{ next }}">
+    {% if contributor %}
+      <input type="hidden" name="contributor" value="1">
+    {% endif %}
+    {{ form }}
+    {{ csrf() }}
+    <p><button type="submit" class="btn btn-submit">{{ _('Continue') }}</button></p>
+  </form>
+{% endblock %}


### PR DESCRIPTION
This does a couple of things:
- Implements a mobile version of the Persona signup page (select a username page)
- Changes the `browserid_verify` view to redirect to `browserid_signup` instead of just showing the signup form.

r?
