### PR TITLE
Add settings to user profile, hidden behind auth..

### DIFF
--- a/kitsune/questions/api.py
+++ b/kitsune/questions/api.py
@@ -39,6 +39,9 @@ class QuestionMetaDataSerializer(serializers.ModelSerializer):
             obj, created = self.Meta.model.uncached.get_or_create(
                 question=attrs['question'], name=attrs['name'],
                 defaults={'value': attrs['value']})
+            if not created:
+                obj.value = attrs['value']
+                obj.save()
             return obj
 
 

--- a/kitsune/users/models.py
+++ b/kitsune/users/models.py
@@ -175,6 +175,10 @@ class Profile(ModelBase, SearchMixin):
 
         return max(dates)
 
+    @property
+    def settings(self):
+        return self.user.settings
+
 
 @register_mapping_type
 class UserMappingType(SearchMappingType):

--- a/kitsune/users/tests/__init__.py
+++ b/kitsune/users/tests/__init__.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User, Group, Permission
 from django.contrib.contenttypes.models import ContentType
 
 from kitsune.sumo.tests import LocalizingClient, TestCase, with_save
-from kitsune.users.models import Profile
+from kitsune.users.models import Profile, Setting
 
 
 class TestCaseBase(TestCase):
@@ -74,3 +74,13 @@ def add_permission(user, model, permission_codename):
                                                name=permission_codename,
                                                content_type=content_type)
     user.user_permissions.add(permission)
+
+
+@with_save
+def setting(**kwargs):
+    defaults = {
+        'name': ''.join(random.choice(letters) for _ in range(10)),
+        'value': ''.join(random.choice(letters) for _ in range(10)),
+    }
+    defaults.update(kwargs)
+    return Setting(**defaults)


### PR DESCRIPTION
The user settings API works very much like the questions metadata API. And I discovered that the questions metadata API is broken. I fixed the question metadata API, kind of. I implemented the user settings API the same way. I hid the settings API with a new field I made that hides it uniless certain conditions are met. In this case I check for a logged in user that matches the user being queried. I also put email address in a field like that too.

I'm really not satisfied with how DRF and our metadata-like models interact. I'm not sure what to do about that. I tried making a field/serializer thing that acted like a dictionary, but couldn't get it to work.

@willkg I'm curious what you think about the PermissionsMod class. It's the field decorator we talked about that implements the permission fields.

r?
