### PR TITLE
Add lint checks to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ env: DJANGO_LIVE_TEST_SERVER_ADDRESS="localhost:9900-9999"
 
 install: scripts/travis/install.sh
 before_script: scripts/travis/setup.sh
-script: scripts/travis/test.sh
+script:
+  - scripts/lint.sh
+  - scripts/travis/test.sh
 
 notifications:
     email: false

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -22,17 +22,22 @@ FLAKE8_IGNORE=(
 # Files to lint is either the list of arguments to this script, or the
 # kitsune directory.
 FILES="$@"
-FLAKE8_FILES=()
 
+FLAKE8_FILES=()
 for f in $FILES; do
     # If it is a directory, or if it is a python file, lint it with flake8.
     if [[ -d $f ]] || echo $f | grep -E '.py$' > /dev/null; then
         FLAKE8_FILES+=($f)
     fi
 done
-
 FLAKE8_IGNORE=$(IFS=,; echo "${FLAKE8_IGNORE[*]}")
-flake8 --exclude=$FLAKE8_IGNORE ${FLAKE8_FILES[*]}
-FLAKE_RETURN=$?
+
+# If there are files to run through flake8, do it.
+if [[ -n ${FLAKE8_FILES[*]} ]]; then
+  flake8 --exclude=$FLAKE8_IGNORE ${FLAKE8_FILES[*]}
+  FLAKE_RETURN=$?
+else
+  FLAKE_RETURN=0
+fi
 
 exit $FLAKE_RETURN


### PR DESCRIPTION
This (should) enforce that lint.sh passes for every Travis build. I also tweaked the lint script to deal with having no Python files to lint. Travis should run this, including the lint code.

r?
