### PR TITLE
[bug 967535] Track some Get Involved click events.

### DIFF
--- a/kitsune/landings/templates/landings/includes/register_contributor.html
+++ b/kitsune/landings/templates/landings/includes/register_contributor.html
@@ -6,7 +6,7 @@
           <form method="post" action="{{ url('users.make_contributor') }}">
             <input type="hidden" name="return_to" value="{{ request.get_full_path() }}">
             {{ csrf() }}
-            <button id="sign-up-contributor" class="btn btn-submit">{{ _('Sign me up') }} &raquo;</button>
+            <button id="sign-up-contributor" class="btn btn-submit" data-ga-click="_trackEvent | Sign Me Up Click | Logged In">{{ _('Sign me up') }} &raquo;</button>
           </form>
         {% else %}
           {% if waffle.flag('browserid') %}
@@ -16,7 +16,9 @@
             </form>
             <a id="sign-up-contributor" class="btn btn-submit browserid-login" data-form="gi-browserid-form" data-next="{{ request.get_full_path() }}" href="#">{{ _('Sign me up') }} &raquo;</a>
           {% else %}
-            <a id="sign-up-contributor" class="btn btn-submit" href="{{ url('users.auth_contributor') }}">{{ _('Sign me up') }} &raquo;</a>
+            <a id="sign-up-contributor" class="btn btn-submit" href="{{ url('users.auth_contributor') }}" data-ga-click="_trackEvent | Sign Me Up Click | Logged Out">
+              {{ _('Sign me up') }} &raquo;
+            </a>
           {% endif %}
         {% endif %}
         <h3>{{ _('Sign up as a volunteer') }}</h3>

--- a/kitsune/sumo/static/js/analytics.js
+++ b/kitsune/sumo/static/js/analytics.js
@@ -32,6 +32,7 @@ if (alternateUrl) {
 })();
 
 
+// Track clicks to links with data-ga-click attr.
 $('body').on('click', 'a[data-ga-click]', function(ev) {
   ev.preventDefault();
 
@@ -45,6 +46,24 @@ $('body').on('click', 'a[data-ga-click]', function(ev) {
   // Delay the click navigation by 100ms to ensure the event is tracked.
   setTimeout(function() {
     document.location.href = href;
+  }, 100);
+
+  return false;
+});
+
+// Track clicks to form buttons with data-ga-click attr.
+$('body').on('click', 'button[data-ga-click]', function(ev) {
+  ev.preventDefault();
+
+  var $this = $(this);
+  // Split by '|', and allow for white space on either side.
+  var gaData = $this.data('ga-click').split(/\s*\|\s*/);
+
+  _gaq.push(gaData);
+
+  // Delay the form post by 100ms to ensure the event is tracked.
+  setTimeout(function() {
+    $this.closest('form').submit();
   }, 100);
 
   return false;

--- a/kitsune/users/templates/users/includes/macros.html
+++ b/kitsune/users/templates/users/includes/macros.html
@@ -73,7 +73,7 @@
     </ul>
     <div class="submit">
       <input type="hidden" name="register" value="1">
-      <button type="submit" data-type="submit" data-name="register" class="btn btn-submit">
+      <button type="submit" class="btn btn-submit" {% if contributor %}data-ga-click="_trackEvent | Register Click | Contributor"{% endif %}>
         {{ _('Register') }}
       </button>
     </div>


### PR DESCRIPTION
r?

To verify,
- Click the sign me up button in the Get Involved pages and verify a request goes out to GA
- Click on the register button from /en-US/users/authcontributor and verify a request goes out to GA
