### PR TITLE
[bug 1164205] Refactor search suggest api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,141 @@
+===
+API
+===
+
+SUMO has a series of API endpoints to access data.
+
+.. contents::
+
+
+Search suggest API
+==================
+
+:Endpoint:     ``/api/2/search/suggest/``
+:Method:       ``GET``
+:Content type: ``application/json``
+:Response:     ``application/json``
+
+The search suggest API allows you to get back kb documents and aaq
+questions that match specified arguments.
+
+Arguments can be specified in the url querystring or in the HTTP
+request body.
+
+
+Required arguments
+------------------
+
++-------------------+--------+--------------------------------------------------------+
+|argument           |type    |notes                                                   |
++===================+========+========================================================+
+|q                  |string  |This is the text you're querying for.                   |
++-------------------+--------+--------------------------------------------------------+
+
+
+Optional arguments
+------------------
+
++-------------------+--------+--------------------------------------------------------+
+|argument           |type    |notes                                                   |
++===================+========+========================================================+
+|locale             |string  |default: ``settings.WIKI_DEFAULT_LANGUAGE``             |
+|                   |        |                                                        |
+|                   |        |The locale code to restrict results to.                 |
+|                   |        |                                                        |
+|                   |        |Examples:                                               |
+|                   |        |                                                        |
+|                   |        |* ``en-US``                                             |
+|                   |        |* ``fr``                                                |
++-------------------+--------+--------------------------------------------------------+
+|product            |string  |default: None                                           |
+|                   |        |                                                        |
+|                   |        |The product to restrict results to.                     |
+|                   |        |                                                        |
+|                   |        |Example:                                                |
+|                   |        |                                                        |
+|                   |        |* ``firefox``                                           |
++-------------------+--------+--------------------------------------------------------+
+|max_documents      |integer |default: 10                                             |
+|                   |        |                                                        |
+|                   |        |The maximum number of documents you want back.          |
++-------------------+--------+--------------------------------------------------------+
+|max_questions      |integer |default: 10                                             |
+|                   |        |                                                        |
+|                   |        |The maximum number of questions you want back.          |
++-------------------+--------+--------------------------------------------------------+
+
+
+Responses
+---------
+
+All response bodies are in JSON.
+
+HTTP 200: Success
+~~~~~~~~~~~~~~~~~
+
+With an HTTP 200, you'll get back a set of results in JSON.
+
+::
+
+   {
+       "documents": [
+           {
+               "title": ...               # title of kb article
+               "url": ...                 # url of kb article
+               "slug": ...                # slug of kb article
+               "summary": ...             # paragraph summary of kb article (plaintext)
+           }
+           ...
+       ],
+       "questions": [
+           {
+               "id": ...                  # integer id of the question
+               "answers": ...             # list of answer ids
+               "content": ...             # content of question (in html)
+               "created": ...             # datetime stamp in iso-8601 format
+               "creator": ...             # JSON object describing the creator
+               "involved": ...            # list of JSON objects describing everyone who
+                                            participated in the question
+               "is_archived": ...         # boolean for whether this question is archived
+               "is_locked": ...           # boolean for whether this question is locked
+               "is_solved": ...           # boolean for whether this question is solved
+               "is_spam": ...             # boolean for whether this question is spam
+               "is_taken": ...            # FIXME:
+               "last_answer": ...         # id for the last answer
+               "num_answers": ...         # total number of answers
+               "locale": ...              # the locale for the question
+               "metadata": ...            # metadata collected for the question
+               "tags": ...                # tags for the qeustion
+               "num_votes_past_week": ... # the number of votes in the last week
+               "num_votes": ...           # the total number of votes
+               "product": ...             # the product
+               "solution": ...            # id of answer marked as a solution if any
+               "taken_until": ...         # FIXME:
+               "taken_by": ...            # FIXME:
+               "title": ...               # title of the question
+               "topic": ...               # FIXME:
+               "updated_by": ...          # FIXME:
+               "updated": ...             # FIXME:
+           },
+           ...
+       ]
+   }
+
+
+Examples
+--------
+
+Using curl::
+
+    curl -X GET "http://localhost:8000/api/2/search/suggest/?q=videos"
+
+    curl -X GET "http://localhost:8000/api/2/search/suggest/?q=videos&max_documents=3&max_questions=3"
+
+    curl -X GET "http://localhost:8000/api/2/search/suggest/" \
+         -H "Content-Type: application/json" \
+         -d '
+    {
+       "q": "videos",
+       "max_documents": 3,
+       "max_questions": 0
+    }'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Part 3: SUMO
 .. toctree::
    :maxdepth: 2
 
+   api
    bots
    deployments
    sop

