### PR TITLE
[bug 987337] Show topic descriptions on topic pages.

### DIFF
--- a/kitsune/products/templates/products/documents.html
+++ b/kitsune/products/templates/products/documents.html
@@ -40,6 +40,17 @@
         </h1>
       {% endif %}
 
+      {# Show the description if it is different than the title. Otherwise, don't bother. #}
+      {% if (subtopic and subtopic.title != subtopic.description) or (not subtopic and topic.title != topic.description) %}
+        <h2 class="topic-description cf">
+          {% if subtopic %}
+             {{ _(subtopic.description, 'DB: products.Topic.description') }}
+          {% else %}
+            {{ _(topic.description, 'DB: products.Topic.description') }}
+          {% endif %}
+        </h2>
+      {% endif %}
+
       <ul class="topic-list">
         {% if not subtopic and subtopics %}
           {# only show subtopics on the parent topic page #}
@@ -48,6 +59,9 @@
               <a href="{{ url('products.subtopics', product_slug=product.slug, topic_slug=topic.slug, subtopic_slug=subtopic.slug) }}">
                 {{ _(subtopic.title, 'DB: products.Topic.title') }}
               </a>
+              {% if subtopic.title != subtopic.description %}
+                {{ _(subtopic.description, 'DB: products.Topic.description') }}
+              {% endif %}
             </li>
           {% endfor %}
         {% endif %}

--- a/kitsune/sumo/static/less/products.less
+++ b/kitsune/sumo/static/less/products.less
@@ -30,7 +30,7 @@
 
      .download-content {
        background: url('../img/firefox-small.png') no-repeat;
-       color: #B5E786;    
+       color: #B5E786;
        display: block;
        min-height: 40px;
        margin-left: -34px;
@@ -143,6 +143,7 @@
   }
 
   & + .topic-title {
+    margin-bottom: 0;
     margin-top: 0;
     padding-left: 28px;
     position: relative;
@@ -157,6 +158,10 @@
       width: 8px;
     }
   }
+}
+
+.topic-description {
+  margin-top: 0;
 }
 
 .sidebar-nav {
@@ -260,6 +265,10 @@
   > ul {
     background: #fff;
     padding: 30px;
+  }
+
+  .topic-list {
+    margin-top: 20px;
   }
 }
 


### PR DESCRIPTION
This adds the topic descriptions to the topic pages (for example, /products/firefox/get-started) when they are different from the title.

Should be straightforward yo.

r?
