### PR TITLE
Use django-cors-headers instead of CORS by hand.

### DIFF
--- a/kitsune/gallery/api.py
+++ b/kitsune/gallery/api.py
@@ -3,8 +3,7 @@ from django.db.models import Q
 from rest_framework import generics, serializers
 
 from kitsune.gallery.models import Image
-from kitsune.sumo.api import (CORSMixin, LocaleNegotiationMixin,
-                              InequalityFilterBackend, DateTimeUTCField)
+from kitsune.sumo.api import LocaleNegotiationMixin, InequalityFilterBackend, DateTimeUTCField
 
 
 class ImageShortSerializer(serializers.ModelSerializer):
@@ -29,7 +28,7 @@ class ImageDetailSerializer(ImageShortSerializer):
             'creator')
 
 
-class ImageList(CORSMixin, LocaleNegotiationMixin, generics.ListAPIView):
+class ImageList(LocaleNegotiationMixin, generics.ListAPIView):
     """List all image ids."""
     queryset = Image.objects.all()
     serializer_class = ImageShortSerializer
@@ -51,6 +50,6 @@ class ImageList(CORSMixin, LocaleNegotiationMixin, generics.ListAPIView):
         return queryset
 
 
-class ImageDetail(CORSMixin, generics.RetrieveAPIView):
+class ImageDetail(generics.RetrieveAPIView):
     queryset = Image.objects.all()
     serializer_class = ImageDetailSerializer

--- a/kitsune/notifications/api.py
+++ b/kitsune/notifications/api.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers, viewsets, permissions, mixins
 
 from kitsune.notifications.models import PushNotificationRegistration
-from kitsune.sumo.api import CORSMixin, OnlyCreatorEdits
+from kitsune.sumo.api import OnlyCreatorEdits
 
 
 class PushNotificationRegistrationSerializer(serializers.ModelSerializer):
@@ -29,8 +29,7 @@ class PushNotificationRegistrationSerializer(serializers.ModelSerializer):
         return attrs
 
 
-class PushNotificationRegistrationViewSet(CORSMixin,
-                                          mixins.CreateModelMixin,
+class PushNotificationRegistrationViewSet(mixins.CreateModelMixin,
                                           mixins.DestroyModelMixin,
                                           viewsets.GenericViewSet):
     model = PushNotificationRegistration

--- a/kitsune/products/api.py
+++ b/kitsune/products/api.py
@@ -5,8 +5,7 @@ from rest_framework import generics, serializers
 from tower import ugettext_lazy as _lazy
 
 from kitsune.products.models import Product, Topic
-from kitsune.sumo.api import (CORSMixin, LocaleNegotiationMixin,
-                              LocalizedCharField)
+from kitsune.sumo.api import LocaleNegotiationMixin, LocalizedCharField
 from kitsune.wiki.api import DocumentShortSerializer
 
 
@@ -96,7 +95,7 @@ class ProductSerializer(serializers.ModelSerializer):
         fields = ('id', 'title', 'slug', 'description', 'platforms', 'visible')
 
 
-class ProductList(CORSMixin, generics.ListAPIView):
+class ProductList(generics.ListAPIView):
     """List all documents."""
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
@@ -135,7 +134,7 @@ class TopicSerializer(serializers.ModelSerializer):
         return DocumentShortSerializer(docs, many=True).data
 
 
-class TopicDetail(CORSMixin, LocaleNegotiationMixin, generics.RetrieveAPIView):
+class TopicDetail(LocaleNegotiationMixin, generics.RetrieveAPIView):
     queryset = Topic.objects.all()
     serializer_class = TopicSerializer
 
@@ -173,7 +172,7 @@ class RootTopicSerializer(TopicShortSerializer):
         }
 
 
-class TopicList(CORSMixin, LocaleNegotiationMixin, generics.ListAPIView):
+class TopicList(LocaleNegotiationMixin, generics.ListAPIView):
     queryset = Topic.objects.filter(parent=None)
     serializer_class = RootTopicSerializer
 

--- a/kitsune/questions/api.py
+++ b/kitsune/questions/api.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 
 from kitsune.products.api import TopicField
 from kitsune.questions.models import Question, Answer, QuestionMetaData
-from kitsune.sumo.api import DateTimeUTCField, CORSMixin, OnlyCreatorEdits, GenericAPIException
+from kitsune.sumo.api import DateTimeUTCField, OnlyCreatorEdits, GenericAPIException
 
 
 class QuestionMetaDataSerializer(serializers.ModelSerializer):
@@ -154,7 +154,7 @@ class QuestionFilter(django_filters.FilterSet):
         return queryset
 
 
