### PR TITLE
[bug 1164565] Fix document results in search suggest API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -80,10 +80,15 @@ With an HTTP 200, you'll get back a set of results in JSON.
    {
        "documents": [
            {
+               "id": ...                  # id of kb article
                "title": ...               # title of kb article
                "url": ...                 # url of kb article
                "slug": ...                # slug of kb article
+               "locale": ...              # locale of the article
+               "products": ...            # list of products for the article
+               "topics": ...              # list of topics for the article
                "summary": ...             # paragraph summary of kb article (plaintext)
+               "html": ...                # html of the article
            }
            ...
        ],

--- a/kitsune/search/tests/test_api.py
+++ b/kitsune/search/tests/test_api.py
@@ -222,14 +222,6 @@ class SuggestViewTests(ElasticTestCase):
         req = self.client.get(reverse('search.suggest'), {'q': 'emails', 'locale': 'fr'})
         eq_([d['slug'] for d in req.data['documents']], [d1.slug])
 
-    def test_document_fields(self):
-        self._make_document()
-        self.refresh()
-
-        req = self.client.get(reverse('search.suggest'), {'q': 'emails'})
-        eq_(len(req.data['documents']), 1)
-        eq_(sorted(req.data['documents'][0].keys()), ['slug', 'summary', 'title', 'url'])
-
     def test_serializer_fields(self):
         """Test that fields from the serializer are included."""
         self._make_question()

--- a/kitsune/wiki/api.py
+++ b/kitsune/wiki/api.py
@@ -19,10 +19,13 @@ class DocumentShortSerializer(serializers.ModelSerializer):
 
 
 class DocumentDetailSerializer(DocumentShortSerializer):
+    summary = serializers.CharField(source='summary', read_only=True)
+    url = serializers.CharField(source='get_absolute_url', read_only=True)
+
     class Meta:
         model = Document
-        fields = ('id', 'title', 'slug', 'locale', 'products', 'topics',
-                  'html')
+        fields = ('id', 'title', 'slug', 'url', 'locale', 'products', 'topics',
+                  'summary', 'html')
 
 
 class DocumentList(LocaleNegotiationMixin, generics.ListAPIView):

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -325,6 +325,12 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
         return self.current_revision.content_parsed
 
     @property
+    def summary(self):
+        if not self.current_revision:
+            return ''
+        return self.current_revision.summary
+
+    @property
     def language(self):
         return settings.LANGUAGES_DICT[self.locale.lower()]
 
@@ -720,8 +726,8 @@ class DocumentMappingType(SearchMappingType):
         d['document_is_archived'] = obj.is_archived
         d['document_display_order'] = obj.original.display_order
 
+        d['document_summary'] = obj.summary
         if obj.current_revision is not None:
-            d['document_summary'] = obj.current_revision.summary
             d['document_keywords'] = obj.current_revision.keywords
             d['updated'] = int(time.mktime(
                 obj.current_revision.created.timetuple()))


### PR DESCRIPTION
This switches document results to use DocumentDetailSerializer. It also
fixes DocumentDetailSerializer to include the document summary which is
on the current revision and the document url.

r?