### PR TITLE
[bug 1161050] Invalid locales should raise HTTP 400

### DIFF
--- a/kitsune/search/api.py
+++ b/kitsune/search/api.py
@@ -32,6 +32,15 @@ def suggest(request):
         errors['q'] = 'This field is required.'
     if product is not None and not Product.objects.filter(slug=product).exists():
         errors['product'] = 'Could not find product with slug "{0}".'.format(product)
+    if locale not in settings.SUMO_LANGUAGES:
+        if settings.NON_SUPPORTED_LOCALES.get(locale):
+            errors['locale'] = (
+                'Locale "{0}" is not supported, but has fallback locale "{1}".'.format(
+                    locale, settings.NON_SUPPORTED_LOCALES[locale])
+            )
+        else:
+            errors['locale'] = 'Could not find locale "{0}".'.format(locale)
+
     if errors:
         raise GenericAPIException(400, errors)
 
@@ -55,9 +64,10 @@ def _question_suggestions(searcher, text, locale, product, max_results):
         question_is_archived=False,
         question_is_locked=False,
         question_is_solved=True)
-
     if product is not None:
         search_filter &= es_utils.F(product=product)
+    if locale is not None:
+        search_filter &= es_utils.F(question_locale=locale)
 
     questions = []
     searcher = _query(searcher, QuestionMappingType, search_filter, text, locale)

--- a/kitsune/search/tests/test_api.py
+++ b/kitsune/search/tests/test_api.py
@@ -2,6 +2,8 @@ from nose.tools import eq_
 
 from rest_framework.test import APIClient
 
+from django.conf import settings
+
 from kitsune.search.tests.test_es import ElasticTestCase
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.questions.tests import question, answer
@@ -65,6 +67,30 @@ class SuggestViewTests(ElasticTestCase):
         eq_(res.status_code, 400)
         eq_(res.data['detail'], {'product': 'Could not find product with slug "nonexistant".'})
 
+    def test_invalid_locale(self):
+        res = self.client.get(reverse('search.suggest'), {
+            'locale': 'bad-medicine',
+            'q': 'search',
+        })
+        eq_(res.status_code, 400)
+        eq_(res.data['detail'], {'locale': 'Could not find locale "bad-medicine".'})
+
+    def test_invalid_fallback_locale(self):
+        for locale, fallback in settings.NON_SUPPORTED_LOCALES.items():
+            if fallback is not None:
+                break
+
+        res = self.client.get(reverse('search.suggest'), {
+            'locale': locale,
+            'q': 'search',
+        })
+        eq_(res.status_code, 400)
+        eq_(
+            res.data['detail'],
+            {'locale': 'Locale "{0}" is not supported, but has fallback locale "{1}".'.format(
+                locale, fallback)}
+        )
+
     def test_invalid_numbers(self):
         res = self.client.get(reverse('search.suggest'), {
             'max_questions': 'a',
@@ -124,6 +150,22 @@ class SuggestViewTests(ElasticTestCase):
 
         req = self.client.get(reverse('search.suggest'), {'q': 'emails', 'product': p1.slug})
         eq_([q['id'] for q in req.data['questions']], [q1.id])
+
+    def test_locale_filter_works_for_questions(self):
+        q1 = self._make_question(locale='fr')
+        self._make_question(locale='en-US')
+        self.refresh()
+
+        req = self.client.get(reverse('search.suggest'), {'q': 'emails', 'locale': 'fr'})
+        eq_([q['id'] for q in req.data['questions']], [q1.id])
+
+    def test_locale_filter_works_for_documents(self):
+        d1 = self._make_document(slug='right-doc', locale='fr')
+        self._make_document(slug='wrong-doc', locale='en-US')
+        self.refresh()
+
+        req = self.client.get(reverse('search.suggest'), {'q': 'emails', 'locale': 'fr'})
+        eq_([d['slug'] for d in req.data['documents']], [d1.slug])
 
     def test_document_fields(self):
         self._make_document()


### PR DESCRIPTION
This fixes the search suggest api to return an HTTP 400 if you try to
filter on an invalid locale.

Further, it fixes the questions search so that it filters on
locale--previously, it didn't.

Adds some additional tests for behavior that wasn't previously tested.

r?