### PR TITLE
Add retry search button to search fail page.

### DIFF
--- a/kitsune/search/templates/search/down.html
+++ b/kitsune/search/templates/search/down.html
@@ -5,5 +5,11 @@
   <h1>{{ _('Search Unavailable') }}</h1>
 
   <p>{{ _('Search is temporarily unavailable. Please try again in a few minutes.') }}</p>
+
+  <p>
+    <a class="btn" href="{{ request.META.PATH_INFO + '?' + request.META.QUERY_STRING }}">
+      Try your search again
+    </a>
+  </p>
 </article>
 {% endblock %}


### PR DESCRIPTION
This will be particularly useful when synonyms are changing.

Is there a better way to get the complete URL? This seems like a really unfortunate way to do it.

r?
