### PR TITLE
Fix show/hide details on AAQ

### DIFF
--- a/kitsune/sumo/static/js/questions.js
+++ b/kitsune/sumo/static/js/questions.js
@@ -129,13 +129,13 @@
     // Hide the browser/system details for users on FF with js enabled
     // and are submitting a question for FF on desktop.
     function hideDetails($form, aaq) {
-        $form.find('ol').addClass('hide-details');
+        $form.find('ul').addClass('hide-details');
         $form.find('a.show, a.hide').click(function(ev) {
             ev.preventDefault();
             $(this).closest('li')
                 .toggleClass('show')
                 .toggleClass('hide')
-                .closest('ol')
+                .closest('ul')
                     .toggleClass('show-details');
         });
 


### PR DESCRIPTION
Found this little thing that got broken when we fixed bug 682235 in 3448e63d7c1a6b6cb48d7dc7d210f904df786f85...

Basically "show/hide details" hasn't been working since

small r?
