### PR TITLE
[bug 998200] Fixed Privacy policy and few link

### DIFF
--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -204,7 +204,7 @@
         <li><a href="http://www.mozilla.org/en-US/contact/spaces/">{{ _('Contact Us') }}</a></li>
         <li><a href="http://www.mozilla.org/privacy/websites/">{{ _('Privacy Policy') }}</a></li>
         <li><a href="http://www.mozilla.org/about/legal.html">{{ _('Legal Notices') }}</a></li>
-        <li><a href="http://mozilla.org/legal/fraud-report/">{{ _('Report Trademark Abuse') }}</a></li>
+        <li><a href="http://www.mozilla.org/legal/fraud-report/">{{ _('Report Trademark Abuse') }}</a></li>
         <li><a href="https://github.com/mozilla/kitsune/">{{ _('Source Code') }}</a></li>
       </ul>
     </div>


### PR DESCRIPTION
The url for the privacy policy has changed from http://www.mozilla.org/privacy-policy.html to http://www.mozilla.org/privacy/websites/

We should update the page to reflect this.
