### PR TITLE
Add setting to skip migrations when building test db

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -23,6 +23,9 @@ STAGE = False
 
 SESSION_COOKIE_SECURE = False
 
+# Don't run migrations on syncdb when we create the test database
+SOUTH_TESTS_MIGRATE = False
+
 # The way we do live server test cases is greedy with ports. This gives
 # it more ports, but won't clobber settings from the environment.
 if 'DJANGO_LIVE_TEST_SERVER_ADDRESS' not in os.environ:


### PR DESCRIPTION
We periodically add data via data migrations. However with test-utils,
the first time you run tests that depend on that new data, they work but
subsequent tests will fail.

However, this is the same situation we had with schematic. We use model
makers to generate data we need for tests.

Ergo, there's no reason to run the south migrations to create the test
db.

This shuts that off.

r?
