### PR TITLE
[bug 1088807] Fix Option A.

### DIFF
--- a/kitsune/users/api.py
+++ b/kitsune/users/api.py
@@ -143,13 +143,7 @@ class ProfileViewSet(mixins.CreateModelMixin,
         filters.DjangoFilterBackend,
         filters.OrderingFilter,
     ]
-    filter_fields = [
-        'user__date_joined',
-    ]
-    ordering_fields = [
-        'user__username',
-        'name',
-        'user__date_joined',
-    ]
+    filter_fields = []
+    ordering_fields = []
     # Default, if not overwritten
     ordering = ('-user__date_joined',)


### PR DESCRIPTION
This is one way to fix the problem. But it makes for some ugly URLs.

Implementing a `ProfileFilter` is easy:

```
class ProfileFilter(django_filters.FilterSet):
    date_joined = django_filters.DateTimeFilter(name='user__date_joined')

    class Meta:
        model = Profile
        fields = ['date_joined']
```

But the ordering stuff doesn't look as easy. Do we want that?

r?
