### PR TITLE
[bug 971009] Upgrade to celery v3.1.17

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,9 +7,8 @@ anyjson==0.3.1
 # sha256: SjoIXs8fzSc2VzU4_6EU8fQzGzu73Wk4Hm4XLEnJdQ8
 Babel==0.9.6
 
-# billiard: tags/v3.3.0.9
-# sha256: JHw2XY75uDAZW1znrmH9ufpEYQJalYhyMNKpcPEmrpM
-https://github.com/celery/billiard/archive/5652fe69e0a0623cea8f9f0c2810e001d4ad53df.tar.gz#egg=billiard
+# sha256: czbsWbjQoTKh7p8WagY9RKXn8tL-FfefvO3aWDu9YcE
+billiard==3.3.0.9
 
 # bleach: tags/v1.2.1
 # sha256: TZ4IUMAsbo3fhQxiIK1u1Ba4-UXvK0mZKvjSBbxQxNA
@@ -22,9 +21,8 @@ https://github.com/jbalogh/django-debug-cache-panel/archive/a6b0f248b721bdd759ee
 # sha256: y0Y3TzyIPFgNFCp50mCYg3E6hnzIbgUUFjrc54TOJGg
 carrot==0.10.7
 
-# celery: tags/v3.1.17
-# sha256: j-caPcm7jTVr_BSOPaM1MLF7EBtlmH_no2IeVKCwKKg
-https://github.com/celery/celery/archive/a4acff48ef1f98e822f5b09b5bf389179fec5049.tar.gz#egg=celery
+# sha256: z-K2UyaL1Ybi0Ip16Ib3vjvlW6Ny9y4vV0eut2xHA2I
+celery==3.1.17
 
 # check: master~9
 # sha256: BJ7houDdUh-nH8g2T9aYtS4DTrGyKicd-EBjHJJOoAc
@@ -185,9 +183,8 @@ https://github.com/jsocol/jingo-minify/archive/51c158a18e6c5ff7c6fd030ffa4cba511
 # sha256: GQQPAbOp2MY-TVeTb3hxCQgZm2k3CrRKD3QH3YkfAZs
 Jinja2==2.5.2
 
-# kombu: tags/v3.0.24
-# sha256: cwj3G8RrlHtkLMohfObd2NqKEcLWyfnFKNaOt6bdGu4
-https://github.com/celery/kombu/archive/161d87b1ea4496b449941c3af07f9b63880e962f.tar.gz#egg=kombu
+# sha256: uf8EN2BxE66nAf1RIsKvpAwF3_bx2k9YsvHqGNnyv40
+kombu==3.0.24
 
 # sha256: _rvld3LyBrrNJG-kH980xSySPl2sB5CxXJ3umX64pww
 logilab-astng==0.20.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,9 +7,9 @@ anyjson==0.3.1
 # sha256: SjoIXs8fzSc2VzU4_6EU8fQzGzu73Wk4Hm4XLEnJdQ8
 Babel==0.9.6
 
-# billiard: tags/v2.7.3.34
-# sha256: YKE9uzfN1UL1JUZXDT451i6erJQVPRDdfCT_poTAVy0
-https://github.com/celery/billiard/archive/f24a943cb4b6992717fa8d1db7e220d576377631.tar.gz#egg=billiard==2.7.3.34
+# billiard: tags/v3.3.0.9
+# sha256: JHw2XY75uDAZW1znrmH9ufpEYQJalYhyMNKpcPEmrpM
+https://github.com/celery/billiard/archive/5652fe69e0a0623cea8f9f0c2810e001d4ad53df.tar.gz#egg=billiard
 
 # bleach: tags/v1.2.1
 # sha256: TZ4IUMAsbo3fhQxiIK1u1Ba4-UXvK0mZKvjSBbxQxNA
@@ -22,9 +22,9 @@ https://github.com/jbalogh/django-debug-cache-panel/archive/a6b0f248b721bdd759ee
 # sha256: y0Y3TzyIPFgNFCp50mCYg3E6hnzIbgUUFjrc54TOJGg
 carrot==0.10.7
 
-# celery: tags/v3.0.24
-# sha256: _ac6RdnCKQYtOWzlu9JE-TNp1GBNPe_6gO2wft0dTAQ
-https://github.com/celery/celery/archive/53aac9e633302af2aeb8fd8089ed95b6d1e0c9d6.tar.gz#egg=celery==3.0.24
+# celery: tags/v3.1.17
+# sha256: j-caPcm7jTVr_BSOPaM1MLF7EBtlmH_no2IeVKCwKKg
+https://github.com/celery/celery/archive/a4acff48ef1f98e822f5b09b5bf389179fec5049.tar.gz#egg=celery
 
 # check: master~9
 # sha256: BJ7houDdUh-nH8g2T9aYtS4DTrGyKicd-EBjHJJOoAc
@@ -67,9 +67,9 @@ https://github.com/mozilla/django-badger/archive/c04372aa76dfaa2de7db838359cba2c
 # sha256: Z9bMfMcy--u-CtXQ0FvcEt3DgzBjGWVknYaYEu34e8c
 https://github.com/jbalogh/django-cache-machine/archive/7c3d3abfc85fc26d0e522fd05e9a42fc9b9a5430.tar.gz#egg=django-cache-machine
 
-# django-celery: tags/v3.0.23
-# sha256: ESLN3T2iyCrFz0i2k9G1Um7goYVPgRaii1DpoxwqmOg
-https://github.com/celery/django-celery/archive/b11b358cbc0d7b3ca15575d27332d4ae37beca27.tar.gz#egg=django-celery==3.0.23
+# django-celery: master
+# sha256: fv5_GlUdCxO2Ads3OkhBwbJs-yIir3I4yxmiXIi4JQo
+https://github.com/celery/django-celery/archive/9f8738e43251c2b42e4f68b4a65a8bc215aec149.tar.gz#egg=django-celery
 
 # sha256: LM9zUZ6iBbiNtFP39hcPs9CiGo4yU_JXjvDNUp95pY8
 django-cors-headers==0.13
@@ -185,9 +185,9 @@ https://github.com/jsocol/jingo-minify/archive/51c158a18e6c5ff7c6fd030ffa4cba511
 # sha256: GQQPAbOp2MY-TVeTb3hxCQgZm2k3CrRKD3QH3YkfAZs
 Jinja2==2.5.2
 
-# kombu: tags/v2.5.15
-# sha256: q7LQnb_YEdLVBSbXyqK6p5foIFShJ_v0jeL-r0fPyb8
-https://github.com/celery/kombu/archive/00efce7d9f9b8740e8df889987caf55700fd1b77.tar.gz#egg=kombu==2.5.15
+# kombu: tags/v3.0.24
+# sha256: cwj3G8RrlHtkLMohfObd2NqKEcLWyfnFKNaOt6bdGu4
+https://github.com/celery/kombu/archive/161d87b1ea4496b449941c3af07f9b63880e962f.tar.gz#egg=kombu
 
 # sha256: _rvld3LyBrrNJG-kH980xSySPl2sB5CxXJ3umX64pww
 logilab-astng==0.20.1


### PR DESCRIPTION
Here is the fjord commit for reference: https://github.com/mozilla/fjord/commit/9dff1949b093fc9e192ace41f876f6becf802f55

r?