### PR TITLE
[bug 920099] Don't send badge award emails on stage

### DIFF
--- a/kitsune/kbadge/badges.py
+++ b/kitsune/kbadge/badges.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.dispatch import receiver
 
 from badger.signals import badge_was_awarded
@@ -6,9 +7,11 @@ from kitsune.kbadge.tasks import send_award_notification
 
 
 @receiver(badge_was_awarded)
-def notify_award_recipient(sender, **kwargs):
+def notify_award_recipient(sender, award, **kwargs):
     """Notifies award recipient that he/she has an award!"""
-    award = kwargs['award']
-
-    # Kick off the task to send the email
-    send_award_notification.delay(award)
+    # -dev and -stage have STAGE = True which means they won't send
+    # notification emails of newly awarded badges which would spam the
+    # bejesus out of everyone.
+    if not settings.STAGE:
+        # Kick off the task to send the email
+        send_award_notification.delay(award)


### PR DESCRIPTION
This adds some code that prevents STAGE=True environments from sending
email from badge awards. Why? So everyone doesn't get spammed by badges
getting awarded on -stage.

Right now that covers -dev and -stage environments. settings.py defaults
STAGE to False, so -prod and developer environments will continue to
send notification emails when badges are awarded.

r?
