### PR TITLE
[bug 795871] Fixes issue with focous on Mozilla Support Logo

### DIFF
--- a/kitsune/sumo/static/less/main.less
+++ b/kitsune/sumo/static/less/main.less
@@ -69,6 +69,10 @@ body {
     .logo {
       float: left;
       margin-top: 20px;
+
+      img{
+       display:block;
+      }
     }
   }
 

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -153,7 +153,7 @@
         {% if not hide_header_search %}
           {{ search_box(settings, id='support-search', params=search_params) }}
         {% endif %}
-        <a href="{{ url('home') }}"><img class="logo" alt="mozilla support" src="{{ STATIC_URL }}img/mozilla-support.png" /></a>
+        <a href="{{ url('home') }}" class="logo"><img alt="mozilla support" src="{{ STATIC_URL }}img/mozilla-support.png" /></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes the issue of missing focus on Mozilla Support logo when Navigating via keyboard using tab key. 
