### PR TITLE
[bug 956063] Fix display_name traceback.

### DIFF
--- a/kitsune/forums/templates/forums/includes/post.html
+++ b/kitsune/forums/templates/forums/includes/post.html
@@ -36,7 +36,7 @@
     {{ datetimeformat(post.created, format='longdatetime') }}
     <a href="#post-{{ post.id }}" class="permalink" title="{{ _('Link to this post.') }}">#</a>
   </div>
-  {% if post.id and post.updated_by and post.created != post.updated %}
+  {% if post.updated_by %}
     {{ _('Modified by {name} on {datetime}')|fe(name=display_name(post.updated_by), datetime=datetimeformat(post.updated, format='longdatetime')) }}
   {% endif %}
 </div>

--- a/kitsune/kbforums/templates/kbforums/includes/post.html
+++ b/kitsune/kbforums/templates/kbforums/includes/post.html
@@ -38,7 +38,7 @@
       <a class="reply" data-post="{{ post.id }}" href="#thread-reply">{{ _('Reply') }}</a>
     </span>
   {% endif %}
-  {% if post.id and post.created != post.updated %}
+  {% if post.updated_by %}
     <span class="post-modified">
       {{ _('Modified by {name} on {datetime}')|fe(name=display_name(post.updated_by), datetime=datetimeformat(post.updated, format='longdatetime')) }}
     </span>


### PR DESCRIPTION
Stop trying to display the name of the updater if there is none.

r?
