### PR TITLE
[Bug 1164008] Filter out Pocket related tweets

### DIFF
--- a/kitsune/customercare/cron.py
+++ b/kitsune/customercare/cron.py
@@ -58,7 +58,7 @@ def collect_tweets():
 
         search_options = {
             'q': ('firefox OR #fxinput OR @firefoxbrasil OR #firefoxos '
-                  'OR @firefox_es'),
+                  'OR @firefox_es -pocket'),
             'count': settings.CC_TWEETS_PERPAGE,  # Items per page.
             'result_type': 'recent',  # Retrieve tweets by date.
         }


### PR DESCRIPTION
added '-pocket' to the query used to find tweets for Army of Awesome, per bugzilla bug #1164008