### PR TITLE
[bug 1056298] Fix createsuperuser

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -8,6 +8,12 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'kitsune.settings_local')
 os.environ.setdefault('CELERY_CONFIG_MODULE', 'kitsune.settings_local')
 from django.conf import settings
 
+# MONKEYPATCH! WOO HOO!
+# Need this so we patch before running Django-specific commands which
+# import Jingo and then result in a circular import.
+from kitsune.sumo.monkeypatch import patch
+patch()
+
 # Import for side-effect: configures our logging handlers.
 from kitsune import log_settings
 


### PR DESCRIPTION
This adds a patch call to manage.py. The problem is that various
Django-specific subcommands at some point import Jingo which eventually
results in a circular import. Adding the patch call here guarantees
that Jingo and all that stuff is imported before we import the things we
need to import to execute the subcommand.

r?
