### PR TITLE
Don't error during deploy when there are no .pycs to remove.

### DIFF
--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -25,7 +25,7 @@ def update_code(ctx, tag):
         ctx.local("git checkout -f %s" % tag)
         ctx.local("git submodule sync")
         ctx.local("git submodule update --init --recursive")
-        ctx.local('find vendor/ -type f -name "*.pyc" | xargs rm')
+        ctx.local('find vendor/ -type f -name "*.pyc" | xargs rm -f')
 
 
 @task


### PR DESCRIPTION
During deploy we remove all .pyc files. When I was hacking on the Peep stuff, stage got in a state where there were no .pyc files to remove, and that caused an error, since rm didn't have any arguments. It is possible to get in this state in other ways, mainly in relation to new deploys or broken deploys.

This is the commit that is actually on stage.

quick r?
