### PR TITLE
[bug 979434] Fix _check_username

### DIFF
--- a/kitsune/users/forms.py
+++ b/kitsune/users/forms.py
@@ -460,7 +460,7 @@ def username_allowed(username):
 
 
 def _check_username(username):
-    if not username_allowed(username):
+    if username and not username_allowed(username):
         msg = _('The user name you entered is inappropriate. Please pick '
                 'another and consider that our helpers are other Firefox '
                 'users just like you.')


### PR DESCRIPTION
The argument passed into _check_username can sometimes be None because
it's coming out of cleaned_data, but wasn't valid. Because of that,
username_allowed returns False and then everything goes to straight to
hell.

This commit fixes that.

r?
