### PR TITLE
[Bug 1133326] Cleanup survey code, and add Firefox refresh survey

### DIFF
--- a/kitsune/sumo/south_migrations/0004_add_refresh_survey_flag.py
+++ b/kitsune/sumo/south_migrations/0004_add_refresh_survey_flag.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        """Create the Firefox Refresh Survey sample."""
+        Sample = orm['waffle.Sample']
+        Sample.objects.get_or_create(
+            name='refresh-survey',
+            note='Samples users that refresh Firefox to give them a survey.',
+            percent=50.0)
+
+    def backwards(self, orm):
+        """Delete the Firefox Refresh Survey sample."""
+        Sample = orm['waffle.Sample']
+        Sample.objects.filter(name='refresh-survey').delete()
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'waffle.flag': {
+            'Meta': {'object_name': 'Flag'},
+            'authenticated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'everyone': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'languages': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'percent': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '3', 'decimal_places': '1', 'blank': 'True'}),
+            'rollout': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'superusers': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'testing': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'waffle.sample': {
+            'Meta': {'object_name': 'Sample'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'percent': ('django.db.models.fields.DecimalField', [], {'max_digits': '4', 'decimal_places': '1'})
+        },
+        u'waffle.switch': {
+            'Meta': {'object_name': 'Switch'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'note': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['waffle', 'sumo']
+    symmetrical = True

--- a/kitsune/sumo/static/js/surveygizmo.js
+++ b/kitsune/sumo/static/js/surveygizmo.js
@@ -1,10 +1,38 @@
 ;(function() {
+    function launchWindow(url) {
+        var sg_div = document.createElement("div");
+        sg_div.innerHTML = (
+            '<h1>You have been selected for a survey</h1>' +
+            '<p>We appreciate your feedback!</p><p><a href="' + url + '">Please click here start it now.</a></p>' +
+            '<a href="#" onclick="document.getElementById(\'sg-popup\').style.display = \'none\';return false;">No, thank you.</a>'
+        );
+        sg_div.id = "sg-popup";
+        document.body.appendChild(sg_div);
+    }
+
     var surveys = {
         site_survey: function() {
             var surveyGizmoURL = $('body').data('surveygizmo-url') ||
-                "http://www.surveygizmo.com/s3/popup/1002970/46488f9ad4eb";
-            // This ugly pile is generated code from Survey Gizmo. Bug 782809.
-            window.addEventListener("load",function(e) {if (!readCookie("hasSurveyed")) {launchWindow(document.getElementById("sg_div"));createCookie("hasSurveyed", 1, 365);}});function launchWindow(){var sg_div = document.createElement("div");sg_div.innerHTML = "<h1>You have been selected for a survey</h1><p>We appreciate your feedback!</p><p><a href=\"" + surveyGizmoURL + "\">Please click here start it now.</a> </p> <a href=\"#\" onclick=\"document.getElementById('sg-popup').style.display = 'none';return false;\">No, thank you.</a> ";sg_div.id = "sg-popup";sg_div.style.position = "absolute";sg_div.style.width = "500px";sg_div.style.top = "100px";sg_div.style.left = "400px";sg_div.style.backgroundColor = "#ffffff";sg_div.style.borderColor = "#000000";sg_div.style.borderStyle = "solid";sg_div.style.padding = "20px";sg_div.style.fontSize = "16px";sg_div.style.zIndex = "1000";document.body.appendChild(sg_div);}function createCookie(name,value,days) {if (days) {var date = new Date();date.setTime(date.getTime()+(days*24*60*60*1000));var expires = "; expires="+date.toGMTString();}else var expires = "";document.cookie = name+"="+value+expires+"; path=/";}function readCookie(name) {var nameEQ = name + "=";var ca = document.cookie.split(";");for(var i=0;i < ca.length;i++) {var c = ca[i];while (c.charAt(0)==" ") c = c.substring(1,c.length);if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);}return null;}
+                "https://www.surveygizmo.com/s3/popup/1002970/46488f9ad4eb";
+            // This is adapted from a snipptet given by Survey Gizmo.
+            // It has been formatted to fit your screen. Bug 782809.
+            if (!$.cookie('hasSurveyed')) {
+                window.addEventListener("load", function(e) {
+                    launchWindow(surveyGizmoURL);
+                    $.cookie('hasSurveyed', '1', {expires: 365});
+                });
+            }
+        },
+
+        firefox_refresh: function() {
+            var surveyGizmoURL = 'https://www.surveygizmo.com/s3/2010802/69cc2a79f50b';
+            if ($.cookie('showFirefoxResetSurvey') === '1' && !$.cookie('hasEverFirefoxResetSurvey')) {
+                window.addEventListener("load", function(e) {
+                    launchWindow(surveyGizmoURL);
+                    $.cookie('showFirefoxResetSurvey', '0', {expires: 365});
+                    $.cookie('hasEverFirefoxResetSurvey', '1', {expires: 365});
+                });
+            }
         }
     };
 

--- a/kitsune/sumo/static/js/ui.js
+++ b/kitsune/sumo/static/js/ui.js
@@ -341,6 +341,7 @@
       if (_gaq) {
         _gaq.push(['_trackEvent', 'Refresh Firefox', 'click refresh button']);
       }
+      $.cookie('showFirefoxResetSurvey', '1', {expires: 365});
 
       Mozilla.UITour.resetFirefox();
     }

--- a/kitsune/sumo/static/js/ui.js
+++ b/kitsune/sumo/static/js/ui.js
@@ -341,7 +341,9 @@
       if (_gaq) {
         _gaq.push(['_trackEvent', 'Refresh Firefox', 'click refresh button']);
       }
-      $.cookie('showFirefoxResetSurvey', '1', {expires: 365});
+      if (JSON.parse($('body').data('waffle-refresh-survey'))) {
+        $.cookie('showFirefoxResetSurvey', '1', {expires: 365});
+      }
 
       Mozilla.UITour.resetFirefox();
     }

--- a/kitsune/sumo/static/less/main.less
+++ b/kitsune/sumo/static/less/main.less
@@ -88,7 +88,7 @@ body {
       top: 0;
       width: 100%;
       z-index: 9999;
-      
+
       .logo {
         left: 0;
         margin: 13px 0;
@@ -1860,6 +1860,18 @@ input[type=button],
   }
 }
 
+#sg-popup {
+  background: #ffffff;
+  border: 1px solid #000000;
+  fontSize: 16px;
+  left: 400px;
+  padding: 20px;
+  position: absolute;
+  top: 100px;
+  width: 500px;
+  z-index: 1000;
+}
+
 .html-rtl {
   > .breadcrumbs {
     > .container_12 {
@@ -1949,4 +1961,3 @@ input[type=button],
     }
   }
 }
-

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -1,6 +1,6 @@
 {% from 'includes/common_macros.html' import announcement_bar, search_box, aux_nav, favicon with context %}
 {% if request.LANGUAGE_CODE == settings.WIKI_DEFAULT_LANGUAGE and waffle.flag('surveygizmo') %}
-  {% set SURVEY_GIZMOS = (SURVEY_GIZMOS or []) + ['site_survey'] %}
+  {% set SURVEY_GIZMOS = (SURVEY_GIZMOS or []) + ['site_survey', 'firefox_refresh'] %}
 {% endif %}
 {% if request.LANGUAGE_CODE == 'xx' %}
   {% set meta = [('robots', 'noindex')] %}

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -73,6 +73,7 @@
       {% if ga_alternate_url %}
         data-ga-alternate-url="{{ ga_alternate_url }}"
       {% endif %}
+      data-waffle-refresh-survey="{{ waffle.sample('refresh-survey')|json }}"
 {% if extra_body_attrs -%}
   {% for attr, val in extra_body_attrs.items() %}{{ attr }}="{{ val }}" {% endfor %}
 {%- endif %}>


### PR DESCRIPTION
To test: You could set up [all the rigmarole to trigger a refresh on localhost](http://kitsune.readthedocs.org/en/latest/notes.html?highlight=https#about-support-api), which is quite annoying, or you could just set the cookie manually. That's what I did.

r?