### PR TITLE
Remove useless output from cron jobs.

### DIFF
--- a/kitsune/customercare/cron.py
+++ b/kitsune/customercare/cron.py
@@ -226,8 +226,6 @@ def get_customercare_stats():
     ]
     """
     if settings.STAGE:
-        print ('Skipped get_customercare_stats(). '
-               'Set settings.STAGE to False to run it for real.')
         return
 
     contributor_stats = {}

--- a/kitsune/dashboards/cron.py
+++ b/kitsune/dashboards/cron.py
@@ -18,8 +18,6 @@ from kitsune.wiki.utils import num_active_contributors
 @cronjobs.register
 def reload_wiki_traffic_stats():
     if settings.STAGE:
-        print ('Skipped reload_wiki_traffic_stats(). '
-               'Set settings.STAGE to False to run it for real.')
         return
 
     for period, _ in PERIODS:

--- a/kitsune/kpi/cron.py
+++ b/kitsune/kpi/cron.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db.models import Count, F
 
 import cronjobs
+from statsd import statsd
 
 from kitsune.customercare.models import Reply
 from kitsune.dashboards import LAST_90_DAYS
@@ -413,8 +414,6 @@ def process_exit_surveys():
     if settings.STAGE:
         # Only run this on prod, it doesn't need to be running multiple times
         # from different places.
-        print ('Skipped email address processing in process_exit_surveys(). '
-               'Set settings.STAGE to False to run it for real.')
         return
 
     startdate = date.today() - timedelta(days=2)
@@ -430,7 +429,7 @@ def process_exit_surveys():
         for email in emails:
             add_email_to_campaign(survey, email)
 
-        print '%s emails processed for %s...' % (len(emails), survey)
+        statsd.gauge('survey.{0}'.format(survey), len(emails))
 
 
 def _process_exit_survey_results():
@@ -481,8 +480,6 @@ def survey_recent_askers():
     if settings.STAGE:
         # Only run this on prod, it doesn't need to be running multiple times
         # from different places.
-        print('Skipped email address processing in survey_recent_askers(). '
-              'Set settings.STAGE to False to run it for real.')
         return
 
     # We get the email addresses of all users that asked a question 2 days
@@ -498,4 +495,4 @@ def survey_recent_askers():
     for email in emails:
             add_email_to_campaign('askers', email)
 
-    print '%s emails added to askers survey...' % len(emails)
+    statsd.gauge('survey.askers', len(emails))

--- a/kitsune/questions/cron.py
+++ b/kitsune/questions/cron.py
@@ -110,8 +110,6 @@ def auto_archive_old_questions():
 def reload_question_traffic_stats():
     """Reload question views from the analytics."""
     if settings.STAGE:
-        print ('Skipped reload_question_traffic_stats(). '
-               'Set settings.STAGE to False to run it for real.')
         return
 
     QuestionVisits.reload_from_analytics(verbose=settings.DEBUG)


### PR DESCRIPTION
Anytime we print in cron jobs, it sends email to us. I don't think these things need to send emails. The survey counts are interesting, but I think those would be better served in statsd now. If you were using these emails, feel free to r- this.

@rlr r?
