### PR TITLE
[Bug 1166021] Clear out static files between builds.

### DIFF
--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -46,6 +46,7 @@ def update_locales(ctx):
 @task
 def update_assets(ctx):
     with ctx.lcd(settings.SRC_DIR):
+        ctx.local("git clean -fxd -- static")
         ctx.local("python2.7 manage.py nunjucks_precompile")
         ctx.local("./node_modules/.bin/bower install --allow-root")
         ctx.local("python2.7 manage.py collectstatic --noinput")


### PR DESCRIPTION
This resolves a problem with new version of Bower files not being picked up.

I'm not sure if this is the fault of Pipeline, or Django's static system, or some other bibs and bobs, but I know that nuking it all fixes the problem. Plus, this means we are rebuilding more of our deployments everytime, which moves us closer to immutable deploys, so yay!

This uses git clean instead of a simple rm because we keep two .htaccess files in the static/ file that are tracked by git. git clean won't remove those.

r?