### PR TITLE
Change search admin urls

### DIFF
--- a/kitsune/search/admin.py
+++ b/kitsune/search/admin.py
@@ -263,7 +263,7 @@ def search(request):
          })
 
 
-admin.site.register_view('search', view=search,
+admin.site.register_view('search-maintenance', view=search,
                          name='Search - Index Maintenance')
 
 
@@ -328,7 +328,7 @@ def index_view(request):
          })
 
 
-admin.site.register_view('index', view=index_view,
+admin.site.register_view('search-index', view=index_view,
                          name='Search - Index Browsing')
 
 
@@ -418,7 +418,7 @@ def troubleshooting_view(request):
          })
 
 
-admin.site.register_view('troubleshooting', view=troubleshooting_view,
+admin.site.register_view('search-troubleshooting', view=troubleshooting_view,
                          name='Search - Index Troubleshooting')
 
 


### PR DESCRIPTION
I changed the urls for our search admin views because now we have models in the search app and that made /admin/search/ conflict with /admin/search when running the dev server. For whatever reason, our trailing slash handling is different in prod though. I'm not sure if I should worry about that.

Anyway, quick r?
