### PR TITLE
Revert "[Bug 1074861] Add --no-use-wheel to peep deploys."

### DIFF
--- a/docs/hacking_howto.rst
+++ b/docs/hacking_howto.rst
@@ -161,24 +161,17 @@ need to install different files.
 
 Python 2.7::
 
-    $ ./scripts/peep.py install -r requirements/default.txt --no-use-wheel
+    $ ./scripts/peep.py install -r requirements/default.txt
 
 Python 2.6::
 
-    $ ./scripts/peep.py install -r requirements/py26.txt --no-use-wheel
+    $ ./scripts/peep.py install -r requirements/py26.txt
 
 If you have any issues installing via ``peep``, be sure you have the required
 header files from the packages listed in the requirements section above.
 
-For more information on ``peep``, refer to the
-`README <https://github.com/erikrose/peep>`_ on the Github page for the project.
-
-.. Note::
-
-   The ``--no-use-wheel`` option is to work around a bug in Pip that causes
-   wheels to not properly clean up the packages they replace in some situations.
-   See `This Peep issue <https://github.com/erikrose/peep/issues/50>`_ and
-   `This Pip issue <https://github.com/pypa/pip/issues/1825>`_ for more details
+For more information on ``peep``, refer to the `README
+<https://github.com/erikrose/peep>` on the Github page for the project.
 
 
 Javascript Packages

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -8,7 +8,7 @@ sudo ln -s /usr/lib/`uname -i`-linux-gnu/libjpeg.so ~/virtualenv/python2.6/lib/
 sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.6/lib/
 
 echo "Install Python dependencies"
-python scripts/peep.py install -r requirements/py26.txt --no-use-wheel
+python scripts/peep.py install -r requirements/py26.txt
 pip install nosenicedots > /dev/null
 pip freeze
 echo

--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -126,7 +126,7 @@ def setup_dependencies(ctx):
         activate_env = os.path.join(settings.SRC_DIR, 'virtualenv', 'bin', 'activate_this.py')
         execfile(activate_env, dict(__file__=activate_env))
 
-        ctx.local('python scripts/peep.py install --no-use-wheel -r requirements/py26.txt')
+        ctx.local('python scripts/peep.py install -r requirements/py26.txt')
         ctx.local('virtualenv --relocatable virtualenv')
 
         # Fix lib64 symlink to be relative instead of absolute.


### PR DESCRIPTION
Until Bug 1078389 is resolved.

This reverts commit a1b32036209781c555285675e4d53e76408400e3.

Since we can't install wheels anyways, this doesn't expose us to the problems detailed in [bug 1074861](https://bugzilla.mozilla.org/show_bug.cgi?id=1074861) until after we upgrade pip ([bug 1078389](https://bugzilla.mozilla.org/show_bug.cgi?id=1078389)). After we upgrade pip, we can apply this commit again, and it should work.

quick r?
