### PR TITLE
[bug 1012657] Catch and handle TransportError.

### DIFF
--- a/kitsune/wiki/facets.py
+++ b/kitsune/wiki/facets.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Count
 
-from elasticsearch.exceptions import ConnectionError, NotFoundError
+from elasticsearch.exceptions import TransportError
 from statsd import statsd
 
 from kitsune.products.models import Topic
@@ -96,7 +96,7 @@ def _documents_for(locale, topics=None, products=None):
             _documents_for_cache_key(locale, topics, products),
             documents)
         statsd.incr('wiki.facets.documents_for.es')
-    except (ConnectionError, NotFoundError):
+    except TransportError:
         # Finally, hit the database (through cache machine)
         # NOTE: The documents will be the same ones returned by ES
         # but they won't be in the correct sort (by votes in the last


### PR DESCRIPTION
TransportError is the base class of all the errors we want to catch. I think.

r?
