### PR TITLE
[Bug 1131145] Send welcome emails to first time contributors.

### DIFF
--- a/kitsune/community/cron.py
+++ b/kitsune/community/cron.py
@@ -1,0 +1,80 @@
+import cronjobs
+from datetime import datetime, timedelta
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from django.db.models import F, Q
+
+from tower import ugettext as _
+
+from kitsune.questions.models import Answer
+from kitsune.sumo.email_utils import make_mail, safe_translation, send_messages
+from kitsune.users.models import Profile
+from kitsune.wiki.models import Revision
+
+
+@cronjobs.register
+def send_welcome_emails():
+    """Send a welcome email to first time contributors.
+
+    Anyone who has made a contribution more than 24 hours ago and has not
+    already gotten a welcome email should get a welcome email.
+    """
+
+    wait_period = datetime.now() - timedelta(hours=24)
+    messages = []
+    context = {
+        'host': Site.objects.get_current().domain,
+    }
+
+    # Answers
+
+    answer_filter = Q(created__lte=wait_period)
+    answer_filter &= ~Q(question__creator=F('creator'))
+    answer_filter &= Q(creator__profile__first_answer_email_sent=False)
+
+    answer_recipient_ids = set(
+        Answer.objects
+        .filter(answer_filter)
+        .values_list('creator', flat=True))
+
+    @safe_translation
+    def _make_answer_email(locale, to):
+        return make_mail(subject=_('Thank you for your contribution to Mozilla Support!'),
+                         text_template='community/email/first_answer.ltxt',
+                         html_template='community/email/first_answer.html',
+                         context_vars=context,
+                         from_email=settings.TIDINGS_FROM_ADDRESS,
+                         to_email=to.email)
+
+    for user in User.objects.filter(id__in=answer_recipient_ids):
+        messages.append(_make_answer_email(user.profile.locale, user))
+
+    Profile.objects.filter(user__id__in=answer_recipient_ids).update(first_answer_email_sent=True)
+
+    # Localization
+
+    l10n_filter = Q(created__lte=wait_period)
+    l10n_filter &= ~Q(document__locale=settings.WIKI_DEFAULT_LANGUAGE)
+    l10n_filter &= Q(creator__profile__first_l10n_email_sent=False)
+
+    l10n_recipient_ids = set(
+        Revision.objects
+        .filter(l10n_filter)
+        .values_list('creator', flat=True))
+
+    # This doesn't need localized, and so don't need the `safe_translation` helper.
+    for user in User.objects.filter(id__in=l10n_recipient_ids):
+        messages.append(make_mail(
+            subject='Thank you for your contribution to Mozilla Support!',
+            text_template='community/email/first_l10n.ltxt',
+            html_template='community/email/first_l10n.html',
+            context_vars=context,
+            from_email=settings.TIDINGS_FROM_ADDRESS,
+            to_email=user.email))
+
+    Profile.objects.filter(user__id__in=l10n_recipient_ids).update(first_l10n_email_sent=True)
+
+    # Release the Kraken!
+    send_messages(messages)

--- a/kitsune/community/cron.py
+++ b/kitsune/community/cron.py
@@ -51,8 +51,6 @@ def send_welcome_emails():
     for user in User.objects.filter(id__in=answer_recipient_ids):
         messages.append(_make_answer_email(user.profile.locale, user))
 
-    Profile.objects.filter(user__id__in=answer_recipient_ids).update(first_answer_email_sent=True)
-
     # Localization
 
     l10n_filter = Q(created__lte=wait_period)
@@ -74,7 +72,8 @@ def send_welcome_emails():
             from_email=settings.TIDINGS_FROM_ADDRESS,
             to_email=user.email))
 
-    Profile.objects.filter(user__id__in=l10n_recipient_ids).update(first_l10n_email_sent=True)
-
     # Release the Kraken!
     send_messages(messages)
+
+    Profile.objects.filter(user__id__in=answer_recipient_ids).update(first_answer_email_sent=True)
+    Profile.objects.filter(user__id__in=l10n_recipient_ids).update(first_l10n_email_sent=True)

--- a/kitsune/community/templates/community/email/first_answer.html
+++ b/kitsune/community/templates/community/email/first_answer.html
@@ -1,76 +1,76 @@
 {% extends 'email/base.html' %}
 
 {% block content %}
-    <p>
-        {% trans %}
-            Thank you for your first contribution to the Mozilla support
-            forums! You just made somebody's day!
-        {% endtrans %}
-    </p>
+  <p>
+    {% trans %}
+      Thank you for your first contribution to the Mozilla support
+      forums! You just made somebody's day!
+    {% endtrans %}
+  </p>
 
-    <p>
-        {% trans %}
-            Mozilla support is fully powered by our volunteer community that is
-            helping hundreds of users everyday. This community is formed by
-            passionate Firefox and Thunderbird users who take some of their
-            spare time to help others. We couldn't do it without your passion
-            and enthusiasm. Your contribution, as minor as it might seem, has
-            tremendous value. Solving one issue in the support forums can help
-            up to 1000 users a day!
-        {% endtrans %}
-    </p>
+  <p>
+    {% trans %}
+      Mozilla support is fully powered by our volunteer community that is
+      helping hundreds of users everyday. This community is formed by
+      passionate Firefox and Thunderbird users who take some of their
+      spare time to help others. We couldn't do it without your passion
+      and enthusiasm. Your contribution, as minor as it might seem, has
+      tremendous value. Solving one issue in the support forums can help
+      up to 1000 users a day!
+    {% endtrans %}
+  </p>
 
-    <p><strong>{{ _('Tell us about yourself!') }}</strong></p>
+  <p><strong>{{ _('Tell us about yourself!') }}</strong></p>
 
