### PR TITLE
Add postatus webapp url to emails

### DIFF
--- a/kitsune/sumo/cron.py
+++ b/kitsune/sumo/cron.py
@@ -58,7 +58,9 @@ def send_postatus_errors():
         mail_admins(
             subject='[SUMO] postatus errors %s' % datestamp,
             message=(
-                'These are the errors in the SUMO postatus file:\n\n' +
+                'These are the errors in the SUMO postatus file.\n' +
+                'See http://postatus.paas.allizom.org/p/SUMO for details\n'
+                'and bug generation links.\n\n'
                 '\n'.join(errordata)
                 )
             )


### PR DESCRIPTION
The webapp has links to auto-generate bug reports which makes it super
handy. Adding a link to the email connects the two.

Quick r?
