### PR TITLE
[bug 1114031] Pass on q= param when filtering.

### DIFF
--- a/kitsune/search/templates/search/results.html
+++ b/kitsune/search/templates/search/results.html
@@ -24,7 +24,7 @@
       {% if not advanced %}
         {# Don't show filtering to advanced search users #}
 
-        {% set base_url = url('search') %}
+        {% set base_url = url('search')|urlparams(q=q) %}
 
         {% if product %}
           {# In basic search, you can only filter one product at a time. #}


### PR DESCRIPTION
Oops. Pretty sure I F'd this up when removing other useless params from search.

STR from the bug: `When I visit https://support.mozilla.org/en-US/search?q=test and click on "HELP ARTICLES ONLY", it redirects to https://support.mozilla.org/en-US/search?w=1 instead of keeping the part "q=test" and adding "&w=1".`

r?