-class QuestionViewSet(CORSMixin, viewsets.ModelViewSet):
+class QuestionViewSet(viewsets.ModelViewSet):
     serializer_class = QuestionSerializer
     queryset = Question.uncached.all()
     paginate_by = 20
@@ -270,7 +270,7 @@ class AnswerFilter(django_filters.FilterSet):
         ]
 
 
-class AnswerViewSet(CORSMixin, viewsets.ModelViewSet):
+class AnswerViewSet(viewsets.ModelViewSet):
     serializer_class = AnswerSerializer
     queryset = Answer.uncached.all()
     paginate_by = 20

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import platform
+import re
 from datetime import date
 
 from bundles import MINIFY_BUNDLES
@@ -417,6 +418,7 @@ MIDDLEWARE_CLASSES = (
     'kitsune.sumo.middleware.MobileSwitchMiddleware',
 
     'kitsune.sumo.middleware.Forbidden403Middleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'kitsune.sumo.middleware.RemoveSlashMiddleware',
     'kitsune.inproduct.middleware.EuBuildMiddleware',
@@ -480,6 +482,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admin',
+    'corsheaders',
     'kitsune.users',
     'dennis.django_dennis',
     'tower',
@@ -883,6 +886,23 @@ AXES_REVERSE_PROXY_HEADER = 'HTTP_X_CLUSTER_CLIENT_IP'
 
 # Set this to True to wrap each HTTP request in a transaction on this database.
 ATOMIC_REQUESTS = True
+
+# CORS Setup
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = [
+    r'^/api/1/gallery/.*$',
+    r'^/api/1/kb/.*$',
+    r'^/api/1/products/.*',
+    r'^/api/1/users/get_token$',
+    r'^/api/1/users/test_auth$',
+    r'^/api/2/answer/.*$',
+    r'^/api/2/pushnotification/.*$',
+    r'^/api/2/question/.*$',
+    r'^/api/2/user/.*$',
+]
+# Now combine all those regexes with one big "or".
+CORS_URLS_REGEX = re.compile('|'.join('({0})'.format(r) for r in CORS_URLS_REGEX))
+CORS_URLS_REGEX = '.*'
 
 # XXX Fix this when Bug 1059545 is fixed
 CC_IGNORE_USERS = []

--- a/kitsune/sumo/api.py
+++ b/kitsune/sumo/api.py
@@ -11,43 +11,6 @@ from kitsune.sumo.utils import uselocale
 from kitsune.sumo.urlresolvers import get_best_language
 
 
-class CORSMixin(object):
-    """
-    Mixin to enable cross origin access of an API by setting CORS headers.
-
-    This should come before DRF mixins and base classes in class definitions.
-
-    This allows all requests to work cross origin, with no limit. This should
-    only be used on APIs intended for general public consumption, that have
-    any sensitive parts protected by authorization.
-
-    GET requests to these APIs should not cause write operations, as they can
-    be triggered by things like image tags. All write operations should be in
-    response to POST, PUT, PATCH, or DELETE requests.
-
-    TODO: This should be configurable to not allow 100% of things, if desired.
-    """
-    def finalize_response(self, request, response, *args, **kwargs):
-        response = (super(CORSMixin, self)
-                    .finalize_response(request, response, *args, **kwargs))
-
-        response['Access-Control-Allow-Origin'] = '*'
-
-        # OPTION requests are pre-flight requests. We need to tell the browser
-        # it is ok to make the real request.
-        if request.method == 'OPTIONS':
-            # If the client doesn't care what to allow, allow everything.
-            allowed_methods = request.META.get(
-                'HTTP_ACCESS_CONTROL_REQUEST_HEADERS',
-                'POST,GET,PATCH,DELETE,PUT,OPTIONS,HEAD')
-            response['Access-Control-Allow-Methods'] = '*'
-            response['Access-Control-Allow-Headers'] = allowed_methods
-            response['Access-Control-Allow-Max-Age'] = '3600'
-            response['Access-Control-Allow-Credentials'] = 'true'
-
-        return response
-
-
 class GenericAPIException(APIException):
     """Generic Exception, since DRF doesn't provide one.
 

--- a/kitsune/users/api.py
+++ b/kitsune/users/api.py
@@ -16,11 +16,10 @@ from rest_framework import viewsets, serializers, mixins, filters, permissions
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.decorators import permission_classes, api_view
-from rest_framework.authtoken import views as authtoken_views
 from rest_framework.authtoken.models import Token
 
 from kitsune.access.decorators import login_required
-from kitsune.sumo.api import CORSMixin, DateTimeUTCField, GenericAPIException
+from kitsune.sumo.api import DateTimeUTCField, GenericAPIException
 from kitsune.sumo.decorators import json_view
 from kitsune.users.helpers import profile_avatar
 from kitsune.users.models import Profile, RegistrationProfile
@@ -72,10 +71,6 @@ def test_auth(request):
         'username': request.user.username,
         'authorized': True,
     })
-
-
-class GetToken(CORSMixin, authtoken_views.ObtainAuthToken):
-    """Add CORS headers to the ObtainAuthToken view."""
 
 
 class OnlySelfEdits(permissions.BasePermission):
@@ -191,8 +186,7 @@ class ProfileSerializer(serializers.ModelSerializer):
         return attrs
 
 
-class ProfileViewSet(CORSMixin,
-                     mixins.CreateModelMixin,
+class ProfileViewSet(mixins.CreateModelMixin,
                      mixins.RetrieveModelMixin,
                      mixins.ListModelMixin,
                      mixins.UpdateModelMixin,

--- a/kitsune/users/tests/test_api.py
+++ b/kitsune/users/tests/test_api.py
@@ -150,27 +150,6 @@ class TestUserSerializer(TestCase):
             [u'Usernames may only be letters, numbers, "." and "-".']})
 
 
-class TestGetToken(TestCase):
-
-    def setUp(self):
-        self.url = reverse('users.get_token')
-        self.user = user(password='testpass', save=True)
-        self.data = {
-            'username': self.user.username,
-            'password': 'testpass',
-        }
-
-    def test_it_works(self):
-        res = self.client.post(self.url, data=self.data)
-        eq_(res.status_code, 200)
-        eq_(res.data.keys(), ['token'])
-
-    def test_it_has_cors(self):
-        res = self.client.post(self.url, data=self.data)
-        eq_(res.status_code, 200)
-        ok_(res.has_header('Access-Control-Allow-Origin'))
-
-
 class TestUserView(TestCase):
 
     def setUp(self):

--- a/kitsune/users/urls_api.py
+++ b/kitsune/users/urls_api.py
@@ -11,7 +11,7 @@ router.register(r'user', api.ProfileViewSet, base_name='user')
 urlpatterns = patterns(
     '',
     url('^1/users/test_auth$', api.test_auth, name='users.test_auth'),
-    url('^1/users/get_token$', api.GetToken.as_view(), name='users.get_token'),
+    url('^1/users/get_token$', 'rest_framework.authtoken.views.obtain_auth_token'),
     url('^2/user/generate', api.ProfileViewSet.as_view({'post': 'generate'}),
         name='user-generate'),
     url('^2/', include(router.urls)),

--- a/kitsune/wiki/api.py
+++ b/kitsune/wiki/api.py
@@ -4,8 +4,7 @@ from django.shortcuts import get_object_or_404
 
 from rest_framework import generics, serializers, status
 
-from kitsune.sumo.api import (CORSMixin, GenericAPIException,
-                              LocaleNegotiationMixin)
+from kitsune.sumo.api import GenericAPIException, LocaleNegotiationMixin
 from kitsune.wiki.models import Document
 from kitsune.wiki.config import REDIRECT_HTML
 
@@ -26,7 +25,7 @@ class DocumentDetailSerializer(DocumentShortSerializer):
                   'html')
 
 
-class DocumentList(CORSMixin, LocaleNegotiationMixin, generics.ListAPIView):
+class DocumentList(LocaleNegotiationMixin, generics.ListAPIView):
     """List all documents."""
     queryset = Document.objects.all()
     serializer_class = DocumentShortSerializer
@@ -77,8 +76,7 @@ class DocumentList(CORSMixin, LocaleNegotiationMixin, generics.ListAPIView):
         return queryset
 
 
-class DocumentDetail(CORSMixin, LocaleNegotiationMixin,
-                     generics.RetrieveAPIView):
+class DocumentDetail(LocaleNegotiationMixin, generics.RetrieveAPIView):
     queryset = Document.objects.all()
     serializer_class = DocumentDetailSerializer
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -70,6 +70,9 @@ https://github.com/jbalogh/django-cache-machine/archive/7c3d3abfc85fc26d0e522fd0
 # sha256: ESLN3T2iyCrFz0i2k9G1Um7goYVPgRaii1DpoxwqmOg
 https://github.com/celery/django-celery/archive/b11b358cbc0d7b3ca15575d27332d4ae37beca27.tar.gz#egg=django-celery
 
+# sha256: LM9zUZ6iBbiNtFP39hcPs9CiGo4yU_JXjvDNUp95pY8
+django-cors-headers==0.13
+
 # sha256: F3KVsUQkAMks22fo4Y-f9ZRvtEL4WBO50IN4I3IuoI0
 django-cronjobs==0.2.3
 


### PR DESCRIPTION
I've failed at writing CORS stuff twice now. This removes the CORS mixin I made, and using django-cors-headers instead.

r?
