### PR TITLE
[Bug 1041681] Temporarily disable Axes.

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -437,7 +437,7 @@ MIDDLEWARE_CLASSES = (
     'commonware.middleware.StrictTransportMiddleware',
     'commonware.middleware.XSSProtectionHeader',
     'commonware.middleware.RobotsTagHeader',
-    'axes.middleware.FailedLoginMiddleware'
+    # 'axes.middleware.FailedLoginMiddleware'
 )
 
 # Auth
@@ -528,7 +528,7 @@ INSTALLED_APPS = (
     'kitsune.products',
     'rest_framework',
     'statici18n',
-    'axes',
+    # 'axes',
 
     # App for Sentry:
     'raven.contrib.django',

--- a/kitsune/users/views.py
+++ b/kitsune/users/views.py
@@ -74,7 +74,7 @@ def user_auth(request, contributor=False, register_form=None, login_form=None):
 
 @ssl_required
 @anonymous_csrf
-@watch_login
+# @watch_login
 @mobile_template('users/{mobile/}login.html')
 def login(request, template):
     """Try to log the user in."""


### PR DESCRIPTION
Since this is causing login failures from IPv6 users, temporarily disable it.

STR:
1. Run Django bound to an ipv6 address. I did this with `./manage.py runserver '[::0]:8000'. (This is similar to binding to 0.0.0.0)
2. Visit the site using a **long** IPv6 address (`[::1]`, the equivalent of 127.0.0.1, will not reproduce the problem). In particular, it must be at least 16 characters long. You could use your "link local" address, which would start with "fe80". The format for getting Firefox to go to ipv6 address is `http://[fe80:.....]:8000/`. The brackets are really important.
3. Try and login. It should error, something about database truncation.

After applying the patch, the problem should be fixed.

r?
