### PR TITLE
solution field should be the id, not the text.

### DIFF
--- a/kitsune/questions/api.py
+++ b/kitsune/questions/api.py
@@ -46,7 +46,7 @@ class QuestionSerializer(serializers.ModelSerializer):
     is_solved = serializers.Field(source='is_solved')
     metadata = QuestionMetaDataSerializer(source='metadata_set', required=False)
     num_votes = serializers.Field(source='num_votes')
-    solution = serializers.Field()  # Read only
+    solution = serializers.PrimaryKeyRelatedField(read_only=True)
     updated_by = serializers.SlugRelatedField(slug_field='username', required=False)
 
     class Meta:

--- a/kitsune/questions/tests/test_api.py
+++ b/kitsune/questions/tests/test_api.py
@@ -11,7 +11,7 @@ from kitsune.products.tests import product, topic
 from kitsune.sumo.urlresolvers import reverse
 
 
-class TestQuestionSerializerSerialization(TestCase):
+class TestQuestionSerializerDeserialization(TestCase):
 
     def setUp(self):
         self.profile = profile()
@@ -75,8 +75,16 @@ class TestQuestionSerializerSerialization(TestCase):
         ok_(serializer.is_valid())
         eq_(serializer.object.topic, self.topic)
 
+    def test_solution_is_readonly(self):
+        q = question(save=True)
+        a = answer(question=q, save=True)
+        self.data['solution'] = a.id
+        serializer = api.QuestionSerializer(context=self.context, data=self.data, instance=q)
+        serializer.save()
+        eq_(q.solution, None)
 
-class TestQuestionSerializerDeserialization(TestCase):
+
+class TestQuestionSerializerSerialization(TestCase):
 
     def setUp(self):
         self.asker = user(save=True)
@@ -128,6 +136,14 @@ class TestQuestionSerializerDeserialization(TestCase):
         serializer = api.QuestionSerializer(instance=self.question)
         eq_(sorted(serializer.data['involved']),
             self._names(self.asker, self.helper1, self.helper2))
+
+    def test_solution_is_id(self):
+        a = self._answer(self.helper1)
+        self.question.solution = a
+        self.question.save()
+
+        serializer = api.QuestionSerializer(instance=self.question)
+        eq_(serializer.data['solution'], a.id)
 
 
 class TestQuestionViewSet(TestCase):


### PR DESCRIPTION
While double checking the solution field on stage, I noticed that the solution was actually the text of the solution, instead of the ID as intended. So that sucks. I fixed it, and I added a test to verify it.

r?
