### PR TITLE
[Bug 1143946] Community Hub: Filter by last_contribution_date advanced filter.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,6 @@
     "nwmatcher": "nwmatcher#1.3.4",
     "pikaday": "~1.3.2",
     "react": "#0.13.0",
-    "underscore": "underscore#1.2.1"
+    "underscore": "underscore#1.8.2"
   }
 }

--- a/kitsune/community/api.py
+++ b/kitsune/community/api.py
@@ -111,6 +111,21 @@ class TopContributorsBase(views.APIView):
         dt = datetime.combine(date, datetime.max.time())
         return F(created__lte=dt)
 
+    def filter_locale(self, value):
+        return F(locale=value)
+
+    def _filter_by_users(self, users_filter):
+        users = UserMappingType.reshape(
+            UserMappingType
+            .search()
+            .filter(users_filter)
+            .values_dict('id')
+            .everything())
+
+        user_ids = [u['id'] for u in users]
+
+        return F(creator_id__in=user_ids)
+
     def filter_username(self, value):
         username_lower = value.lower()
 
@@ -119,17 +134,17 @@ class TopContributorsBase(views.APIView):
             F(idisplay_name__prefix=username_lower) |
             F(itwitter_usernames__prefix=username_lower))
 
-        users = UserMappingType.reshape(
-            UserMappingType
-            .search()
-            .filter(username_filter)
-            .values_dict('id')
-            [:BIG_NUMBER])
+        return self._filter_by_users(username_filter)
 
-        return F(creator_id__in=[u['id'] for u in users])
+    def filter_last_contribution_date__gt(self, value):
+        date = fields.DateField().from_native(value)
+        dt = datetime.combine(date, datetime.max.time())
+        return self._filter_by_users(F(last_contribution_date__gt=dt))
 
-    def filter_locale(self, value):
-        return F(locale=value)
+    def filter_last_contribution_date__lt(self, value):
+        date = fields.DateField().from_native(value)
+        dt = datetime.combine(date, datetime.max.time())
+        return self._filter_by_users(F(last_contribution_date__lt=dt))
 
     def filter_product(self, value):
         return F(product=value)

--- a/kitsune/community/api.py
+++ b/kitsune/community/api.py
@@ -114,17 +114,22 @@ class TopContributorsBase(views.APIView):
     def filter_locale(self, value):
         return F(locale=value)
 
-    def _filter_by_users(self, users_filter):
+    def _filter_by_users(self, users_filter, invert=False):
         users = UserMappingType.reshape(
             UserMappingType
             .search()
+            # Optimization: Filter out users that have never contributed.
+            .filter(~F(last_contribution_date=None))
             .filter(users_filter)
             .values_dict('id')
             .everything())
 
         user_ids = [u['id'] for u in users]
 
-        return F(creator_id__in=user_ids)
+        res = F(creator_id__in=user_ids)
+        if invert:
+            res = ~res
+        return res
 
     def filter_username(self, value):
         username_lower = value.lower()
@@ -142,9 +147,10 @@ class TopContributorsBase(views.APIView):
         return self._filter_by_users(F(last_contribution_date__gt=dt))
 
     def filter_last_contribution_date__lt(self, value):
+        # This query usually covers a lot of users, so inverting it makes it a lot faster.
         date = fields.DateField().from_native(value)
         dt = datetime.combine(date, datetime.max.time())
-        return self._filter_by_users(F(last_contribution_date__lt=dt))
+        return self._filter_by_users(~F(last_contribution_date__lt=dt), invert=True)
 
     def filter_product(self, value):
         return F(product=value)

