### PR TITLE
[bug 987471] close_old_connections() before updating metrics

### DIFF
--- a/kitsune/dashboards/models.py
+++ b/kitsune/dashboards/models.py
@@ -2,6 +2,7 @@ import logging
 from datetime import date, timedelta
 
 from django.conf import settings
+from django.db import connection, close_old_connections
 from django.db import models
 
 from tower import ugettext_lazy as _lazy
@@ -49,10 +50,23 @@ class WikiDocumentVisits(ModelBase):
         counts = googleanalytics.pageviews_by_document(
             *period_dates(period), verbose=verbose)
         if counts:
+            # Close any existing connections because our load balancer times
+            # them out at 5 minutes and the GA calls take forever.
+            close_old_connections()
+
             # Delete and remake the rows:
             # Horribly inefficient until
             # http://code.djangoproject.com/ticket/9519 is fixed.
-            cls.objects.filter(period=period).delete()
+            # cls.objects.filter(period=period).delete()
+
+            # Instead, we use raw SQL!
+            cursor = connection.cursor()
+            cursor.execute(
+                'DELETE FROM `dashboards_wikidocumentvisits`'
+                '    WHERE `period` = %s',
+                [period])
+
+            # Now we create them again with fresh data.
             for doc_id, visits in counts.iteritems():
                 cls.objects.create(document=Document(pk=doc_id), visits=visits,
                                    period=period)


### PR DESCRIPTION
Our DB load balancer closes connections after 5 minutes. Our cron
jobs that talk to google analytics, take a lot more than that. So
we now close the connections before updating the database with
fresh data from google analytics. This means new connections are
opened and all is good.

I'm not sure if all that above is exactly correct. BUT, I tried this on
stage and it solves the symptoms.

I don't know of a way to test this locally, so I propose we ship and
test in prod when it runs overnight. Unless there is something
horrible about it.

r?
