### PR TITLE
[Bug 1156206] Enable Tswana as a locale for SUMO

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -151,6 +151,7 @@ SUMO_LANGUAGES = (
     'ta-LK',
     'te',
     'th',
+    'tn',
     'tr',
     'uk',
     'ur',
@@ -209,6 +210,7 @@ SIMPLE_WIKI_LANGUAGES = [
     'gl',
     'kn',
     'ml',
+    'tn',
 ]
 
 # Languages that should show up in language switcher.
@@ -262,7 +264,6 @@ NON_SUPPORTED_LOCALES = {
     'sah': None,
     'son': None,
     'sv-SE': 'sv',
-    'tn': 'en',
 }
 
 ES_LOCALE_ANALYZERS = {


### PR DESCRIPTION
This should add tn as a localizable locale on SUMO and redirect users to
the FAQ page by default. (with no added mess like in the previous PR, apologies for that)