### PR TITLE
[Bug 1091268] API to generate users.

### DIFF
--- a/kitsune/users/api.py
+++ b/kitsune/users/api.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from string import letters
 
 from django.contrib.auth.models import User
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.views.decorators.http import require_GET
@@ -19,7 +20,7 @@ from rest_framework.authtoken import views as authtoken_views
 from rest_framework.authtoken.models import Token
 
 from kitsune.access.decorators import login_required
-from kitsune.sumo.api import CORSMixin, DateTimeUTCField
+from kitsune.sumo.api import CORSMixin, DateTimeUTCField, GenericAPIException
 from kitsune.sumo.decorators import json_view
 from kitsune.users.helpers import profile_avatar
 from kitsune.users.models import Profile, RegistrationProfile
@@ -237,6 +238,9 @@ class ProfileViewSet(CORSMixin,
         in each category, this algorithm can support almost 90K users
         before there is a 1% chance of failure.
         """
+        if not settings.STAGE or settings.DEBUG:
+            raise GenericAPIException(503, 'User generation temporarily only available on stage.')
+
         digits = ''
         # The loop counter isn't used. This is an escape hatch.
         for i in range(20):

--- a/kitsune/users/urls_api.py
+++ b/kitsune/users/urls_api.py
@@ -12,6 +12,7 @@ urlpatterns = patterns(
     '',
     url('^1/users/test_auth$', api.test_auth, name='users.test_auth'),
     url('^1/users/get_token$', api.GetToken.as_view(), name='users.get_token'),
-    url('^2/user/generate', api.ProfileViewSet.as_view({'post': 'generate'})),
+    url('^2/user/generate', api.ProfileViewSet.as_view({'post': 'generate'}),
+        name='user-generate'),
     url('^2/', include(router.urls)),
 )


### PR DESCRIPTION
The lists here aren't final, I'm waiting for NI on the bug. What do you think of the general idea though? This generally works like:

``` bash
$ http POST http://kitsune/api/2/user/generate
<headers>

{
    "password": "IhkUvecGas",
    "token": "6b58d402579e8a409b3a3de0d72880bb3b36295a",
    "user": {
        "avatar": "https://secure.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=48",
        "bio": null,
        "city": null,
        "country": null,
        "date_joined": "2014-10-30T11:51:53.261",
        "display_name": null,
        "facebook": null,
        "irc_handle": null,
        "locale": "en-US",
        "timezone": "US/Pacific",
        "twitter": null,
        "username": "HappyGreenCat",
        "website": null
    }
}
```

The avatar is obviously bogus, since there is no email. I'd like to someday fix that and let us have a real hybrid avatar system, but for now these uses get the default avatar.

f?
