### PR TITLE
[bug 989115] Implemented simple wiki landing page for configured locales

### DIFF
--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -6,9 +6,11 @@ from django.shortcuts import get_object_or_404, render
 from mobility.decorators import mobile_template
 
 from kitsune.products.models import Product, Topic
+from kitsune.wiki.decorators import check_simple_wiki_locale
 from kitsune.wiki.facets import topics_for, documents_for
 
 
+@check_simple_wiki_locale
 @mobile_template('products/{mobile/}products.html')
 def product_list(request, template):
     """The product picker page."""
@@ -17,6 +19,7 @@ def product_list(request, template):
         'products': products})
 
 
+@check_simple_wiki_locale
 @mobile_template('products/{mobile/}product.html')
 def product_landing(request, template, slug):
     """The product landing page."""
@@ -45,6 +48,7 @@ def product_landing(request, template, slug):
     })
 
 
+@check_simple_wiki_locale
 @mobile_template('products/{mobile/}documents.html')
 def document_listing(request, template, product_slug, topic_slug,
                      subtopic_slug=None):

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -176,6 +176,11 @@ FXOS_LANGUAGES = [
     'tr',
 ]
 
+# These languages will get a wiki page instead of the product and topic pages.
+SIMPLE_WIKI_LANGUAGES = [
+    'et',
+]
+
 # Languages that should show up in language switcher.
 LANGUAGE_CHOICES = tuple(
     [(lang, LOCALES[lang].native) for lang in SUMO_LANGUAGES

--- a/kitsune/wiki/config.py
+++ b/kitsune/wiki/config.py
@@ -79,3 +79,5 @@ REDIRECT_SLUG = _lazy(u'%(old)s-redirect-%(number)i')
 
 # Template for the cache key of the full article html.
 DOC_HTML_CACHE_KEY = u'doc_html:{mobile}:{locale}:{slug}'
+
+SIMPLE_WIKI_LANDING_PAGE_SLUG = 'frequently-asked-questions'

--- a/kitsune/wiki/decorators.py
+++ b/kitsune/wiki/decorators.py
@@ -1,0 +1,25 @@
+from functools import wraps
+
+from django import http
+from django.conf import settings
+
+from statsd import statsd
+
+from kitsune.sumo.urlresolvers import reverse
+from kitsune.wiki.config import SIMPLE_WIKI_LANDING_PAGE_SLUG
+
+
+def check_simple_wiki_locale(view_func):
+    """A view decorator that redirects configured locales to FAQ wiki page"""
+
+    @wraps(view_func)
+    def _check_simple_wiki_locale(request, *args, **kwargs):
+        if request.LANGUAGE_CODE in settings.SIMPLE_WIKI_LANGUAGES:
+            statsd.incr('wiki.redirect_to_faq')
+            url = reverse(
+                'wiki.document', args=[SIMPLE_WIKI_LANDING_PAGE_SLUG])
+            return http.HttpResponseRedirect(url)
+
+        return view_func(request, *args, **kwargs)
+
+    return _check_simple_wiki_locale

--- a/kitsune/wiki/tests/test_decorators.py
+++ b/kitsune/wiki/tests/test_decorators.py
@@ -1,0 +1,38 @@
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.test.utils import override_settings
+
+from nose.tools import eq_
+
+from kitsune.sumo.tests import TestCase
+from kitsune.wiki.decorators import check_simple_wiki_locale
+
+
+rf = RequestFactory()
+
+
+@override_settings(SIMPLE_WIKI_LANGUAGES=['es'])
+class SimpleWikiDecoratorTests(TestCase):
+
+    def test_faq_locale_redirects(self):
+
+        @check_simple_wiki_locale
+        def temp(request):
+            return HttpResponse('OK')
+
+        req = rf.get('/es/products/firefox')
+        req.LANGUAGE_CODE = 'es'
+        res = temp(req)
+        eq_(302, res.status_code)
+        eq_('/kb/frequently-asked-questions', res['location'])
+
+    def test_non_faq_locale_doesnt_redirect(self):
+
+        @check_simple_wiki_locale
+        def temp(request):
+            return HttpResponse('OK')
+
+        req = rf.get('/de/products/firefox')
+        req.LANGUAGE_CODE = 'de'
+        res = temp(req)
+        eq_(200, res.status_code)


### PR DESCRIPTION
I implemented a decorator that requests certain configured locales to be redirected to a configured kb page. The settings still aren't set (waiting for the info) but the actual code is ready to go I think.

To test:
- Run tests
- Add 'es' to the 'SIMPLE_WIKI_LANGUAGES' setting. Go to '/es/products/firefox' and see it redirect you to '/es/kb/faq' which will be a 404 if you haven't created it.

r?
