### PR TITLE
[bug 1122539] Handle the 0 case

### DIFF
--- a/kitsune/search/api.py
+++ b/kitsune/search/api.py
@@ -47,6 +47,9 @@ def suggest(request):
 
 
 def _question_suggestions(searcher, text, locale, product, max_results):
+    if max_results <= 0:
+        return []
+
     search_filter = es_utils.F(
         model='questions_question',
         question_is_archived=False,

--- a/kitsune/search/tests/test_api.py
+++ b/kitsune/search/tests/test_api.py
@@ -74,6 +74,13 @@ class SuggestViewTests(ElasticTestCase):
         req = self.client.get(reverse('search.suggest'), {'q': 'emails'})
         eq_([q['id'] for q in req.data['questions']], [q1.id])
 
+    def test_max_results_0(self):
+        self._make_question()
+        self.refresh()
+
+        req = self.client.get(reverse('search.suggest'), {'q': 'emails', 'max_questions': '0'})
+        eq_(len(req.data['questions']), 0)
+
     def test_product_filter_works(self):
         p1 = product(save=True)
         p2 = product(save=True)


### PR DESCRIPTION
If max_questions or max_documents (or both) are 0, then we should do the
least amount of work and just return [].

r?