### PR TITLE
[Bug 1141065] Convert format string to unicode in gallery template.

### DIFF
--- a/kitsune/gallery/templates/gallery/includes/upload_media_form.html
+++ b/kitsune/gallery/templates/gallery/includes/upload_media_form.html
@@ -16,7 +16,7 @@
 {% macro form_row(form, field_name, classes='') %}
   {% set html = form[field_name] %}
   {% if form[field_name].help_text %}
-    {% set html = '{old_html}<div class="details">{details}</div>'|f(
+    {% set html = to_unicode('{old_html}<div class="details">{details}</div>')|f(
                     old_html=html, details=form[field_name].help_text) %}
   {% endif %}
   {{ raw_row(html,

--- a/kitsune/sumo/helpers.py
+++ b/kitsune/sumo/helpers.py
@@ -450,3 +450,8 @@ def add_utm(url_, campaign, source='notification', medium='email'):
     """Add the utm_* tracking parameters to a URL."""
     return urlparams(
         url_, utm_campaign=campaign, utm_source=source, utm_medium=medium)
+
+
+@register.function
+def to_unicode(str):
+    return unicode(str)


### PR DESCRIPTION
Is there a better way to make this a unicode string? I tried making it `u'{old_html}...`, but that was a syntax error.

r?