### PR TITLE
[Bug 1162223] Use correct variable name for topics in mobile document view.

### DIFF
--- a/kitsune/wiki/templates/wiki/mobile/document.html
+++ b/kitsune/wiki/templates/wiki/mobile/document.html
@@ -7,8 +7,8 @@
 {% set title = _('{t} | {c}')|f(t=document.title, c=document.get_category_display()) %}
 {% set headline = title %}
 
-{% if products.all()[0] and topics.all()[0] %}
-  {% set return_url = url('products.documents', product_slug=products.all()[0].slug, topic_slug=topics.all()[0].slug) %}
+{% if products.all()[0] and product_topics.all()[0] %}
+  {% set return_url = url('products.documents', product_slug=products.all()[0].slug, topic_slug=product_topics.all()[0].slug) %}
 {% elif products.all()[0] %}
   {% set return_url = url('products.product', slug=products.all()[0].slug) %}
 {% else %}


### PR DESCRIPTION
This was a flub from #2504. I changed a variable name in the view and the desktop template, but forgot about the mobile template.

r?