### PR TITLE
[bug 937183] Add sanitizing tests

### DIFF
--- a/kitsune/sumo/tests/test_parser.py
+++ b/kitsune/sumo/tests/test_parser.py
@@ -246,6 +246,40 @@ class TestWikiParser(TestCase):
             'onload="alert(1)" &lt;="" p=""&gt;&lt;/iframe&gt;</p>',
             self.p.parse(content))
 
+    def test_injections(self):
+        testdata = (
+            # Normal image urls
+            ('<img src="https://example.com/nursekitty.jpg">',
+             '<p><img src="https://example.com/nursekitty.jpg">\n</p>'),
+
+            ('<img src=https://example.com/nursekitty.jpg />',
+             '<p><img src="https://example.com/nursekitty.jpg">\n</p>'),
+
+            ('<img src="https://example.com/nursekitty.jpg" />',
+             '<p><img src="https://example.com/nursekitty.jpg">\n</p>'),
+
+            ('<img src=https://example.com/nursekitty.jpg </img>',
+             '<p><img src="https://example.com/nursekitty.jpg"></p>'),
+
+            # Script insertions from OWASP site
+            ('<IMG SRC=`javascript:alert("\'XSS\'")`>',
+             '<p><img>\n</p>'),
+
+            ('<IMG SRC=javascript:alert("XSS")>',
+             '<p><img>\n</p>'),
+
+            ('<IMG SRC=JaVaScRiPt:alert(\'XSS\')>',
+             '<p><img>\n</p>'),
+
+            ('<IMG SRC=javascript:alert(\'XSS\')>',
+             '<p><img>\n</p>'),
+
+            ('<IMG SRC="javascript:alert(\'XSS\');">',
+             '<p><img>\n</p>'),
+        )
+        for content, expected in testdata:
+            eq_(expected, self.p.parse(content))
+
 
 class TestWikiInternalLinks(TestCase):
     def setUp(self):


### PR DESCRIPTION
This adds some xss-related tests for sumo.parser.wiki_to_html which we use in a bunch of places. These sorts of issues pop up periodically, so it's easier to have a test for them that we can point to and also to catch possible regressions down the line as we tweak different parts of the parser and upgrade bleach.

We can add to these tests as we go along.

r?
