### PR TITLE
[bug 936559] Redirect xh to en-US.

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -230,6 +230,7 @@ NON_SUPPORTED_LOCALES = {
     'nn-NO': 'no',
     'oc': 'fr',
     'sv-SE': 'sv',
+    'xh': None,
 }
 
 ES_LOCALE_ANALYZERS = {


### PR DESCRIPTION
/xh/ now redirects to /en-US/

tiny r?
