### PR TITLE
[bug 932333] Delete RegistrationProfile during user activation.

### DIFF
--- a/kitsune/users/models.py
+++ b/kitsune/users/models.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.contrib.sites.models import Site
-from django.core.mail import EmailMultiAlternatives
 from django.db import models
 
 from celery.task import task
@@ -227,6 +226,9 @@ class RegistrationManager(ConfirmationManager):
                     user = profile.user
                     user.is_active = True
                     user.save()
+
+                    # We don't need the RegistrationProfile anymore, delete it.
+                    profile.delete()
 
                     # If user registered as contributor, send them the
                     # welcome email.

--- a/kitsune/users/tests/test_views.py
+++ b/kitsune/users/tests/test_views.py
@@ -108,6 +108,9 @@ class RegisterTests(TestCase):
         user_ = User.objects.get(pk=user_.pk)
         assert user_.is_active
 
+        # Verify that the RegistrationProfile was nuked.
+        eq_(0, RegistrationProfile.objects.filter(activation_key=key).count())
+
     @mock.patch.object(Site.objects, 'get_current')
     def test_question_created_time_on_user_activation(self, get_current):
         get_current.return_value.domain = 'su.mo.com'


### PR DESCRIPTION
This ended up being way easier than I thought.

The problem was that when we cleaned out the RegistrationProfiles as they expired, we were deleting users that never activated along with users that had activated and contributed but then had been deactivated. This patch takes care of that second case. As soon as a user is activated, we delete their RegistrationProfile. Now the cron job only cleans up RegistrationProfiles for users that never activated which is what we want.

r?
