### PR TITLE
Fix redis config files

### DIFF
--- a/configs/redis/redis-persistent.conf
+++ b/configs/redis/redis-persistent.conf
@@ -9,7 +9,7 @@ save 900 1
 save 300 10
 save 60 10000
 rdbcompression yes
-dbfilename /var/redis/sumo-persistent/dump.rdb
+dbfilename dump.rdb
 dir /var/redis/sumo-persistent/
 maxmemory 2147483648
 maxmemory-policy volatile-lru

--- a/configs/redis/redis-template.erb
+++ b/configs/redis/redis-template.erb
@@ -11,7 +11,7 @@ save 300 10
 save 60 10000
 <% end %>
 rdbcompression yes
-dbfilename /var/redis/<%= name %>/dump.rdb
+dbfilename dump.rdb
 dir /var/redis/<%= name %>/
 <% unless redis_slaveof_ip.empty? %>
     slaveof <%= redis_slaveof_ip %> <%= port %>

--- a/configs/redis/redis-test.conf
+++ b/configs/redis/redis-test.conf
@@ -6,7 +6,7 @@ loglevel verbose
 logfile stdout
 databases 4
 rdbcompression yes
-dbfilename /var/redis/sumo-test/dump.rdb
+dbfilename dump.rdb
 dir /var/redis/sumo-test/
 maxmemory 15032385536
 maxmemory-policy allkeys-lru

--- a/configs/redis/redis-volatile.conf
+++ b/configs/redis/redis-volatile.conf
@@ -6,7 +6,7 @@ loglevel verbose
 logfile stdout
 databases 4
 rdbcompression yes
-dbfilename /var/redis/sumo/dump.rdb
+dbfilename dump.rdb
 dir /var/redis/sumo/
 maxmemory 15032385536
 maxmemory-policy allkeys-lru


### PR DESCRIPTION
Redis 2.8.4 complains about this:

```
*** FATAL CONFIG FILE ERROR ***
Reading the configuration file, at line 12
>>> 'dbfilename /var/redis/sumo-persistent/dump.rdb'
dbfilename can't be a path, just a filename
```

r?
