### PR TITLE
Questions: Add is_solved and filtering to API.

### DIFF
--- a/kitsune/questions/models.py
+++ b/kitsune/questions/models.py
@@ -340,7 +340,7 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
 
     @property
     def is_solved(self):
-        return not not self.solution_id
+        return self.solution_id is not None
 
     @property
     def is_escalated(self):


### PR DESCRIPTION
Espressive was talking about needing this. I was surprised it wasn't already included in the API.

I also sorted the fields in QuestionSerializer, to make sure I didn't duplicate anything.

r?
