### PR TITLE
[bug 939164] Fix product/topic edit form when one is missing.

### DIFF
--- a/kitsune/questions/templates/questions/answers.html
+++ b/kitsune/questions/templates/questions/answers.html
@@ -198,15 +198,17 @@
           <li id="question-details">
             <span>{{ _('Question details') }}</span>
             <div class="folder">
-              {% if product %}
-                {% set product = product[0] %}
+              {% if product or (user and user.has_perm('questions.change_question')) %}
                 <div class="sidebox tight condensed">
                   <span class="title">{{ _('Product') }}</span>
-                  <span class="detail">{{ _(product.title, 'DB: products.Product.title') }}</span>
+                  {% if product %}
+                    {% set product = product[0] %}
+                    <span class="detail">{{ _(product.title, 'DB: products.Product.title') }}</span>
+                  {% endif %}
                   {% if user and user.has_perm('questions.change_question') %}
                     <select id="details-product" name="product">
                       {% for p in all_products %}
-                        <option {% if p.id == product.id %}selected="selected"{% endif %} value="{{ p.id }}" data-url="{{ url('products.product', p.slug) }}">{{ p.title }}</option>
+                        <option {% if product and p.id == product.id %}selected="selected"{% endif %} value="{{ p.id }}" data-url="{{ url('products.product', p.slug) }}">{{ p.title }}</option>
                       {% endfor %}
                     </select>
                   {% endif %}
@@ -214,15 +216,17 @@
                 </div>
               {% endif %}
 
-              {% if topic %}
-                {% set topic = topic[0] %}
+              {% if topic or (user and user.has_perm('questions.change_question')) %}
                 <div class="sidebox tight condensed">
                   <span class="title">{{ _('Topic') }}</span>
-                  <span class="detail">{{ _(topic.title, 'DB: products.Topic.title') }}</span>
+                  {% if topic %}
+                    {% set topic = topic[0] %}
+                    <span class="detail">{{ _(topic.title, 'DB: products.Topic.title') }}</span>
+                  {% endif %}
                   {% if user and user.has_perm('questions.change_question') %}
                     <select id="details-topic" name="topic">
                       {% for t in all_topics %}
-                        <option {% if t.id == topic.id %}selected="selected"{% endif %} value="{{ t.id }}">{{ t.title }}</option>
+                        <option {% if topic and t.id == topic.id %}selected="selected"{% endif %} value="{{ t.id }}">{{ t.title }}</option>
                       {% endfor %}
                     </select>
                   {% endif %}


### PR DESCRIPTION
When the product or topic was missing from a question, there was no way to edit them because the form was incomplete and failing validation.

To test:

1- If you have a recent DB, go to the question mentioned in the bug: http://localhost:8000/en-US/questions/974614
2- Under QUESTION DETAILS, click EDIT DETAILS. If you are on master, you're only allowed to change the form but, if you click SAVE CHANGES, it doesn't work. If you are on this branch, it should work just fine.

If you don't have a recent db, you can get an existing question and remove the topic from it:

```
from kitsune.questions.models import Question
q = Question.objects.get(id=999999)
q.topics.clear()
```

Anyway, r?
