### PR TITLE
[bug 1087390] Make TopicField, which knows to look at products.

### DIFF
--- a/kitsune/questions/api.py
+++ b/kitsune/questions/api.py
@@ -4,6 +4,7 @@ from rest_framework import serializers, viewsets, permissions, filters, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from kitsune.products.api import TopicField
 from kitsune.questions.models import Question, Answer, QuestionMetaData
 from kitsune.sumo.api import CORSMixin, OnlyCreatorEdits
 
@@ -38,7 +39,7 @@ class QuestionMetaDataSerializer(serializers.ModelSerializer):
 class QuestionShortSerializer(serializers.ModelSerializer):
     # Use slugs for product and topic instead of ids.
     product = serializers.SlugRelatedField(required=True, slug_field='slug')
-    topic = serializers.SlugRelatedField(required=True, slug_field='slug')
+    topic = TopicField(required=True)
     # Use usernames for creator and updated_by instead of ids.
     creator = serializers.SlugRelatedField(
         slug_field='username', required=False)


### PR DESCRIPTION
This solves a problem in the API where when you try and create a question, you specify a topic and a product. Our topics are not unique by slug, but by (slug, product), so the build in SlugRelatedField of DRF couldn't get a specific topic instance for us. This makes a new field that looks at both the value of topic and product to find a topic to use. The idea that a SlugRelatedField is uniquely identifiable by it's slug is pretty deeply engrained, and the idea of having a field that needs more data to get it's deserialized value is kind of weird to DRF.

r?
