### PR TITLE
API: Include the url for the image file.

### DIFF
--- a/kitsune/gallery/api.py
+++ b/kitsune/gallery/api.py
@@ -15,7 +15,7 @@ class ImageShortSerializer(serializers.ModelSerializer):
         fields = ('id', 'title', 'url', 'locale', 'width', 'height')
 
     def get_url(self, obj):
-        return obj.get_absolute_url()
+        return obj.file.url
 
 
 class ImageDetailSerializer(ImageShortSerializer):


### PR DESCRIPTION
While actually using this api, I realized `get_absolute_url()` is not what I wanted, because that's the URL for the view. Now the API returns the URL for the image file.

Tiny r?
