### PR TITLE
[Bug 1074959] Add metadata API.

### DIFF
--- a/kitsune/sumo/api.py
+++ b/kitsune/sumo/api.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.conf import settings
 
-from rest_framework import fields, permissions
+from rest_framework import fields, permissions, serializers
 from rest_framework.exceptions import APIException
 from rest_framework.filters import BaseFilterBackend
 from tower import ugettext as _


### PR DESCRIPTION
This isn't as nice as I wanted. The metadata field of questions is a list of objects in the API. Semantically it should be a dict, but I couldn't get DRF to play nice with writing in that format. There is some support for writing directly to the object with POST and PATCH, but it's kind of derpy, so I also added endpoints for `set_metadata` and `delete_metadata` that work intuitively for single items.

r?
