### PR TITLE
Fixed localized articles not showing share links.

### DIFF
--- a/kitsune/wiki/templates/wiki/document.html
+++ b/kitsune/wiki/templates/wiki/document.html
@@ -69,11 +69,12 @@ valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
       {{ document_messages(document, redirected_from) }}
       {{ document_content(document, fallback_reason, request, settings) }}
 
-    {% if document.share_link %}
+    {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
+    {% if share_link %}
       <p>
         <br/>
-        {% set share_link='<a href="' + document.share_link + '">' + document.share_link + '</a>' %}
-        {{ _('Share this article: {link}')|f(link=share_link)|safe }}
+        {% set link='<a href="' + share_link + '">' + share_link + '</a>' %}
+        {{ _('Share this article: {link}')|f(link=link)|safe }}
       </p>
     {% endif %}
 

--- a/kitsune/wiki/templates/wiki/mobile/document.html
+++ b/kitsune/wiki/templates/wiki/mobile/document.html
@@ -36,11 +36,12 @@
     {{ document_messages(document, redirected_from) }}
     {{ document_content(document, fallback_reason, request, settings) }}
 
-    {% if document.share_link %}
+    {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
+    {% if share_link %}
       <p>
         <br/>
-        {% set share_link='<a href="' + document.share_link + '">' + document.share_link + '</a>' %}
-        {{ _('Share this article: {link}')|f(link=share_link)|safe }}
+        {% set link='<a href="' + share_link + '">' + share_link + '</a>' %}
+        {{ _('Share this article: {link}')|f(link=link)|safe }}
       </p>
     {% endif %}
 


### PR DESCRIPTION
Because localized articles are based off of the en-US locale most of the time, they weren't having their share links show up. We now check for a share link either on the document itself or on its parent.

r?
