### PR TITLE
[Bug 1121627] Use the right query for search suggestions API.

### DIFF
--- a/kitsune/search/api.py
+++ b/kitsune/search/api.py
@@ -63,9 +63,6 @@ def suggest(request):
     # Transform query to be locale aware.
     query = es_utils.es_query_with_analyzer(query, locale)
 
-    query = dict(('%s__match' % field, 'emails')
-                 for field in QuestionMappingType.get_query_fields())
-
     searcher = (
         es_utils.AnalyzerS()
         .es(urls=settings.ES_URLS)


### PR DESCRIPTION
I had these lines in the function while I was pulling my hair out trying to debug things. Removing them makes documents work again, and makes it so we aren't always searching for "emails".

This was pretty dumb of me.

r?