### PR TITLE
[bug 952515] Stop showing escalated and offtopic by default.

### DIFF
--- a/kitsune/questions/models.py
+++ b/kitsune/questions/models.py
@@ -315,12 +315,20 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
         return not not self.solution_id
 
     @property
+    def is_escalated(self):
+        return config.ESCALATE_TAG_NAME in [t.name for t in self.my_tags]
+
+    @property
+    def is_offtopic(self):
+        return config.OFFTOPIC_TAG_NAME in [t.name for t in self.my_tags]
+
+    @property
     def my_tags(self):
         """A caching wrapper around self.tags.all()."""
         cache_key = self.tags_cache_key % self.id
         tags = cache.get(cache_key)
         if tags is None:
-            tags = self.tags.all().order_by('name')
+            tags = list(self.tags.all().order_by('name'))
             cache.add(cache_key, tags, CACHE_TIMEOUT)
         return tags
 

--- a/kitsune/questions/templates/questions/questions.html
+++ b/kitsune/questions/templates/questions/questions.html
@@ -2,6 +2,12 @@
 {% from "dashboards/includes/macros.html" import product_selector, topic_selector %}
 {% set title = _('Firefox Support Forum') %}
 {% set classes = 'questions' %}
+{% if offtopic %}
+  {% set classes = classes + ' show-offtopic' %}
+{% endif %}
+{% if escalated %}
+  {% set classes = classes + ' show-escalated' %}
+{% endif %}
 {% set crumbs = [(None, _('Support Forum'))] %}
 {% set canonical_url = unlocalized_url('questions.questions')|urlparams(None, request.GET) %}
 {% if questions.number > 1 %}
@@ -152,7 +158,7 @@
     {% if questions.object_list %}
       <article class="questions">
         {% for question in questions.object_list %}
-          <section id="question-{{ question.id }}" class="cf">
+          <section id="question-{{ question.id }}" class="cf{% if question.is_escalated %} escalated{% endif %}{% if question.is_offtopic %} offtopic{% endif %}">
             <div class="question-meta {% if not question.num_answers %}urgent{% endif %}">
               <div class="have-problem-this-week">
                 <h4>{{ question.num_votes_past_week }}</h4>
@@ -194,7 +200,7 @@
               {% endif %}
             </div>
           </section>
-          <aside>
+          <aside class="{% if question.is_escalated %} escalated{% endif %}{% if question.is_offtopic %} offtopic{% endif %}">
             <div class="user-meta">
               {{ _('Posted by {user}')|f(user=display_name(question.creator)) }}
               {{ _('on') }} {{ datetimeformat(question.created, format='datetime') }}

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -166,14 +166,6 @@ def questions(request, template):
     else:
         owner = None
 
-    if escalated:
-        question_qs = question_qs.filter(
-            tags__slug__in=[config.ESCALATE_TAG_NAME])
-
-    if offtopic:
-        question_qs = question_qs.filter(
-            tags__slug__in=[config.OFFTOPIC_TAG_NAME])
-
     feed_urls = ((urlparams(reverse('questions.feed'),
                             product=product_slug, topic=topic_slug),
                   QuestionsFeed().title()),)

--- a/kitsune/sumo/static/less/questions.less
+++ b/kitsune/sumo/static/less/questions.less
@@ -731,6 +731,23 @@ h2 {
       }
     }
   }
+
+  .escalated,
+  .offtopic {
+    display: none;
+  }
+}
+
+.show-escalated {
+  .escalated {
+    display: block;
+  }
+}
+
+.show-offtopic {
+  .offtopic {
+    display: block;
+  }
 }
 
 #aaq_progress {


### PR DESCRIPTION
Hiding and showing for these questions is via CSS now. (mostly because I dont want to slow down the db queries)

r?
