### PR TITLE
[bug 962646] Remove <noscript/> fallback for KB images.

### DIFF
--- a/kitsune/sumo/templates/wikiparser/hook_image.html
+++ b/kitsune/sumo/templates/wikiparser/hook_image.html
@@ -43,18 +43,6 @@
   </a>
 {% endif %}
 
-{% if lazy_enabled %}
-  <noscript>
-    {% if params['link'] %}
-      <a href="{{ params['link'] }}"{% if params['page'] and not params['found'] %} class="new"{% endif %}>
-    {% endif %}
-    {{ render_image() }}
-    {% if params['link'] %}
-      </a>
-    {% endif %}
-  </noscript>
-{% endif %}
-
 {% if has_frame %}
   {% if params['caption'] %}
     <div class="caption"


### PR DESCRIPTION
To verify:

1- Run tests
2- Upload an image, edit or create a new article with the image. Preview should work. Submit it and approve it. The image should show up on the Article page and view source should show that the noscript isn't there.

r?
