### PR TITLE
[bug 1044997] Fix weekly digest emails

### DIFF
--- a/kitsune/wiki/cron.py
+++ b/kitsune/wiki/cron.py
@@ -54,6 +54,10 @@ def reindex_kb():
 def send_weekly_ready_for_review_digest():
     """Sends out the weekly "Ready for review" digest email."""
 
+    # If this is stage, do nothing.
+    if settings.STAGE:
+        return
+
     @email_utils.safe_translation
     def _send_mail(locale, user, context):
         subject = _('[Reviews Pending: %s] SUMO needs your help!' % locale)

--- a/kitsune/wiki/templates/wiki/email/ready_for_review_weekly_digest.html
+++ b/kitsune/wiki/templates/wiki/email/ready_for_review_weekly_digest.html
@@ -33,7 +33,7 @@
         <ul>
           {% for d in product_docs %}
             <li>
-              <a href="{{ url('wiki.document_revisions', d.slug) }}">
+              <a href="https://{{ host }}{{ url('wiki.document_revisions', d.slug) }}">
                 {{ d.title }}
               </a>
             </li>

--- a/kitsune/wiki/templates/wiki/email/ready_for_review_weekly_digest.ltxt
+++ b/kitsune/wiki/templates/wiki/email/ready_for_review_weekly_digest.ltxt
@@ -10,12 +10,18 @@ helping users.
 
 {{ _('If you have a moment please review these articles:') }}
 
-{% for d in docs %}
-{{ d.title }}
-({{ url('wiki.document_revisions', d.slug) }})
+{% for p in products %}{% set product_docs = docs.filter(products__in=[p]) %}
+{% if product_docs %}
+{{ _(p.title, 'DB: products.Product.title') }}
 
+{% for d in product_docs %}
+{{ d.title }}
+(https://{{ host }}{{ url('wiki.document_revisions', d.slug) }})
 {% endfor %}
 
+
+{% endif %}
+{% endfor %}
 {% trans %}
 Many thanks for your contribution on behalf of SUMO and the happy users who are
 helped by your work!


### PR DESCRIPTION
This does a bunch of things:
- Prevents the cron from sending an email if `settings.STAGE == True`
- Fixes the URLs in the emails (both HTML and plain-text)
- Fixes the formatting of the plain-text email to match the HTML email

r?
