### PR TITLE
Update wiki.less

### DIFF
--- a/kitsune/sumo/static/less/wiki.less
+++ b/kitsune/sumo/static/less/wiki.less
@@ -70,6 +70,7 @@ article {
 #os_input,
 #browser_input {
   cursor: pointer;
+  padding: 0 10px;
 }
 
 .wait {


### PR DESCRIPTION
I added 10px padding (right and left) for .selectbox class, to make the texts displayed in the Select input boxes for OS and Mozilla Version in KB articles.

Example

Open the below link you can find 2 select box right to the firefox logo above editing tools option.
https://support.mozilla.org/en-US/kb/firefox-takes-long-time-start-up
