### PR TITLE
Adding Open SSL and Mysql Library in requirments of Kitsune Doc

### DIFF
--- a/docs/hacking_howto.rst
+++ b/docs/hacking_howto.rst
@@ -91,7 +91,6 @@ These are required for the minimum installation:
 * libjpeg and headers
 * zlib and headers
 * libssl library
-* libmysqlclient library
 
 These are optional:
 

--- a/docs/hacking_howto.rst
+++ b/docs/hacking_howto.rst
@@ -90,7 +90,7 @@ These are required for the minimum installation:
 * libxslt and headers
 * libjpeg and headers
 * zlib and headers
-* libssl library
+* libssl and headers
 
 These are optional:
 

--- a/docs/hacking_howto.rst
+++ b/docs/hacking_howto.rst
@@ -90,6 +90,8 @@ These are required for the minimum installation:
 * libxslt and headers
 * libjpeg and headers
 * zlib and headers
+* libssl library
+* libmysqlclient library
 
 These are optional:
 


### PR DESCRIPTION
While installing Kitsune, following Library is needed. 
* Open SSL Library named libssl
* MySQL Library named libmysqlclient

So this both should be added into Requirments.