### PR TITLE
[bug 946695] Use document.get_products() instead of document.products.all().

### DIFF
--- a/kitsune/wiki/templates/wiki/includes/sidebar_modules.html
+++ b/kitsune/wiki/templates/wiki/includes/sidebar_modules.html
@@ -49,8 +49,7 @@
           {% endif %}
           {% if include_showfor %}
             <li>
-              {# The parent has precedence because products are inherited. #}
-              {{ show_for((parent or document).products.all(), header=False) }}
+              {{ show_for((document or parent).get_products(), header=False) }}
             </li>
           {% endif %}
         </ul>

--- a/kitsune/wiki/templates/wiki/review_revision.html
+++ b/kitsune/wiki/templates/wiki/review_revision.html
@@ -33,7 +33,7 @@
           <div id="doc-content">
             {{ revision.content_parsed|safe }}
           </div>
-          {{ show_for(document.products.all(), _('Article is for:')) }}
+          {{ show_for(document.get_products(), _('Article is for:')) }}
         </details>
       {% else %}
         <p>{{ _('This document does not have a current revision.') }}</p>
@@ -68,7 +68,7 @@
 
 {% block side_bottom %}
   {% if not revision.reviewed and not document.current_revision %}
-    {{ show_for(document.products.all(), _('Article is for:')) }}
+    {{ show_for(document.get_products(), _('Article is for:')) }}
   {% endif %}
 {% endblock %}
 

--- a/kitsune/wiki/templates/wiki/revision.html
+++ b/kitsune/wiki/templates/wiki/revision.html
@@ -98,6 +98,6 @@
 
 {% block side_bottom %}
   <div>
-    {{ show_for(document.products.all(), header=_('Article is for:')) }}
+    {{ show_for(document.get_products(), header=_('Article is for:')) }}
   </div>
 {% endblock %}

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -42,7 +42,6 @@ from kitsune.wiki.forms import (
     ReviewForm)
 from kitsune.wiki.models import Document, Revision, HelpfulVote, ImportantDate
 from kitsune.wiki.parser import wiki_to_html
-from kitsune.wiki.showfor import showfor_data
 from kitsune.wiki.tasks import (
     send_reviewed_notification, schedule_rebuild_kb,
     send_contributor_notification)
@@ -407,10 +406,7 @@ def preview_revision(request):
 
     if slug and locale:
         doc = get_object_or_404(Document, slug=slug, locale=locale)
-        if doc.parent:
-            products = doc.parent.products.all()
-        else:
-            products = doc.products.all()
+        products = doc.get_products()
     else:
         products = Product.objects.all()
 


### PR DESCRIPTION
Another commit. This one should fix the revision page for non en-US locales.
