### PR TITLE
[bug 998200] Privacy policy url fixed

### DIFF
--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -201,10 +201,10 @@
     </div>
     <div class="grid_2">
       <ul>
-        <li><a href="http://www.mozilla.org/about/contact.html">{{ _('Contact Us') }}</a></li>
+        <li><a href="http://www.mozilla.org/en-US/contact/spaces/">{{ _('Contact Us') }}</a></li>
         <li><a href="http://www.mozilla.org/privacy/websites/">{{ _('Privacy Policy') }}</a></li>
         <li><a href="http://www.mozilla.org/about/legal.html">{{ _('Legal Notices') }}</a></li>
-        <li><a href="http://www.mozilla.org/legal/fraud-report/index.html">{{ _('Report Trademark Abuse') }}</a></li>
+        <li><a href="http://mozilla.org/legal/fraud-report/">{{ _('Report Trademark Abuse') }}</a></li>
         <li><a href="https://github.com/mozilla/kitsune/">{{ _('Source Code') }}</a></li>
       </ul>
     </div>


### PR DESCRIPTION
The url for the privacy policy has changed from http://www.mozilla.org/privacy-policy.html to http://www.mozilla.org/privacy/websites/

We should update the /about/ page to reflect this.
