### PR TITLE
Use dennis_shim.py for 10x speedup

### DIFF
--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -31,15 +31,14 @@ def update_code(ctx, tag):
 def update_locales(ctx):
     with ctx.lcd(os.path.join(settings.SRC_DIR, 'locale')):
         ctx.local("svn up")
-        ctx.local("./compile-mo.sh .")
 
     # Run the script that lints the .po files and compiles to .mo the
     # the ones that don't have egregious errors in them. This prints
     # stdout to the deploy log and also to media/postatus.txt so
     # others can see what happened.
-    # with ctx.lcd(settings.SRC_DIR):
-    #     ctx.local('date > media/postatus.txt')
-    #     ctx.local('./scripts/compile-linted-mo.sh | /usr/bin/tee -a media/postatus.txt')
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local('date > media/postatus.txt')
+        ctx.local('./scripts/compile-linted-mo.sh | /usr/bin/tee -a media/postatus.txt')
 
 
 @task


### PR DESCRIPTION
Turns out running dennis in ./manage.py is uber-slow because of all the
django/whatever stuff. Running dennis directly with a shim that sets up
the sys.path correctly is _so much faster_.

Also, this updates dennis to v0.3.8 which picks up a fix for false
positives in mismatched variables error detection.

r?
