### PR TITLE
[bug 1134221] Upgrade django-waffle to 0.10.1

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -154,9 +154,8 @@ https://github.com/erikrose/django-tidings/archive/b68cbb1044e7020d3ed02f17dcce3
 # sha256: oQq2W0PNuSKyEZW5OaqP3tEjDRnAVaqBUWNnUgLdT78
 https://github.com/brosner/django-timezones/archive/ce12f4538fb98612c61b380421e5f39d3f6b2019.tar.gz#egg=django-timezones
 
-# django-waffle: master~1
-# sha256: Go2dIsmkcwf28MPrPT3uDp8X23im0q_Tgc2aGp8tJrQ
-https://github.com/jsocol/django-waffle/archive/a5beffb15d07b6c5f92e04dba15ab609ab52e940.tar.gz#egg=django-waffle
+# sha256: dEJWIK08Kh8FFR8MyFGrfiYYbaOfsDma_Aqo7uu9IBs
+django-waffle==0.10.1
 
 # sha256: NWZcEPVSRwd27M_RWSLTdI4w18AQLrd_3kfOKX2WuyM
 djangorestframework==2.3.14


### PR DESCRIPTION
r?

For reference, here is the list of commits that are new:
https://github.com/jsocol/django-waffle/compare/a5beffb15d07b6c5f92e04dba15ab609ab52e940...b3775edeba4fa63247129621e39d63f705c90ebc

Nothing really alarming. Of interest, django 1.7 support.