### PR TITLE
[Bug 1132544] Don't use bulk create for notifications.

### DIFF
--- a/kitsune/notifications/tasks.py
+++ b/kitsune/notifications/tasks.py
@@ -40,8 +40,9 @@ def add_notification_for_action(action_id):
     # assocated with those Follow objects, and fire off a  notification to
     # every one of them. Use a set to only notify each user once.
     users_to_notify = set(f.user for f in Follow.objects.filter(query))
-    notifications = [Notification(owner=u, action=action) for u in users_to_notify]
-    Notification.objects.bulk_create(notifications)
+    # Don't use bulk save since that wouldn't trigger signal handlers
+    for u in users_to_notify:
+        Notification.objects.create(owner=u, action=action)
 
 
 @task(ignore_result=True)


### PR DESCRIPTION
I added a failing test, then poked at things until the tests passed. Yay TDD! Luckily, I was able to track this down quickly. I was expecting something harder.

Is there a way to make bulk creating Notification objects an error? I don't think we will ever want that.