### PR TITLE
[bug 1148082] Fix --no-skip

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -48,6 +48,9 @@ Some other helpful flags are:
 ``--pdb-fail``:
   Drop into PDB on a test failure. This usually drops you right at the
   assertion.
+``--no-skip``:
+  All SkipTests show up as errors. This is handy when things shouldn't be
+  skipping silently with reckless abandon.
 
 
 Running a Subset of Tests

--- a/kitsune/customercare/tests/test_cron.py
+++ b/kitsune/customercare/tests/test_cron.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.test.utils import override_settings
 
 from mock import patch
-from nose import SkipTest
 from nose.tools import eq_
 
 from kitsune.customercare.cron import (
@@ -15,7 +14,7 @@ from kitsune.customercare.cron import (
 from kitsune.customercare.models import Tweet, Reply
 from kitsune.customercare.tests import tweet, twitter_account, reply
 from kitsune.sumo.redis_utils import redis_client, RedisError
-from kitsune.sumo.tests import TestCase
+from kitsune.sumo.tests import SkipTest, TestCase
 
 
 class TwitterCronTestCase(TestCase):

--- a/kitsune/dashboards/tests/test_cron.py
+++ b/kitsune/dashboards/tests/test_cron.py
@@ -3,7 +3,6 @@ from datetime import date, timedelta
 
 from django.conf import settings
 
-from nose import SkipTest
 from nose.tools import eq_
 
 from kitsune.dashboards.cron import (
@@ -14,7 +13,7 @@ from kitsune.dashboards.models import (
     WikiMetric, L10N_TOP20_CODE, L10N_ALL_CODE)
 from kitsune.products.tests import product
 from kitsune.sumo.redis_utils import redis_client, RedisError
-from kitsune.sumo.tests import TestCase
+from kitsune.sumo.tests import SkipTest, TestCase
 from kitsune.users.tests import user
 from kitsune.wiki.models import HelpfulVote, Revision
 from kitsune.wiki.tests import revision, document

--- a/kitsune/gallery/tests/test_templates.py
+++ b/kitsune/gallery/tests/test_templates.py
@@ -1,11 +1,10 @@
-from nose import SkipTest
 from nose.tools import eq_
 from pyquery import PyQuery as pq
 
 from kitsune.gallery.models import Image, Video
 from kitsune.gallery.tests import image, video
 from kitsune.sumo.helpers import urlparams
-from kitsune.sumo.tests import TestCase, get, LocalizingClient, post
+from kitsune.sumo.tests import SkipTest, TestCase, get, LocalizingClient, post
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.users.tests import user
 

--- a/kitsune/search/tests/__init__.py
+++ b/kitsune/search/tests/__init__.py
@@ -3,12 +3,11 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 from elasticutils.contrib.django import get_es
-from nose import SkipTest
 from test_utils import TestCase
 
 from kitsune.search import es_utils
 from kitsune.search.models import generate_tasks, Synonym
-from kitsune.sumo.tests import with_save
+from kitsune.sumo.tests import SkipTest, with_save
 
 
 # Dummy request for passing to question_searcher() and brethren.

--- a/kitsune/sumo/tests/__init__.py
+++ b/kitsune/sumo/tests/__init__.py
@@ -1,4 +1,6 @@
+import os
 import re
+import sys
 from functools import wraps
 from os import listdir
 from os.path import join, dirname
@@ -11,7 +13,6 @@ from django.test.client import Client
 from django.test.utils import override_settings
 
 import django_nose
-from nose import SkipTest
 from nose.tools import eq_
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
@@ -20,6 +21,15 @@ from test_utils import TestCase as OriginalTestCase
 
 from kitsune import sumo
 from kitsune.sumo.urlresolvers import reverse, split_path
+
+
+# We do this gooftastic thing because nose uses unittest.SkipTest in
+# Python 2.7 which doesn't work with the whole --no-skip thing.
+if '--no-skip' in sys.argv or 'NOSE_WITHOUT_SKIP' in os.environ:
+    class SkipTest(Exception):
+        pass
+else:
+    from nose import SkipTest
 
 
 def get(client, url, **kwargs):

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -10,14 +10,13 @@ from django.utils.encoding import smart_str
 
 import mock
 from bleach import clean
-from nose import SkipTest
 from nose.tools import eq_
 from pyquery import PyQuery as pq
 from wikimarkup.parser import ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 
 from kitsune.products.tests import product, topic
 from kitsune.sumo.helpers import urlparams
-from kitsune.sumo.tests import post, get, attrs_eq, MobileTestCase
+from kitsune.sumo.tests import SkipTest, post, get, attrs_eq, MobileTestCase
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.users.tests import user, add_permission
 from kitsune.wiki.events import (

--- a/kitsune/wiki/tests/test_views.py
+++ b/kitsune/wiki/tests/test_views.py
@@ -7,11 +7,10 @@ from django.contrib.sites.models import Site
 
 import mock
 from nose.tools import eq_
-from nose import SkipTest
 from pyquery import PyQuery as pq
 
 from kitsune.products.tests import product
-from kitsune.sumo.tests import TestCase, LocalizingClient
+from kitsune.sumo.tests import SkipTest, TestCase, LocalizingClient
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.sumo.redis_utils import redis_client, RedisError
 from kitsune.users.tests import user, add_permission


### PR DESCRIPTION
nose has a skip plugin which enhances SkipTest raising beyond our
wildest imaginations. However, there are certain occasions where we want
skipped things to not skip with reckless abandon but instead don the
malevolent cloak of errorhood.

nose has a --no-skip argument for exactly this sort of sordid thing, but
it's totally busted and doesn't work.

This changes the code around so that it works correctly.

Skip the tests or don't, but please don't skip this review! r?