### PR TITLE
Deploy script: stop priming port :80

### DIFF
--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -83,8 +83,7 @@ def deploy_app(ctx):
 
 @hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def prime_app(ctx):
-    for http_port in range(80, 82):
-        ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:%s/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
+    ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:81/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
 
 
 @hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})


### PR DESCRIPTION
We went full HTTPS yesterday, so there is nothing at port 80 anymore.

r?
