### PR TITLE
[Bug 1163855] Make helptext unicode for Profile fields

### DIFF
--- a/kitsune/dashboards/tests/test_cron.py
+++ b/kitsune/dashboards/tests/test_cron.py
@@ -10,7 +10,7 @@ from kitsune.dashboards.cron import (
     _get_current_unhelpful, update_l10n_coverage_metrics,
     update_l10n_contributor_metrics)
 from kitsune.dashboards.models import (
-    WikiMetric, L10N_TOP20_CODE, L10N_ALL_CODE)
+    WikiMetric, L10N_TOP20_CODE, L10N_TOP100_CODE, L10N_ALL_CODE)
 from kitsune.products.tests import product
 from kitsune.sumo.redis_utils import redis_client, RedisError
 from kitsune.sumo.tests import SkipTest, TestCase
@@ -278,46 +278,62 @@ class L10nMetricsTests(TestCase):
         update_l10n_coverage_metrics()
 
         # Verify es metrics.
-        eq_(4, WikiMetric.objects.filter(locale='es').count())
+        eq_(6, WikiMetric.objects.filter(locale='es').count())
         eq_(5.0, WikiMetric.objects.get(
             locale='es', product=p, code=L10N_TOP20_CODE).value)
+        eq_(5.0, WikiMetric.objects.get(
+            locale='es', product=None, code=L10N_TOP100_CODE).value)
         eq_(5.0, WikiMetric.objects.get(
             locale='es', product=p, code=L10N_ALL_CODE).value)
         eq_(5.0, WikiMetric.objects.get(
             locale='es', product=None, code=L10N_TOP20_CODE).value)
         eq_(5.0, WikiMetric.objects.get(
+            locale='es', product=None, code=L10N_TOP100_CODE).value)
+        eq_(5.0, WikiMetric.objects.get(
             locale='es', product=None, code=L10N_ALL_CODE).value)
 
         # Verify de metrics.
-        eq_(4, WikiMetric.objects.filter(locale='de').count())
+        eq_(6, WikiMetric.objects.filter(locale='de').count())
         eq_(10.0, WikiMetric.objects.get(
             locale='de', product=p, code=L10N_TOP20_CODE).value)
+        eq_(10.0, WikiMetric.objects.get(
+            locale='de', product=None, code=L10N_TOP100_CODE).value)
         eq_(10.0, WikiMetric.objects.get(
             locale='de', product=p, code=L10N_ALL_CODE).value)
         eq_(10.0, WikiMetric.objects.get(
             locale='de', product=None, code=L10N_TOP20_CODE).value)
         eq_(10.0, WikiMetric.objects.get(
+            locale='de', product=None, code=L10N_TOP100_CODE).value)
+        eq_(10.0, WikiMetric.objects.get(
             locale='de', product=None, code=L10N_ALL_CODE).value)
 
         # Verify ru metrics.
-        eq_(4, WikiMetric.objects.filter(locale='ru').count())
+        eq_(6, WikiMetric.objects.filter(locale='ru').count())
         eq_(100.0, WikiMetric.objects.get(
             locale='ru', product=p, code=L10N_TOP20_CODE).value)
+        eq_(100.0, WikiMetric.objects.get(
+            locale='ru', product=None, code=L10N_TOP100_CODE).value)
         eq_(100.0, WikiMetric.objects.get(
             locale='ru', product=p, code=L10N_ALL_CODE).value)
         eq_(100.0, WikiMetric.objects.get(
             locale='ru', product=None, code=L10N_TOP20_CODE).value)
         eq_(100.0, WikiMetric.objects.get(
+            locale='ru', product=None, code=L10N_TOP100_CODE).value)
+        eq_(100.0, WikiMetric.objects.get(
             locale='ru', product=None, code=L10N_ALL_CODE).value)
 
         # Verify it metrics.
-        eq_(4, WikiMetric.objects.filter(locale='it').count())
+        eq_(6, WikiMetric.objects.filter(locale='it').count())
         eq_(0.0, WikiMetric.objects.get(
             locale='it', product=p, code=L10N_TOP20_CODE).value)
