### PR TITLE
Bug 793786 - [RTL] Breadcrumb is on the left and inverted

### DIFF
--- a/kitsune/sumo/static/less/main.less
+++ b/kitsune/sumo/static/less/main.less
@@ -1796,3 +1796,18 @@ input[type=button],
     }
   }
 }
+
+.html-rtl {
+  > .breadcrumbs {
+    > .container_12 {
+      > #breadcrumbs {
+        > li {
+          float: right;
+        }
+        > li:before {
+          margin: 0px 0px 0px 6px;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This Fixes the Bug with Breadcrumbs List when viewing page in RTL languages.
