### PR TITLE
Make migrations users/0006 more independent.

### DIFF
--- a/kitsune/users/migrations/0006_add_migration_user.py
+++ b/kitsune/users/migrations/0006_add_migration_user.py
@@ -3,16 +3,17 @@ import datetime
 from south.db import db
 from south.v2 import DataMigration
 from django.db import models
+from django.contrib.auth.hashers import make_password
 
 class Migration(DataMigration):
 
     def forwards(self, orm):
         """Adds a user to be used for migrations."""
         from django.contrib.auth.models import User
-        # Setting password to None makes it an unusable account.
-        User.objects.create_user(username='migrations',
-                                 email='migrations@mozilla.org',
-                                 password=None)
+        # ``make_password(None)`` makes an unusable password.
+        orm['auth.User'].objects.create(
+            username='migrations',
+            password=make_password(None))
 
     def backwards(self, orm):
         """Removes the user to be used for migrations."""

--- a/kitsune/users/migrations/0006_add_migration_user.py
+++ b/kitsune/users/migrations/0006_add_migration_user.py
@@ -9,7 +9,6 @@ class Migration(DataMigration):
 
     def forwards(self, orm):
         """Adds a user to be used for migrations."""
-        from django.contrib.auth.models import User
         # ``make_password(None)`` makes an unusable password.
         orm['auth.User'].objects.create(
             username='migrations',


### PR DESCRIPTION
@safwanrahman was having trouble with this: adding new fields to our profile model breaks this migration, since it calls all the bits and bobs to create a new profile as well as a new user. The fields would be missing, and things would break.

r?