-    <p>
-        {% trans intro_url=host + '/en-US/forums/contributors', irc_url='https://client01.chat.mibbit.com/?server=irc.mozilla.org&channel=#sumo' %}
-            We are always very happy to hear from new people who like helping
-            on the forums so If you haven’t met our community yet
-            <a href="{{ intro_url }}">
-                please take a minute to introduce yourself
-            </a>.
-            If you want to stay low-profile, that’s also ok :). You can also
-            find us all hanging out on IRC, on the
-            <a href="{{ irc_url }}">
-                #sumo channel
-            </a>.
-        {% endtrans %}
-    </p>
+  <p>
+    {% trans intro_url=host + '/en-US/forums/contributors', irc_url='https://client01.chat.mibbit.com/?server=irc.mozilla.org&channel=#sumo' %}
+      We are always very happy to hear from new people who like helping
+      on the forums so if you haven’t met our community yet
+      <a href="{{ intro_url }}">
+        please take a minute to introduce yourself
+      </a>.
+      If you want to stay low-profile, that’s also ok :). You can also
+      find us all hanging out on IRC, on the
+      <a href="{{ irc_url }}">
+        #sumo channel
+      </a>.
+    {% endtrans %}
+  </p>
 
-    <p><strong>{{ _('Learn new things') }}</strong></p>
+  <p><strong>{{ _('Learn new things') }}</strong></p>
 
-    <p>
-        {% trans training_url=host + '/en-US/kb/introduction-contributor-quality-training?utm_source=training&utm_medium=1intro&utm_term=cqt&utm_campaign=Contributorqualitytraining' %}
-            If you are interested in learning more about how this whole support
-            thing works, check out our
-            <a href="{{ training_url }}">
-                contributor training
-            </a>.
-            This includes some cool troubleshooting info, guidelines, how to
-            questions, and info about where to find more help if stuck.
-        {% endtrans %}
-    </p>
+  <p>
+    {% trans training_url=host + '/en-US/kb/introduction-contributor-quality-training?utm_source=training&utm_medium=1intro&utm_term=cqt&utm_campaign=Contributorqualitytraining' %}
+      If you are interested in learning more about how this whole support
+      thing works, check out our
+      <a href="{{ training_url }}">
+        contributor training
+      </a>.
+      This includes some cool troubleshooting info, guidelines, how-to
+      questions, and info about where to find more help if stuck.
+    {% endtrans %}
+  </p>
 
-    <p><strong>{{ _('Stay in touch') }}</strong></p>
+  <p><strong>{{ _('Stay in touch') }}</strong></p>
 
-    <p>
-        {% trans forums_url=host + '/forums/contributors', blog_url='http://blog.mozilla.org/sumo/', twitter_url='http://twitter.com/sumo_mozilla', meetings_url='https://wiki.mozilla.org/Support/Weekly_Meetings' %}
-            Finally, if you want to follow all news related to SUMO, don’t
-            forget about our
-            <a href="{{ forums_url }}">community forums</a>,
-            <a href="{{ blog_url }}">official blog</a> and
-            <a href="{{ twitter_url }}">Twitter account</a>.
-            We also
-            <a href="{{ meetings_url }}">
-                meet almost every Monday
-            </a> - and you can join us.
-        {% endtrans %}
-    </p>
+  <p>
+    {% trans forums_url=host + '/forums/contributors', blog_url='http://blog.mozilla.org/sumo/', twitter_url='http://twitter.com/sumo_mozilla', meetings_url='https://wiki.mozilla.org/Support/Weekly_Meetings' %}
+      Finally, if you want to follow all news related to SUMO, don’t
+      forget about our
+      <a href="{{ forums_url }}">community forums</a>,
+      <a href="{{ blog_url }}">official blog</a> and
+      <a href="{{ twitter_url }}">Twitter account</a>.
+      We also
+      <a href="{{ meetings_url }}">
+        meet almost every Monday
+      </a> - and you can join us.
+    {% endtrans %}
+  </p>
 
-    <p>
-        {% trans %}
-            Thank you once more. We are looking forward to seeing you more often
-            around SUMO! Keep rocking!
-        {% endtrans %}
-    </p>
+  <p>
+    {% trans %}
+      Thank you once more. We are looking forward to seeing you more often
+      around SUMO! Keep rocking!
+    {% endtrans %}
+  </p>
 {% endblock %}

