### PR TITLE
[Bug 1164972] Makes Kbox overlay on top of scrollmenu in SUMO.

### DIFF
--- a/kitsune/sumo/static/less/main.less
+++ b/kitsune/sumo/static/less/main.less
@@ -106,7 +106,7 @@ body {
       position: fixed;
       top: 0;
       width: 100%;
-      z-index: 9999;
+      z-index: 97;
 
       .logo {
         left: 0;


### PR DESCRIPTION
Makes the kbox model on top of scroll menu in SUMO.

Kbox has z-index of 98, so I change the z-index value of scroll menu to be 97

How is the menu now
![screenshot from 2015-05-15 00 28 08](https://cloud.githubusercontent.com/assets/1151263/7639580/b5327e64-fa9a-11e4-8ae8-c94ef3ae4d62.png)

After Changing Z-index
![screenshot from 2015-05-15 00 27 45](https://cloud.githubusercontent.com/assets/1151263/7639593/d4fce7c0-fa9a-11e4-8a9e-abc3e13eb587.png)
