### PR TITLE
[Bug 1159120] Dont show warning to the contributor

### DIFF
--- a/kitsune/questions/templates/questions/question_details.html
+++ b/kitsune/questions/templates/questions/question_details.html
@@ -30,7 +30,7 @@
 {% block above_main %}
   <h1>{{ _('Support Forum') }}</h1>
 
-  {% if question.is_taken %}
+  {% if question.is_taken and question.taken_by != request.user %}
     <div class="taken-notice">
       {{ _('{user} is currently working on this problem.')|f(user=question.taken_by) }}
       <a href="#question-reply">{{ _('Post a reply') }}</a> |


### PR DESCRIPTION
Bug 1159120 - Contributor should not see that they are working on a thread
This patch will make insure that if the user is working on the question, the Warning will not show
r?