--- a/kitsune/search/tests/test_api.py
+++ b/kitsune/search/tests/test_api.py
@@ -1,3 +1,4 @@
+import json
 from nose.tools import eq_
 
 from rest_framework.test import APIClient
@@ -65,7 +66,7 @@ class SuggestViewTests(ElasticTestCase):
             'q': 'search',
         })
         eq_(res.status_code, 400)
-        eq_(res.data['detail'], {'product': 'Could not find product with slug "nonexistant".'})
+        eq_(res.data['detail'], {'product': [u'Could not find product with slug "nonexistant".']})
 
     def test_invalid_locale(self):
         res = self.client.get(reverse('search.suggest'), {
@@ -73,7 +74,7 @@ class SuggestViewTests(ElasticTestCase):
             'q': 'search',
         })
         eq_(res.status_code, 400)
-        eq_(res.data['detail'], {'locale': 'Could not find locale "bad-medicine".'})
+        eq_(res.data['detail'], {'locale': [u'Could not find locale "bad-medicine".']})
 
     def test_invalid_fallback_locale_none_case(self):
         # Test the locale -> locale case.
@@ -90,8 +91,8 @@ class SuggestViewTests(ElasticTestCase):
         eq_(res.status_code, 400)
         eq_(
             res.data['detail'],
-            {'locale': 'Locale "{0}" is not supported, but has fallback locale "{1}".'.format(
-                locale, fallback)}
+            {'locale': [u'"{0}" is not supported, but has fallback locale "{1}".'.format(
+                locale, fallback)]}
         )
 
     def test_invalid_fallback_locale_non_none_case(self):
@@ -109,8 +110,8 @@ class SuggestViewTests(ElasticTestCase):
         eq_(res.status_code, 400)
         eq_(
             res.data['detail'],
-            {'locale': 'Locale "{0}" is not supported, but has fallback locale "{1}".'.format(
-                locale, settings.WIKI_DEFAULT_LANGUAGE)}
+            {'locale': [u'"{0}" is not supported, but has fallback locale "{1}".'.format(
+                locale, settings.WIKI_DEFAULT_LANGUAGE)]}
         )
 
     def test_invalid_numbers(self):
@@ -121,14 +122,14 @@ class SuggestViewTests(ElasticTestCase):
         })
         eq_(res.status_code, 400)
         eq_(res.data['detail'], {
-            'max_questions': 'This field must be an integer.',
-            'max_documents': 'This field must be an integer.',
+            'max_questions': [u'Enter a whole number.'],
+            'max_documents': [u'Enter a whole number.'],
         })
 
     def test_q_required(self):
         res = self.client.get(reverse('search.suggest'))
         eq_(res.status_code, 400)
-        eq_(res.data['detail'], {'q': 'This field is required.'})
+        eq_(res.data['detail'], {'q': [u'This field is required.']})
 
     def test_it_works(self):
         q1 = self._make_question()
@@ -138,6 +139,38 @@ class SuggestViewTests(ElasticTestCase):
         req = self.client.get(reverse('search.suggest'), {'q': 'emails'})
         eq_([q['id'] for q in req.data['questions']], [q1.id])
         eq_([d['title'] for d in req.data['documents']], [d1.title])
+
+    def test_filters_in_postdata(self):
+        q1 = self._make_question()
+        d1 = self._make_document()
+        self.refresh()
+
+        data = json.dumps({'q': 'emails'})
+        # Note: Have to use .generic() because .get() will convert the
+        # data into querystring params and then it's clownshoes all
+        # the way down.
+        req = self.client.generic(
+            'GET', reverse('search.suggest'), data=data,
+            content_type='application/json')
+        eq_(req.status_code, 200)
+        eq_([q['id'] for q in req.data['questions']], [q1.id])
+        eq_([d['title'] for d in req.data['documents']], [d1.title])
+
+    def test_both_querystring_and_body_raises_error(self):
+        self._make_question()
+        self._make_document()
+        self.refresh()
+
+        data = json.dumps({'q': 'emails'})
+        # Note: Have to use .generic() because .get() will convert the
+        # data into querystring params and then it's clownshoes all
+        # the way down.
+        req = self.client.generic(
+            'GET', reverse('search.suggest') + '?max_documents=3', data=data,
+            content_type='application/json')
+        eq_(req.status_code, 400)
+        eq_(req.data,
+            {u'detail': 'Put all parameters either in the querystring or the HTTP request body.'})
 
     def test_questions_max_results_0(self):
         self._make_question()


### PR DESCRIPTION
This refactors the search suggest API to use more DRF-y things including
built-in DRF-y validation.

In the process of doing this, I changed it so that you can provide the filter
parameters in the querystring OR in the HTTP request body as JSON.

r?