### PR TITLE
[bug 932348] Escalate questions to zendesk when tagged "escalate".

### DIFF
--- a/kitsune/questions/signals.py
+++ b/kitsune/questions/signals.py
@@ -1,0 +1,3 @@
+import django.dispatch
+
+tag_added = django.dispatch.Signal(providing_args=['question_id', 'tag_name'])


### PR DESCRIPTION
To test this...
- Run the tests.
- Tag a question with escalate. You should see an error in your console since you probably don't have valid zendesk credentials in your settings.

r?
