### PR TITLE
[bug 1039823] Filter tweets and mentions correctly

### DIFF
--- a/kitsune/customercare/cron.py
+++ b/kitsune/customercare/cron.py
@@ -19,7 +19,6 @@ from kitsune.sumo.utils import chunked
 
 
 LINK_REGEX = re.compile('https?\:', re.IGNORECASE)
-MENTION_REGEX = re.compile('(^|\W)@')
 RT_REGEX = re.compile('^rt\W', re.IGNORECASE)
 
 ALLOWED_USERS = [
@@ -160,12 +159,10 @@ def _filter_tweet(item, allow_links=False):
     # No mentions, except of ALLOWED_USERS. Let's remove
     # these from the text before checking for mentions.
     # Note: This has some edge cases like @firefoxrocks that will pass by.
-    filtered_text = text
-    for username in [u['username'].lower() for u in ALLOWED_USERS]:
-        filtered_text = filtered_text.replace('@%s' % username, '')
-    if MENTION_REGEX.search(filtered_text):
-        statsd.incr('customercare.tweet.rejected.reply_or_mention')
-        return None
+    for user in item['entities']['user_mentions']:
+        if user['id'] not in allowed_user_ids:
+            statsd.incr('customercare.tweet.rejected.reply_or_mention')
+            return None
 
     # No retweets
     if RT_REGEX.search(text) or text.find('(via ') > -1:
@@ -184,8 +181,8 @@ def _filter_tweet(item, allow_links=False):
         return None
 
     # Exlude users with firefox in the handle
-    if ('firefox' in screen_name.lower() and
-            item['user']['id'] not in allowed_user_ids):
+    if 'firefox' in screen_name.lower():
+        statsd.incr('customercare.tweet.rejected.firefox_in_handle')
         return None
 
     # Exclude problem words

--- a/kitsune/customercare/tests/test_cron.py
+++ b/kitsune/customercare/tests/test_cron.py
@@ -28,6 +28,9 @@ class TwitterCronTestCase(TestCase):
             "screen_name": "jspeis",
             "id": 2142841,
         },
+        "entities": {
+            "user_mentions": [],
+        },
         "metadata": {
             "result_type": "recent",
         },
@@ -48,17 +51,17 @@ class TwitterCronTestCase(TestCase):
 
     def test_mentions(self):
         """Filter out mentions."""
-        self.tweet['text'] = 'Hey @someone!'
+        self.tweet['entities']['user_mentions'].append({'id': 123456})
         assert _filter_tweet(self.tweet) is None
 
     def test_firefox_mention(self):
         """Don't filter out @firefox mentions."""
-        self.tweet['text'] = 'Hey @firefox!'
+        self.tweet['entities']['user_mentions'].append({'id': 2142731})
         eq_(self.tweet, _filter_tweet(self.tweet))
 
     def test_firefoxbrasil_mention(self):
         """Don't filter out @FirefoxBrasil mentions."""
-        self.tweet['text'] = 'Olá @FirefoxBrasil!'
+        self.tweet['entities']['user_mentions'].append({'id': 150793437})
         eq_(self.tweet, _filter_tweet(self.tweet))
 
     def test_replies(self):


### PR DESCRIPTION
- We do not want ANY tweets from accounts with 'firefox' in the screen name. 
- Also the way we used to check for mentions with a regex was flawed, and since Twitter now provides a list of mentioned users, we may as well use that.

r?
