### PR TITLE
[Bug 1166489] Fix links in welcome emails to contributors.

### DIFF
--- a/kitsune/community/templates/community/email/first_answer.html
+++ b/kitsune/community/templates/community/email/first_answer.html
@@ -23,7 +23,7 @@
   <p><strong>{{ _('Tell us about yourself!') }}</strong></p>
 
   <p>
-    {% trans intro_url='https://' + host + '/forums/contributors', irc_url='https://client01.chat.mibbit.com/?server=irc.mozilla.org&channel=#sumo' %}
+    {% trans intro_url='/forums/contributors', irc_url='https://client01.chat.mibbit.com/?server=irc.mozilla.org&channel=#sumo' %}
       We are always very happy to hear from new people who like helping
       on the forums so if you haven’t met our community yet
       <a href="{{ intro_url }}">
@@ -40,7 +40,7 @@
   <p><strong>{{ _('Learn new things') }}</strong></p>
 
   <p>
-    {% trans training_url='https://' + host + '/kb/introduction-contributor-quality-training?utm_source=training&utm_medium=1intro&utm_term=cqt&utm_campaign=Contributorqualitytraining' %}
+    {% trans training_url='/kb/introduction-contributor-quality-training?utm_source=training&utm_medium=1intro&utm_term=cqt&utm_campaign=Contributorqualitytraining' %}
       If you are interested in learning more about how this whole support
       thing works, check out our
       <a href="{{ training_url }}">
@@ -54,7 +54,7 @@
   <p><strong>{{ _('Stay in touch') }}</strong></p>
 
   <p>
-    {% trans forums_url='https://' + host + '/forums/contributors', blog_url='http://blog.mozilla.org/sumo/', twitter_url='http://twitter.com/sumo_mozilla', meetings_url='https://wiki.mozilla.org/Support/Weekly_Meetings' %}
+    {% trans forums_url='/forums/contributors', blog_url='http://blog.mozilla.org/sumo/', twitter_url='http://twitter.com/sumo_mozilla', meetings_url='https://wiki.mozilla.org/Support/Weekly_Meetings' %}
       Finally, if you want to follow all news related to SUMO, don’t
       forget about our
       <a href="{{ forums_url }}">community forums</a>,

--- a/kitsune/community/templates/community/email/first_answer.html
+++ b/kitsune/community/templates/community/email/first_answer.html
@@ -23,7 +23,7 @@
   <p><strong>{{ _('Tell us about yourself!') }}</strong></p>
 
   <p>
-    {% trans intro_url=host + '/en-US/forums/contributors', irc_url='https://client01.chat.mibbit.com/?server=irc.mozilla.org&channel=#sumo' %}
+    {% trans intro_url='https://' + host + '/forums/contributors', irc_url='https://client01.chat.mibbit.com/?server=irc.mozilla.org&channel=#sumo' %}
       We are always very happy to hear from new people who like helping
       on the forums so if you haven’t met our community yet
       <a href="{{ intro_url }}">
@@ -40,7 +40,7 @@
   <p><strong>{{ _('Learn new things') }}</strong></p>
 
   <p>
-    {% trans training_url=host + '/en-US/kb/introduction-contributor-quality-training?utm_source=training&utm_medium=1intro&utm_term=cqt&utm_campaign=Contributorqualitytraining' %}
+    {% trans training_url='https://' + host + '/kb/introduction-contributor-quality-training?utm_source=training&utm_medium=1intro&utm_term=cqt&utm_campaign=Contributorqualitytraining' %}
       If you are interested in learning more about how this whole support
       thing works, check out our
       <a href="{{ training_url }}">
@@ -54,7 +54,7 @@
   <p><strong>{{ _('Stay in touch') }}</strong></p>
 
   <p>
-    {% trans forums_url=host + '/forums/contributors', blog_url='http://blog.mozilla.org/sumo/', twitter_url='http://twitter.com/sumo_mozilla', meetings_url='https://wiki.mozilla.org/Support/Weekly_Meetings' %}
+    {% trans forums_url='https://' + host + '/forums/contributors', blog_url='http://blog.mozilla.org/sumo/', twitter_url='http://twitter.com/sumo_mozilla', meetings_url='https://wiki.mozilla.org/Support/Weekly_Meetings' %}
       Finally, if you want to follow all news related to SUMO, don’t
       forget about our
       <a href="{{ forums_url }}">community forums</a>,

--- a/kitsune/community/templates/community/email/first_answer.ltxt
+++ b/kitsune/community/templates/community/email/first_answer.ltxt
@@ -24,10 +24,10 @@ yourself. If you want to stay low-profile, that’s also ok :). You can also fin
 us all hanging out on IRC, on the #sumo channel on irc.mozilla.org.
 {% endtrans %}
 
