### PR TITLE
[bug 912563] Make canned responses more discoverable

### DIFF
--- a/kitsune/sumo/static/css/cannedresponses.css
+++ b/kitsune/sumo/static/css/cannedresponses.css
@@ -1,5 +1,7 @@
-.markup-toolbar-button.btn-cannedresponses {
+.markup-toolbar-link.btn-cannedresponses {
     background-image: url(../img/icon.magic-hat.png);
+    background-repeat: no-repeat;
+    padding: 6px 40px 6px !important;
 }
 
 #responses-area,

--- a/kitsune/sumo/static/js/markup.js
+++ b/kitsune/sumo/static/js/markup.js
@@ -788,14 +788,14 @@ Marky.MediaButton.prototype = $.extend({}, Marky.SimpleButton.prototype, {
  * The canned responses helper
  */
 Marky.CannedResponsesButton = function() {
-    this.name = gettext('Insert a canned response...');
+    this.name = gettext('Common responses');
     this.classes = 'btn-cannedresponses';
     this.openTag = '';
     this.closeTag = '';
     this.defaultText = gettext('cannedresponses');
     this.everyline = false;
 
-    this.html = '<button class="markup-toolbar-button" />';
+    this.html = '<a class="markup-toolbar-link" href="#"/>';
 };
 
 Marky.CannedResponsesButton.prototype = $.extend({}, Marky.SimpleButton.prototype, {


### PR DESCRIPTION
This adds a description of "Common responses" right next to the top hat.
