### PR TITLE
[Bug 1119374] Fix up question topic charts

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -1665,9 +1665,15 @@ def metrics(request, locale_code=None):
         start = date.today() - timedelta(days=30)
         end = date.today()
 
+    graph_data = stats_topic_data(bucket_days, start, end, locale_code, product)
+
+    for group in graph_data:
+        for name, count in group.items():
+            if count == 0:
+                del group[name]
+
     data = {
-        'graph': stats_topic_data(
-            bucket_days, start, end, locale_code, product),
+        'graph': graph_data,
         'form': form,
         'current_locale': locale_code,
         'product': product,

--- a/kitsune/sumo/static/js/questions.metrics-dashboard.js
+++ b/kitsune/sumo/static/js/questions.metrics-dashboard.js
@@ -1,141 +1,141 @@
 (function() {
 
-function init() {
-  makeTopicsGraph();
-  makeMetricsGraph();
-}
-
-function makeTopicsGraph() {
-  var $topics, datums, seriesSpec, key;
-
-  $('input[type=date]').datepicker({
-    dateFormat: 'yy-mm-dd'
-  });
-
-  $topics = $('#topic-stats');
-  if ($topics.length === 0) {
-    return;
-  }
-
-  datums = $topics.data('graph');
-  seriesSpec = [];
-  window.datums = datums;
-
-  var min = 3;
-
-  for (key in datums[0]) {
-    if (key === 'date' || !datums[0].hasOwnProperty(key)) continue;
-    // TODO: these names should be localized.
-    seriesSpec.push({
-      name: key,
-      slug: key,
-      func: k.Graph.identity(key)
-    });
-  }
-
-  new k.Graph($topics, {
-    data: {
-      datums: datums,
-      seriesSpec: seriesSpec
-    },
-    graph: {
-      renderer: 'bar',
-      width: 690,
-      unstack: false
-    },
-    options: {
-      slider: false
+    function init() {
+        makeTopicsGraph();
+        makeMetricsGraph();
     }
-  }).render();
-}
 
-function makeMetricsGraph() {
-  var $container = $('#questions-metrics');
-  $.getJSON($container.data('url'), function(data) {
-    // Fill in 0s so bucketing doesn't freak out...
-    var objects = data.objects;
-    objects.forEach(function(object) {
-      object.questions = object.questions || 0;
-      object.solved = object.solved || 0
-      object.responded_24 = object.responded_24 || 0
-      object.responded_72 = object.responded_72 || 0
-    });
+    function makeTopicsGraph() {
+        var $topics, datums, seriesSpec, key;
 
-    new k.Graph($container, {
-      data: {
-        datums: objects,
-        seriesSpec: [
-          {
-            name: gettext('Questions'),
-            slug: 'questions',
-            func: k.Graph.identity('questions'),
-            color: '#5d84b2',
-            axisGroup: 'questions',
-            area: true
-          },
-          {
-            name: gettext('Solved'),
-            slug: 'num_solved',
-            func: k.Graph.identity('solved'),
-            color: '#aa4643',
-            axisGroup: 'questions',
-            area: true
-          },
-          {
-            name: gettext('% Solved'),
-            slug: 'solved',
-            func: k.Graph.fraction('solved', 'questions'),
-            color: '#aa4643',
-            axisGroup: 'percent',
-            type: 'percent'
-          },
-          {
-            name: gettext('Responded in 24 hours'),
-            slug: 'num_responded_24',
-            func: k.Graph.identity('responded_24'),
-            color: '#89a54e',
-            axisGroup: 'questions',
-            area: true
-          },
-          {
-            name: gettext('% Responded in 24 hours'),
-            slug: 'responded_24',
-            func: k.Graph.fraction('responded_24', 'questions'),
-            color: '#89a54e',
-            axisGroup: 'percent',
-            type: 'percent'
-          },
-          {
-            name: gettext('Responded in 72 hours'),
-            slug: 'num_responded_72',
-            func: k.Graph.identity('responded_72'),
-            color: '#80699b',
-            axisGroup: 'questions',
-            area: true
-          },
-          {
-            name: gettext('% Responded in 72 hours'),
-            slug: 'responded_72',
-            func: k.Graph.fraction('responded_72', 'questions'),
-            color: '#80699b',
-            axisGroup: 'percent',
-            type: 'percent'
-          }
-        ]
-      },
-      options: {
-        legend: 'mini',
-        slider: true,
-        bucket: true
-      },
-      graph: {
-        width: 880,
-        height: 300
-      },
-    }).render();
-  });
-}
+        $('input[type=date]').datepicker({
+            dateFormat: 'yy-mm-dd'
+        });
 
-$(document).ready(init);
+        $topics = $('#topic-stats');
+        if ($topics.length === 0) {
+            return;
+        }
+
+        datums = $topics.data('graph');
+        seriesSpec = [];
+        window.datums = datums;
+
+        var min = 3;
+
+        for (key in datums[0]) {
+            if (key === 'date' || !datums[0].hasOwnProperty(key)) continue;
+            // TODO: these names should be localized.
+            seriesSpec.push({
+                name: key,
+                slug: key,
+                func: k.Graph.identity(key)
+            });
+        }
+
+        new k.Graph($topics, {
+            data: {
+                datums: datums,
+                seriesSpec: seriesSpec
+            },
+            graph: {
+                renderer: 'bar',
+                width: 690,
+                unstack: false
+            },
+            options: {
+                slider: false
+            }
+        }).render();
+    }
+
+    function makeMetricsGraph() {
+        var $container = $('#questions-metrics');
+        $.getJSON($container.data('url'), function(data) {
+            // Fill in 0s so bucketing doesn't freak out...
+            var objects = data.objects;
+            objects.forEach(function(object) {
+                object.questions = object.questions || 0;
+                object.solved = object.solved || 0
+                object.responded_24 = object.responded_24 || 0
+                object.responded_72 = object.responded_72 || 0
+            });
+
+            new k.Graph($container, {
+                data: {
+                    datums: objects,
+                    seriesSpec: [
+                        {
+                            name: gettext('Questions'),
+                            slug: 'questions',
+                            func: k.Graph.identity('questions'),
+                            color: '#5d84b2',
+                            axisGroup: 'questions',
+                            area: true
+                        },
+                        {
+                            name: gettext('Solved'),
+                            slug: 'num_solved',
+                            func: k.Graph.identity('solved'),
+                            color: '#aa4643',
+                            axisGroup: 'questions',
+                            area: true
+                        },
+                        {
+                            name: gettext('% Solved'),
+                            slug: 'solved',
+                            func: k.Graph.fraction('solved', 'questions'),
+                            color: '#aa4643',
+                            axisGroup: 'percent',
+                            type: 'percent'
+                        },
+                        {
+                            name: gettext('Responded in 24 hours'),
+                            slug: 'num_responded_24',
+                            func: k.Graph.identity('responded_24'),
+                            color: '#89a54e',
+                            axisGroup: 'questions',
+                            area: true
+                        },
+                        {
+                            name: gettext('% Responded in 24 hours'),
+                            slug: 'responded_24',
+                            func: k.Graph.fraction('responded_24', 'questions'),
+                            color: '#89a54e',
+                            axisGroup: 'percent',
+                            type: 'percent'
+                        },
+                        {
+                            name: gettext('Responded in 72 hours'),
+                            slug: 'num_responded_72',
+                            func: k.Graph.identity('responded_72'),
+                            color: '#80699b',
+                            axisGroup: 'questions',
+                            area: true
+                        },
+                        {
+                            name: gettext('% Responded in 72 hours'),
+                            slug: 'responded_72',
+                            func: k.Graph.fraction('responded_72', 'questions'),
+                            color: '#80699b',
+                            axisGroup: 'percent',
+                            type: 'percent'
+                        }
+                    ]
+                },
+                options: {
+                    legend: 'mini',
+                    slider: true,
+                    bucket: true
+                },
+                graph: {
+                    width: 880,
+                    height: 300
+                },
+            }).render();
+        });
+    }
+
+    $(document).ready(init);
 
 })();

--- a/kitsune/sumo/static/js/questions.metrics-dashboard.js
+++ b/kitsune/sumo/static/js/questions.metrics-dashboard.js
@@ -19,9 +19,6 @@
 
         datums = $topics.data('graph');
         seriesSpec = [];
-        window.datums = datums;
-
-        var min = 3;
 
         for (key in datums[0]) {
             if (key === 'date' || !datums[0].hasOwnProperty(key)) continue;

--- a/kitsune/sumo/static/js/rickshaw_utils.js
+++ b/kitsune/sumo/static/js/rickshaw_utils.js
@@ -758,8 +758,8 @@
    * {created: 1367270055, foo: 10, bar: 20, baz: 30} and return a number.
    */
 
-// Returns the value associated with a key.
-// identity('foo') -> 10
+  // Returns the value associated with a key.
+  // identity('foo') -> 10
   Graph.identity = function (key) {
     return function (d) {
       return d[key];
@@ -821,7 +821,7 @@
   };
 
 
-// Monkey Patches. Agh!
+  // Monkey Patches. Agh!
   Graph.monkeyPatch = function (graph) {
 
     // The bar render's _frequentInterval function normally replaces itself
@@ -964,7 +964,7 @@
       var eventX = e.offsetX || e.layerX;
       var eventY = e.offsetY || e.layerY;
 
-      var i, j = 0, k;
+      var i, j, k;
       var points = [];
       var nearestPoint;
 
@@ -977,8 +977,7 @@
       for (i = 0; i < active.length; i += 1) {
         series = active[i];
 
-        j += 1;
-        data = this.graph.stackedData[j];
+        data = this.graph.stackedData[i];
         domainX = graph.x.invert(eventX);
 
         domainIndexScale = d3.scale.linear()
@@ -1014,7 +1013,7 @@
         point = {
           series: series,
           value: value,
-          order: j,
+          order: i,
           name: series.name
         };
 
@@ -1065,7 +1064,7 @@
     } else {
       $(this.graph.element).parent()
         .after($axis)
-        .css('margin-right', '20px');
+        .css('margin-right', '10px');
     }
 
     var oldWidth = $(this.graph.element).outerWidth();


### PR DESCRIPTION
* Put the y-axis on the same line.
* Remove topics with no data.
* Fix the hover tool tips.

Since I re-indented a file, this is probably best viewed with [`?w=1`](2355/files?w=1).

r?