### PR TITLE
[Bug 1037905] Support more FxOS version.

### DIFF
--- a/kitsune/sumo/static/js/browserdetect.js
+++ b/kitsune/sumo/static/js/browserdetect.js
@@ -152,7 +152,10 @@ var BrowserDetect = {
         18.0: 1.0,
         18.1: 1.1,
         26.0: 1.2,
-        28.0: 1.3
+        28.0: 1.3,
+        30.0: 1.4,
+        32.0: 2.0,
+        34.0: 2.1
     }
 };
 BrowserDetect.init();  // TODO: Do this lazily.

--- a/kitsune/sumo/static/js/showfor.js
+++ b/kitsune/sumo/static/js/showfor.js
@@ -186,20 +186,22 @@ ShowFor.prototype.updateUI = function() {
 
     var verSlug, $version;
 
-    if (browser === 'firefox' && this.productSlugs.indexOf('firefox') !== -1) {
-        verSlug = 'fx' + version;
-        $version = productElems.firefox.find('select.version');
-        this.ensureSelect($version, 'version', 'firefox', verSlug);
+    if (version) {
+        if (browser === 'firefox' && this.productSlugs.indexOf('firefox') !== -1) {
+            verSlug = 'fx' + version;
+            $version = productElems.firefox.find('select.version');
+            this.ensureSelect($version, 'version', 'firefox', verSlug);
 
-    } else if (browser === 'mobile' && this.productSlugs.indexOf('mobile') !== -1) {
-        verSlug = 'm' + version;
-        $version = productElems.mobile.find('select.version');
-        this.ensureSelect($version, 'version', 'mobile', verSlug);
+        } else if (browser === 'mobile' && this.productSlugs.indexOf('mobile') !== -1) {
+            verSlug = 'm' + version;
+            $version = productElems.mobile.find('select.version');
+            this.ensureSelect($version, 'version', 'mobile', verSlug);
 
-    } else if (browser === 'firefox-os' && this.productSlugs.indexOf('firefox-os') !== -1) {
-        verSlug = 'fxos' + version.toFixed(1);
-        $version = productElems['firefox-os'].find('select.version');
-        this.ensureSelect($version, 'version', 'firefox-os', verSlug);
+        } else if (browser === 'firefox-os' && this.productSlugs.indexOf('firefox-os') !== -1) {
+            verSlug = 'fxos' + version.toFixed(1);
+            $version = productElems['firefox-os'].find('select.version');
+            this.ensureSelect($version, 'version', 'firefox-os', verSlug);
+        }
     }
 
     $products.find('select.platform').each(function(i, elem) {


### PR DESCRIPTION
This adds more versions to our FxOS detection, and also fixes the bug that caused JS to error when the version was unknown.

Small r?