--- a/kitsune/community/templates/community/email/first_answer.html
+++ b/kitsune/community/templates/community/email/first_answer.html
@@ -1,0 +1,76 @@
+{% extends 'email/base.html' %}
+
+{% block content %}
+    <p>
+        {% trans %}
+            Thank you for your first contribution to the Mozilla support
+            forums! You just made somebody's day!
+        {% endtrans %}
+    </p>
+
+    <p>
+        {% trans %}
+            Mozilla support is fully powered by our volunteer community that is
+            helping hundreds of users everyday. This community is formed by
+            passionate Firefox and Thunderbird users who take some of their
+            spare time to help others. We couldn't do it without your passion
+            and enthusiasm. Your contribution, as minor as it might seem, has
+            tremendous value. Solving one issue in the support forums can help
+            up to 1000 users a day!
+        {% endtrans %}
+    </p>
+
+    <p><strong>{{ _('Tell us about yourself!') }}</strong></p>
+
+    <p>
+        {% trans intro_url=host + '/en-US/forums/contributors', irc_url='https://client01.chat.mibbit.com/?server=irc.mozilla.org&channel=#sumo' %}
+            We are always very happy to hear from new people who like helping
+            on the forums so If you haven’t met our community yet
+            <a href="{{ intro_url }}">
+                please take a minute to introduce yourself
+            </a>.
+            If you want to stay low-profile, that’s also ok :). You can also
+            find us all hanging out on IRC, on the
+            <a href="{{ irc_url }}">
+                #sumo channel
+            </a>.
+        {% endtrans %}
+    </p>
+
+    <p><strong>{{ _('Learn new things') }}</strong></p>
+
+    <p>
+        {% trans training_url=host + '/en-US/kb/introduction-contributor-quality-training?utm_source=training&utm_medium=1intro&utm_term=cqt&utm_campaign=Contributorqualitytraining' %}
+            If you are interested in learning more about how this whole support
+            thing works, check out our
+            <a href="{{ training_url }}">
+                contributor training
+            </a>.
+            This includes some cool troubleshooting info, guidelines, how to
+            questions, and info about where to find more help if stuck.
+        {% endtrans %}
+    </p>
+
+    <p><strong>{{ _('Stay in touch') }}</strong></p>
+
+    <p>
+        {% trans forums_url=host + '/forums/contributors', blog_url='http://blog.mozilla.org/sumo/', twitter_url='http://twitter.com/sumo_mozilla', meetings_url='https://wiki.mozilla.org/Support/Weekly_Meetings' %}
+            Finally, if you want to follow all news related to SUMO, don’t
+            forget about our
+            <a href="{{ forums_url }}">community forums</a>,
+            <a href="{{ blog_url }}">official blog</a> and
+            <a href="{{ twitter_url }}">Twitter account</a>.
+            We also
+            <a href="{{ meetings_url }}">
+                meet almost every Monday
+            </a> - and you can join us.
+        {% endtrans %}
+    </p>
+
+    <p>
+        {% trans %}
+            Thank you once more. We are looking forward to seeing you more often
+            around SUMO! Keep rocking!
+        {% endtrans %}
+    </p>
+{% endblock %}

