### PR TITLE
[bug 947206] Change log_error to log_exception

### DIFF
--- a/kitsune/sumo/email_utils.py
+++ b/kitsune/sumo/email_utils.py
@@ -38,7 +38,7 @@ def safe_translation(f):
         try:
             with uselocale(locale):
                 return f(locale, *args, **kwargs)
-        except (TypeError, KeyError, ValueError, IndexError) as e:
+        except (TypeError, KeyError, ValueError, IndexError):
             # Types of errors, and examples.
             #
             # TypeError: Not enough arguments for string
@@ -49,7 +49,7 @@ def safe_translation(f):
             #    '%(foo)a' or '%(foo)' or '{foo'
             # IndexError: Not enough arguments for .format() style string.
             #    '{0} {1}'.format(42)
-            log.error('Bad translation in locale "%s": %s', locale, e)
+            log.exception('Bad translation in locale "%s"', locale)
 
             with uselocale(settings.WIKI_DEFAULT_LANGUAGE):
                 return f(settings.WIKI_DEFAULT_LANGUAGE, *args, **kwargs)

--- a/kitsune/sumo/tests/test_email_utils.py
+++ b/kitsune/sumo/tests/test_email_utils.py
@@ -113,7 +113,7 @@ class SafeTranslationTests(TestCase):
         eq_(len(mocked_log.method_calls), 1)
 
         method_name, method_args, method_kwargs = mocked_log.method_calls[0]
-        eq_(method_name, 'error')
+        eq_(method_name, 'exception')
         assert 'Bad translation' in method_args[0]
         eq_(method_args[1], 'fr')
 


### PR DESCRIPTION
Right now one of the strings is kicking up an error, but we have no idea
which string it is because there's no traceback. This changes the
log_error to a log_exception which will give us a traceback which
hopefully will make it to Sentry and then we should be able to track
down the problem string.

Quick r?