-* Introductions - {{ host }}/en-US/forums/contributors
+* Introductions - https://{{ host }}/forums/contributors
 * IRC - https://www.mibbit.com/?server=irc.mozilla.org&channel=#sumo
 
-{% trans url='https://support.mozilla.org/en-US/forums/contributors' %}
+{% trans url='https://{{ host }}/forums/contributors' %}
 The community forum is at {{ url }} .
 {% endtrans %}
 
@@ -40,7 +40,7 @@ works, check out our contributor training. This includes some cool
 troubleshooting info, guidelines, how-to questions, and info about where to
 find more help if stuck.
 {% endtrans %}
-https://support.mozilla.org/en-US/kb/introduction-contributor-quality-training
+https://{{ host }}/kb/introduction-contributor-quality-training
 
 ---
 {{ _('Stay in touch') }}
@@ -49,7 +49,7 @@ https://support.mozilla.org/en-US/kb/introduction-contributor-quality-training
 Finally, if you want to follow all news related to SUMO, don’t forget about our
 {% endtrans %}
 
-* {{ _('Community forums') }} - {{ host }}/forums/contributors
+* {{ _('Community forums') }} - https://{{ host }}/forums/contributors
 * {{ _('Official blog') }} - http://blog.mozilla.org/sumo/
 * {{ _('Twitter account') }} - http://twitter.com/sumo_mozilla
 * {{ _('Weekly meetings') }} - https://wiki.mozilla.org/Support/Weekly_Meetings

--- a/kitsune/community/templates/community/email/first_l10n.html
+++ b/kitsune/community/templates/community/email/first_l10n.html
@@ -20,7 +20,7 @@
   <p><strong>Team up</strong></p>
   <p>
     It’s always a good idea to get in touch with your Locale Leaders.
-    <a href="https://support.mozilla.org/kb/locales">
+    <a href="https://{{ host }}/kb/locales">
         You can find them clicking your language’s name in this list
     </a>.
     Send them a Private Message - they are there to help you help others
@@ -30,7 +30,7 @@
   <p>
     If you want to get in touch with other people localizing SUMO in your
     language,
-    <a href="https://support.mozilla.org/forums/l10n-forum/711196?last=64679">
+    <a href="https://{{ host }}/forums/l10n-forum/711196?last=64679">
       go to our l10n forums
     </a>.
     You can also find people hanging out on IRC at
@@ -46,7 +46,7 @@
   <p><strong>Stay in touch</strong></p>
   <p>
     Finally, if you want to follow all news related to SUMO, don’t forget about
-    <a href="https://support.mozilla.org/forums/contributors">
+    <a href="https://{{ host }}/forums/contributors">
       our community forums
     </a>,
     <a href="http://blog.mozilla.org/sumo/">
@@ -67,7 +67,7 @@
   <p>
     So, now that you know how easy it is to improve our community-powered
     support wiki in your language, why not
-    <a href="https://support.mozilla.org/localization">
+    <a href="https://{{ host }}/localization">
       localize another article
     </a>?
   </p>

--- a/kitsune/community/templates/community/email/first_l10n.html
+++ b/kitsune/community/templates/community/email/first_l10n.html
@@ -20,7 +20,7 @@
   <p><strong>Team up</strong></p>
   <p>
     It’s always a good idea to get in touch with your Locale Leaders.
-    <a href="https://{{ host }}/kb/locales">
+    <a href="/locales">
         You can find them clicking your language’s name in this list
     </a>.
     Send them a Private Message - they are there to help you help others
@@ -30,7 +30,7 @@
   <p>
     If you want to get in touch with other people localizing SUMO in your
     language,
-    <a href="https://{{ host }}/forums/l10n-forum/711196?last=64679">
+    <a href="/forums/l10n-forum/711196?last=64679">
       go to our l10n forums
     </a>.
     You can also find people hanging out on IRC at
@@ -46,7 +46,7 @@
   <p><strong>Stay in touch</strong></p>
   <p>
     Finally, if you want to follow all news related to SUMO, don’t forget about
-    <a href="https://{{ host }}/forums/contributors">
+    <a href="/forums/contributors">
       our community forums
     </a>,
     <a href="http://blog.mozilla.org/sumo/">
@@ -67,7 +67,7 @@
   <p>
     So, now that you know how easy it is to improve our community-powered
     support wiki in your language, why not
-    <a href="https://{{ host }}/localization">
+    <a href="/localization">
       localize another article
     </a>?
   </p>

