### PR TITLE
[bug 1013471] Fix for Accidental deletion of profiles

### DIFF
--- a/kitsune/sumo/static/js/ui.js
+++ b/kitsune/sumo/static/js/ui.js
@@ -7,6 +7,16 @@
     initFolding();
     initAnnouncements();
 
+    $('#delete-profile-username-input').keyup(function(ev) {
+      var username = $('#delete-profile-username').val();
+      var inputUsername = $('#delete-profile-username-input').val();
+      if (inputUsername === username) {
+        $('#delete-profile-button').prop('disabled', false);
+      } else {
+        $('#delete-profile-button').prop('disabled', true)
+      }
+    });
+
     $(window).scroll(_.throttle(function() {
       if ($(window).scrollTop() > $('body > header').outerHeight()) {
         $('body').addClass('scroll-header');

--- a/kitsune/users/templates/users/edit_profile.html
+++ b/kitsune/users/templates/users/edit_profile.html
@@ -59,12 +59,28 @@
       </form>
     </article>
     {% if request.user == profile.user %}
-      <form method="post" action="{{ url('users.close_account') }}" data-confirm="confirm" data-confirm-text="{{ _('Are you sure you want to close your account? You cannot undo this action.') }}">
+    <p>
+      <a id="delete-profile" class="btn btn-warning">{{ _('Close account and delete all profile information') }}</a>
+    </p>
+
+    <div class="kbox" title="{{ _('Are you sure') }}" data-target="#delete-profile" data-modal="true">
+      <form method="post" action="{{ url('users.close_account') }}">
         {{ csrf() }}
         <p>
-          <button type="submit" class="btn btn-warning">{{ _('Close account and delete all profile information') }}</button>
+          {{ _('Deleting your account will prevent you from answering or posting questions in Mozilla Support. This action will clear your profile and cannot be restored again.') }}
+        </p>
+        <p>
+          {{ _('Please type in your username to confirm') }}
+        </p>
+        <p>
+          <input id="delete-profile-username-input" name="entered_username" type="text">
+          <input id="delete-profile-username" name="account_username" type="hidden" value="{{ profile.user.username }}">
+        </p>
+        <p>
+          <button type="submit" id="delete-profile-button" class="btn btn-warning" disabled>{{ _('Delete My Account') }}</button>
         </p>
       </form>
+    </div>
     {% endif %}
   </div>
 {% endblock %}


### PR DESCRIPTION
Implemented the prompt for user name as mentioned by @rehandalal on bug 1013471 in #comment5 
 
What is happening

1. The delete button is disabled in HTML, it gets activated once the page is loaded so that there is no accidental deletion if JavaScript fails to load
2. Once the user clicks the button it prompt the user with a warning message and asks for username. If the username entered is correct the deletions continues else its aborted.

I hope this is fine, any way sorry for the long delay