### PR TITLE
[Bug 1159479] Add breadcrumbs to KB articles.

### DIFF
--- a/kitsune/forums/tests/test_templates.py
+++ b/kitsune/forums/tests/test_templates.py
@@ -79,13 +79,13 @@ class PostsTemplateTests(ForumTestCase):
 
     def test_long_title_truncated_in_crumbs(self):
         """A very long thread title gets truncated in the breadcrumbs"""
-        t = thread(title='A thread with a very very long title', save=True)
+        t = thread(title='A thread with a very very very very long title', save=True)
         forum_post(thread=t, save=True)
 
         response = get(self.client, 'forums.posts', args=[t.forum.slug, t.id])
         doc = pq(response.content)
         crumb = doc('#breadcrumbs li:last-child')
-        eq_(crumb.text(), 'A thread with a very very ...')
+        eq_(crumb.text(), 'A thread with a very very very very ...')
 
     def test_edit_post_moderator(self):
         """Editing post as a moderator works."""

--- a/kitsune/kbforums/tests/test_templates.py
+++ b/kitsune/kbforums/tests/test_templates.py
@@ -76,12 +76,12 @@ class PostsTemplateTests(KBForumTestCase):
     def test_long_title_truncated_in_crumbs(self):
         """A very long thread title gets truncated in the breadcrumbs"""
         d = document(save=True)
-        t = thread(title='A thread with a very very very' * 5, document=d,
+        t = thread(title='A thread with a very very very very very' * 5, document=d,
                    save=True)
         response = get(self.client, 'wiki.discuss.posts', args=[d.slug, t.id])
         doc = pq(response.content)
         crumb = doc('#breadcrumbs li:last-child')
-        eq_(crumb.text(), 'A thread with a very very ...')
+        eq_(crumb.text(), 'A thread with a very very very very ...')
 
     def test_edit_post_moderator(self):
         """Editing post as a moderator works."""

--- a/kitsune/products/models.py
+++ b/kitsune/products/models.py
@@ -7,6 +7,7 @@ from PIL import Image
 from uuid import uuid4
 
 from kitsune.sumo.models import ModelBase
+from kitsune.sumo.urlresolvers import reverse
 
 
 HOT_TOPIC_SLUG = 'hot'
@@ -108,6 +109,9 @@ class Product(ModelBase):
                     settings.MEDIA_ROOT, settings.PRODUCT_IMAGE_PATH,
                     'logo-sprite.png'))
 
+    def get_absolute_url(self):
+        return reverse('products.product', kwargs={'slug': self.slug})
+
 
 # Note: This is the "new" Topic class
 class Topic(ModelBase):
@@ -167,6 +171,20 @@ class Topic(ModelBase):
         }
         query.update(kwargs)
         return Document.objects.filter(**query)
+
+    def get_absolute_url(self):
+        if self.parent is None:
+            return reverse('products.documents', kwargs={
+                'product_slug': self.product.slug,
+                'topic_slug': self.slug,
+            })
+        else:
+            assert self.parent.parent is None
+            return reverse('products.subtopics', kwargs={
+                'product_slug': self.product.slug,
+                'topic_slug': self.parent.slug,
+                'subtopic_slug': self.slug,
+            })
 
 
 class Version(ModelBase):

--- a/kitsune/products/tests/test_models.py
+++ b/kitsune/products/tests/test_models.py
@@ -16,3 +16,27 @@ class TopicModelTests(TestCase):
         eq_(t1.path, [t1.slug])
         eq_(t2.path, [t1.slug, t2.slug])
         eq_(t3.path, [t1.slug, t2.slug, t3.slug])
+
+    def test_absolute_url(self):
+        p = product(save=True)
+        t = topic(product=p, save=True)
+        expected = '/products/{p}/{t}'.format(p=p.slug, t=t.slug)
+        actual = t.get_absolute_url()
+        eq_(actual, expected)
+
+    def test_absolute_url_subtopic(self):
+        p = product(save=True)
+        t1 = topic(product=p, save=True)
+        t2 = topic(parent=t1, product=p, save=True)
+        expected = '/products/{p}/{t1}/{t2}'.format(p=p.slug, t1=t1.slug, t2=t2.slug)
+        actual = t2.get_absolute_url()
+        eq_(actual, expected)
+
+
+class ProductModelTests(TestCase):
+
+    def test_absolute_url(self):
+        p = product(save=True)
+        expected = '/products/{p}'.format(p=p.slug)
+        actual = p.get_absolute_url()
+        eq_(actual, expected)

--- a/kitsune/sumo/templates/layout/breadcrumbs.html
+++ b/kitsune/sumo/templates/layout/breadcrumbs.html
@@ -6,7 +6,7 @@
           {% if target %}
             <li><a href="{{ target }}">{{ label|truncate(length=30) }}</a></li>
           {% else %}
-            <li>{{ label|truncate(length=30) }}</li>
+            <li>{{ label|truncate(length=40) }}</li>
           {% endif %}
         {% endfor %}
       </ol>

