### PR TITLE
[Bug 1123420, 1122539] Refactor and improve search suggestion APIs.

### DIFF
--- a/kitsune/search/api.py
+++ b/kitsune/search/api.py
@@ -4,7 +4,8 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from kitsune.products.models import Product
-from kitsune.questions.models import QuestionMappingType
+from kitsune.questions.models import Question, QuestionMappingType
+from kitsune.questions.api import QuestionSerializer
 from kitsune.search import es_utils
 from kitsune.sumo.api import GenericAPIException
 from kitsune.wiki.models import DocumentMappingType
@@ -59,10 +60,8 @@ def _question_suggestions(searcher, text, locale, product, max_results):
     searcher = _query(searcher, QuestionMappingType, search_filter, text, locale)
 
     for result in searcher[:max_results]:
-        questions.append({
-            'id': result['id'],
-            'title': result['question_title'],
-        })
+        q = Question.objects.get(id=result['id'])
+        questions.append(QuestionSerializer(instance=q).data)
 
     return questions
 

--- a/kitsune/search/tests/test_api.py
+++ b/kitsune/search/tests/test_api.py
@@ -83,3 +83,12 @@ class SuggestViewTests(ElasticTestCase):
 
         req = self.client.get(reverse('search.suggest'), {'q': 'emails', 'product': p1.slug})
         eq_([q['id'] for q in req.data['questions']], [q1.id])
+
+    def test_serializer_fields(self):
+        """Test that fields from the serializer are included."""
+        self._make_question()
+        self.refresh()
+
+        req = self.client.get(reverse('search.suggest'), {'q': 'emails'})
+        # Check that a field that is only available from the DB is in the response.
+        assert 'metadata' in req.data['questions'][0]


### PR DESCRIPTION
This makes the search suggestion do two separate queries for data, which fixes that goofy thing they did to try and get enough of both document types. It also switches to pulling the questions from the DB and using the API serializer. This increases consistency with the rest of the API, and provides some data to BuddyUp that is needed for their UX that isn't in ES.

r?