### PR TITLE
[bug 928901] Fixed Needs Attention filter

### DIFF
--- a/kitsune/questions/managers.py
+++ b/kitsune/questions/managers.py
@@ -26,7 +26,7 @@ class QuestionManager(ManagerBase):
     #      the status is "Needs Attention"
     def needs_attention(self):
         qs = self.filter(solution__isnull=True, is_locked=False,
-                         created__gte=datetime.now() - timedelta(days=7))
+                         updated__gte=datetime.now() - timedelta(days=7))
         return qs.filter(Q(last_answer__creator=F('creator')) |
                          Q(last_answer__isnull=True))
 


### PR DESCRIPTION
It should filter by updated in the last 7 days, instead of created. Otherwise, recent replies will get lost for older questions.

See https://support.mozilla.org/en-US/forums/contributors/709835?last=55969&page=2#post-55965:

"The "needs attention" tab is only showing questions where the last post was made less than 7 days ago."

tiny r?