--- a/kitsune/community/static/js/AdvancedFilters.jsx
+++ b/kitsune/community/static/js/AdvancedFilters.jsx
@@ -1,0 +1,327 @@
+/* globals _:false, React:false */
+import {Icon} from './contributors-common.jsx';
+import cx from 'classnames';
+import moment from 'moment';
+
+const DATE_FORMAT = 'YYYY-MM-DD';
+
+const availableFilters = {
+    'last_contribution_date': {
+        title: 'Days since last contribution',
+        type: 'days_relative',
+        ops: {
+            /* Yes, these are backwards. It is beceause the real data type is
+             * a date, but we are dealing with relative days.
+             * "less than 3 days ago" translates to "date > (now - 3 days)"
+             * The subtraction flips the comparotor.
+             */
+            'gt': 'less than',
+            'lt': 'greater than',
+        },
+    },
+};
+
+
+/* This shows a button that counts the number of advanced filters in use, and
+ * when clicked expands to show all of the filters.
+ */
+export default class AdvancedFilters extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            expanded: false,
+        };
+    }
+
+    /** Expand or collapse the detail window. */
+    toggleExpand() {
+        var {expanded} = this.state;
+        expanded = !expanded;
+        this.setState({expanded});
+    }
+
+    /**
+     * Get only the filters that are listed as "advanced filters" in
+     * `availableFilters`. Filters with a name like "foo__op" are considered
+     * equivalent to filters named "foo".
+     */
+    applicableFilters() {
+        let applicableFilters = {};
+        let availableFilterNames = [];
+        _.forEach(availableFilters, (filter, name) => {
+            _.forEach(filter.ops, (displayName, op) => {
+                if (op === 'eq') {
+                    availableFilterNames.push(name);
+                } else {
+                    availableFilterNames.push(`${name}__${op}`);
+                }
+            });
+        });
+
+        return _.pick(this.props.filters, ...availableFilterNames);
+    }
+
+    render() {
+        return (
+            <div className="AdvancedFilters">
+                <AdvancedFiltersSummary
+                    count={_.keys(this.applicableFilters()).length}
+                    toggleExpand={this.toggleExpand.bind(this)}/>
+
+                {this.state.expanded
+                    ? <AdvancedFiltersDetails
+                        filters={this.applicableFilters()}
+                        setFilters={this.props.setFilters}
+                        toggleExpand={this.toggleExpand.bind(this)}/>
+                    : null}
+            </div>
+        )
+    }
+}
+
+/* This shows the number of filters applied, and toggles expanding the window. */
+class AdvancedFiltersSummary extends React.Component {
+    render() {
+        return (
+            <div className="AdvancedFilters__summary Filters__item--button" onClick={this.props.toggleExpand}>
+                <Icon name="filter"/>
+                {this.props.count > 0
+                    ? <span className="AdvancedFilters__summary__number">{this.props.count}</span>
+                    : null}
+            </div>
+        );
+    }
+}
+
+AdvancedFiltersSummary.propTypes = {
+    count: React.PropTypes.number.isRequired,
+    toggleExpand: React.PropTypes.func.isRequired,
+};
+
+
+let getFilterId = (function() {
+    let next = 0;
+    return function() {
+        next++;
+        return `filter-${next}`;
+    }
+})();
+
+
+/* This shows a row for each filter. */
+class AdvancedFiltersDetails extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            filters: this.convertFiltersIncoming(),
+        };
+    }
+
+    /**
+     * The filters passed to AdvancedFiltersDetails come in the form of a
+     * mapping from names to values. This converts that into a list of objectss
+     * like {name, op, value, id}. `op` comes from Django-style __ suffixes,
+     * and `id` is just a simple global incrementing counter. This is used as
+     * a React key when rendering filters.
+     *
+     * Example: {foo__gt: 5, bar: 4} would be serialized as [
+     *   {name: foo, op: gt, value: 4, id: <ID>},
+     *   {name: bar, op: eq, value: 5, id: <ID>},
+     * ]
+     *
+     * @returns {Array} A list of filter objects.
+     */
+    convertFiltersIncoming(props=this.props) {
+        return _.map(props.filters, (value, name) => {
+            let op;
+            if (name.indexOf('__') >= -1) {
+                [, name, op] = /(.*)__(.*)/.exec(name);
+            } else {
+                op = 'eq';
+            }
+            return {name, op, value, id: getFilterId()};
+        });
+    }
+
+    /**
+     * The internal format of filters is a list of filter objects. This
+     * converts those back into a map of filter names to filter values.
+     *
+     * @returns {Object} A map of filter names to filter values.
+     */
+    convertFiltersOutgoing() {
+        let externalFilters = this.props.filters;
+        let internalFilters = this.state.filters;
+        var newFilters = {};
+        // Clear all the old filters out. We can't reliable update them in place.
+        _.forEach(externalFilters, (_, key) => {newFilters[key] = undefined; });
+        // set all the new filters
+        _.forEach(internalFilters, (filter) => {
+            let fullName = filter.name;
+            if (filter.op !== 'eq') {
+                fullName += '__' + filter.op;
+            }
+            newFilters[fullName] = filter.value;
+        });
+        return newFilters;
+    }
+
+    componentWillReceiveProps(newProps) {
+        this.setState({
+            filters: this.convertFiltersIncoming(newProps),
+        });
+    }
+
+    /**
+     * Update the internal state of the detail view in response to a change event
+     * usually on a form input. If the event did not come directly from a form
+     * input, then an optional name and value can be passed.
+     *
+     * @param {Number} idx Index of the filter being updated.
+     * @param {Event} ev Event that triggered this. Will be `preventDefault`ed.
+     * @param {String} [name=ev.target.name] Name of the field to update. By default,
+     *     this will be pulled from the target element's name attribute.
+     * @param {String} [name=ev.target.value] Value of the field to update. By default,
+     *     this will be pulled from the target element's value attribute.
+     */
+    handleChange(idx, ev, name=ev.target.name, value=ev.target.value) {
+        ev.preventDefault();
+        let {filters} = this.state;
+        filters[idx][name] = value;
+        this.setState({filters});
+    }
+
+    /**
+     * Adds a new filter to the UI.
+     *
+     * Calls `ev.preventDefault`.
+     *
+     * @param {Event} ev The event that triggered this. Will be `preventDefault`ed.
+     */
+    addFilter(ev) {
+        ev.preventDefault();
+        let {filters} = this.state;
+        /* TODO: This just hard codes a default in, but there should probably
+         * be a way to have a null filter. */
+        filters.push({
+            name: 'last_contribution_date',
+            op: 'gt',
+            value: moment().subtract(7, 'days').format(DATE_FORMAT),
+            id: getFilterId(),
+        });
+        this.setState({filters});
+    }
+
+    /**
+     * Remove a filter, by index.
+     *
+     * @param {Number} idx The index of the filter to remove.
+     * @param {Event} ev The event that triggered this action. Will be `preventDefault`ed.
+     */
+    removeFilter(idx, ev) {
+        ev.preventDefault();
+        let {filters} = this.state;
+        filters.splice(idx, 1);
+        this.setState({filters});
+    }
+
+    /**
+     * Commit all internal state to external filters, and close the dialog.
+     */
+    commit() {
+        this.props.setFilters(this.convertFiltersOutgoing());
+        this.props.toggleExpand();
+    }
+
+    render() {
+        return (
+            <div className="Filters__window AdvancedFilters__detail">
+                <h2>Filters</h2>
+                <ul>
+                    {this.state.filters.map((filter, idx) => (
+                        <AdvancedFilterLine {...filter}
+                            key={filter.id}
+                            onChange={this.handleChange.bind(this, idx)}
+                            remove={this.removeFilter.bind(this, idx)}/>
+                    ))}
+                    <li>
+                        <a href="#" onClick={this.addFilter.bind(this)}>Add another filter</a>
+                    </li>
+                </ul>
+                <div className="AdvancedFilters__detail__actions">
+                    <button className="btn" onClick={this.props.toggleExpand}>Cancel</button>
+                    <button className="btn btn-submit" onClick={this.commit.bind(this)}>
+                        Apply
+                    </button>
+                </div>
+            </div>
+        );
+    }
+}
+
+/** This is a single row in the filter view. */
+class AdvancedFilterLine extends React.Component {
+    render() {
+        let valueInput;
+        if (availableFilters[this.props.name].type === 'days_relative') {
+            valueInput = <DayRelativeComponent
+                name="value"
+                value={this.props.value}
+                onChange={this.props.onChange}/>;
+        } else {
+            valueInput = <input
+                name="value"
+                value={this.props.value}
+                onChange={this.props.onChange}/>;
+        }
+
+        return <li className="AdvancedFilters__detail__filterRow">
+            <select name="name" value={this.props.name} onChange={this.props.onChange}>
+                {_.map(availableFilters, (filter, name) =>
+                    <option key={filter} value={filter.name}>{filter.title}</option>
+                )}
+            </select>
+            <select name="op" value={this.props.op} onChange={this.props.onChange}>
+                {_.map(availableFilters[this.props.name].ops, (displayName, op) => (
+                    <option key={op} value={op}>{displayName}</option>
+                ))}
+            </select>
+            {valueInput}
+            <a href="#" onClick={this.props.remove}>Remove</a>
+        </li>;
+    }
+}
+
+/**
+ * The input for this is a date represented as a string. The value shown to the
+ * user is the number of days ago that date was.
+ */
+class DayRelativeComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            daysAgo: moment().diff(moment(this.props.value), 'days'),
+            valid: true,
+        };
+    }
+
+    handleChange(ev) {
+        this.setState({daysAgo: ev.target.value});
+        let daysAgo = parseInt(ev.target.value);
+        if (isNaN(daysAgo)) {
+            this.setState({valid: false});
+        } else {
+            this.setState({valid: true});
+            let targetDate = moment().subtract(daysAgo, 'days').format(DATE_FORMAT);
+            this.props.onChange(ev, this.props.name, targetDate);
+        }
+    }
+
+    render() {
+        return <input
+            valid
+            name={this.props.name}
+            value={this.state.daysAgo}
+            onChange={this.handleChange.bind(this)}/>;
+    }
+}

