### PR TITLE
[Bug 979347] AAQ: Hide troubleshooting box.

### DIFF
--- a/kitsune/questions/templates/questions/includes/aaq_macros.html
+++ b/kitsune/questions/templates/questions/includes/aaq_macros.html
@@ -187,7 +187,7 @@
 
 
 {% macro troubleshooting_instructions(field) %}
-<span id="troubleshooting-install">
+  <span id="troubleshooting-install">
     <a href="{{ settings.TROUBLESHOOTER_ADDON_URL }}" class="btn btn-important" id="install-troubleshooting-addon">
       {{ _('Automatically add') }}
     </a>
@@ -195,11 +195,12 @@
       {{ _('A window will open in the top corner. Click <em>Allow</em>, and then click <em>Install</em>.') }}
     </span>
   </span>
-<span id="troubleshooting-manual">
-  {{ _('If the automated way doesn\'t work, <a class="expander" href="#troubleshooting-help">try these manual steps</a>.') }}
+  <span id="troubleshooting-manual">
+    {{ _('If the automated way doesn\'t work, <a class="expander" href="{0}">try these manual steps</a>.')|f('#troubleshooting-help,#troubleshooting-field')|safe }}
   </span>
   <span id="troubleshooting-explanation">
     {{ _('This field was populated automatically with the add-on called <em>Troubleshooter</em>.') }}
+    <a href="#troubleshooting-field" class="expander">{{ _('See the data') }}</a>.
   </span>
   <ol id="troubleshooting-help">
     <li>{{ _('Open <em>Help &gt; Troubleshooting Information</em>.') }}
@@ -223,7 +224,7 @@
       </ul>
     </li>
   </ol>
-  <p>
+  <p id="troubleshooting-field">
     {{ field }}
   </p>
 {% endmacro %}

--- a/kitsune/sumo/static/less/questions.less
+++ b/kitsune/sumo/static/less/questions.less
@@ -1056,6 +1056,10 @@ h2 {
   #troubleshooting-explanation {
     display: none;
   }
+
+  #troubleshooting-field {
+    display: none;
+  }
 }
 
 #selected-category,


### PR DESCRIPTION
To test:
- Make sure to use the url 'http://localhost:8080', so the troubleshooter addon will work right.
- Uninstall the addon, if it is installed.
- Ask a question. Try and add troubleshooting data manually.
- Try the automated way.
- Try to toggle the field visible/hidden.
- Post the questionl, it should have the data, even with a hidden form

r?
