### PR TITLE
[bug 985601] Add support for multiple products in questions_list view.

### DIFF
--- a/kitsune/questions/templates/questions/mobile/question_list.html
+++ b/kitsune/questions/templates/questions/mobile/question_list.html
@@ -4,7 +4,15 @@
 
 {% set styles = ('mobile/questions',) %}
 {% set classes = 'questions' %}
-{% set product_title = _(product.title, 'DB: products.Product.title') if product else _('All Products') %}
+
+{% if all_products %}
+  {% set product_title = _('All Products') %}
+{% elif multiple_products %}
+  {% set product_title = _('Multiple Products') %}
+{% else %}
+  {% set product_title = _(products[0].title, 'DB: products.Product.title') %}
+{% endif %}
+
 {% set title = _('{product} Support Forum')|f(product=product_title) %}
 {% set headline = title %}
 {% set return_url = url('questions.home') %}
@@ -32,8 +40,9 @@
       <section id="product-switcher" class="swipeable">
         <ul>
           {% for p in product_list %}
-            <li class="{% if p == product %}selected{% endif %}">
-              <a href="{% if p == product %}{{ questions_url(_product=None) }}{% else %}{{ questions_url(_product=p.slug) }}{% endif %}">
+            {% set selected = not multiple_products and p == products[0] %}
+            <li{% if selected %} class="selected"{% endif %}>
+              <a href="{% if selected %}{{ questions_url(_product=None) }}{% else %}{{ questions_url(_product=p.slug) }}{% endif %}">
                 <span class="logo-sprite logo-{{ p.slug }}"></span>
                 {{ _(p.title, 'DB: products.Product.title') }}
               </a>

--- a/kitsune/questions/templates/questions/question_list.html
+++ b/kitsune/questions/templates/questions/question_list.html
@@ -11,7 +11,13 @@
   {% set classes = classes + ' show-escalated' %}
 {% endif %}
 
-{% set product_title = _(product.title, 'DB: products.Product.title') if product else _('All Products') %}
+{% if all_products %}
+  {% set product_title = _('All Products') %}
+{% elif multiple_products %}
+  {% set product_title = _('Multiple Products') %}
+{% else %}
+  {% set product_title = _(products[0].title, 'DB: products.Product.title') %}
+{% endif %}
 
 {% set title = _('{product} Support Forum')|f(product=product_title) %}
 

--- a/kitsune/questions/tests/test_templates.py
+++ b/kitsune/questions/tests/test_templates.py
@@ -885,9 +885,10 @@ class TaggingViewTestsAsTagger(TestCaseBase):
                                     HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertContains(response, 'canonicalName')
         tags = Question.objects.get(id=self.question.id).tags.all()
-        eq_([t.name for t in tags],
-            ['purplepurplepurple'])  # Test the backend since we don't have a
-                                     # newly rendered page to rely on.
+
+        # Test the backend since we don't have a newly rendered page to
+        # rely on.
+        eq_([t.name for t in tags], ['purplepurplepurple'])
 
     def test_add_async_no_tag(self):
         """Assert adding an empty tag asynchronously yields an AJAX error."""
@@ -1053,8 +1054,8 @@ class QuestionsTemplateTestCase(TestCaseBase):
 
         # u should have a contributor badge on q1 but not q2
         self.client.login(username=u.username, password="testpass")
-        response = self.client.get(urlparams(reverse('questions.list', args=['all']),
-                                             show='all'))
+        response = self.client.get(
+            urlparams(reverse('questions.list', args=['all']), show='all'))
         doc = pq(response.content)
         eq_(1,
             len(doc('#question-%s .thread-contributed.highlighted' % q1.id)))
@@ -1093,8 +1094,8 @@ class QuestionsTemplateTestCase(TestCaseBase):
         tagname = 'mobile'
         tag(name=tagname, slug=tagname, save=True)
         self.client.login(username=u.username, password="testpass")
-        tagged = urlparams(reverse('questions.list', args=['all']), tagged=tagname,
-                           show='all')
+        tagged = urlparams(reverse(
+            'questions.list', args=['all']), tagged=tagname, show='all')
 
         # First there should be no questions tagged 'mobile'
         response = self.client.get(tagged)
@@ -1119,8 +1120,10 @@ class QuestionsTemplateTestCase(TestCaseBase):
             doc('link[rel="canonical"]')[0].attrib['href'])
 
         # Test a tag that doesn't exist. It shouldnt blow up.
-        url = urlparams(reverse(
-            'questions.list', args=['all']), tagged='garbage-plate', show='all')
+        url = urlparams(
+            reverse('questions.list', args=['all']),
+            tagged='garbage-plate',
+            show='all')
         response = self.client.get(url)
         eq_(200, response.status_code)
 
@@ -1158,6 +1161,12 @@ class QuestionsTemplateTestCase(TestCaseBase):
         check(p2.slug, [q3])
         # Filter on p3 -> No results
         check(p3.slug, [])
+        # Filter on p1,p2
+        check('%s,%s' % (p1.slug, p2.slug), [q2, q3])
+        # Filter on p1,p3
+        check('%s,%s' % (p1.slug, p3.slug), [q2, q3])
+        # Filter on p2,p3
+        check('%s,%s' % (p2.slug, p3.slug), [q3])
 
     def test_topic_filter(self):
         p = product(save=True)
@@ -1182,7 +1191,7 @@ class QuestionsTemplateTestCase(TestCaseBase):
 
             # This won't work, because the test case base adds more tests than
             # we expect in it's setUp(). TODO: Fix that.
-            #eq_(len(expected), len(doc('.questions > section')))
+            # eq_(len(expected), len(doc('.questions > section')))
 
             for q in expected:
                 eq_(1, len(doc('.questions > section[id=question-%s]' % q.id)))
@@ -1514,7 +1523,8 @@ class AAQTemplateTestCase(TestCaseBase):
 class ProductForumTemplateTestCase(TestCaseBase):
     def test_product_forum_listing(self):
         firefox = product(title='Firefox', slug='firefox', save=True)
-        android = product(title='Firefox for Android', slug='mobile', save=True)
+        android = product(
+            title='Firefox for Android', slug='mobile', save=True)
         fxos = product(title='Firefox OS', slug='firefox-os', save=True)
 
         response = self.client.get(reverse('questions.home'))

--- a/kitsune/questions/urls.py
+++ b/kitsune/questions/urls.py
@@ -41,7 +41,8 @@ urlpatterns = patterns(
         'marketplace_category', name='questions.marketplace_aaq_category'),
 
     # TODO: Factor out `/(?P<question_id>\d+)` below
-    url(r'^/(?P<question_id>\d+)$', 'question_details', name='questions.details'),
+    url(r'^/(?P<question_id>\d+)$', 'question_details',
+        name='questions.details'),
     url(r'^/(?P<question_id>\d+)/edit$',
         'edit_question', name='questions.edit_question'),
     url(r'^/(?P<question_id>\d+)/edit-details$',
@@ -84,7 +85,7 @@ urlpatterns = patterns(
         name='questions.tagged_feed'),
 
     # Question lists
-    url(r'^/(?P<product_slug>[\w+\-]+)$', 'question_list',
+    url(r'^/(?P<product_slug>[\w+\-\,]+)$', 'question_list',
         name='questions.list'),
 
     # Flag content ("Report this post")


### PR DESCRIPTION
Products are specified as comma-separated slugs in the URL.

To test,
- Run the tests
- Look at each of the product forums and verify
- Look at the All Products forum and verify
- Try some combinations like `/questions/thunderbird,webmaker`, `/questions/mobile,firefox-os`, etc

r?
