### PR TITLE
[bug 1037900] Fix showfor link in wiki editor.

### DIFF
--- a/kitsune/sumo/static/js/markup.js
+++ b/kitsune/sumo/static/js/markup.js
@@ -307,7 +307,7 @@ Marky.ShowForButton.prototype = $.extend({}, Marky.SimpleButton.prototype, {
                        '<a href="#cancel" class="kbox-cancel"></a></div>' +
                        '</section>'),
             $placeholder = $html.find('div.placeholder'),
-            data = $(this.textarea).data('showfor'),
+            data = JSON.parse($(document).find('.showfor-data').html()),
             kbox;
 
         $html.find('button').text(gettext('Add Rule')).click(function(e){
@@ -320,21 +320,29 @@ Marky.ShowForButton.prototype = $.extend({}, Marky.SimpleButton.prototype, {
             kbox.close();
         });
         $html.find('a.kbox-cancel').text(gettext('Cancel'));
-        appendOptions($placeholder, data.versions);
-        appendOptions($placeholder, data.oses);
 
-        function appendOptions($ph, options) {
-            $.each(options, function(i, value) {
-                $ph.append($('<h2/>').text(value[0]));
-                $.each(value[1], function(i, value) {
-                    $ph.append(
-                        $('<label/>').text(value[1]).prepend(
-                            $('<input type="checkbox" name="showfor"/>')
-                                .attr('value', value[0])
-                        )
-                    );
-                });
+        var products = data.products;
+        $.each(products, function(i, product) {
+            $placeholder.append($('<h2/>').text(product.title));
+            $.each(data.versions[product.slug], function(i, version) {
+                appendCheckbox($placeholder, version);
             });
+            $placeholder.append($('<br/>'));
+            $.each(data.platforms[product.slug], function(i, platform) {
+                appendCheckbox($placeholder, platform);
+            });
+        });
+
+        function appendCheckbox($ph, option) {
+            if (!option.visible) {
+                return;
+            }
+            $ph.append(
+                $('<label/>').text(option.name).prepend(
+                    $('<input type="checkbox" name="showfor"/>')
+                        .attr('value', option.slug)
+                )
+            );
         }
 
         kbox = new KBox($html, {

--- a/kitsune/sumo/static/less/includes/editor-tools.less
+++ b/kitsune/sumo/static/less/includes/editor-tools.less
@@ -107,6 +107,7 @@ button {
 
 #showfor-modal {
   label {
+    float: left;
     padding: 0 15px 0 0;
   }
 
@@ -299,6 +300,7 @@ section.marky {
 
   #showfor-modal {
     label {
+      float: right;
       padding: 0 0 0 15px;
     }
 

--- a/kitsune/wiki/templates/wiki/edit.html
+++ b/kitsune/wiki/templates/wiki/edit.html
@@ -96,6 +96,10 @@
       {% endif %}
     </article>
   </div>
+
+  <script type="application/json" class="showfor-data">
+    {{ showfor_data(document.get_products()) }}
+  </script>
 {% endblock %}
 
 {% block side_top %}

--- a/kitsune/wiki/templates/wiki/new_document.html
+++ b/kitsune/wiki/templates/wiki/new_document.html
@@ -46,6 +46,10 @@
       <div id="preview"></div>
     </article>
   </div>
+
+  <script type="application/json" class="showfor-data">
+    {{ showfor_data(products) }}
+  </script>
 {% endblock %}
 
 {% block side_top %}

--- a/kitsune/wiki/templates/wiki/translate.html
+++ b/kitsune/wiki/templates/wiki/translate.html
@@ -205,6 +205,10 @@
       {% endif %}
     </article>
   </div>
+
+  <script type="application/json" class="showfor-data">
+    {{ showfor_data(document.get_products()) }}
+  </script>
 {% endblock %}
 
 {% block side_promos %}{% endblock %}

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -214,7 +214,8 @@ def new_document(request):
         rev_form = RevisionForm()
         return render(request, 'wiki/new_document.html', {
             'document_form': doc_form,
-            'revision_form': rev_form})
+            'revision_form': rev_form,
+            'products': Product.objects.filter(visible=True)})
 
     post_data = request.POST.copy()
     post_data.update({'locale': request.LANGUAGE_CODE})
@@ -229,7 +230,8 @@ def new_document(request):
 
     return render(request, 'wiki/new_document.html', {
         'document_form': doc_form,
-        'revision_form': rev_form})
+        'revision_form': rev_form,
+        'products': Product.objects.filter(visible=True)})
 
 
 _document_lock_key = 'sumo::wiki::document::{id}::lock'


### PR DESCRIPTION
These seems to be fallout from the great showfor rewrite of last year. I rewrote the bit of js that parsed showfor data and shows checkboxes for all the platforms and versions available.

This can be tested on the document edit and translate pages.

r?
