### PR TITLE
[Bug 1093509] In wiki, when translating, always show approved text in LTR.

### DIFF
--- a/kitsune/wiki/templates/wiki/translate.html
+++ b/kitsune/wiki/templates/wiki/translate.html
@@ -171,7 +171,7 @@
             <div class="approved">
               <h3>{{ _('Approved {default_locale} version:')|f(default_locale=settings.LANGUAGES_DICT[settings.WIKI_DEFAULT_LANGUAGE.lower()]) }}</h3>
               <div id="content-or-diff" class="content">
-                <textarea readonly="readonly">{{ based_on.content }}</textarea>
+                <textarea readonly="readonly"{% if settings.WIKI_DEFAULT_LANGUAGE.lower() not in settings.LANGUAGES_BIDI %} dir="ltr"{% endif %}>{{ based_on.content }}</textarea>
               </div>
             </div>
             <div class="localized">


### PR DESCRIPTION
@mythmon r?

This is imperfect, because it assumes that the "default" language of the app is always an LTR language. I guess it won't ever be a problem for us, since the default should always be English, but that might not be the case for other users of kitsune. Does that matter? If so, what would be a good way to know if the default language is RTL or LTR? 