+        eq_(0.0, WikiMetric.objects.get(
+            locale='it', product=None, code=L10N_TOP100_CODE).value)
         eq_(0.0, WikiMetric.objects.get(
             locale='it', product=p, code=L10N_ALL_CODE).value)
         eq_(0.0, WikiMetric.objects.get(
             locale='it', product=None, code=L10N_TOP20_CODE).value)
+        eq_(0.0, WikiMetric.objects.get(
+            locale='it', product=None, code=L10N_TOP100_CODE).value)
         eq_(0.0, WikiMetric.objects.get(
             locale='it', product=None, code=L10N_ALL_CODE).value)
 

--- a/kitsune/questions/tests/test_api.py
+++ b/kitsune/questions/tests/test_api.py
@@ -717,7 +717,9 @@ class TestQuestionFilter(TestCase):
         eq_(list(res), [q])
 
     def test_it_works_with_users_who_have_gotten_first_contrib_emails(self):
-        # Yes, really.
+        # This flag caused a regression, tracked in bug 1163855.
+        # The error was that the help text on the field was a str instead of a
+        # unicode. Yes, really, that matters apparently.
         u = profile(first_answer_email_sent=True).user
         question(creator=u, save=True)
         url = reverse('question-list')

--- a/kitsune/questions/tests/test_api.py
+++ b/kitsune/questions/tests/test_api.py
@@ -715,3 +715,11 @@ class TestQuestionFilter(TestCase):
         q = question(taken_by=u, taken_until=taken_until, save=True)
         res = self.filter_instance.filter_is_taken(self.queryset, False)
         eq_(list(res), [q])
+
+    def test_it_works_with_users_who_have_gotten_first_contrib_emails(self):
+        # Yes, really.
+        u = profile(first_answer_email_sent=True).user
+        question(creator=u, save=True)
+        url = reverse('question-list')
+        res = self.client.get(url)
+        eq_(res.status_code, 200)

--- a/kitsune/users/migrations/0006_auto_update_help_text_email_sent_fields.py
+++ b/kitsune/users/migrations/0006_auto_update_help_text_email_sent_fields.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import kitsune.sumo.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0005_set_initial_contrib_email_flag'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='profile',
+            name='first_l10n_email_sent',
+            field=models.BooleanField(default=False, help_text='Has been sent a first revision contribution email.'),
+            preserve_default=True,
+        ),
+    ]

--- a/kitsune/users/migrations/0006_auto_update_help_text_email_sent_fields.py
+++ b/kitsune/users/migrations/0006_auto_update_help_text_email_sent_fields.py
@@ -15,7 +15,13 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='profile',
             name='first_l10n_email_sent',
-            field=models.BooleanField(default=False, help_text='Has been sent a first revision contribution email.'),
+            field=models.BooleanField(default=False, help_text=u'Has been sent a first revision contribution email.'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='profile',
+            name='first_answer_email_sent',
+            field=models.BooleanField(default=False, help_text=u'Has been sent a first answer contribution email.'),
             preserve_default=True,
         ),
     ]

--- a/kitsune/users/models.py
+++ b/kitsune/users/models.py
@@ -70,9 +70,9 @@ class Profile(ModelBase, SearchMixin):
     locale = LocaleField(default=settings.LANGUAGE_CODE,
                          verbose_name=_lazy(u'Preferred language'))
     first_answer_email_sent = models.BooleanField(
-        default=False, help_text=_lazy('Has been sent a first answer contribution email.'))
+        default=False, help_text=_lazy(u'Has been sent a first answer contribution email.'))
     first_l10n_email_sent = models.BooleanField(
-        default=False, help_text=_lazy('Has been sent a first revision contribution email.'))
+        default=False, help_text=_lazy(u'Has been sent a first revision contribution email.'))
 
     class Meta(object):
         permissions = (('view_karma_points', 'Can view karma points'),


### PR DESCRIPTION
Because apparently this matters a lot to... something? It was causing tracebacks in the API on prod. I updated the tests to find this kind of error, though I don't really understand it.

r?