### PR TITLE
[bug 968202] Add UI strings #s and progress bar to l10n dash.

### DIFF
--- a/kitsune/dashboards/templates/dashboards/includes/macros.html
+++ b/kitsune/dashboards/templates/dashboards/includes/macros.html
@@ -76,7 +76,7 @@
           </tr>
         {% endif %}
       {% endfor %}
-      <tr>
+      <tr class="ui-strings-row">
         <td class="row-title">
           {{ _('User Interface') }}
           <div>

--- a/kitsune/sumo/static/js/dashboards.js
+++ b/kitsune/sumo/static/js/dashboards.js
@@ -4,6 +4,7 @@
         initWatchMenu();
         initNeedsChange();
         initAnnouncements();
+        initL10nStringsStats();
     }
 
     // Hook up readout mode links (like "This Week" and "All Time") to swap
@@ -141,6 +142,63 @@
                 }
             });
         });
+    }
+
+    function initL10nStringsStats() {
+        // Create the progress bar for UI string stats in the overview
+        // section of the l10n dashboard.
+        var $tr = $('tr.ui-strings-row');
+        var $tds = $tr.find('td');
+        var now = new Date();
+        var cacheBust = now.getYear().toString() +
+                        now.getMonth().toString() +
+                        now.getDay().toString();
+
+        if ($tr.length === 0) {
+            return;
+        }
+
+        $.getJSON(
+            $('body').data('media-url') +
+                'uploads/l10n_summary.json?_cacke=' + cacheBust,
+            function(data) {
+                var localeData = data['locales'][$('html').attr('lang')];
+                var className = 'bad';
+
+                // Fill in the numbers in the second column.
+                $($tds[1]).html(
+                    interpolate(
+                        gettext('%(num)s <small>of %(total)s</small>'),
+                        {
+                            num: localeData.translated,
+                            total: localeData.total
+                        },
+                        true
+                    )
+                );
+
+                // Fill in the progress bar in the third column.
+                if (localeData.percent >= 20) {
+                    className = 'better';
+                }
+                if (localeData.percent === 100) {
+                    className = 'best';
+                }
+                $($tds[2]).html(
+                    interpolate(
+                        '%(percent)s% ' +
+                        '<div class="percent-graph">' +
+                            '<div style="width: %(percent)%" class="%(className)s">' +
+                            '</div>' +
+                        '</div>',
+                        {
+                            percent: localeData.percent,
+                            className: className
+                        },
+                        true
+                    )
+                );
+            });
     }
 
     $(document).ready(init);

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -58,6 +58,7 @@
       data-readonly="{{ settings.READ_ONLY|json }}"
       data-usernames-api="{{ url('users.api.usernames') }}"
       data-static-url="{{ STATIC_URL }}"
+      data-media-url="{{ MEDIA_URL }}"
       {% if SURVEY_GIZMOS %}
         data-survey-gizmos="{{ SURVEY_GIZMOS|json }}"
       {% else %}


### PR DESCRIPTION
A bunch of ugly js that fills in the up to date numbers and progress bar for UI strings on the l10n dashboard.

<img src="http://f.cl.ly/items/3R3y1K120S2l1V111W18/Screen%20Shot%202014-03-13%20at%202.42.31%20PM.png" />

r?
