### PR TITLE
[Bug 1074861] Add --no-use-wheel to docs and Travis.

### DIFF
--- a/docs/hacking_howto.rst
+++ b/docs/hacking_howto.rst
@@ -161,17 +161,24 @@ need to install different files.
 
 Python 2.7::
 
-    $ ./scripts/peep.py install -r requirements/default.txt
+    $ ./scripts/peep.py install -r requirements/default.txt --no-use-wheel
 
 Python 2.6::
 
-    $ ./scripts/peep.py install -r requirements/py26.txt
+    $ ./scripts/peep.py install -r requirements/py26.txt --no-use-wheel
 
 If you have any issues installing via ``peep``, be sure you have the required
 header files from the packages listed in the requirements section above.
 
-For more information on ``peep``, refer to the `README
-<https://github.com/erikrose/peep>` on the Github page for the project.
+For more information on ``peep``, refer to the
+`README <https://github.com/erikrose/peep>`_ on the Github page for the project.
+
+.. Note::
+
+   The ``--no-use-wheel`` option is to work around a bug in Pip that causes
+   wheels to not properly clean up the packages they replace in some situations.
+   See `This Peep issue <https://github.com/erikrose/peep/issues/50>`_ and
+   `This Pip issue <https://github.com/pypa/pip/issues/1825>`_ for more details
 
 
 Javascript Packages

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -8,7 +8,7 @@ sudo ln -s /usr/lib/`uname -i`-linux-gnu/libjpeg.so ~/virtualenv/python2.6/lib/
 sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.6/lib/
 
 echo "Install Python dependencies"
-python scripts/peep.py install -r requirements/py26.txt
+python scripts/peep.py install -r requirements/py26.txt --no-use-wheel
 pip install nosenicedots > /dev/null
 pip freeze
 echo


### PR DESCRIPTION
This is a partial cherry-pick of
a1b32036209781c555285675e4d53e76408400e3. The difference is that it
doesn't change deployments.

This is mainly because I noticed in #2156 that Travis was failing because it got some wheels instead of tarballs during installation.

This isn't a complete fix for the issue, I don't expect this to close the bug.

r?
