### PR TITLE
[bug 1030532] Needs change comment now cleared.

### DIFF
--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -543,8 +543,14 @@ def review_revision(request, document_slug, revision_id):
                     doc.allows(request.user, 'edit_needs_change') and
                     rev.is_approved):
                 doc.needs_change = form.cleaned_data['needs_change']
-                doc.needs_change_comment = \
-                    form.cleaned_data['needs_change_comment']
+
+                # Remove comment if no changes are needed.
+                if doc.needs_change:
+                    doc.needs_change_comment = \
+                        form.cleaned_data['needs_change_comment']
+                else:
+                    doc.needs_change_comment = ''
+
                 doc.save()
 
             # Send notifications of approvedness and readiness:


### PR DESCRIPTION
When the 'Needs change' box is unchecked during a KB article revision and the form is submitted, the 'Needs change' comment is now cleared.
