### PR TITLE
[bug 927857] Suppress outdated warning on Update Firefox article.

### DIFF
--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -102,16 +102,18 @@
 {% endif %}
 
 <div id="announcements">
-  {# This will get conditionally shown if it is needed. #}
-  {% call announcement_bar('outdated', 'error') %}
-    <span>
-      {{ _('Your Firefox is out of date and may contain a security risk!') }}
-    </span>
-    <a class="download-button" href="http://www.mozilla.org/firefox/new/#download-fx"
-     data-ga-click="_trackEvent | External Links | Top Banner - Firefox Upgrades">
-      {{ _('Upgrade Firefox') }}
-    </a>
-  {% endcall %}
+  {% if not suppress_outdated_warning %}
+    {# This will get conditionally shown (by js) if it is needed. #}
+    {% call announcement_bar('outdated', 'error') %}
+      <span>
+        {{ _('Your Firefox is out of date and may contain a security risk!') }}
+      </span>
+      <a class="download-button" href="http://www.mozilla.org/firefox/new/#download-fx"
+       data-ga-click="_trackEvent | External Links | Top Banner - Firefox Upgrades">
+        {{ _('Upgrade Firefox') }}
+      </a>
+    {% endcall %}
+  {% endif %}
 
   {% for announ in get_announcements() %}
     {% call announcement_bar(announ.id, 'warn') %}

--- a/kitsune/wiki/templates/wiki/document.html
+++ b/kitsune/wiki/templates/wiki/document.html
@@ -30,6 +30,11 @@
   {% set meta = meta + [('description', document.current_revision.summary)] %}
 {% endif %}
 
+{% if document.slug == 'update-firefox-latest-version' %}
+  {# Don't show the Firefox outdated warning on the "Update firefox" article. #}
+  {% set suppress_outdated_warning = True %}
+{% endif %}
+
 {% block above_main %}
   <h1 class="product-title cf">
     {% set prod_url = url('products.product', slug=product.slug) %}

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -369,6 +369,25 @@ class DocumentTests(TestCaseBase):
         doc = pq(response.content)
         assert 'rel' not in doc('#doc-content a')[0].attrib
 
+    def test_no_outdated_on_update_firefox_article(self):
+        """Verify the Update Firefox article doesn't show outdated warning."""
+        # Create a document and verify the warning is on the page.
+        r = revision(save=True, content='Some text.', is_approved=True)
+        response = self.client.get(r.document.get_absolute_url())
+        eq_(200, response.status_code)
+        doc = pq(response.content)
+        eq_(1, len(doc('#announce-outdated')))
+
+        # Change the slug to match the Update Firefox article.
+        # Verify that the outdated warning isn't on the page anymore.
+        d = r.document
+        d.slug = 'update-firefox-latest-version'
+        d.save()
+        response = self.client.get(r.document.get_absolute_url())
+        eq_(200, response.status_code)
+        doc = pq(response.content)
+        eq_(0, len(doc('#announce-outdated')))
+
 
 class MobileArticleTemplate(MobileTestCase):
     def setUp(self):


### PR DESCRIPTION
Don't show the Firefox outdated warning on the "Update firefox" article.

And a test for that.

r?
