### PR TITLE
[Bug 1033339] Fix error in download warning.

### DIFF
--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -32,7 +32,7 @@ def product_landing(request, template, slug):
 
     versions = product.versions.filter(default=True)
     if versions:
-        latest_version = versions[0].max_version
+        latest_version = versions[0].min_version
     else:
         latest_version = 0
 


### PR DESCRIPTION
The max version of the version if a `<` version, so it is the next version number. The min version is the right number to use.

r?
