### PR TITLE
Add send_postatus_errors cron job

### DIFF
--- a/kitsune/sumo/cron.py
+++ b/kitsune/sumo/cron.py
@@ -1,0 +1,47 @@
+from django.conf import settings
+from django.core.mail import mail_admins
+
+import cronjobs
+import requests
+
+
+@cronjobs.register
+def send_postatus_errors():
+    """Looks at postatus file and sends an email with errors"""
+
+    # Gah! Don't do this on stage!
+    if settings.STAGE:
+        return
+
+    def new_section(line):
+        return (line.startswith('dennis ')
+                or line.startswith('BUSTED')
+                or line.startswith('COMPILED'))
+
+    # Download the postatus file
+    postatus = requests.get('https://support.mozilla.org/media/postatus.txt')
+
+    # Parse it to see which locales have issues
+    lines = postatus.content.splitlines()
+    datestamp = lines.pop(0)
+
+    errordata = []
+
+    print len(lines)
+
+    while lines:
+        line = lines.pop(0)
+        if line.startswith('>>> '):
+            while lines and not new_section(line):
+                errordata.append(line)
+                line = lines.pop(0)
+
+    # If we have errors to send, send them
+    if errordata:
+        mail_admins(
+            subject='[SUMO] postatus errors %s' % datestamp,
+            message=(
+                'These are the errors in the SUMO postatus file:\n\n'
+                '\n'.join(errordata)
+                )
+            )

--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -39,6 +39,7 @@ HOME = /tmp
 0 0 * * * {{ cron }} generate_missing_share_links
 42 22 * * * {{ django }} cleanup
 30 3 * * * root {{ rscripts }} scripts/l10n_completion.py --truncate 30 locale media/uploads/l10n_history.json media/uploads/l10n_summary.json
+30 3 * * * {{ cron }} send_postatus_errors
 
 # Once per week.
 21 03 * * 3 {{ django }} purge_hashes


### PR DESCRIPTION
This cron job should run once a day. It'll keep an eye on postatus.txt
in production and send out an email if there are errors blocking locales
from having their strings get updated.

The use case here is that it turns out no one is watching the postatus.txt file, so some locales haven't had their strings updated in SUMO for months now. This will make sure everyone gets annoyed by emails when stuff is failing.

I'm pretty sure it works, but can't really test it totally.

I have it mailing the admins, but maybe there's a better group to email?

Anyhow, r?
