### PR TITLE
[bug 1133788] Allow add and delete of Locale instances.

### DIFF
--- a/kitsune/wiki/admin.py
+++ b/kitsune/wiki/admin.py
@@ -84,14 +84,5 @@ class LocaleAdmin(admin.ModelAdmin):
     readonly_fields = ('locale',)
     search_fields = ('locale',)
 
-    # Disable adding and deleting new locales from the admin.
-    # Use migrations instead.
-
-    def has_add_permission(self, request):
-        return False
-
-    def has_delete_permission(self, request, *args, **kwargs):
-        return False
-
 
 admin.site.register(Locale, LocaleAdmin)


### PR DESCRIPTION
This is one option to solve the problem. The other option is using migrations as we have been when we were adding locales ourselves. But I don't think we can expect the l10n manager to provide those for us in a PR.

Is it time to make locale management fully admin/db driven?

r?