### PR TITLE
[bug 971782] JS fix for data bucketing (weekly, monthly).

### DIFF
--- a/kitsune/sumo/static/js/questions.metrics-dashboard.js
+++ b/kitsune/sumo/static/js/questions.metrics-dashboard.js
@@ -53,10 +53,8 @@ function makeMetricsGraph() {
   var $container = $('#questions-metrics');
   $.getJSON($container.data('url'), function(data) {
     // Fill in 0s so bucketing doesn't freak out...
-    var object;
     var objects = data.objects;
-    objects.forEach(function() {
-      object = this;
+    objects.forEach(function(object) {
       object.questions = object.questions || 0;
       object.solved = object.solved || 0
       object.responded_24 = object.responded_24 || 0


### PR DESCRIPTION
The bucketing implemented in Rickshaw does not like missing data
for any dates. It wants explicit 0s. This zero-fills all the
dates.

To verify, go to http://localhost:8000/en-US/questions/dashboard/metrics/en-US?product=firefox-os, change the dropdown to weekly and make sure that it's not a flat line on 0 like in prod. You might need a recentish db dump, but it doesn't have to be the latest.

r?
