### PR TITLE
Make BrowserifyCompiler account for cache-busted files.

### DIFF
--- a/kitsune/lib/pipeline_compilers.py
+++ b/kitsune/lib/pipeline_compilers.py
@@ -1,3 +1,5 @@
+import re
+
 from django.conf import settings
 from django.utils.encoding import smart_bytes
 
@@ -9,7 +11,8 @@ class BrowserifyCompiler(CompilerBase):
     output_extension = 'browserified.js'
 
     def match_file(self, path):
-        return path.endswith('.browserify.js')
+        # Allow for cache busting hashes between ".browserify" and ".js"
+        return re.search(r'\.browserify(\.[a-fA-F0-9]+)?\.js$', path) is not None
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
         command = "%s %s %s > %s" % (

--- a/kitsune/lib/tests/test_pipeline_compilers.py
+++ b/kitsune/lib/tests/test_pipeline_compilers.py
@@ -1,0 +1,20 @@
+from kitsune.lib.pipeline_compilers import BrowserifyCompiler
+from kitsune.sumo.tests import TestCase
+
+
+class TestBrowserifyCompiler(TestCase):
+
+    def setUp(self):
+        self.compiler = BrowserifyCompiler(False, None)
+
+    def test_matches_files_no_hash(self):
+        assert self.compiler.match_file('community-l10n.browserify.js')
+
+    def test_matches_files_hash(self):
+        assert self.compiler.match_file('community-l10n.browserify.e6d41cfdc0d1.js')
+
+    def test_doesnt_match_non_browserify_no_hash(self):
+        assert not self.compiler.match_file('community-l10n.js')
+
+    def test_doesnt_match_non_browserify_hash(self):
+        assert not self.compiler.match_file('community-l10n.e6d41cfdc0d1.js')


### PR DESCRIPTION
This will allow Browserify stuff (and so React stuff) to work in prod and stage.

r?