### PR TITLE
[bug 963088] Fix deprecation warnings in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -21,27 +21,14 @@ sys.path[:0] = new_sys_path
 
 # Now we can import from third-party libraries.
 
-from django.core.management import execute_manager, setup_environ
-
-try:
-    from kitsune import settings_local as settings
-except ImportError:
-    try:
-        from kitsune import settings  # Assumed to be in the same directory.
-    except ImportError:
-        sys.stderr.write(
-            "Error: Tried importing 'settings_local.py' and 'settings.py' "
-            "but neither could be found (or they're throwing an ImportError)."
-            " Please come back and try again later.")
-        raise
-
-# The first thing execute_manager does is call `setup_environ`.  Logging config
-# needs to access settings, so we'll setup the environ early.
-setup_environ(settings)
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'kitsune.settings_local')
+os.environ.setdefault('CELERY_CONFIG_MODULE', 'kitsune.settings_local')
+from django.conf import settings
 
 # Import for side-effect: configures our logging handlers.
 from kitsune import log_settings
 
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
To verify:
- Verify the dev server works
- Verify you can run the shell `./manage.py shell`
- Run the tests
- Verify any other manage.py comman (`./manage.py cleanup`?)
- Verify any of our cron jobs (`./manage.py cron update_weekly_votes`?)
- Comment with an `R+` below.

r?
