### PR TITLE
[bug 994070] Update purge_hashes for django 1.6

### DIFF
--- a/kitsune/users/management/commands/purge_hashes.py
+++ b/kitsune/users/management/commands/purge_hashes.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from django.contrib.auth.models import User
-from django.contrib.auth.hashers import UNUSABLE_PASSWORD
+from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.core.management.base import BaseCommand
 
 
@@ -11,6 +11,9 @@ class Command(BaseCommand):
     def handle(self, *args, **kw):
         old = datetime.now() - timedelta(365)
         users = User.objects.filter(last_login__lt=old)
-        users = users.exclude(password=UNUSABLE_PASSWORD)
-        num = users.update(password=UNUSABLE_PASSWORD)
-        print 'Cleared %d passwords.' % num
+        users = users.exclude(password__startswith=UNUSABLE_PASSWORD_PREFIX)
+        for user in users:
+            user.set_unusable_password()
+            user.save()
+
+        print 'Cleared %d passwords.' % len(users)


### PR DESCRIPTION
In django 1.6, instead of having a constant unusable password, it now has a unusable password prefix (`!`) followed by random chars.

To test, run `./manage.py purge_hashes`. It takes a bit to run (30 minutes or so maybe?) the first time, because it has to set 600k+ user's passwords to the new unusable.

r?
