### PR TITLE
Fix remove button on AoA tweets loaded through infinite scroll.

### DIFF
--- a/kitsune/customercare/tests/test_views.py
+++ b/kitsune/customercare/tests/test_views.py
@@ -109,12 +109,15 @@ class TweetListTests(TestCase):
             {'id': tw.tweet_id})
         eq_(r.status_code, 418)  # Don't tell a teapot to brew coffee.
 
+
+class MoreTweetsTests(TestCase):
+
     def test_remove_in_infinite_scroll(self):
-        max_id = max(t['id'] for t in _get_tweets())
+        tw = tweet(save=True)
 
         req = RequestFactory().get(
             reverse('customercare.more_tweets', locale='en-US'),
-            {'max_id': max_id + 1})
+            {'max_id': tw.id + 1})
         req.session = {}
         req.twitter = Mock()
         req.twitter.authed = True
@@ -124,7 +127,7 @@ class TweetListTests(TestCase):
         res = more_tweets(req)
         eq_(res.status_code, 200)
         doc = pq(res.content)
-        assert len(doc('.results-user')) > 0
+        eq_(len(doc('.results-user')), 1)
 
 
 class CountTests(TestCase):

--- a/kitsune/customercare/views.py
+++ b/kitsune/customercare/views.py
@@ -113,6 +113,7 @@ def _count_answered_tweets(since=None):
     return q.count()
 
 
+# @ssl_required
 @require_GET
 def more_tweets(request):
     """AJAX view returning a list of tweets."""

--- a/kitsune/customercare/views.py
+++ b/kitsune/customercare/views.py
@@ -126,7 +126,9 @@ def more_tweets(request):
             locale=request.LANGUAGE_CODE,
             max_id=max_id,
             filter=filter,
-            https=request.is_secure())})
+            https=request.is_secure()),
+        'authed': request.user.is_authenticated() and request.twitter.authed,
+    })
 
 
 @ssl_required


### PR DESCRIPTION
The `authed` variable is used in the template to make sure that the user should be allowed to see the button, but it wasn't being included in the infinite scroll view.

r?