### PR TITLE
[Bug 1111809] Make newlines work in questions again.

### DIFF
--- a/kitsune/sumo/static/less/questions.less
+++ b/kitsune/sumo/static/less/questions.less
@@ -145,7 +145,7 @@ h2 {
       margin-top: 12px;
     }
 
-    > p {
+    .content {
       white-space: pre-wrap;
     }
 


### PR DESCRIPTION
The PR for quoting questions broke this selector.

r?
