### PR TITLE
[Bug 1141436] Fix visible html tags

### DIFF
--- a/kitsune/wiki/templates/wiki/mobile/document.html
+++ b/kitsune/wiki/templates/wiki/mobile/document.html
@@ -41,7 +41,7 @@
       <p>
         <br/>
         {% set link='<a href="' + share_link + '">' + share_link + '</a>' %}
-        {{ _('Share this article: {link}')|f(link=link)|safe }}
+        {{ _('Share this article: {link}')|f(link=link|safe) }}
       </p>
     {% endif %}
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1141436 (Share Article template is not showing properly in Mobile View) for further information.