### PR TITLE
[Bug 1118033] Return vote count from question and answer helpful APIs.

### DIFF
--- a/kitsune/questions/tests/test_api.py
+++ b/kitsune/questions/tests/test_api.py
@@ -215,7 +215,8 @@ class TestQuestionViewSet(TestCase):
         u = profile().user
         self.client.force_authenticate(user=u)
         res = self.client.post(reverse('question-helpful', args=[q.id]))
-        eq_(res.status_code, 204)
+        eq_(res.status_code, 200)
+        eq_(res.data, {'num_votes': 1})
         eq_(Question.objects.get(id=q.id).num_votes, 1)
 
     def test_helpful_double_vote(self):
@@ -404,7 +405,8 @@ class TestAnswerViewSet(TestCase):
         u = profile().user
         self.client.force_authenticate(user=u)
         res = self.client.post(reverse('answer-helpful', args=[a.id]))
-        eq_(res.status_code, 204)
+        eq_(res.status_code, 200)
+        eq_(res.data, {'num_helpful_votes': 1, 'num_unhelpful_votes': 0})
         eq_(Answer.objects.get(id=a.id).num_votes, 1)
 
     def test_helpful_double_vote(self):


### PR DESCRIPTION
```shell
$ http -p b POST :8000/api/2/question/1040466/helpful/ Authorization:'token ...'                              
{
    "num_votes": 2
}

$ http -p b POST :8000/api/2/answer/675063/helpful/ Authorization:'token ...' 
{
    "num_helpful_votes": 1,
    "num_unhelpful_votes": 1
}
```

r?