### PR TITLE
[Bug 1119304] Upgrade to Django 1.6.10

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -40,8 +40,8 @@ https://github.com/jsocol/commonware/archive/b5544185b2d24adc1eb512735990752400c
 # sha256: MxnZwEi7pMyJqWkRgdDgIYei8JtDQ_0vz2zL-EtO4Yo
 dennis==0.6.1
 
-# sha256: mmQhHJajJiuyVFrMgq9djz2gF1KZ98fpAeTtRVvpZfs
-Django==1.6.7
+# sha256: VOtZznhUAcfR_e7SRe_OWX6Q-BHWog9rXGkxwASdY6Y
+Django==1.6.10
 
 # django-adminplus: tags/v0.2.1
 # sha256: hFyepTe0iD7ynH-YlVoiYeg_AZWYzBNed4Y8JHy6Klg


### PR DESCRIPTION
I got this hash in two ways: I downloaded the tarball from PyPI with peep and checked it, and I also re-encoded the [published sha256 sum from Django](https://www.djangoproject.com/m/pgp/Django-1.6.10.checksum.txt) to base64. They both matched.

This commit is signed with [my GPG key](https://keybase.io/mythmon) (`DAFE 0A2F 0B02 90B5 7AC3  5186 CD8D 37A4 6031 DC1C`).

r?