--- a/kitsune/community/templates/community/email/first_answer.ltxt
+++ b/kitsune/community/templates/community/email/first_answer.ltxt
@@ -1,0 +1,58 @@
+{# This is an email.  Whitespace matters! #}
+{% autoescape false %}
+{% trans %}
+Thank you for your first contribution to the Mozilla support forums! You just
+made somebody's day!
+{% endtrans %}
+
+{% trans %}
+Mozilla support is fully powered by our volunteer community that is helping
+hundreds of users everyday. This community is formed by passionate Firefox and
+Thunderbird users who take some of their spare time to help others. We couldn't
+do it without your passion and enthusiasm. Your contribution, as minor as it
+might seem, has tremendous value. Solving one issue in the support forums can
+help up to 1000 users a day!
+{% endtrans %}
+
+---
+{{ _('Tell us about yourself!') }}
+
+{% trans %}
+We are always very happy to hear from new people who like helping on the forums
+so If you haven’t met our community yet please take a minute to introduce
+yourself. If you want to stay low-profile, that’s also ok :). You can also find
+us all hanging out on IRC, on the #sumo channel on irc.mozilla.org.
+{% endtrans %}
+
+{% trans url='https://support.mozilla.org/en-US/forums/contributors' %}
+The community forum is at {{ url }}.
+{% endtrans %}
+
+---
+{{ _('Learn new things') }}
+
+{% trans %}
+If you are interested in learning more about how this whole support thing
+works, check out our contributor training. This includes some cool
+troubleshooting info, guidelines, how to questions, and info about where to
+find more help if stuck.
+{% endtrans %}
+https://support.mozilla.org/en-US/kb/introduction-contributor-quality-training
+
+---
+{{ _('Stay in touch') }}
+
+{% trans %}
+Finally, if you want to follow all news related to SUMO, don’t forget about our
+{% endtrans %}
+
+* {{ _('Community forums') }} (https://support.mozilla.org/forums/contributors
+* {{ _('Official blog') }} (http://blog.mozilla.org/sumo/)
+* {{ _('Twitter account') }} (http://twitter.com/sumo_mozilla)
+* {{ _('Weekly meetings') }} (https://wiki.mozilla.org/Support/Weekly_Meetings)
+
+{% trans %}
+Thank you once more. We are looking forward to seeing you more often around
+SUMO! Keep rocking!
+{% endtrans %}
+{% endautoescape %}

--- a/kitsune/community/templates/community/email/first_answer.ltxt
+++ b/kitsune/community/templates/community/email/first_answer.ltxt
@@ -19,13 +19,16 @@ help up to 1000 users a day!
 
 {% trans %}
 We are always very happy to hear from new people who like helping on the forums
-so If you haven’t met our community yet please take a minute to introduce
+so if you haven’t met our community yet please take a minute to introduce
 yourself. If you want to stay low-profile, that’s also ok :). You can also find
 us all hanging out on IRC, on the #sumo channel on irc.mozilla.org.
 {% endtrans %}
 
+* Introductions - {{ host }}/en-US/forums/contributors
+* IRC - https://www.mibbit.com/?server=irc.mozilla.org&channel=#sumo
+
 {% trans url='https://support.mozilla.org/en-US/forums/contributors' %}
-The community forum is at {{ url }}.
+The community forum is at {{ url }} .
 {% endtrans %}
 
 ---
@@ -34,7 +37,7 @@ The community forum is at {{ url }}.
 {% trans %}
 If you are interested in learning more about how this whole support thing
 works, check out our contributor training. This includes some cool
-troubleshooting info, guidelines, how to questions, and info about where to
+troubleshooting info, guidelines, how-to questions, and info about where to
 find more help if stuck.
 {% endtrans %}
 https://support.mozilla.org/en-US/kb/introduction-contributor-quality-training
@@ -46,10 +49,10 @@ https://support.mozilla.org/en-US/kb/introduction-contributor-quality-training
 Finally, if you want to follow all news related to SUMO, don’t forget about our
 {% endtrans %}
 
-* {{ _('Community forums') }} (https://support.mozilla.org/forums/contributors
-* {{ _('Official blog') }} (http://blog.mozilla.org/sumo/)
-* {{ _('Twitter account') }} (http://twitter.com/sumo_mozilla)
-* {{ _('Weekly meetings') }} (https://wiki.mozilla.org/Support/Weekly_Meetings)
+* {{ _('Community forums') }} - {{ host }}/forums/contributors
+* {{ _('Official blog') }} - http://blog.mozilla.org/sumo/
+* {{ _('Twitter account') }} - http://twitter.com/sumo_mozilla
+* {{ _('Weekly meetings') }} - https://wiki.mozilla.org/Support/Weekly_Meetings
 
 {% trans %}
 Thank you once more. We are looking forward to seeing you more often around

--- a/kitsune/community/templates/community/email/first_l10n.html
+++ b/kitsune/community/templates/community/email/first_l10n.html
@@ -1,0 +1,79 @@
+{# this does not need translated, since it is being sent to localizers #}
+{% extends 'email/base.html' %}
+
+{% block content %}
+    <p>
+        Thank you for your first contribution to our Knowledge Base in your
+        language! You can consider yourself an Open Web rockstar on the rise
+        :-) Your contribution will now undergo review by our awesome community
+        members and should be published soon.
+    </p>
+
+    <p>
+        SUMO has millions of visitors each month and more than 60% of them view
+        pages in languages other than English. You may think that you
+        translated just one page, but for all the users who speak your language
+        it makes a <strong>huge</strong> difference.
+    </p>
+
+
+    <p><strong>Team up</strong></p>
+    <p>
+        It’s always a good idea to get in touch with your Locale Leaders.
+        <a href="https://support.mozilla.org/kb/locales">
+            You can find them clicking your language’s name in this list
+        </a>.
+        Send them a Private Message - they are there to help you help others
+        through your localizing skills!
+    </p>
+
+    <p>
+        If you want to get in touch with other people localizing SUMO in your
+        language,
+        <a href="https://support.mozilla.org/forums/l10n-forum/711196?last=64679">
+            go to our l10n forums
+        </a>.
+        You can also find people hanging out on IRC at
+        <a href="https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23sumo-l10ns">
+            #sumo-l10ns
+        </a>
+        and
+        <a href="https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo">
+            #sumo.
+        </a>
+    </p>
+
+    <p><strong>Stay in touch</strong></p>
+    <p>
+        Finally, if you want to follow all news related to SUMO, don’t forget about
+        <a href="https://support.mozilla.org/forums/contributors">
+            our community forums
+        </a>,
+        <a href="http://blog.mozilla.org/sumo/">
+            official blog
+        </a>
+        and
+        <a href="http://twitter.com/sumo_mozilla">
+            Twitter account
+        </a>.
+        We also
+        <a href="https://wiki.mozilla.org/Support/Weekly_Meetings">
+            meet almost every Monday
+        </a>
+        - and you can join us.
+    </p>
+
+    <p><strong>Keep rocking</strong></p>
+    <p>
+        So, now that you know how easy it is to improve our community-powered
+        support wiki in your language, why not
+        <a href="https://support.mozilla.org/localization">
+            localize another article
+        </a>?
+    </p>
+
+    <p>
+        Thank you once more. We are looking forward to seeing you more often
+        around SUMO!
+    </p>
+{% endblock %}

--- a/kitsune/community/templates/community/email/first_l10n.html
+++ b/kitsune/community/templates/community/email/first_l10n.html
@@ -1,79 +1,79 @@
-{# this does not need translated, since it is being sent to localizers #}
+{# This does not need translated, since it is being sent to localizers. #}
 {% extends 'email/base.html' %}
 
 {% block content %}
-    <p>
-        Thank you for your first contribution to our Knowledge Base in your
-        language! You can consider yourself an Open Web rockstar on the rise
-        :-) Your contribution will now undergo review by our awesome community
-        members and should be published soon.
-    </p>
+  <p>
+    Thank you for your first contribution to our Knowledge Base in your
+    language! You can consider yourself an Open Web rockstar on the rise.
+    :-) Your contribution will now undergo review by our awesome community
+    members and should be published soon.
+  </p>
 
-    <p>
-        SUMO has millions of visitors each month and more than 60% of them view
-        pages in languages other than English. You may think that you
-        translated just one page, but for all the users who speak your language
-        it makes a <strong>huge</strong> difference.
-    </p>
+  <p>
+    SUMO has millions of visitors each month and more than 60% of them view
+    pages in languages other than English. You may think that you
+    translated just one page, but for all the users who speak your language
+    it makes a <strong>huge</strong> difference.
+  </p>
 
 
-    <p><strong>Team up</strong></p>
-    <p>
-        It’s always a good idea to get in touch with your Locale Leaders.
-        <a href="https://support.mozilla.org/kb/locales">
-            You can find them clicking your language’s name in this list
-        </a>.
-        Send them a Private Message - they are there to help you help others
-        through your localizing skills!
-    </p>
+  <p><strong>Team up</strong></p>
+  <p>
+    It’s always a good idea to get in touch with your Locale Leaders.
+    <a href="https://support.mozilla.org/kb/locales">
+        You can find them clicking your language’s name in this list
+    </a>.
+    Send them a Private Message - they are there to help you help others
+    through your localizing skills!
+  </p>
 
-    <p>
-        If you want to get in touch with other people localizing SUMO in your
-        language,
-        <a href="https://support.mozilla.org/forums/l10n-forum/711196?last=64679">
-            go to our l10n forums
-        </a>.
-        You can also find people hanging out on IRC at
-        <a href="https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23sumo-l10ns">
-            #sumo-l10ns
-        </a>
-        and
-        <a href="https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo">
-            #sumo.
-        </a>
-    </p>
+  <p>
+    If you want to get in touch with other people localizing SUMO in your
+    language,
+    <a href="https://support.mozilla.org/forums/l10n-forum/711196?last=64679">
+      go to our l10n forums
+    </a>.
+    You can also find people hanging out on IRC at
+    <a href="https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo-l10ns">
+      #sumo-l10ns
+    </a>
+    and
+    <a href="https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo">
+      #sumo.
+    </a>
+  </p>
 
-    <p><strong>Stay in touch</strong></p>
-    <p>
-        Finally, if you want to follow all news related to SUMO, don’t forget about
-        <a href="https://support.mozilla.org/forums/contributors">
-            our community forums
-        </a>,
-        <a href="http://blog.mozilla.org/sumo/">
-            official blog
-        </a>
-        and
-        <a href="http://twitter.com/sumo_mozilla">
-            Twitter account
-        </a>.
-        We also
-        <a href="https://wiki.mozilla.org/Support/Weekly_Meetings">
-            meet almost every Monday
-        </a>
-        - and you can join us.
-    </p>
+  <p><strong>Stay in touch</strong></p>
+  <p>
+    Finally, if you want to follow all news related to SUMO, don’t forget about
+    <a href="https://support.mozilla.org/forums/contributors">
+      our community forums
+    </a>,
+    <a href="http://blog.mozilla.org/sumo/">
+      official blog
+    </a>
+    and
+    <a href="http://twitter.com/sumo_mozilla">
+      Twitter account
+    </a>.
+    We also
+    <a href="https://wiki.mozilla.org/Support/Weekly_Meetings">
+      meet almost every Monday
+    </a>
+    - and you can join us.
+  </p>
 
-    <p><strong>Keep rocking</strong></p>
-    <p>
-        So, now that you know how easy it is to improve our community-powered
-        support wiki in your language, why not
-        <a href="https://support.mozilla.org/localization">
-            localize another article
-        </a>?
-    </p>
+  <p><strong>Keep rocking</strong></p>
+  <p>
+    So, now that you know how easy it is to improve our community-powered
+    support wiki in your language, why not
+    <a href="https://support.mozilla.org/localization">
+      localize another article
+    </a>?
+  </p>
 
-    <p>
-        Thank you once more. We are looking forward to seeing you more often
-        around SUMO!
-    </p>
+  <p>
+    Thank you once more. We are looking forward to seeing you more often
+    around SUMO!
+  </p>
 {% endblock %}

--- a/kitsune/community/templates/community/email/first_l10n.ltxt
+++ b/kitsune/community/templates/community/email/first_l10n.ltxt
@@ -1,0 +1,58 @@
+{# This is an email.  Whitespace matters! #}
+{% autoescape false %}
+{% trans %}
+Thank you for your first contribution to the Mozilla support forums! You just
+made somebody's day!
+{% endtrans %}
+
+{% trans %}
+Mozilla support is fully powered by our volunteer community that is helping
+hundreds of users everyday. This community is formed by passionate Firefox and
+Thunderbird users who take some of their spare time to help others. We couldn't
+do it without your passion and enthusiasm. Your contribution, as minor as it
+might seem, has tremendous value. Solving one issue in the support forums can
+help up to 1000 users a day!
+{% endtrans %}
+
+---
+{{ _('Tell us about yourself!') }}
+
+{% trans %}
+We are always very happy to hear from new people who like helping on the forums
+so If you haven’t met our community yet please take a minute to introduce
+yourself. If you want to stay low-profile, that’s also ok :). You can also find
+us all hanging out on IRC, on the #sumo channel on irc.mozilla.org.
+{% endtrans %}
+
+{% trans url='https://support.mozilla.org/en-US/forums/contributors' %}
+The community forum is at {{ url }}.
+{% endtrans %}
+
+---
+{{ _('Learn new things') }}
+
+{% trans %}
+If you are interested in learning more about how this whole support thing
+works, check out our contributor training. This includes some cool
+troubleshooting info, guidelines, how to questions, and info about where to
+find more help if stuck.
+{% endtrans %}
+https://support.mozilla.org/en-US/kb/introduction-contributor-quality-training
+
+---
+{{ _('Stay in touch') }}
+
+{% trans %}
+Finally, if you want to follow all news related to SUMO, don’t forget about our
+{% endtrans %}
+
+* {{ _('Community forums') }} (https://support.mozilla.org/forums/contributors
+* {{ _('Official blog') }} (http://blog.mozilla.org/sumo/)
+* {{ _('Twitter account') }} (http://twitter.com/sumo_mozilla)
+* {{ _('Weekly meetings') }} (https://wiki.mozilla.org/Support/Weekly_Meetings)
+
+{% trans %}
+Thank you once more. We are looking forward to seeing you more often around
+SUMO! Keep rocking!
+{% endtrans %}
+{% endautoescape %}

--- a/kitsune/community/templates/community/email/first_l10n.ltxt
+++ b/kitsune/community/templates/community/email/first_l10n.ltxt
@@ -33,10 +33,10 @@ Stay in touch
 
 Finally, if you want to follow all news related to SUMO, don’t forget about our
 
-* {{ _('Community forums') }} - {{ host }}/forums/contributors
-* {{ _('Official blog') }} - http://blog.mozilla.org/sumo/
-* {{ _('Twitter account') }} - http://twitter.com/sumo_mozilla
-* {{ _('Weekly meetings') }} - https://wiki.mozilla.org/Support/Weekly_Meetings
+* Community forums - {{ host }}/forums/contributors
+* Official blog - http://blog.mozilla.org/sumo/
+* Twitter account - http://twitter.com/sumo_mozilla
+* Weekly meetings - https://wiki.mozilla.org/Support/Weekly_Meetings
 
 ---
 Keep rocking

--- a/kitsune/community/templates/community/email/first_l10n.ltxt
+++ b/kitsune/community/templates/community/email/first_l10n.ltxt
@@ -1,58 +1,52 @@
 {# This is an email.  Whitespace matters! #}
+{# This does not need translated, since it is being sent to localizers. #}
 {% autoescape false %}
-{% trans %}
-Thank you for your first contribution to the Mozilla support forums! You just
-made somebody's day!
-{% endtrans %}
 
-{% trans %}
-Mozilla support is fully powered by our volunteer community that is helping
-hundreds of users everyday. This community is formed by passionate Firefox and
-Thunderbird users who take some of their spare time to help others. We couldn't
-do it without your passion and enthusiasm. Your contribution, as minor as it
-might seem, has tremendous value. Solving one issue in the support forums can
-help up to 1000 users a day!
-{% endtrans %}
+Thank you for your first contribution to our Knowledge Base in your language!
+You can consider yourself an Open Web rockstar on the rise. :-) Your
+contribution will now undergo review by our awesome community members and
+should be published soon.
+
+SUMO has millions of visitors each month and more than 60% of them view pages
+in languages other than English. You may think that you translated just one
+page, but for all the users who speak your language it makes a *huge* difference.
 
 ---
-{{ _('Tell us about yourself!') }}
+Team up
 
-{% trans %}
-We are always very happy to hear from new people who like helping on the forums
-so If you haven’t met our community yet please take a minute to introduce
-yourself. If you want to stay low-profile, that’s also ok :). You can also find
-us all hanging out on IRC, on the #sumo channel on irc.mozilla.org.
-{% endtrans %}
+It’s always a good idea to get in touch with your Locale Leaders. You can find
+them clicking your language’s name on the locale page, linked below Send them
+a Private Message - they are there to help you help others through your
+localizing skills!
 
-{% trans url='https://support.mozilla.org/en-US/forums/contributors' %}
-The community forum is at {{ url }}.
-{% endtrans %}
+* Locale Page - https://support.mozilla.org/kb/locales
 
----
-{{ _('Learn new things') }}
+If you want to get in touch with other people localizing SUMO in your language
+you can check out the forums or our IRC channels.
 
-{% trans %}
-If you are interested in learning more about how this whole support thing
-works, check out our contributor training. This includes some cool
-troubleshooting info, guidelines, how to questions, and info about where to
-find more help if stuck.
-{% endtrans %}
-https://support.mozilla.org/en-US/kb/introduction-contributor-quality-training
+* L10n forums - https://support.mozilla.org/forums/l10n-forum/711196?last=64679
+* L10n IRC channel - https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo-l10ns
+* General SUMO IRC channel - https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo
 
 ---
-{{ _('Stay in touch') }}
+Stay in touch
 
-{% trans %}
 Finally, if you want to follow all news related to SUMO, don’t forget about our
-{% endtrans %}
 
-* {{ _('Community forums') }} (https://support.mozilla.org/forums/contributors
-* {{ _('Official blog') }} (http://blog.mozilla.org/sumo/)
-* {{ _('Twitter account') }} (http://twitter.com/sumo_mozilla)
-* {{ _('Weekly meetings') }} (https://wiki.mozilla.org/Support/Weekly_Meetings)
+* {{ _('Community forums') }} - {{ host }}/forums/contributors
+* {{ _('Official blog') }} - http://blog.mozilla.org/sumo/
+* {{ _('Twitter account') }} - http://twitter.com/sumo_mozilla
+* {{ _('Weekly meetings') }} - https://wiki.mozilla.org/Support/Weekly_Meetings
 
-{% trans %}
-Thank you once more. We are looking forward to seeing you more often around
-SUMO! Keep rocking!
-{% endtrans %}
+---
+Keep rocking
+
+So, now that you know how easy it is to improve our community-powered support
+wiki in your language, why not localize another article?
+
+* Localization dashboard: https://support.mozilla.org/localization
+localize another article
+
+Thank you once more. We are looking forward to seeing you more often
+around SUMO!
 {% endautoescape %}

--- a/kitsune/community/tests/test_cron.py
+++ b/kitsune/community/tests/test_cron.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta
+
+from django.core import mail
+from django.contrib.auth.models import User
+from django.test.utils import override_settings
+
+from nose.tools import eq_
+
+from kitsune.community import cron
+from kitsune.questions.tests import answer, question
+from kitsune.sumo.tests import attrs_eq, TestCase
+from kitsune.users.tests import profile
+from kitsune.wiki.tests import document, revision
+
+
+class WelcomeEmailsTests(TestCase):
+
+    def test_answer_welcome_email(self):
+        u1 = profile().user
+        u2 = profile(first_answer_email_sent=True).user
+        u3 = profile().user
+
+        two_days = datetime.now() - timedelta(hours=48)
+
+        q = question(creator=u1, save=True)
+        answer(question=q, creator=u1, created=two_days, save=True)
+        answer(question=q, creator=u2, created=two_days, save=True)
+        answer(question=q, creator=u3, created=two_days, save=True)
+
+        # Clear out the notifications that were sent
+        mail.outbox = []
+        # Send email(s) for welcome messages
+        cron.send_welcome_emails()
+
+        # There should be an email for u3 only.
+        # u1 was the asker, and so did not make a contribution.
+        # u2 has already recieved the email
+
+        eq_(len(mail.outbox), 1)
+        attrs_eq(mail.outbox[0], to=[u3.email])
+
+        # u3's flag should now be set.
+        u3 = User.objects.get(id=u3.id)
+        eq_(u3.profile.first_answer_email_sent, True)
+
+    @override_settings(WIKI_DEFAULT_LANGUAGE='en-US')
+    def test_l10n_welcome_email(self):
+        u1 = profile().user
+        u2 = profile(first_l10n_email_sent=True).user
+
+        two_days = datetime.now() - timedelta(hours=48)
+
+        d = document(locale='ru', save=True)
+        revision(document=d, creator=u1, created=two_days, save=True)
+        revision(document=d, creator=u2, created=two_days, save=True)
+
+        # Clear out the notifications that were sent
+        mail.outbox = []
+        # Send email(s) for welcome messages
+        cron.send_welcome_emails()
+
+        # There should be an email for u1 only.
+        # u2 has already recieved the email
+
+        eq_(len(mail.outbox), 1)
+        attrs_eq(mail.outbox[0], to=[u1.email])
+
+        # u3's flag should now be set.
+        u1 = User.objects.get(id=u1.id)
+        eq_(u1.profile.first_l10n_email_sent, True)

--- a/kitsune/sumo/email_utils.py
+++ b/kitsune/sumo/email_utils.py
@@ -19,6 +19,9 @@ log = logging.getLogger('k.email')
 
 def send_messages(messages):
     """Sends a a bunch of EmailMessages."""
+    if not messages:
+        return
+
     conn = mail.get_connection(fail_silently=True)
     conn.open()
 
@@ -30,6 +33,9 @@ def safe_translation(f):
     """Call `f` which has first argument `locale`. If `f` raises an
     exception indicative of a bad localization of a string, try again in
     `settings.WIKI_DEFAULT_LANGUAGE`.
+
+    The translation system will be manipulated for each call to make normal
+    calls to `gettext` and friends use the appropriate language.
 
     NB: This means `f` will be called up to two times!
     """

--- a/kitsune/sumo/email_utils.py
+++ b/kitsune/sumo/email_utils.py
@@ -34,8 +34,8 @@ def safe_translation(f):
     exception indicative of a bad localization of a string, try again in
     `settings.WIKI_DEFAULT_LANGUAGE`.
 
-    The translation system will be manipulated for each call to make normal
-    calls to `gettext` and friends use the appropriate language.
+    The translation system will be manipulated so that calls to gettext and
+    friends will use the appropriate language.
 
     NB: This means `f` will be called up to two times!
     """

--- a/kitsune/sumo/migrations/__init__.py
+++ b/kitsune/sumo/migrations/__init__.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+
+
+class MigrationStatusPrinter(object):
+    """
+    Print migration status in an attractive way during a Django migration run.
+
+    In particular, you get output that looks like this
+
+        Running migrations:
+          Applying users.0005_set_initial_contrib_email_flag...
+            set first_l10n_email_sent on 2793 profiles.
+            set first_answer_email_sent on 46863 profiles.
+            OK
+
+    Each step that wants to use this class should make its own instance.
+    Reusing instances will not result in the right print behavior.
+    """
+
+    def __init__(self):
+        self.printed_yet = False
+
+    def info(self, msg, *args, **kwargs):
+        if not self.printed_yet:
+            print('\n   ', end='')
+            self.printed_yet = True
+        msg = msg.format(*args, **kwargs)
+        print(' {0}'.format(msg), end='\n   ')

--- a/kitsune/users/migrations/0004_auto_add_contrib_email_flags.py
+++ b/kitsune/users/migrations/0004_auto_add_contrib_email_flags.py
@@ -19,13 +19,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='profile',
             name='first_answer_email_sent',
-            field=models.BooleanField(default=False, verbose_name='Has been sent a first answer contribution email.'),
+            field=models.BooleanField(default=False, help_text='Has been sent a first answer contribution email.'),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='profile',
             name='first_l10n_email_sent',
-            field=models.BooleanField(default=False, verbose_name='Has been sent a first revision contribution email.'),
+            field=models.BooleanField(default=False, help_text='Has been sent a first l10n contribution email.'),
             preserve_default=True,
         ),
     ]

--- a/kitsune/users/migrations/0004_auto_add_contrib_email_flags.py
+++ b/kitsune/users/migrations/0004_auto_add_contrib_email_flags.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Add first_answer_email_sent and first_l10n_email_sent fields to Profile.
+"""
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import kitsune.sumo.models  # noqa
+import timezones.fields  # noqa
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0003_auto_20150430_1304'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='first_answer_email_sent',
+            field=models.BooleanField(default=False, verbose_name='Has been sent a first answer contribution email.'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='profile',
+            name='first_l10n_email_sent',
+            field=models.BooleanField(default=False, verbose_name='Has been sent a first revision contribution email.'),
+            preserve_default=True,
+        ),
+    ]

--- a/kitsune/users/migrations/0005_set_initial_contrib_email_flag.py
+++ b/kitsune/users/migrations/0005_set_initial_contrib_email_flag.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Set the `first_{revision,question}_email_sent` flags for existing users, to
+avoid back filling welcome emails to contributors.
+"""
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations
+from django.db.models import F
+
+
+def contrib_email_flags_forwards(apps, schema_editor):
+    Profile = apps.get_model('users', 'Profile')
+    Answer = apps.get_model('questions', 'Answer')
+    Revision = apps.get_model('wiki', 'Revision')
+
+    l10n_contributor_ids = set(
+        Revision.objects
+        .exclude(document__locale='en-US')
+        .values_list('creator', flat=True))
+    (Profile.objects
+        .filter(user__id__in=l10n_contributor_ids)
+        .update(first_l10n_email_sent=True))
+
+    answer_contributor_ids = set(
+        Answer.objects
+        .exclude(question__creator=F('creator'))
+        .values_list('creator', flat=True))
+    (Profile.objects
+        .filter(user__id__in=answer_contributor_ids)
+        .update(first_answer_email_sent=True))
+
+
+def contrib_email_flags_backwards(apps, schema_editor):
+    Profile = apps.get_model('users', 'Profile')
+    Profile.objects.all().update(first_l10n_email_sent=False, first_answer_email_sent=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0004_auto_add_contrib_email_flags'),
+        ('wiki', '0001_initial'),
+        ('questions', '0001_initial'),
+        ('auth', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.RunPython(contrib_email_flags_forwards, contrib_email_flags_backwards),
+    ]

--- a/kitsune/users/migrations/0005_set_initial_contrib_email_flag.py
+++ b/kitsune/users/migrations/0005_set_initial_contrib_email_flag.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
 """
-Set the `first_{revision,question}_email_sent` flags for existing users, to
-avoid back filling welcome emails to contributors.
+Set the `first_{revision,question}_email_sent` flags for existing users that
+have made the appropriate type of contribution. This is to avoid back filling
+welcome emails to contributors.
 """
 from __future__ import unicode_literals
+
+import sys
 
 from django.conf import settings
 from django.db import migrations
 from django.db.models import F
+
+from kitsune.sumo.migrations import MigrationStatusPrinter
 
 
 def contrib_email_flags_forwards(apps, schema_editor):
@@ -30,6 +35,11 @@ def contrib_email_flags_forwards(apps, schema_editor):
     (Profile.objects
         .filter(user__id__in=answer_contributor_ids)
         .update(first_answer_email_sent=True))
+
+    if '--test' not in sys.argv:
+        status = MigrationStatusPrinter()
+        status.info('set first_l10n_email_sent on {0} profiles.', len(l10n_contributor_ids))
+        status.info('set first_answer_email_sent on {0} profiles.', len(answer_contributor_ids))
 
 
 def contrib_email_flags_backwards(apps, schema_editor):

--- a/kitsune/users/models.py
+++ b/kitsune/users/models.py
@@ -70,9 +70,9 @@ class Profile(ModelBase, SearchMixin):
     locale = LocaleField(default=settings.LANGUAGE_CODE,
                          verbose_name=_lazy(u'Preferred language'))
     first_answer_email_sent = models.BooleanField(
-        default=False, verbose_name=_lazy('Has been sent a first answer contribution email.'))
+        default=False, help_text=_lazy('Has been sent a first answer contribution email.'))
     first_l10n_email_sent = models.BooleanField(
-        default=False, verbose_name=_lazy('Has been sent a first revision contribution email.'))
+        default=False, help_text=_lazy('Has been sent a first revision contribution email.'))
 
     class Meta(object):
         permissions = (('view_karma_points', 'Can view karma points'),

--- a/kitsune/users/models.py
+++ b/kitsune/users/models.py
@@ -69,6 +69,10 @@ class Profile(ModelBase, SearchMixin):
                             verbose_name=_lazy(u'City'))
     locale = LocaleField(default=settings.LANGUAGE_CODE,
                          verbose_name=_lazy(u'Preferred language'))
+    first_answer_email_sent = models.BooleanField(
+        default=False, verbose_name=_lazy('Has been sent a first answer contribution email.'))
+    first_l10n_email_sent = models.BooleanField(
+        default=False, verbose_name=_lazy('Has been sent a first revision contribution email.'))
 
     class Meta(object):
         permissions = (('view_karma_points', 'Can view karma points'),

--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -16,8 +16,8 @@ HOME = /tmp
 */10 * * * * {{ cron }} enqueue_lag_monitor_task
 
 # Every hour.
-59 * * * * {{ cron }} escalate_questions
 30 * * * * {{ cron }} send_welcome_emails
+59 * * * * {{ cron }} escalate_questions
 
 # Every 6 hours.
 00 */6 * * * {{ django }} update_product_details -q > /dev/null

--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -17,6 +17,7 @@ HOME = /tmp
 
 # Every hour.
 59 * * * * {{ cron }} escalate_questions
+30 * * * * {{ cron }} send_welcome_emails
 
 # Every 6 hours.
 00 */6 * * * {{ django }} update_product_details -q > /dev/null

--- a/scripts/travis/setup.sh
+++ b/scripts/travis/setup.sh
@@ -75,6 +75,10 @@ mkdir -p redis-state/sumo-test/
 echo "Starting XVFB for Selenium tests."
 /usr/bin/Xvfb :99 -ac -screen 0 1280x1024x16 >/dev/null 2>/dev/null &
 
+echo "Running migrations"
+./manage.py migrate --list
+./manage.py migrate
+
 echo "Doing static dance."
 ./manage.py nunjucks_precompile
 ./manage.py collectstatic --noinput > /dev/null


### PR DESCRIPTION
This is mostly stateless, in that we don't have to have a job sit in a queue for 24 hours so we can send this. It won't "backfill" and send emails to all our old contributors. People who haven't made a contribution, but make one after this lands will get an email (so it is not just new users).

I'm pretty fuzzy on the email template stuff, especially translating the .ltxt email. I'd appreciate someone looking carefully at that in particular.

r?