### PR TITLE
[bug 1013471] Fix for Accidental deletion of profiles

### DIFF
--- a/kitsune/sumo/static/js/ui.js
+++ b/kitsune/sumo/static/js/ui.js
@@ -7,6 +7,14 @@
     initFolding();
     initAnnouncements();
 
+    $('#delete-profile').click(function(){
+      if($("input[type='checkbox'].acknowledge:checked").length){
+        $(".delete-profile-btn").removeAttr('disabled');
+      }else{
+        $(".delete-profile-btn").attr('disabled','disabled');
+      }
+    });    
+
     $(window).scroll(_.throttle(function() {
       if ($(window).scrollTop() > $('body > header').outerHeight()) {
         $('body').addClass('scroll-header');

--- a/kitsune/users/templates/users/edit_profile.html
+++ b/kitsune/users/templates/users/edit_profile.html
@@ -59,11 +59,10 @@
       </form>
     </article>
     {% if request.user == profile.user %}
-      <form method="post" action="{{ url('users.close_account') }}" data-confirm="confirm" data-confirm-text="{{ _('Are you sure you want to close your account? You cannot undo this action.') }}">
+      <form method="post" action="{{ url('users.close_account') }}" data-confirm="confirm" data-confirm-text="{{ _('Are you sure you want to close your account? You cannot undo this action.') }}" id="delete-profile">
         {{ csrf() }}
-        <p>
-          <button type="submit" class="btn btn-warning">{{ _('Close account and delete all profile information') }}</button>
-        </p>
+        <p><input type="checkbox" class="acknowledge"> </input> I acknowledge that deleting my account will prevent me from answering/posting questions in Mozilla Support.</p>
+        <button type="submit" disabled="disabled" class="delete-profile-btn btn btn-warning">{{ _('Close account and delete all profile information') }}</button>
       </form>
     {% endif %}
   </div>


### PR DESCRIPTION
Added a checkbox which needs to checked to activate the "Close Account and delete all my profile information"

With checkbox unchecked 
![screenshot from 2014-11-14 16 06 14](https://cloud.githubusercontent.com/assets/1151263/5044593/5ebdaeac-6c18-11e4-90f8-755b6caf6e1d.png)


Checkbox checked ( Delete Buttons becomes active )
![screenshot from 2014-11-14 16 06 20](https://cloud.githubusercontent.com/assets/1151263/5044608/9550472c-6c18-11e4-849e-01d19af08d64.png)