--- a/kitsune/community/templates/community/email/first_l10n.ltxt
+++ b/kitsune/community/templates/community/email/first_l10n.ltxt
@@ -19,12 +19,12 @@ them clicking your language’s name on the locale page, linked below Send them
 a Private Message - they are there to help you help others through your
 localizing skills!
 
-* Locale Page - https://support.mozilla.org/kb/locales
+* Locale Page - https://{{ host }}/kb/locales
 
 If you want to get in touch with other people localizing SUMO in your language
 you can check out the forums or our IRC channels.
 
-* L10n forums - https://support.mozilla.org/forums/l10n-forum/711196?last=64679
+* L10n forums - https://{{ host }}/forums/l10n-forum/711196?last=64679
 * L10n IRC channel - https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo-l10ns
 * General SUMO IRC channel - https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo
 
@@ -33,7 +33,7 @@ Stay in touch
 
 Finally, if you want to follow all news related to SUMO, don’t forget about our
 
-* Community forums - {{ host }}/forums/contributors
+* Community forums - https://{{ host }}/forums/contributors
 * Official blog - http://blog.mozilla.org/sumo/
 * Twitter account - http://twitter.com/sumo_mozilla
 * Weekly meetings - https://wiki.mozilla.org/Support/Weekly_Meetings
@@ -44,7 +44,7 @@ Keep rocking
 So, now that you know how easy it is to improve our community-powered support
 wiki in your language, why not localize another article?
 
-* Localization dashboard: https://support.mozilla.org/localization
+* Localization dashboard: https://{{ host }}/localization
 localize another article
 
 Thank you once more. We are looking forward to seeing you more often

--- a/kitsune/community/tests/test_cron.py
+++ b/kitsune/community/tests/test_cron.py
@@ -2,8 +2,10 @@ from datetime import datetime, timedelta
 
 from django.core import mail
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from django.test.utils import override_settings
 
+import mock
 from nose.tools import eq_
 
 from kitsune.community import cron
@@ -15,7 +17,10 @@ from kitsune.wiki.tests import document, revision
 
 class WelcomeEmailsTests(TestCase):
 
-    def test_answer_welcome_email(self):
+    @mock.patch.object(Site.objects, 'get_current')
+    def test_answer_welcome_email(self, get_current):
+        get_current.return_value.domain = 'testserver'
+
         u1 = profile().user
         u2 = profile(first_answer_email_sent=True).user
         u3 = profile().user
@@ -39,12 +44,24 @@ class WelcomeEmailsTests(TestCase):
         eq_(len(mail.outbox), 1)
         attrs_eq(mail.outbox[0], to=[u3.email])
 
+        # Links should be locale-neutral
+        assert 'en-US' not in mail.outbox[0].body
+
+        # Check that no links used the wrong host.
+        assert 'support.mozilla.org' not in mail.outbox[0].body
+        # Check that one link used the right host.
+        assert 'https://testserver/forums/contributors' in mail.outbox[0].body
+        # Assumption: links will be done consistently, and so this is enough testing.
+
         # u3's flag should now be set.
         u3 = User.objects.get(id=u3.id)
         eq_(u3.profile.first_answer_email_sent, True)
 
     @override_settings(WIKI_DEFAULT_LANGUAGE='en-US')
-    def test_l10n_welcome_email(self):
+    @mock.patch.object(Site.objects, 'get_current')
+    def test_l10n_welcome_email(self, get_current):
+        get_current.return_value.domain = 'testserver'
+
         u1 = profile().user
         u2 = profile(first_l10n_email_sent=True).user
 
@@ -64,6 +81,15 @@ class WelcomeEmailsTests(TestCase):
 
         eq_(len(mail.outbox), 1)
         attrs_eq(mail.outbox[0], to=[u1.email])
+
+        # Links should be locale-neutral
+        assert 'en-US' not in mail.outbox[0].body
+
+        # Check that no links used the wrong host.
+        assert 'support.mozilla.org' not in mail.outbox[0].body
+        # Check that one link used the right host.
+        assert 'https://testserver/kb/locales' in mail.outbox[0].body
+        # Assumption: links will be done consistently, and so this is enough testing.
 
         # u3's flag should now be set.
         u1 = User.objects.get(id=u1.id)


### PR DESCRIPTION
This seemed pretty important, so I pulled it into the current sprint to work on. I messed up the links in the urls, and it ended up making links like 'https://support.mozilla.org/support.mozilla.org/en-US/foo'. That's bad. So I fixed it, and I added some mediocre tests for it.

r?