### PR TITLE
[Bug 941376] Add GA events to UpToDate bubble.

### DIFF
--- a/kitsune/products/templates/products/product.html
+++ b/kitsune/products/templates/products/product.html
@@ -35,7 +35,7 @@
             </li>
             <li>
               <a href="http://www.mozilla.org/firefox/new/#download-fx"
-                 data-ga-click="_trackEvent | Download Click | {{ product.slug }}">
+                 data-ga-click="_trackEvent | External Links | Top Banner - UpToDate">
                 {{ _('Continue with download') }}
               </a>
             </li>

--- a/kitsune/sumo/static/js/products.js
+++ b/kitsune/sumo/static/js/products.js
@@ -1,11 +1,19 @@
 (function($, BD) {
+    "use strict";
+
     $(function() {
+        var locale = $('body').attr('lang');
+        var gaBubbleOpen = ['_trackPageview', interpolate('/{0}/products/firefox/up-to-date-download', locale)];
+
         $('.download-firefox .download-button').on('click', function(ev) {
-            var latest_version = $(this).data('latest-version');
-            if ((BD.version >= latest_version) && (BD.browser == 'fx')) {
+            var $this = $(this);
+            var latestVersion = $this.data('latest-version');
+
+            if ((BD.version >= latestVersion) && (BD.browser == 'fx')) {
                 ev.stopPropagation();
                 ev.preventDefault();
-                $(this).siblings('.help-bubble').show();
+                $this.siblings('.help-bubble').show();
+                _gaq.push(gaBubbleOpen);
             }
         });
     });


### PR DESCRIPTION
This tweaks the event that the Firefox download button sends when users are already on the latest version, and adds another event for when the info bubble pops up.

r?
