### PR TITLE
Update wiki-common.less

### DIFF
--- a/kitsune/sumo/static/less/includes/wiki-common.less
+++ b/kitsune/sumo/static/less/includes/wiki-common.less
@@ -17,6 +17,6 @@
   }
 }
 
-.selectbox{
-  padding:0 10px;
+.selectbox {
+  padding: 0 10px;
 }


### PR DESCRIPTION
I added 10px padding (right and left) for .selectbox class, to make the texts displayed in the Select input boxes for OS and Mozilla Version in KB articles.

Example

Open the below link you can find 2 select box right to the firefox logo above editing tools option.
https://support.mozilla.org/en-US/kb/firefox-takes-long-time-start-up
