### PR TITLE
[bug 946498] Unescalate all the questions older than a week.

### DIFF
--- a/kitsune/questions/migrations/0004_unescalate_older_questions.py
+++ b/kitsune/questions/migrations/0004_unescalate_older_questions.py
@@ -9,7 +9,11 @@ class Migration(DataMigration):
     def forwards(self, orm):
         """Unescalate questions over a week old."""
         # Get the escalate tag.
-        tag = orm['taggit.Tag'].objects.get(name='escalate')
+        Tag = orm['taggit.Tag']
+        try:
+            tag = Tag.objects.get(name='escalate')
+        except Tag.DoesNotExist:
+            return
 
         # Get all the items tagged escalate.
         items = tag.taggit_taggeditem_items.all()


### PR DESCRIPTION
The migration is a little weird because we are dealing with the vanilla models that south exposes, so you can't do things like `Question.objects.filter(tags__slug__in='escalate')` or `question.tags.remove('escalate')`. Instead, I have to deal with the models directly.

r?
