### PR TITLE
Revert "Merge pull request #2501 from mythmon/collapse-all-1158595"

### DIFF
--- a/kitsune/sumo/static/js/wiki.js
+++ b/kitsune/sumo/static/js/wiki.js
@@ -1,5 +1,4 @@
-/* globals k:false */
-/**
+/*
  * wiki.js
  * Scripts for the wiki app.
  */
@@ -737,20 +736,9 @@
 
   $(document).ready(init);
 
-  /**
-   * Collapse sections in a wiki article.
-   *
-   * Only collapses articles with a table of contents (TOC).
-   *
-   * @returns {boolean} Whether anything was collapsed.
-   */
   window.k.makeWikiCollapsable = function() {
-    var $toc = $('#toc');
-    if ($toc.length === 0) {
-      return false;
-    }
     // Hide the TOC
-    $toc.hide();
+    $('#toc').hide();
 
     // Make sections collapsable
     $('#doc-content h1').each(function() {
@@ -782,10 +770,11 @@
     $('#doc-content').on('click', 'h1', function() {
       $(this).closest('.wiki-section').toggleClass('collapsed');
     });
-    return true;
   }
 
-  k.makeWikiCollapsable();
+  if ($('#doc-content').is('.collapsible')) {
+    k.makeWikiCollapsable();
+  }
 
   function initExitSupportFor() {
     $('#support-for-exit').live('click', function() {
@@ -794,3 +783,4 @@
   }
 
 }(jQuery));
+

--- a/kitsune/wiki/config.py
+++ b/kitsune/wiki/config.py
@@ -3,6 +3,32 @@ from tower import ugettext_lazy as _lazy
 TEMPLATE_TITLE_PREFIX = 'Template:'
 DOCUMENTS_PER_PAGE = 100
 
+COLLAPSIBLE_DOCUMENTS = {
+    u'en-US': [
+        u'firefox-os-support-forum-contributors-training',
+        u'firefox-android-support-forum-contributors',
+        u'firefox-support-forum-contributors',
+        u'introduction-contributor-quality-training',
+        u'angry-user-training',
+        u'evaluating-solution-forum',
+        u'how-answer-escalated-questions',
+        u'navigate-support-forum-platform',
+        u'how-stop-firefox-making-automatic-connections',
+    ],
+    u'cs': [
+        u'jak-firefoxu-zabranit-v-automatickem-navazovani-sp',
+    ],
+    u'de': [
+        u'Firefox-baut-unaufgeforderte-Verbindungen-auf',
+    ],
+    u'it': [
+        u'firefox-connessioni-non-richieste',
+    ],
+    u'pt-BR': [
+        u'como-fazer-o-firefox-parar-de-se-conectar-automati',
+    ]
+}
+
 # Wiki configuration.
 
 # Defines products supported, categories, edit significances and

--- a/kitsune/wiki/templates/wiki/document.html
+++ b/kitsune/wiki/templates/wiki/document.html
@@ -52,7 +52,7 @@
     <article class="wiki-doc">
       {{ document_title(document) }}
       {{ document_messages(document, redirected_from) }}
-      {{ document_content(document, fallback_reason, request, settings) }}
+      {{ document_content(document, fallback_reason, request, settings, document_css_class) }}
 
     {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
     {% if share_link %}

--- a/kitsune/wiki/templates/wiki/includes/document_macros.html
+++ b/kitsune/wiki/templates/wiki/includes/document_macros.html
@@ -41,8 +41,8 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro document_content(document, fallback_reason, request, settings) -%}
-  <section id="doc-content">
+{% macro document_content(document, fallback_reason, request, settings, css_class='') -%}
+  <section id="doc-content" class="{{ css_class }}">
     {% if not fallback_reason %}
       {{ document.html|safe }}
     {% elif fallback_reason == 'no_translation' %}

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -32,7 +32,8 @@ from kitsune.sumo.redis_utils import redis_client, RedisError
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.sumo.utils import paginate, smart_int, get_next_url, truncated_json_dumps
 from kitsune.wiki.config import (
-    CATEGORIES, MAJOR_SIGNIFICANCE, TEMPLATES_CATEGORY, DOCUMENTS_PER_PAGE)
+    CATEGORIES, MAJOR_SIGNIFICANCE, TEMPLATES_CATEGORY, DOCUMENTS_PER_PAGE,
+    COLLAPSIBLE_DOCUMENTS)
 from kitsune.wiki.events import (
     EditDocumentEvent, ReviewableRevisionInLocaleEvent,
     ApproveRevisionInLocaleEvent, ApprovedOrReadyUnion,
@@ -164,6 +165,11 @@ def document(request, document_slug, template=None, document=None):
         ga_push.append(['_trackEvent', 'Incomplete L10n', 'Not Updated',
                         '%s/%s' % (doc.parent.slug, request.LANGUAGE_CODE)])
 
+    if document_slug in COLLAPSIBLE_DOCUMENTS.get(request.LANGUAGE_CODE, []):
+        document_css_class = 'collapsible'
+    else:
+        document_css_class = ''
+
     if request.MOBILE and 'minimal' in request.GET:
         template = '%sdocument-minimal.html' % template
         minimal = True
@@ -206,6 +212,7 @@ def document(request, document_slug, template=None, document=None):
         'related_products': doc.related_products.exclude(pk=product.pk),
         'ga_push': ga_push,
         'breadcrumb_items': breadcrumbs,
+        'document_css_class': document_css_class,
     }
 
     response = render(request, template, data)


### PR DESCRIPTION
This reverts the change that made all KB articles with ToCs collapse sections. This feature isn't ready. It causes real problems in the KB, and needs to bake more before we can put it back.

This reverts commit 130d08ab0930aeadb133918f35ffa17d0eb122dc.