### PR TITLE
[Bug 1089748] API: Filter by question metadata

### DIFF
--- a/kitsune/questions/tests/__init__.py
+++ b/kitsune/questions/tests/__init__.py
@@ -19,8 +19,7 @@ def tags_eq(tagged_object, tag_names):
         sorted(tag_names))
 
 
-@with_save
-def question(**kwargs):
+def question(save=False, **kwargs):
     defaults = dict(title=str(datetime.now()),
                     content='',
                     created=datetime.now(),
@@ -29,7 +28,14 @@ def question(**kwargs):
     defaults.update(kwargs)
     if 'creator' not in kwargs and 'creator_id' not in kwargs:
         defaults['creator'] = profile().user
-    return Question(**defaults)
+    q = Question(**defaults)
+    if save:
+        q.save()
+    if 'metadata' in defaults:
+        if not save:
+            raise ValueError('save must be True if metadata provided.')
+        q.add_metadata(**defaults['metadata'])
+    return q
 
 
 @with_save

--- a/kitsune/questions/tests/test_api.py
+++ b/kitsune/questions/tests/test_api.py
@@ -1,6 +1,8 @@
+import json
 import mock
-from nose.tools import eq_, ok_
+from nose.tools import eq_, ok_, raises
 from rest_framework.test import APIClient
+from rest_framework.exceptions import APIException
 
 from kitsune.sumo.tests import TestCase
 from kitsune.questions import api
@@ -323,18 +325,21 @@ class TestAnswerViewSet(TestCase):
 class TestQuestionFilter(TestCase):
 
     def setUp(self):
-        self.filter = api.QuestionFilter()
-        self.qs = Question.objects.all()
+        self.filter_instance = api.QuestionFilter()
+        self.queryset = Question.objects.all()
+
+    def filter(self, filter_data):
+        return self.filter_instance.filter_metadata(self.queryset, json.dumps(filter_data))
 
     def test_filter_involved(self):
         q1 = question(save=True)
         a1 = answer(question=q1, save=True)
         q2 = question(creator=a1.creator, save=True)
 
-        res = self.filter.filter_involved(self.qs, q1.creator.username)
+        res = self.filter_instance.filter_involved(self.queryset, q1.creator.username)
         eq_(list(res), [q1])
 
-        res = self.filter.filter_involved(self.qs, q2.creator.username)
+        res = self.filter_instance.filter_involved(self.queryset, q2.creator.username)
         # The filter does not have a strong order.
         res = sorted(res, key=lambda q: q.id)
         eq_(res, [q1, q2])
@@ -346,8 +351,34 @@ class TestQuestionFilter(TestCase):
         q1.save()
         q2 = question(save=True)
 
-        res = self.filter.filter_is_solved(self.qs, True)
+        res = self.filter_instance.filter_is_solved(self.queryset, True)
         eq_(list(res), [q1])
 
-        res = self.filter.filter_is_solved(self.qs, False)
+        res = self.filter_instance.filter_is_solved(self.queryset, False)
         eq_(list(res), [q2])
+
+    @raises(APIException)
+    def test_metadata_not_json(self):
+        self.filter_instance.filter_metadata(self.queryset, 'not json')
+
+    @raises(APIException)
+    def test_metadata_bad_json(self):
+        self.filter({'foo': []})
+
+    def test_single_filter_match(self):
+        q1 = question(metadata={'os': 'Linux'}, save=True)
+        question(metadata={'os': 'OSX'}, save=True)
+        res = self.filter({'os': 'Linux'})
+        eq_(list(res), [q1])
+
+    def test_single_filter_no_match(self):
+        question(metadata={'os': 'Linux'}, save=True)
+        question(metadata={'os': 'OSX'}, save=True)
+        res = self.filter({"os": "Windows 8"})
+        eq_(list(res), [])
+
+    def test_multi_filter_is_and(self):
+        q1 = question(metadata={'os': 'Linux', 'category': 'troubleshooting'}, save=True)
+        question(metadata={'os': 'OSX', 'category': 'troubleshooting'}, save=True)
+        res = self.filter({'os': 'Linux', 'category': 'troubleshooting'})
+        eq_(list(res), [q1])


### PR DESCRIPTION
Sorry about the extra commits. I'll rebase those away later. The interesting on is the last commit.

This adds another heavy filter to the questions api. It adds the ability to filter questions by the metadata they have. I talked with espressive about it a bit, and we agreed that a JSON string that has the keys and values to filter on in the querystring made sense. You might have a query like `/api/2/question/?metadata={"os":"Linux","category":"troubleshooting"}&involved=mythmon`, which would filter for Linux, the "troubleshooting" category, and things that I have asked or answered.

r?
