### PR TITLE
[bug 980262] Remove AAQ link from header during AAQ.

### DIFF
--- a/kitsune/questions/templates/questions/includes/question_editing_frame.html
+++ b/kitsune/questions/templates/questions/includes/question_editing_frame.html
@@ -14,6 +14,8 @@ we can compute the edit-title URL.
 {% from "questions/includes/aaq_macros.html" import selected_product, selected_category, aaq_progress %}
 {% from "questions/includes/aaq_macros.html" import troubleshooting_instructions with context %}
 
+{% set hide_aaq_link = True %}
+
 {% block content %}
   <div class="grid_12">
     <article class="main">

--- a/kitsune/questions/tests/test_templates.py
+++ b/kitsune/questions/tests/test_templates.py
@@ -1496,3 +1496,10 @@ class AAQTemplateTestCase(TestCaseBase):
         url = reverse('questions.aaq_step3', args=['desktop', 'lipsum'])
         response = self.client.get(url)
         eq_(302, response.status_code)
+
+    def test_no_aaq_link_in_header(self):
+        """Verify the ASK A QUESTION link isn't present in header."""
+        url = reverse('questions.aaq_step2', args=['desktop'])
+        response = self.client.get(url)
+        eq_(200, response.status_code)
+        assert '/questions/new' not in pq(response.content)('#aux-nav').html()

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -129,7 +129,7 @@
       <div class="cf">
         <nav id="aux-nav" role="navigation">
           <ul>
-            {{ aux_nav(user) }}
+            {{ aux_nav(user, hide_aaq_link) }}
             {% set locale_url = url('sumo.locales') %}
             {% if localizable_url %}
               {% set locale_url = locale_url|urlparams(next=localizable_url) %}

--- a/kitsune/sumo/templates/includes/common_macros.html
+++ b/kitsune/sumo/templates/includes/common_macros.html
@@ -17,14 +17,16 @@
   </form>
 {% endmacro %}
 
-{% macro aux_nav(user) %}
+{% macro aux_nav(user, hide_aaq_link=False) %}
   {% if not settings.READ_ONLY %}
-    {% if request.LANGUAGE_CODE in settings.AAQ_LANGUAGES %}
-      {% set ask_url = url('questions.aaq_step1') %}
-    {% else %}
-      {% set ask_url = url('wiki.document', 'get-community-support') %}
+    {% if not hide_aaq_link %}
+      {% if request.LANGUAGE_CODE in settings.AAQ_LANGUAGES %}
+        {% set ask_url = url('questions.aaq_step1') %}
+      {% else %}
+        {% set ask_url = url('wiki.document', 'get-community-support') %}
+      {% endif %}
+      <li><a href="{{ ask_url }}" class="ask">{{ _('Ask a question') }}</a></li>
     {% endif %}
-    <li><a href="{{ ask_url }}" class="ask">{{ _('Ask a question') }}</a></li>
     {% if user.is_authenticated() %}
       <li class="dropdown">
         <a href="#">{{ _('Contributor Tools') }}</a>


### PR DESCRIPTION
Test included. Click on AAQ and the next page shouldn't show the link anymore.

r?