--- a/kitsune/community/static/js/AdvancedFilters.jsx
+++ b/kitsune/community/static/js/AdvancedFilters.jsx
@@ -13,7 +13,7 @@ const availableFilters = {
             /* Yes, these are backwards. It is beceause the real data type is
              * a date, but we are dealing with relative days.
              * "less than 3 days ago" translates to "date > (now - 3 days)"
-             * The subtraction flips the comparotor.
+             * The subtraction flips the comparator.
              */
             'gt': 'less than',
             'lt': 'greater than',

--- a/kitsune/community/static/js/CommunityFilters.jsx
+++ b/kitsune/community/static/js/CommunityFilters.jsx
@@ -1,5 +1,6 @@
 import {locales, products} from './contributors-common.jsx';
 import DateRangePicker from './DateRangePicker.jsx';
+import AdvancedFilters from './AdvancedFilters.jsx';
 
 export default class CommunityFilters extends React.Component {
     handleChange(ev) {
@@ -19,20 +20,22 @@ export default class CommunityFilters extends React.Component {
         this._timer = setTimeout(this.props.setFilters.bind(null, newFilters), 200);
     }
 
-    makeInput(name) {
-        return <input name={name}
-            autoComplete="off"
-            value={this.props.filters[name]}
-            onChange={this.handleChange.bind(this)}/>
-    }
-
     render() {
-        return <div className="filters">
-            {this.makeInput('username')}
+        return <div className="Filters">
+            <input
+                className="Filters__item"
+                name="username"
+                autoComplete="off"
+                defaultValue={this.props.filters.username}
+                onChange={this.handleChange.bind(this)}
+                placeholder="Filter by username"/>
 
             <DateRangePicker max={moment()} setFilters={this.props.setFilters} filters={this.props.filters} />
 
-            <select name="locale" defaultValue={this.props.filters.locale} onChange={this.handleChange.bind(this)}>
+            <select className="Filters__item"
+                    name="locale"
+                    defaultValue={this.props.filters.locale}
+                    onChange={this.handleChange.bind(this)}>
                 <option value="">Select a locale</option>
                 {locales.map(([name, code]) => <option key={code} value={code}>{name}</option>)}
             </select>
@@ -41,6 +44,8 @@ export default class CommunityFilters extends React.Component {
                 <option value="">Select a product</option>
                 {products.map((prod) => <option key={prod.slug} value={prod.slug}>{prod.title}</option>)}
             </select>
+
+            <AdvancedFilters {...this.props}/>
         </div>;
     }
 }

--- a/kitsune/community/static/js/DateRangePicker.jsx
+++ b/kitsune/community/static/js/DateRangePicker.jsx
@@ -152,7 +152,7 @@ class DateRangeSummaryButton extends React.Component {
 
     render() {
         return (
-            <div className="summary-button" onClick={this.props.onClick}>
+            <div className="summary-button Filters__item--button" onClick={this.props.onClick}>
                 <Icon name="calendar"/>
                 <span className="summary">{this.getSummary()}</span>
                 <Icon name="caret-down"/>
@@ -176,7 +176,7 @@ class DateRangeDetail extends React.Component {
 
     render() {
         return (
-            <div className="detail-window">
+            <div className="Filters__window">
                 <div className="row">
                     <Calendar date={this.props.start}
                         min={this.props.min}

--- a/kitsune/community/static/less/community-new.less
+++ b/kitsune/community/static/less/community-new.less
@@ -86,30 +86,29 @@
     }
 }
 
-.date-range-picker {
-    display: inline-block;
+.Filters {
     position: relative;
 
-    .summary-button {
+    &__item,
+    &__item--button {
+        display: inline-block;
+        margin-right: 5px;
+    }
+
+    &__item--button {
         background: #eee;
         border: 1px solid #aaa;
         border-radius: 4px;
         padding: 3px 5px;
         cursor: pointer;
-
-        .summary {
-            padding: 0 5px;
-        }
     }
 
-    .detail-window {
+    &__window {
         background: #fff;
         box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.3);
-        display: flex;
-        flex-direction: column;
         padding: 3px;
         position: absolute;
-        left: -60px;
+        left: 0px;
         top: 36px;
         z-index: 2;
 
@@ -125,6 +124,22 @@
             width: 16px;
             z-index: -1;
         }
+    }
+}
+
+.date-range-picker {
+    display: inline-block;
+
+    .summary-button {
+        .summary {
+            padding: 0 5px;
+        }
+    }
+
+    .Filters__window {
+        display: flex;
+        flex-direction: column;
+        left: 124px;
 
         .row {
             display: flex;
@@ -211,6 +226,53 @@
             font-weight: bold;
             font-size: 0.9em;
             margin-right: 6px;
+        }
+    }
+}
+
+
+.AdvancedFilters {
+    display: inline-block;
+    float: right;
+
+    &__summary {
+        position: relative;
+
+        &__number {
+            background: #33AFFE;
+            border-radius: 2px;
+            color: #fff;
+            font-weight: bold;
+            font-size: 10px;
+            height: 14px;
+            position: absolute;
+            right: -7px;
+            text-align: center;
+            top: -5px;
+            width: 14px;
+        }
+    }
+
+    &__detail {
+        left: auto;
+        min-height: 100px;
+        min-width: 400px;
+        right: 0;
+
+        &::before {
+            left: auto;
+            right: 12px;
+        }
+
+        ul {
+            margin: 0;
+            padding: 0;
+            list-style: none;
+        }
+
+        &__actions {
+            padding: 5px;
+            text-align: right;
         }
     }
 }


### PR DESCRIPTION
This adds a new major UI component to the top contributors page, advanced filters. Advanced filters are more free form, supporting operators like less than or greater than. They can be added or removed, and live in a dialog opened from the top right. It is kind of ugly, but it works, and is pretty quick too. It looks like this:

![shot_17063](https://cloud.githubusercontent.com/assets/305049/7194620/edeef092-e466-11e4-97c1-42a9f7631b30.png)

and

![shot_17287](https://cloud.githubusercontent.com/assets/305049/7194622/faa31ca0-e466-11e4-9cbf-a332e9de8b62.png)

r?