### PR TITLE
Fix the lint script to ignore migrations files

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -13,7 +13,7 @@
 # new file to the list of ignores.
 
 FLAKE8_IGNORE=(
-    'migrations'
+    '*migrations*'
     'kitsune/settings*'
     'kitsune/sumo/db_strings.py'
     'kitsune/sumo/static/js/libs/ace/kitchen-sink/docs/python.py'


### PR DESCRIPTION
The migrations files are machine-generated shite and linting them is an
exercise in futility. We're better off spending that time writing dubstep
remixes of popular ragtime songs, recording them on wax cylinders and
setting them on fire.

This fixes the lint script to ignore migrations files.

r?
