### PR TITLE
[bug 912440] Clean the to val before using it

### DIFF
--- a/kitsune/sumo/static/js/users.autocomplete.js
+++ b/kitsune/sumo/static/js/users.autocomplete.js
@@ -24,7 +24,7 @@ function init() {
     var prefill = [];
 
     if($("#id_to").val()) {
-        prefill = [{username: $("#id_to").val(), display_name: null}];
+        prefill = [{username: k.safeString($("#id_to").val()), display_name: null}];
     }
 
     var tokenInputSettings = {


### PR DESCRIPTION
The STR are slightly non-trivial and I can't reproduce it without using Live HTTP Headers since the username autocomplete stuff prevents you from writing a message to a non-existent user. Also, I tried to use the dev tools replay and that doesn't work so well right now in Firefox nightly. Definitely use Live HTTP Headers.

I tested using the STR in the bug and also spent some time making sure the form continued to work correctly with normal use scenarios. Everything looks good to me.

Quick r?
