### PR TITLE
[Bug 1104814] Improve visual appearance of quotes in questions forum.

### DIFF
--- a/kitsune/questions/templates/questions/includes/answer.html
+++ b/kitsune/questions/templates/questions/includes/answer.html
@@ -77,7 +77,7 @@
           {{ mark_spam_form(answer_id=answer.id) }}
         {% endif %}
       {% endif %}
-      <a class="reply quoted-reply" href="#question-reply" data-content-id="answer-{{ answer.id }}">{{ _('Reply') }}</a>
+      <a class="reply quoted-reply" href="#question-reply" data-content-id="answer-{{ answer.id }}">{{ _('Quote') }}</a>
     </div>
   {% endif %}
 </div>

--- a/kitsune/sumo/static/less/questions.less
+++ b/kitsune/sumo/static/less/questions.less
@@ -756,6 +756,14 @@ h2 {
         text-align: right;
         width: 250px;
       }
+
+      blockquote {
+        margin: 1.5em 0em;
+        border-radius: 0.3em;
+        background: rgba(180, 192, 200, 0.4);
+        padding: 1em;
+      }
+
     }
 
     .thread-meta {


### PR DESCRIPTION
This should make things easier to read in the questions forum, and mimics the visual appearance found in the contributor forums for block quotes. I used `rgba(...)` instead of a straight hex code so that as quotes nest they are still visually distinct.

r?