--- a/kitsune/wiki/templates/wiki/document.html
+++ b/kitsune/wiki/templates/wiki/document.html
@@ -35,6 +35,10 @@
   {% set extra_body_attrs = {'data-surveygizmo-url': 'http://qsurvey.mozilla.com/s3/63ac9fdb1ce1'} %}
 {% endif %}
 
+{% block breadcrumbs %}
+  {{ breadcrumbs(breadcrumb_items, id='main-breadcrumbs') }}
+{% endblock %}
+
 {% block above_main %}
   <h1 class="product-title cf">
     {% set prod_url = url('products.product', slug=product.slug) %}
@@ -60,7 +64,7 @@
     {% endif %}
 
       <div class="vote-wrap">
-      {# this extra div is to make the js compatible with old theme. TODO: Remove and fix js. #}
+        {# this extra div is to make the js compatible with old theme. TODO: Remove and fix js. #}
         {{ vote_form(document, 'footer') }}
       </div>
 
@@ -81,7 +85,4 @@
   {{ document_tools(doc, parent, user, 'article', settings, include_showfor=True) }}
   {{ topic_sidebar(topics[:10], [], product) }}
   {{ vote_form(document, 'sidebar') }}
-{% endblock %}
-
-{% block breadcrumbs %}
 {% endblock %}

--- a/kitsune/wiki/templates/wiki/document.html
+++ b/kitsune/wiki/templates/wiki/document.html
@@ -83,6 +83,6 @@
     {% set parent = doc.parent %}
   {% endif %}
   {{ document_tools(doc, parent, user, 'article', settings, include_showfor=True) }}
-  {{ topic_sidebar(topics[:10], [], product) }}
+  {{ topic_sidebar(product_topics[:10], [], product) }}
   {{ vote_form(document, 'sidebar') }}
 {% endblock %}

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -154,7 +154,7 @@ def document(request, document_slug, template=None, document=None):
     else:
         product = products[0]
 
-    topics = Topic.objects.filter(product=product, visible=True, parent=None)
+    product_topics = Topic.objects.filter(product=product, visible=True, parent=None)
 
     ga_push = []
     if fallback_reason is not None:
@@ -180,13 +180,17 @@ def document(request, document_slug, template=None, document=None):
     breadcrumbs = [(None, trimmed_title)]
     # Get the dominant topic, and all parent topics. Save the topic chosen for
     # picking a product later.
-    topic = doc.topics.order_by('display_order')[0]
-    first_topic = topic
-    while topic is not None:
-        breadcrumbs.append((topic.get_absolute_url(), topic.title))
-        topic = topic.parent
-    # Get the product
-    breadcrumbs.append((first_topic.product.get_absolute_url(), first_topic.product.title))
+    document_topics = doc.topics.order_by('display_order')
+    if len(document_topics) > 0:
+        topic = document_topics[0]
+        first_topic = topic
+        while topic is not None:
+            breadcrumbs.append((topic.get_absolute_url(), topic.title))
+            topic = topic.parent
+        # Get the product
+        breadcrumbs.append((first_topic.product.get_absolute_url(), first_topic.product.title))
+    else:
+        breadcrumbs.append((product.get_absolute_url(), product.title))
     # The list above was built backwards, so flip this.
     breadcrumbs.reverse()
 
@@ -196,7 +200,7 @@ def document(request, document_slug, template=None, document=None):
         'contributors': contributors,
         'fallback_reason': fallback_reason,
         'is_aoa_referral': request.GET.get('ref') == 'aoa',
-        'topics': topics,
+        'product_topics': product_topics,
         'product': product,
         'products': products,
         'ga_push': ga_push,

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -171,6 +171,25 @@ def document(request, document_slug, template=None, document=None):
         template = '%sdocument.html' % template
         minimal = False
 
+    # Build a set of breadcrumbs, ending with the document's title, and
+    # starting with the product, with the topic(s) in between.
+    # The breadcrumbs are built backwards, and then reversed.
+
+    # Get document title. If it is like "Title - Subtitle", strip off the subtitle.
+    trimmed_title = doc.title.split(' - ')[0].strip()
+    breadcrumbs = [(None, trimmed_title)]
+    # Get the dominant topic, and all parent topics. Save the topic chosen for
+    # picking a product later.
+    topic = doc.topics.order_by('display_order')[0]
+    first_topic = topic
+    while topic is not None:
+        breadcrumbs.append((topic.get_absolute_url(), topic.title))
+        topic = topic.parent
+    # Get the product
+    breadcrumbs.append((first_topic.product.get_absolute_url(), first_topic.product.title))
+    # The list above was built backwards, so flip this.
+    breadcrumbs.reverse()
+
     data = {
         'document': doc,
         'redirected_from': redirected_from,
@@ -181,6 +200,7 @@ def document(request, document_slug, template=None, document=None):
         'product': product,
         'products': products,
         'ga_push': ga_push,
+        'breadcrumb_items': breadcrumbs,
     }
 
     response = render(request, template, data)


### PR DESCRIPTION
This resolves the issue of picking which topic/product to use for a document when there are multiple choices by picking one based on display_order. It doesn't try and preserve the navigation history of a user. It only tries to give the user an idea of where in the hierarchy they are, and how  they can explore the surrounding concepts.

r?