### PR TITLE
Bug 1041662 - Remove warning about Firefox OS

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -159,13 +159,14 @@ AAQ_LANGUAGES = (
 # to add content.
 FXOS_LANGUAGES = [
     'bn-BD',
+    'bn-IN',
     'cs',
     'de',
     'el',
     'en-US',
     'es',
     'fr',
-    'hi',
+    'hi-IN',
     'hr',
     'hu',
     'it',
@@ -176,6 +177,7 @@ FXOS_LANGUAGES = [
     'ro',
     'ru',
     'sr',
+    'ta',
     'sr-Cyrl',
     'tr',
 ]


### PR DESCRIPTION
Adding "bn-IN" and "ta" locale.
Correcting the locale short form of Hindi.
from "hi" to "hi-IN"
