### PR TITLE
Update pre-commit-hooks, to pickup `q` debug check.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: 15b678e9c67c42765c3d579e40672a332f4366d7
+    sha: 2d83e302cc2757a28cedc03e6bb075de913c1804
     hooks:
     -   id: check-added-large-files
     -   id: check-case-conflict


### PR DESCRIPTION
Now if I try and commit anything that contains `import q`, the linter will yell at me. :grinning: