### PR TITLE
[Bug 990816] HTML5 Validation For Questions

### DIFF
--- a/kitsune/questions/templates/questions/includes/aaq_macros.html
+++ b/kitsune/questions/templates/questions/includes/aaq_macros.html
@@ -173,7 +173,7 @@
         <li>{{ error_message }}</li>
       </ul>
     {% endif %}
-    <form id="question-form" class="marketplace" action="" method="post">
+    <form id="question-form" class="marketplace" action="#" method="post">
       {{ csrf() }}
       <ol>
         {{ form.as_ul() }}

--- a/kitsune/questions/templates/questions/question_details.html
+++ b/kitsune/questions/templates/questions/question_details.html
@@ -110,7 +110,7 @@
       <div class="user-meta">
         <div class="avatar">
           <a href="{{ profile_url(question.creator, request.user == question.creator) }}">
-            <img src="{{ profile_avatar(question.creator) }}" height="48" width="48" alt="{{ display_name(question.creator) }}"/>
+            <img src="{{ profile_avatar(question.creator) }}" height="48" width="48" alt="{{ display_name(question.creator) }}" alt=""/>
           </a>
         </div>
         <div class="asked-by">

--- a/kitsune/questions/templates/questions/question_details.html
+++ b/kitsune/questions/templates/questions/question_details.html
@@ -118,9 +118,9 @@
         </div>
         <div class="asked-on">
           {{ _('Posted') }}<br>
-					<span itemprop="dateCreated">
-						{{ datetimeformat(question.created) }}
-					</span>
+          <span itemprop="dateCreated">
+            {{ datetimeformat(question.created) }}
+          </span>
         </div>
       </div>
 

--- a/kitsune/questions/templates/questions/question_details.html
+++ b/kitsune/questions/templates/questions/question_details.html
@@ -118,7 +118,9 @@
         </div>
         <div class="asked-on">
           {{ _('Posted') }}<br>
-          <time itemprop="dateCreated" datetime="{{ question.created }}">{{ datetimeformat(question.created) }}</time>
+					<span itemprop="dateCreated">
+						{{ datetimeformat(question.created) }}
+					</span>
         </div>
       </div>
 

--- a/kitsune/questions/templates/questions/question_details.html
+++ b/kitsune/questions/templates/questions/question_details.html
@@ -252,7 +252,7 @@
                       {% endfor %}
                     </select>
                   {% endif %}
-                  </span>
+
                 </div>
               {% endif %}
 

--- a/kitsune/questions/templates/questions/question_list.html
+++ b/kitsune/questions/templates/questions/question_list.html
@@ -106,7 +106,7 @@
         </div>
       </section>
     </div>
-  </div>
+  
 
   <div id="filter-section"></div>
 
@@ -173,7 +173,7 @@
                       {% set topic = question.topic %}
                       <li>
                         <a href="{{ url('questions.list', topic.product.slug)|urlparams(None, request.GET, topic=None) }}">
-                          <img src="/static/img/blank.png" class="logo-sprite-tiny logo-{{ topic.product.slug }}">
+                          <img src="/static/img/blank.png" class="logo-sprite-tiny logo-{{ topic.product.slug }}" alt="">
                           {{ _(topic.product.title, 'DB: products.Product.title') }}
                         </a>
                       </li>

--- a/kitsune/upload/templates/upload/attachments.html
+++ b/kitsune/upload/templates/upload/attachments.html
@@ -23,7 +23,7 @@
       {% endif %}
     {% endif %}
     <a class="image" href="{{ image.file.url }}">
-      <img src="{{ image.thumbnail_if_set().url }}"/>
+      <img src="{{ image.thumbnail_if_set().url }}" alt=""/>
     </a>
   </div>
 {%- endmacro %}

--- a/kitsune/upload/templates/upload/attachments.html
+++ b/kitsune/upload/templates/upload/attachments.html
@@ -47,7 +47,7 @@
     </div>
     <div class="add-attachment">
       <label for="id_image">{{ _('Add images:') }}</label>
-      <input type="file" id="id_image" name="image" size="30"
+      <input type="file" id="id_image" name="image"
              accept="{{ settings.IMAGE_ALLOWED_MIMETYPES }}"
              title="{{ _('Browse for an image to upload.') }}"/>
       <noscript>


### PR DESCRIPTION
Since every single template file would need validated, I feel that it is beyond the scope of a single bug. That being said, I fixed all the errors I found except for one, which was out of my control since it is dynamically created in:
` line 199 questions/templates/questions/includes/aaq_macros.html`
The `{{ url }}` outputs two anchor links separated by a comma which the validator doesn't appreciate very much. I created the pull request since I corrected the errors listed initially with the bug report.