### PR TITLE
Fixed js module binary paths for docs.

### DIFF
--- a/docs/hacking_howto.rst
+++ b/docs/hacking_howto.rst
@@ -237,7 +237,10 @@ Start with this::
         }
 
     LESS_PREPROCESS = True
-    LESS_BIN = '/path/to/kitsune/node_modules/less/bin/lessc'
+    LESS_BIN = path('node_modules/.bin/lessc')
+    UGLIFY_BIN = path('node_modules/.bin/uglifyjs')
+    CLEANCSS_BIN = path('node_modules/.bin/cleancss')
+    NUNJUCKS_PRECOMPILE_BIN = path('node_modules/.bin/nunjucks-precompile')
 
     # Tells django-axes we aren't behind a reverse proxy.
     AXES_BEHIND_REVERSE_PROXY = False


### PR DESCRIPTION
As per the change in #1999, a docs update to include paths for some of the JS module binaries.
