### PR TITLE
[bug 1004450] Fix circular import in ./manage.py extract

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -550,22 +550,24 @@ TEST_RUNNER = 'kitsune.sumo.tests.TestSuiteRunner'
 
 
 def JINJA_CONFIG():
-    import jinja2
     from django.conf import settings
-    from caching.base import cache
     config = {'extensions': ['tower.template.i18n', 'caching.ext.cache',
                              'jinja2.ext.autoescape', 'jinja2.ext.with_'],
               'finalize': lambda x: x if x is not None else ''}
-    if (hasattr(cache, 'scheme') and 'memcached' in cache.scheme and
-            not settings.DEBUG):
-        # We're passing the _cache object directly to jinja because
-        # Django can't store binary directly; it enforces unicode on it.
-        # Details: http://jinja.pocoo.org/2/documentation/api#bytecode-cache
-        # and in the errors you get when you try it the other way.
-        bc = jinja2.MemcachedBytecodeCache(cache._cache,
-                                           "%sj2:" % settings.CACHE_PREFIX)
-        config['cache_size'] = -1  # Never clear the cache
-        config['bytecode_cache'] = bc
+
+    if not settings.DEBUG:
+        import jinja2
+        from caching.base import cache
+        if hasattr(cache, 'scheme') and 'memcached' in cache.scheme:
+            # We're passing the _cache object directly to jinja because
+            # Django can't store binary directly; it enforces unicode on it.
+            # Details:
+            #     http://jinja.pocoo.org/2/documentation/api#bytecode-cache
+            # and in the errors you get when you try it the other way.
+            bc = jinja2.MemcachedBytecodeCache(cache._cache,
+                                               "%sj2:" % settings.CACHE_PREFIX)
+            config['cache_size'] = -1  # Never clear the cache
+            config['bytecode_cache'] = bc
     return config
 
 # Let Tower know about our additional keywords.


### PR DESCRIPTION
I just reorganized the code a little bit so that the circular import doesn't happen when we run `./manage.py extract`. This assumes that you have `DEBUG = True` locally when you run the command.

r?
