### PR TITLE
[Bug 943525] Cascade document re-renders.

### DIFF
--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -1093,7 +1093,7 @@ class DocumentLink(ModelBase):
     kind = models.CharField(max_length=16)
 
     class Meta:
-        unique_together = ('linked_from', 'linked_to')
+        unique_together = ('linked_from', 'linked_to', 'kind')
 
     def __unicode__(self):
         return (u'<DocumentLink: %s from %r to %r>' %

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -44,7 +44,7 @@ from kitsune.wiki.models import Document, Revision, HelpfulVote, ImportantDate
 from kitsune.wiki.parser import wiki_to_html
 from kitsune.wiki.tasks import (
     send_reviewed_notification, schedule_rebuild_kb,
-    send_contributor_notification)
+    send_contributor_notification, render_document_cascade)
 
 
 log = logging.getLogger('k.wiki')
@@ -520,9 +520,8 @@ def review_revision(request, document_slug, revision_id):
             send_reviewed_notification.delay(rev, doc, msg)
             send_contributor_notification(based_on_revs, rev, doc, msg)
 
-            # Schedule KB rebuild?
             statsd.incr('wiki.review')
-            schedule_rebuild_kb()
+            render_document_cascade.delay(doc)
 
             return HttpResponseRedirect(reverse('wiki.document_revisions',
                                                 args=[document_slug]))


### PR DESCRIPTION
This was easier than I expected, yay!

When ever a revision is approved, instead of maybe re-rendering the entire kb (if that flag is set), this always re-render only the parts of the kb that need changing. "Needs changing" is defined as containg a template link or an include link to a document that has been re-rendered. This can cascade to as many levels as needed, if your include has a template that includes another document. This is resistant to loops and other weird patterns in the graph. These are all done in a celery task, because rendering a bunch wiki documents in a request/response cycle sounds like a bad thing.

In testing I had this as including links as things that would cause a re-render. This was a bad idea and increased the amount of work to be done by an order of magnitude or two. After I fixed that, this got a lot more pleasant.

r?
