### PR TITLE
[bug 932306] Track clicks to Mozilla News links.

### DIFF
--- a/kitsune/sumo/static/js/analytics.js
+++ b/kitsune/sumo/static/js/analytics.js
@@ -51,6 +51,12 @@ $('body').on('click', 'a[data-ga-click]', function(ev) {
 });
 
 
+// Add data-ga-click attribute to Mozilla News links
+$('#mozilla-news a').each(function() {
+  $(this).attr('data-ga-click', '_trackEvent | External Links | Mozilla News');
+});
+
+
 // Track reads (5secs and 10secs on page) of product landing pages.
 if ($('body').is('.product-landing')) {
   setTimeout(function() {


### PR DESCRIPTION
I had to add the `data-ga-click` attr in js because this content is from wiki markup.

Open dev tools and click on a news link to see the call to GA.

r?
