### PR TITLE
[bug 889467] Nix verify_exists arg

### DIFF
--- a/kitsune/sumo/tests/test_forms.py
+++ b/kitsune/sumo/tests/test_forms.py
@@ -18,7 +18,7 @@ class ExampleForm(forms.Form):
     bool = forms.BooleanField()
     textarea = StrippedCharField(widget=forms.Textarea())
     email = forms.EmailField()
-    url = forms.URLField(required=False, verify_exists=False)
+    url = forms.URLField(required=False)
     date = forms.DateField()
     time = forms.TimeField()
 

--- a/kitsune/users/models.py
+++ b/kitsune/users/models.py
@@ -65,13 +65,10 @@ class Profile(ModelBase):
     bio = models.TextField(null=True, blank=True,
                            verbose_name=_lazy(u'Biography'))
     website = models.URLField(max_length=255, null=True, blank=True,
-                              verify_exists=False,
                               verbose_name=_lazy(u'Website'))
     twitter = models.URLField(max_length=255, null=True, blank=True,
-                              verify_exists=False,
                               verbose_name=_lazy(u'Twitter URL'))
     facebook = models.URLField(max_length=255, null=True, blank=True,
-                               verify_exists=False,
                                verbose_name=_lazy(u'Facebook URL'))
     irc_handle = models.CharField(max_length=255, null=True, blank=True,
                                   verbose_name=_lazy(u'IRC nickname'))


### PR DESCRIPTION
The verify_exists arg was removed from URLField in Django 1.4. Using it
kicks up an error in Django 1.5, so I'm taking it out.

Quick r?
