### PR TITLE
Fixed rate limiting on cron share link generation.

### DIFF
--- a/kitsune/wiki/cron.py
+++ b/kitsune/wiki/cron.py
@@ -22,17 +22,18 @@ from kitsune.wiki.config import (HOW_TO_CATEGORY, TROUBLESHOOTING_CATEGORY,
 @cronjobs.register
 def generate_missing_share_links():
     """Generate share links for documents that may be missing them."""
-    documents = (Document.objects.select_related('revision')
-                 .filter(parent=None,
-                         share_link='',
-                         is_template=False,
-                         is_archived=False,
-                         category__in=settings.IA_DEFAULT_CATEGORIES)
-                 .exclude(slug='',
-                          current_revision=None,
-                          html__startswith=REDIRECT_HTML))
+    document_ids = (Document.objects.select_related('revision')
+                    .filter(parent=None,
+                            share_link='',
+                            is_template=False,
+                            is_archived=False,
+                            category__in=settings.IA_DEFAULT_CATEGORIES)
+                    .exclude(slug='',
+                             current_revision=None,
+                             html__startswith=REDIRECT_HTML)
+                    .values_list('id', flat=True))
 
-    tasks.add_short_links(documents)
+    tasks.add_short_links.delay(document_ids)
 
 
 @cronjobs.register

--- a/kitsune/wiki/forms.py
+++ b/kitsune/wiki/forms.py
@@ -188,12 +188,12 @@ class DocumentForm(forms.ModelForm):
 
         # Create the share link if it doesn't exist and is in
         # a category it should show for.
+        doc.save()
         if (doc.category in settings.IA_DEFAULT_CATEGORIES
                 and not doc.share_link):
             # This operates under the constraints of passing in a list.
-            add_short_links.delay([doc])
+            add_short_links.delay([doc.pk])
 
-        doc.save()
         self.save_m2m()
 
         if parent_doc:

--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -19,6 +19,7 @@ HOME = /tmp
 0 */6 * * * {{ django }} update_product_details -q > /dev/null
 40 */6 * * * {{ cron }} purge_tweets
 50 */6 * * * {{ cron }} cache_top_contributors
+20 */6 * * {{ cron }} generate_missing_share_links
 
 
 # Once per day.
@@ -39,7 +40,6 @@ HOME = /tmp
 45 4 * * * {{ cron }} build_kb_bundles
 0 0 * * * {{ cron }} rebuild_kb
 0 22 * * * {{ cron }} get_customercare_stats
-0 0 * * * {{ cron }} generate_missing_share_links
 42 22 * * * {{ django }} cleanup
 30 3 * * * root {{ rscripts }} scripts/l10n_completion.py --truncate 30 locale media/uploads/l10n_history.json media/uploads/l10n_summary.json
 30 3 * * * {{ cron }} send_postatus_errors


### PR DESCRIPTION
This fixes issues we've been having with cron jobs queuing up a ton of share link additions. We now assume if the rate limit is hit, the missed documents will just be caught in the next cron job.
