### PR TITLE
[bug 971014] `Manager.get_empty_query_set() was removed. Use `none()` instead

### DIFF
--- a/kitsune/questions/tests/test_templates.py
+++ b/kitsune/questions/tests/test_templates.py
@@ -1118,6 +1118,12 @@ class QuestionsTemplateTestCase(TestCaseBase):
         eq_('/questions?tagged=mobile&show=all',
             doc('link[rel="canonical"]')[0].attrib['href'])
 
+        # Test a tag that doesn't exist. It shouldnt blow up.
+        url = urlparams(
+            reverse('questions.questions'), tagged='garbage-plate', show='all')
+        response = self.client.get(url)
+        eq_(200, response.status_code)
+
     def test_product_filter(self):
         p1 = product(save=True)
         p2 = product(save=True)

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -182,7 +182,7 @@ def questions(request, template):
                                        args=[tags[0].slug]),
                                TaggedQuestionsFeed().title(tags[0])),)
         else:
-            question_qs = Question.objects.get_empty_query_set()
+            question_qs = Question.objects.none()
 
     # Exclude questions over 90 days old without an answer.
     oldest_date = date.today() - timedelta(days=90)


### PR DESCRIPTION
This fixes: https://errormill.mozilla.org/support/sumo-stage/group/166295/

I added a test that triggers the issue, then fixed it.

Also see: https://github.com/django/django/commit/fb606e10ac07af6014cae838c21bf30cf50e8b40

Small r?
