### PR TITLE
Run Python 2.7 tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ env:
     - TEST_SUITE=django
 
 matrix:
-  allowed_failures:
+  allow_failures:
     - python: 2.7
+  fast_finish: true
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: no
 language: python
-python: "2.6"
+python:
+    - 2.6
+    - 2.7
 node: "0.10"
 
 env:
@@ -10,6 +12,10 @@ env:
   matrix:
     - TEST_SUITE=lint
     - TEST_SUITE=django
+
+matrix:
+  allowed_failures:
+    - python: 2.7
 
 cache:
   directories:

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -2,16 +2,26 @@
 # pwd is the git repo.
 set -e
 
+# None of this is needed for lint tests.
+if [[ $TEST_SUITE == "lint" ]]; then
+  return 0
+fi
+
 echo "Fix path issues"
 ln -s /usr/lib/`uname -i`-linux-gnu/libfreetype.so ~/virtualenv/python2.6/lib/
 ln -s /usr/lib/`uname -i`-linux-gnu/libjpeg.so ~/virtualenv/python2.6/lib/
 ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.6/lib/
 
 echo "Install Python dependencies"
+if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then
+  MAIN_REQ_FILE="requirements/py26.txt"
+else
+  MAIN_REQ_FILE="requirements/py26.txt"
+fi
 python scripts/peep.py install \
-    -r requirements/py26.txt \
-    -r requirements/dev.txt \
-    --no-use-wheel
+  -r $MAIN_REQ_FILE \
+  -r requirements/dev.txt \
+  --no-use-wheel
 # Print the installed packages for the world to see.
 pip freeze
 echo

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -20,7 +20,7 @@ fi
 if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then
   MAIN_REQ_FILE="requirements/py26.txt"
 else
-  MAIN_REQ_FILE="requirements/py26.txt"
+  MAIN_REQ_FILE="requirements/default.txt"
 fi
 python scripts/peep.py install \
   -r $MAIN_REQ_FILE \

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -2,17 +2,21 @@
 # pwd is the git repo.
 set -e
 
-# None of this is needed for lint tests.
-if [[ $TEST_SUITE == "lint" ]]; then
-  return 0
-fi
-
 echo "Fix path issues"
 ln -s /usr/lib/`uname -i`-linux-gnu/libfreetype.so ~/virtualenv/python2.6/lib/
 ln -s /usr/lib/`uname -i`-linux-gnu/libjpeg.so ~/virtualenv/python2.6/lib/
 ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.6/lib/
 
 echo "Install Python dependencies"
+python scripts/peep.py install \
+  -r requirements/dev.txt \
+  --no-use-wheel
+
+# Optimization: None of the rest is needed for lint tests.
+if [[ $TEST_SUITE == "lint" ]]; then
+  exit 0
+fi
+
 if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then
   MAIN_REQ_FILE="requirements/py26.txt"
 else
@@ -20,16 +24,17 @@ else
 fi
 python scripts/peep.py install \
   -r $MAIN_REQ_FILE \
-  -r requirements/dev.txt \
   --no-use-wheel
 # Print the installed packages for the world to see.
 pip freeze
 echo
 
+
 echo "Installing Node.js dependencies"
 npm install > /dev/null 2> /dev/null
 npm list
 echo
+
 
 echo "Installing ElasticSearch"
 tar xzvf vendor/tarballs/elasticsearch-0.90.10.tar.gz > /dev/null

--- a/scripts/travis/setup.sh
+++ b/scripts/travis/setup.sh
@@ -4,7 +4,7 @@ set -e
 
 # None of this is needed for lint tests.
 if [[ $TEST_SUITE == "lint" ]]; then
-  return 0
+  exit 0
 fi
 
 echo "Making settings_local.py"

--- a/scripts/travis/setup.sh
+++ b/scripts/travis/setup.sh
@@ -2,6 +2,11 @@
 # pwd is the git repo.
 set -e
 
+# None of this is needed for lint tests.
+if [[ $TEST_SUITE == "lint" ]]; then
+  return 0
+fi
+
 echo "Making settings_local.py"
 cat > kitsune/settings_local.py <<SETTINGS
 from settings import *


### PR DESCRIPTION
This (should) make Travis run our tests with both Python 2.6 and 2.7, and allow 2.7 to fail without failing the entire build. This is good for transition.