### PR TITLE
[bug 1044997] Fix weekly emails with no documents

### DIFF
--- a/kitsune/wiki/templates/wiki/email/ready_for_review_weekly_digest.html
+++ b/kitsune/wiki/templates/wiki/email/ready_for_review_weekly_digest.html
@@ -43,6 +43,22 @@
     {% endif %}
   {% endfor %}
 
+  {% set product_docs = docs.filter(products=None) %}
+  {% if product_docs %}
+    <p>
+        <strong>{{ _('Other documents') }}</strong>
+        <ul>
+          {% for d in product_docs %}
+            <li>
+              <a href="https://{{ host }}{{ url('wiki.document_revisions', d.slug) }}">
+                {{ d.title }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </p>
+  {% endif %}
+
   <p>
     {% trans %}
       Many thanks for your contribution in behalf of SUMO and the happy users

--- a/kitsune/wiki/templates/wiki/email/ready_for_review_weekly_digest.ltxt
+++ b/kitsune/wiki/templates/wiki/email/ready_for_review_weekly_digest.ltxt
@@ -17,11 +17,22 @@ helping users.
 {% for d in product_docs %}
 {{ d.title }}
 (https://{{ host }}{{ url('wiki.document_revisions', d.slug) }})
-{% endfor %}
 
+{% endfor %}
 
 {% endif %}
 {% endfor %}
+{% set product_docs = docs.filter(products=None) %}
+{% if product_docs %}
+{{ _('Other documents') }}
+
+{% for d in product_docs %}
+{{ d.title }}
+(https://{{ host }}{{ url('wiki.document_revisions', d.slug) }})
+
+{% endfor %}
+
+{% endif %}
 {% trans %}
 Many thanks for your contribution on behalf of SUMO and the happy users who are
 helped by your work!


### PR DESCRIPTION
So some localizers were getting emails listing no documents because when we split the document list by product, we didn't include documents that have no products. 

Also fixed some formatting in the plain-text email.

r?
