### PR TITLE
[Bug 978002] Don't create duplicate links.

### DIFF
--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -657,17 +657,13 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
 
     def add_link_to(self, linked_to, kind):
         """Create a DocumentLink to another Document."""
-        try:
-            DocumentLink(
-                linked_from=self, linked_to=linked_to, kind=kind).save()
-        except IntegrityError:
-            # This link already exists, ok.
-            pass
+        DocumentLink.objects.get_or_create(linked_from=self,
+                                           linked_to=linked_to,
+                                           kind=kind)
 
     @property
     def images(self):
         return Image.objects.filter(documentimage__document=self)
-
 
     def add_image(self, image):
         """Create a DocumentImage to connect self to an Image instance."""
@@ -1125,7 +1121,7 @@ class DocumentImage(ModelBase):
 
     def __unicode__(self):
         return u'<DocumentImage: {doc} includes {img}>'.format(
-            doc=document, img=image)
+            doc=self.document, img=self.image)
 
 
 def _doc_components_from_url(url, required_locale=None, check_host=True):

--- a/kitsune/wiki/parser.py
+++ b/kitsune/wiki/parser.py
@@ -465,7 +465,7 @@ class WhatLinksHereParser(WikiParser):
         """Record a template link between documents, and then call super()."""
 
         params = name.split('|')
-        template = get_object_fallback(Document, 'Template:' + params.pop(0),
+        template = get_object_fallback(Document, 'Template:' + params[0],
                                        locale=self.locale, is_template=True)
 
         if template:


### PR DESCRIPTION
Apparently trying to create a duplicate link has been causing replication to stop on the database servers, because it caused errors. I also fix some lint errors. 

r?
