### PR TITLE
[Bug 1166090] Document template properties validation 

### DIFF
--- a/kitsune/dashboards/tests/test_readouts.py
+++ b/kitsune/dashboards/tests/test_readouts.py
@@ -595,7 +595,6 @@ class TemplateTranslationsTests(ReadoutTestCase):
         """Test the product filtering of the readout."""
         p = product(title='Firefox', slug='firefox', save=True)
         d = TemplateDocumentFactory()
-        d = document(title='Template:test', category=TEMPLATES_CATEGORY, save=True)
         ApprovedRevisionFactory(document=d, is_ready_for_localization=True)
 
         # There shouldn't be any rows yet.

--- a/kitsune/dashboards/tests/test_readouts.py
+++ b/kitsune/dashboards/tests/test_readouts.py
@@ -90,7 +90,7 @@ class L10NOverviewTests(TestCase):
     def test_counting_unready_docs(self):
         """Docs without a ready-for-l10n rev shouldn't count in total."""
         # Make a doc with an approved but not-ready-for-l10n rev:
-        d = TemplateDocumentFactory(is_localizable=True)
+        d = DocumentFactory(is_localizable=True)
         r = ApprovedRevisionFactory(document=d, is_ready_for_localization=False)
 
         # It shouldn't show up in the total:

--- a/kitsune/dashboards/tests/test_readouts.py
+++ b/kitsune/dashboards/tests/test_readouts.py
@@ -17,10 +17,11 @@ from kitsune.dashboards.readouts import (
 from kitsune.products.tests import product
 from kitsune.sumo.tests import TestCase
 from kitsune.wiki.config import (
-    MAJOR_SIGNIFICANCE, MEDIUM_SIGNIFICANCE, TYPO_SIGNIFICANCE,
-    HOW_TO_CONTRIBUTE_CATEGORY, ADMINISTRATION_CATEGORY,
-    CANNED_RESPONSES_CATEGORY)
-from kitsune.wiki.tests import revision, translated_revision, document
+    MAJOR_SIGNIFICANCE, MEDIUM_SIGNIFICANCE, TYPO_SIGNIFICANCE, HOW_TO_CONTRIBUTE_CATEGORY,
+    ADMINISTRATION_CATEGORY, CANNED_RESPONSES_CATEGORY, TEMPLATES_CATEGORY)
+from kitsune.wiki.tests import (
+    revision, translated_revision, document,
+    DocumentFactory, RevisionFactory, TemplateDocumentFactory, ApprovedRevisionFactory)
 
 
 class MockRequest(object):
@@ -76,13 +77,8 @@ class L10NOverviewTests(TestCase):
     def test_counting_unready_templates(self):
         """Templates without a ready-for-l10n rev don't count"""
         # Make a template with an approved but not-ready-for-l10n rev:
-        r = revision(document=document(title='Template:smoo',
-                                       is_localizable=True,
-                                       is_template=True,
-                                       save=True),
-                     is_ready_for_localization=False,
-                     is_approved=True,
-                     save=True)
+        d = TemplateDocumentFactory(is_localizable=True)
+        r = ApprovedRevisionFactory(document=d, is_ready_for_localization=False)
 
         # It shouldn't show up in the total:
         eq_(0, l10n_overview_rows('de')['templates']['denominator'])
@@ -94,12 +90,8 @@ class L10NOverviewTests(TestCase):
     def test_counting_unready_docs(self):
         """Docs without a ready-for-l10n rev shouldn't count in total."""
         # Make a doc with an approved but not-ready-for-l10n rev:
-        r = revision(document=document(title='smoo',
-                                       is_localizable=True,
-                                       save=True),
-                     is_ready_for_localization=False,
-                     is_approved=True,
-                     save=True)
+        d = TemplateDocumentFactory(is_localizable=True)
+        r = ApprovedRevisionFactory(document=d, is_ready_for_localization=False)
 
         # It shouldn't show up in the total:
         eq_(0, l10n_overview_rows('de')['all']['denominator'])
@@ -138,7 +130,9 @@ class L10NOverviewTests(TestCase):
         eq_(1, l10n_overview_rows('de')['all']['denominator'])
 
         t.document.parent.title = t.document.title = 'Template:thing'
-        t.document.parent.is_template = t.document.is_template = True
+        t.document.parent.category = TEMPLATES_CATEGORY
+        # is_template will be automatically set for both templates, and so will
+        # the child document's category.
         t.document.parent.save()
         t.document.save()
         # ...but not when it's a template:
@@ -229,6 +223,7 @@ class L10NOverviewTests(TestCase):
         # Update the parent and translation to be a template
         d = t.document.parent
         d.title = 'Template:Lorem Ipsum Dolor'
+        d.category = TEMPLATES_CATEGORY
         d.save()
         t.document.title = 'Template:Lorem Ipsum Dolor'
         t.document.save()
@@ -350,14 +345,10 @@ class TemplateTests(ReadoutTestCase):
         locale = settings.WIKI_DEFAULT_LANGUAGE
         p = product(title='Firefox', slug='firefox', save=True)
 
-        d = document(save=True)
-        t = document(title='Template:test', save=True)
-
-        revision(document=d, is_approved=True, save=True)
-        revision(document=t, is_approved=True, save=True)
-
-        d.products.add(p)
-        t.products.add(p)
+        d = DocumentFactory(products=[p])
+        t = TemplateDocumentFactory(products=[p])
+        ApprovedRevisionFactory(document=d)
+        ApprovedRevisionFactory(document=TemplateDocumentFactory())
 
         eq_(1, len(self.rows(locale=locale, product=p)))
         eq_(t.title, self.row(locale=locale, product=p)['title'])
@@ -366,8 +357,8 @@ class TemplateTests(ReadoutTestCase):
     def test_needs_changes(self):
         """Test status for article that needs changes"""
         locale = settings.WIKI_DEFAULT_LANGUAGE
-        d = document(title='Template:test', needs_change=True, save=True)
-        revision(document=d, is_approved=True, save=True)
+        d = TemplateDocumentFactory(needs_change=True)
+        ApprovedRevisionFactory(document=d)
 
         row = self.row(locale=locale)
 
@@ -377,8 +368,8 @@ class TemplateTests(ReadoutTestCase):
     def test_needs_review(self):
         """Test status for article that needs review"""
         locale = settings.WIKI_DEFAULT_LANGUAGE
-        d = document(title='Template:test', save=True)
-        revision(document=d, save=True)
+        d = TemplateDocumentFactory()
+        RevisionFactory(document=d)
 
         row = self.row(locale=locale)
 
@@ -388,10 +379,10 @@ class TemplateTests(ReadoutTestCase):
     def test_unready_for_l10n(self):
         """Test status for article that is not ready for l10n"""
         locale = settings.WIKI_DEFAULT_LANGUAGE
-        d = document(title='Template:test', save=True)
-        revision(document=d, is_ready_for_localization=True, save=True)
-        revision(document=d, is_ready_for_localization=False, is_approved=True,
-                 significance=MAJOR_SIGNIFICANCE, save=True)
+        d = TemplateDocumentFactory()
+        RevisionFactory(document=d, is_ready_for_localization=True)
+        ApprovedRevisionFactory(
+            document=d, is_ready_for_localization=False, significance=MAJOR_SIGNIFICANCE)
 
         row = self.row(locale=locale)
 
@@ -594,11 +585,8 @@ class TemplateTranslationsTests(ReadoutTestCase):
 
     def test_untranslated(self):
         """Assert untranslated templates are labeled as such."""
-        d = document(title='Template:test', save=True)
-        untranslated = revision(is_approved=True,
-                                is_ready_for_localization=True,
-                                document=d,
-                                save=True)
+        d = TemplateDocumentFactory()
+        untranslated = ApprovedRevisionFactory(document=d, is_ready_for_localization=True)
         row = self.row()
         eq_(row['title'], untranslated.document.title)
         eq_(unicode(row['status']), 'Translation Needed')
@@ -606,11 +594,9 @@ class TemplateTranslationsTests(ReadoutTestCase):
     def test_by_product(self):
         """Test the product filtering of the readout."""
         p = product(title='Firefox', slug='firefox', save=True)
-        d = document(title='Template:test', save=True)
-        revision(is_approved=True,
-                 is_ready_for_localization=True,
-                 document=d,
-                 save=True)
+        d = TemplateDocumentFactory()
+        d = document(title='Template:test', category=TEMPLATES_CATEGORY, save=True)
+        ApprovedRevisionFactory(document=d, is_ready_for_localization=True)
 
         # There shouldn't be any rows yet.
         eq_(0, len(self.rows(product=p)))

--- a/kitsune/sumo/migrations/__init__.py
+++ b/kitsune/sumo/migrations/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import sys
 
 
 class MigrationStatusPrinter(object):
@@ -21,6 +22,9 @@ class MigrationStatusPrinter(object):
         self.printed_yet = False
 
     def info(self, msg, *args, **kwargs):
+        if 'test' in sys.argv:
+            return
+
         if not self.printed_yet:
             print('\n   ', end='')
             self.printed_yet = True

--- a/kitsune/sumo/tests/test_parser.py
+++ b/kitsune/sumo/tests/test_parser.py
@@ -23,9 +23,9 @@ def pq_img(p, text, selector='img', locale=settings.WIKI_DEFAULT_LANGUAGE):
     return doc(selector)
 
 
-def doc_rev_parser(content, title='Installing Firefox', parser_cls=WikiParser):
+def doc_rev_parser(content, title='Installing Firefox', parser_cls=WikiParser, **kwargs):
     p = parser_cls()
-    d = document(title=title)
+    d = document(title=title, **kwargs)
     d.save()
     r = revision(document=d, content=content, is_approved=True)
     r.save()

--- a/kitsune/users/migrations/0005_set_initial_contrib_email_flag.py
+++ b/kitsune/users/migrations/0005_set_initial_contrib_email_flag.py
@@ -36,10 +36,9 @@ def contrib_email_flags_forwards(apps, schema_editor):
         .filter(user__id__in=answer_contributor_ids)
         .update(first_answer_email_sent=True))
 
-    if '--test' not in sys.argv:
-        status = MigrationStatusPrinter()
-        status.info('set first_l10n_email_sent on {0} profiles.', len(l10n_contributor_ids))
-        status.info('set first_answer_email_sent on {0} profiles.', len(answer_contributor_ids))
+    status = MigrationStatusPrinter()
+    status.info('set first_l10n_email_sent on {0} profiles.', len(l10n_contributor_ids))
+    status.info('set first_answer_email_sent on {0} profiles.', len(answer_contributor_ids))
 
 
 def contrib_email_flags_backwards(apps, schema_editor):

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -329,16 +329,17 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
             if name in ('slug', 'title') and hasattr(self, name):
                 old_name = 'old_' + name
                 if not hasattr(self, old_name):
-                    prefix = TEMPLATE_TITLE_PREFIX
-                    # Two cases here:
-                    # 1. Normal articles are compared cse-insensitively
-                    # 2. Articles that have a changed title are checked
+                    # Normal articles are compared case-insensitively
+                    if getattr(self, name).lower() != value.lower():
+                        setattr(self, old_name, getattr(self, name))
+
+                    # Articles that have a changed title are checked
                     # case-sensitively for the title prefix changing.
-                    if (getattr(self, name).lower() != value.lower() or
-                            (name == 'title' and
-                             (self.title.startswith(prefix) != value.startswith(prefix)))):
+                    ttp = TEMPLATE_TITLE_PREFIX
+                    if name == 'title' and self.title.startswith(ttp) != value.startswith(ttp):
                         # Save original value:
                         setattr(self, old_name, getattr(self, name))
+
                 elif value == getattr(self, old_name):
                     # They changed the attr back to its original value.
                     delattr(self, old_name)

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -162,6 +162,7 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
         """Translations can't be localizable."""
         self._clean_is_localizable()
         self._clean_category()
+        self._clean_template_status()
         self._ensure_inherited_attr('is_archived')
 
     def _clean_is_localizable(self):
@@ -209,14 +210,29 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
                 self.translations.all().update(**{attr: getattr(self, attr)})
 
     def _clean_category(self):
-        """Make sure a doc's category is the same as its parent's."""
+        """Make sure a doc's category is valid."""
         if (not self.parent and
                 self.category not in (id for id, name in CATEGORIES)):
             # All we really need to do here is make sure category != '' (which
             # is what it is when it's missing from the DocumentForm). The extra
             # validation is just a nicety.
             raise ValidationError(_('Please choose a category.'))
+
         self._ensure_inherited_attr('category')
+
+    def _clean_template_status(self):
+        if (self.category == TEMPLATES_CATEGORY and
+                not self.title.startswith(TEMPLATE_TITLE_PREFIX)):
+            # L10n: Note, do not translate "Template:" in this string.
+            raise ValidationError(_(u'Documents in the Template category must have titles that '
+                                    u'start with "Template:". (Current title is "{}")'
+                                    .format(self.title)))
+
+        if self.title.startswith(TEMPLATE_TITLE_PREFIX) and self.category != TEMPLATES_CATEGORY:
+            # L10n: Note, do not translate "Template:" in this string.
+            raise ValidationError(_(u'Documents with titles that start with "Template:" must be '
+                                    u'in the templates category. (Current category is "{}")'
+                                    .format(self.get_category_display())))
 
     def _attr_for_redirect(self, attr, template):
         """Return the slug or title for a new redirect.
@@ -263,39 +279,53 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
         # which would cause a rollback, which would negate any category changes
         # we make here, so don't worry:
         self._clean_category()
+        self._clean_template_status()
 
         slug_changed = hasattr(self, 'old_slug')
         title_changed = hasattr(self, 'old_title')
 
-        # If the slug changed, we clear out the share link so it gets regenerated.
-        self.share_link = ''
+        templateness_changed = (
+            title_changed and
+            # If the title was a template before, and is not now, or vice-versa
+            (self.title.startswith(TEMPLATE_TITLE_PREFIX) !=
+             self.old_title.startswith(TEMPLATE_TITLE_PREFIX)))
+
+        if slug_changed:
+            # Clear out the share link so it gets regenerated.
+            self.share_link = ''
 
         super(Document, self).save(*args, **kwargs)
 
         # Make redirects if there's an approved revision and title or slug
         # changed. Allowing redirects for unapproved docs would (1) be of
         # limited use and (2) require making Revision.creator nullable.
-        if self.current_revision and (slug_changed or title_changed):
+        #
+        # If the "templateness" changed, don't try and make a redirect.
+        # The category and the title-prefix have to stay consistent, and
+        # redirects are in the same category as their targets. There is not
+        # a clear way to construct the redirect without invalidating one of
+        # those conditions.
+        if self.current_revision and (slug_changed or title_changed) and not templateness_changed:
             try:
-                doc = Document.objects.create(locale=self.locale,
-                                              title=self._attr_for_redirect(
-                                                  'title', REDIRECT_TITLE),
-                                              slug=self._attr_for_redirect(
-                                                  'slug', REDIRECT_SLUG),
-                                              category=self.category,
-                                              is_localizable=False)
-                Revision.objects.create(document=doc,
-                                        content=REDIRECT_CONTENT % self.title,
-                                        is_approved=True,
-                                        reviewer=self.current_revision.creator,
-                                        creator=self.current_revision.creator)
+                doc = Document.objects.create(
+                    locale=self.locale,
+                    title=self._attr_for_redirect('title', REDIRECT_TITLE),
+                    slug=self._attr_for_redirect('slug', REDIRECT_SLUG),
+                    category=self.category,
+                    is_localizable=False)
+                Revision.objects.create(
+                    document=doc,
+                    content=REDIRECT_CONTENT % self.title,
+                    is_approved=True,
+                    reviewer=self.current_revision.creator,
+                    creator=self.current_revision.creator)
             except TitleCollision:
                 pass
 
-            if slug_changed:
-                del self.old_slug
-            if title_changed:
-                del self.old_title
+        if slug_changed:
+            del self.old_slug
+        if title_changed:
+            del self.old_title
 
         self.parse_and_calculate_links()
         self.clear_cached_html()
@@ -418,8 +448,8 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
                 # changing to (or staying within) a specific locale.
                 full_url = anchors[0].get('href')
                 (dest_locale, url) = split_path(full_url)
-                if (source_locale != dest_locale
-                        and dest_locale == settings.LANGUAGE_CODE):
+                if (source_locale != dest_locale and
+                        dest_locale == settings.LANGUAGE_CODE):
                     return '/' + source_locale + '/' + url
                 return full_url
 

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -223,16 +223,15 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
     def _clean_template_status(self):
         if (self.category == TEMPLATES_CATEGORY and
                 not self.title.startswith(TEMPLATE_TITLE_PREFIX)):
-            # L10n: Note, do not translate "Template:" in this string.
             raise ValidationError(_(u'Documents in the Template category must have titles that '
-                                    u'start with "Template:". (Current title is "{}")'
-                                    .format(self.title)))
+                                    u'start with "{prefix}". (Current title is "{title}")')
+                                  .format(prefix=TEMPLATE_TITLE_PREFIX, title=self.title))
 
         if self.title.startswith(TEMPLATE_TITLE_PREFIX) and self.category != TEMPLATES_CATEGORY:
-            # L10n: Note, do not translate "Template:" in this string.
-            raise ValidationError(_(u'Documents with titles that start with "Template:" must be '
-                                    u'in the templates category. (Current category is "{}")'
-                                    .format(self.get_category_display())))
+            raise ValidationError(_(u'Documents with titles that start with "{prefix}" must be in '
+                                    u'the templates category. (Current category is "{category}")')
+                                  .format(prefix=TEMPLATE_TITLE_PREFIX,
+                                          category=self.get_category_display()))
 
     def _attr_for_redirect(self, attr, template):
         """Return the slug or title for a new redirect.

--- a/kitsune/wiki/tests/__init__.py
+++ b/kitsune/wiki/tests/__init__.py
@@ -27,6 +27,16 @@ class DocumentFactory(factory.DjangoModelFactory):
     title = factory.Sequence(lambda n: u'đoc-{}'.format(n))
     slug = factory.LazyAttribute(lambda o: slugify(o.title))
 
+    @factory.post_generation
+    def products(doc, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing
+            return
+
+        if extracted is not None:
+            for p in extracted:
+                doc.products.add(p)
+
 
 class TemplateDocumentFactory(DocumentFactory):
     category = TEMPLATES_CATEGORY

--- a/kitsune/wiki/tests/test_models.py
+++ b/kitsune/wiki/tests/test_models.py
@@ -13,8 +13,8 @@ from kitsune.sumo import ProgrammingError
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.wiki.config import (
-    REDIRECT_SLUG, REDIRECT_TITLE, REDIRECT_HTML, MAJOR_SIGNIFICANCE,
-    CATEGORIES, TYPO_SIGNIFICANCE, REDIRECT_CONTENT, TEMPLATES_CATEGORY)
+    REDIRECT_SLUG, REDIRECT_TITLE, REDIRECT_HTML, MAJOR_SIGNIFICANCE, CATEGORIES,
+    TYPO_SIGNIFICANCE, REDIRECT_CONTENT, TEMPLATES_CATEGORY, TEMPLATE_TITLE_PREFIX)
 from kitsune.wiki.models import Document
 from kitsune.wiki.parser import wiki_to_html
 from kitsune.wiki.tests import (
@@ -43,7 +43,7 @@ class DocumentTests(TestCase):
 
         assert not d.is_template
 
-        d.title = 'Template:test'
+        d.title = TEMPLATE_TITLE_PREFIX + 'test'
         d.category = TEMPLATES_CATEGORY
         d.save()
 
@@ -318,7 +318,7 @@ class DocumentTests(TestCase):
         d = DocumentFactory()
 
         # First, try and change just the title. It should fail.
-        d.title = 'Template:' + d.title
+        d.title = TEMPLATE_TITLE_PREFIX + d.title
         self.assertRaises(ValidationError, d.save)
 
         # Next, try and change just the category. It should also fail.
@@ -328,7 +328,7 @@ class DocumentTests(TestCase):
 
         # Finally, try and change both title and category. It should work.
         d = Document.objects.get(id=d.id)  # reset
-        d.title = 'Template:' + d.title
+        d.title = TEMPLATE_TITLE_PREFIX + d.title
         d.category = TEMPLATES_CATEGORY
         d.save()
 
@@ -358,24 +358,24 @@ class DocumentTests(TestCase):
         d_fr = DocumentFactory(parent=d_en, locale='fr')
 
         # Just changing the title isn't enough
-        d_fr.title = 'Template:' + d_fr.title
+        d_fr.title = TEMPLATE_TITLE_PREFIX + d_fr.title
         self.assertRaises(ValidationError, d_fr.save)
 
         # Trying to change the category won't work, since `d_en` will force the
         # old category.
         d_fr = Document.objects.get(id=d_fr.id)  # reset
-        d_fr.title = 'Template:' + d_fr.title
+        d_fr.title = TEMPLATE_TITLE_PREFIX + d_fr.title
         d_fr.category = TEMPLATES_CATEGORY
         self.assertRaises(ValidationError, d_fr.save)
 
         # Change the parent
-        d_en.title = 'Template:' + d_en.title
+        d_en.title = TEMPLATE_TITLE_PREFIX + d_en.title
         d_en.category = TEMPLATES_CATEGORY
         d_en.save()
 
         # Now the French article can be changed too.
         d_fr = Document.objects.get(id=d_fr.id)  # reset
-        d_fr.title = 'Template:' + d_fr.title
+        d_fr.title = TEMPLATE_TITLE_PREFIX + d_fr.title
         d_fr.category = TEMPLATES_CATEGORY
         d_fr.save()
 

--- a/kitsune/wiki/tests/test_models.py
+++ b/kitsune/wiki/tests/test_models.py
@@ -379,6 +379,22 @@ class DocumentTests(TestCase):
         d_fr.category = TEMPLATES_CATEGORY
         d_fr.save()
 
+    # It may seem like there is a missing case here. That is because
+    # there is. There is no test for changing the title and the
+    # category of a translated document at once. This action would be
+    # valid for a non-translated document. Translated documents have an
+    # additional constraint that the category of a translated document
+    # must match the category of the parent.
+    #
+    # Additionally, the UI does not provide a user any way to do this.
+    # The only way this could happen is by direct changes to the
+    # database.
+    #
+    # Due to these reasons, I've left the case of renaming and
+    # recategorizing a template undefined in the tests. If this becomes
+    # something we do in the future, we should revisit this and define
+    # the behavior in a test.
+
 
 class FromUrlTests(TestCase):
     """Tests for Document.from_url()"""

--- a/kitsune/wiki/tests/test_parser.py
+++ b/kitsune/wiki/tests/test_parser.py
@@ -9,11 +9,12 @@ import kitsune.sumo.tests.test_parser
 from kitsune.gallery.models import Video
 from kitsune.gallery.tests import image, video
 from kitsune.sumo.tests import TestCase
+from kitsune.wiki.config import TEMPLATES_CATEGORY
 from kitsune.wiki.models import Document
 from kitsune.wiki.parser import (
     WikiParser, ForParser, PATTERNS, RECURSION_MESSAGE, _key_split,
     _build_template_params as _btp, _format_template_content as _ftc)
-from kitsune.wiki.tests import document, revision
+from kitsune.wiki.tests import document, revision, TemplateDocumentFactory, ApprovedRevisionFactory
 
 
 def doc_rev_parser(*args, **kwargs):
@@ -21,9 +22,9 @@ def doc_rev_parser(*args, **kwargs):
         *args, parser_cls=WikiParser, **kwargs)
 
 
-def doc_parse_markup(content, markup, title='Template:test'):
+def doc_parse_markup(content, markup):
     """Create a doc with given content and parse given markup."""
-    _, _, p = doc_rev_parser(content, title)
+    _, _, p = doc_rev_parser(content, 'Template:test', category=TEMPLATES_CATEGORY)
     doc = pq(p.parse(markup))
     return (doc, p)
 
@@ -191,14 +192,12 @@ class TestWikiTemplate(TestCase):
     def test_template_locale(self):
         """Localized template is returned."""
         py_doc, p = doc_parse_markup('English content', '[[Template:test]]')
-        parent = document()
-        d = document(parent=parent, title='Template:test', locale='fr')
-        d.save()
-        r = revision(content='French content', document=d, is_approved=True)
-        r.save()
-        eq_('English content', py_doc.text())
+        parent = TemplateDocumentFactory()
+        d = TemplateDocumentFactory(parent=parent, title='Template:test', locale='fr')
+        ApprovedRevisionFactory(content='French Content', document=d)
+        eq_(py_doc.text(), 'English content')
         py_doc = pq(p.parse('[[T:test]]', locale='fr'))
-        eq_('French content', py_doc.text())
+        eq_(py_doc.text(), 'French Content')
 
     def test_template_not_exist(self):
         """If template does not exist in set locale or English."""
@@ -297,7 +296,7 @@ class TestWikiTemplate(TestCase):
         eq_({'1': 'a', 'hi': 'test', '3': 'z'}, _btp(['hi=test', 'a', '3=z']))
 
     def test_unapproved_template(self):
-        document(title='Template:new').save()
+        TemplateDocumentFactory(title='Template:new')
         p = WikiParser()
         doc = pq(p.parse('[[T:new]]'))
         eq_('The template "new" does not exist or has no approved revision.',
@@ -305,12 +304,8 @@ class TestWikiTemplate(TestCase):
 
     def test_for_in_template(self):
         """Verify that {for}'s render correctly in template."""
-        d = document(title='Template:for')
-        d.save()
-        r = revision(document=d,
-                     content='{for win}windows{/for}{for mac}mac{/for}')
-        r.is_approved = True
-        r.save()
+        d = TemplateDocumentFactory(title='Template:for')
+        ApprovedRevisionFactory(document=d, content='{for win}windows{/for}{for mac}mac{/for}')
         p = WikiParser()
         content = p.parse('[[Template:for]]')
         eq_('<p><span class="for" data-for="win">windows</span>'
@@ -339,30 +334,23 @@ class TestWikiTemplate(TestCase):
 
     def test_direct_recursion(self):
         """Make sure direct recursion is caught on the very first nesting."""
-        d = document(title='Template:Boo')
-        d.save()
+        d = TemplateDocumentFactory(title='Template:Boo')
 
         # Twice so the second revision sees content identical to itself:
-        for i in range(2):
-            revision(document=d, content='Fine [[Template:Boo]] Fellows',
-                     is_approved=True).save()
+        for _ in range(2):
+            ApprovedRevisionFactory(document=d, content='Fine [[Template:Boo]] Fellows')
 
         eq_('<p>Fine %s Fellows\n</p>' % (RECURSION_MESSAGE % 'Template:Boo'),
             d.content_parsed)
 
     def test_indirect_recursion(self):
         """Make sure indirect recursion is caught."""
-        boo = document(title='Template:Boo')
-        boo.save()
-        yah = document(title='Template:Yah')
-        yah.save()
-        revision(document=boo, content='Paper [[Template:Yah]] Cups',
-                 is_approved=True).save()
-        revision(document=yah, content='Wooden [[Template:Boo]] Bats',
-                 is_approved=True).save()
+        boo = TemplateDocumentFactory(title='Template:Boo')
+        yah = TemplateDocumentFactory(title='Template:Yah')
+        ApprovedRevisionFactory(document=boo, content='Paper [[Template:Yah]] Cups')
+        ApprovedRevisionFactory(document=yah, content='Wooden [[Template:Boo]] Bats')
         recursion_message = RECURSION_MESSAGE % 'Template:Boo'
-        eq_('<p>Paper Wooden %s Bats\n Cups\n</p>' % recursion_message,
-            boo.content_parsed)
+        eq_('<p>Paper Wooden %s Bats\n Cups\n</p>' % recursion_message, boo.content_parsed)
 
 
 class TestWikiInclude(TestCase):
@@ -840,7 +828,7 @@ class WhatLinksHereTests(TestCase):
         eq_([d.linked_from.title for d in d2.links_to()], ['D3'])
 
     def test_templates(self):
-        d1, _, _ = doc_rev_parser('Oh hai', title='Template:D1')
+        d1, _, _ = doc_rev_parser('Oh hai', title='Template:D1', category=TEMPLATES_CATEGORY)
         d2, _, _ = doc_rev_parser('[[Template:D1]]', title='D2')
 
         eq_(len(d1.links_to()), 1)

--- a/kitsune/wiki/tests/test_tasks.py
+++ b/kitsune/wiki/tests/test_tasks.py
@@ -15,7 +15,7 @@ from nose.tools import eq_
 
 from kitsune.sumo.tests import TestCase
 from kitsune.users.tests import add_permission, user
-from kitsune.wiki.config import TEMPLATES_CATEGORY
+from kitsune.wiki.config import TEMPLATES_CATEGORY, TEMPLATE_TITLE_PREFIX
 from kitsune.wiki.models import Revision, Document
 from kitsune.wiki.tasks import (
     send_reviewed_notification, rebuild_kb, schedule_rebuild_kb,
@@ -190,8 +190,10 @@ class TestDocumentRenderCascades(TestCaseBase):
         return re.sub(r'\s+', ' ', bleach.clean(html, strip=True)).strip()
 
     def test_cascade(self):
-        d1, _, _ = doc_rev_parser('one ', title='Template:D1', category=TEMPLATES_CATEGORY)
-        d2, _, _ = doc_rev_parser('[[T:D1]] two', title='Template:D2', category=TEMPLATES_CATEGORY)
+        d1, _, _ = doc_rev_parser(
+            'one ', title=TEMPLATE_TITLE_PREFIX + 'D1', category=TEMPLATES_CATEGORY)
+        d2, _, _ = doc_rev_parser(
+            '[[T:D1]] two', title=TEMPLATE_TITLE_PREFIX + 'D2', category=TEMPLATES_CATEGORY)
         d3, _, _ = doc_rev_parser('[[T:D1]] [[T:D2]] three', title='D3')
 
         eq_(self._clean(d3), u'one one two three')

--- a/kitsune/wiki/tests/test_tasks.py
+++ b/kitsune/wiki/tests/test_tasks.py
@@ -15,6 +15,7 @@ from nose.tools import eq_
 
 from kitsune.sumo.tests import TestCase
 from kitsune.users.tests import add_permission, user
+from kitsune.wiki.config import TEMPLATES_CATEGORY
 from kitsune.wiki.models import Revision, Document
 from kitsune.wiki.tasks import (
     send_reviewed_notification, rebuild_kb, schedule_rebuild_kb,
@@ -189,8 +190,8 @@ class TestDocumentRenderCascades(TestCaseBase):
         return re.sub(r'\s+', ' ', bleach.clean(html, strip=True)).strip()
 
     def test_cascade(self):
-        d1, _, _ = doc_rev_parser('one ', title='Template:D1')
-        d2, _, _ = doc_rev_parser('[[T:D1]] two', title='Template:D2')
+        d1, _, _ = doc_rev_parser('one ', title='Template:D1', category=TEMPLATES_CATEGORY)
+        d2, _, _ = doc_rev_parser('[[T:D1]] two', title='Template:D2', category=TEMPLATES_CATEGORY)
         d3, _, _ = doc_rev_parser('[[T:D1]] [[T:D2]] three', title='D3')
 
         eq_(self._clean(d3), u'one one two three')

--- a/kitsune/wiki/tests/test_views.py
+++ b/kitsune/wiki/tests/test_views.py
@@ -323,7 +323,7 @@ class DocumentEditingTests(TestCase):
                      'form': 'doc'})
         self.client.post(reverse('wiki.edit_document', args=[d.slug]), data)
 
-        eq_(sorted(Document.objects.get(slug=d.slug).products
+        eq_(sorted(Document.objects.get(id=d.id).products
                    .values_list('id', flat=True)),
             sorted([prod.id for prod in [prod_desktop, prod_mobile]]))
 
@@ -331,7 +331,7 @@ class DocumentEditingTests(TestCase):
                      'form': 'doc'})
         self.client.post(reverse('wiki.edit_document', args=[data['slug']]),
                          data)
-        eq_(sorted(Document.objects.get(slug=d.slug).products
+        eq_(sorted(Document.objects.get(id=d.id).products
                    .values_list('id', flat=True)),
             sorted([prod.id for prod in [prod_desktop]]))
 

--- a/kitsune/wiki/tests/test_views.py
+++ b/kitsune/wiki/tests/test_views.py
@@ -15,7 +15,8 @@ from kitsune.sumo.tests import SkipTest, TestCase, LocalizingClient, MobileTestC
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.users.tests import user, add_permission
 from kitsune.wiki.config import (
-    CATEGORIES, TEMPLATES_CATEGORY, TYPO_SIGNIFICANCE, MEDIUM_SIGNIFICANCE, MAJOR_SIGNIFICANCE)
+    CATEGORIES, TEMPLATES_CATEGORY, TYPO_SIGNIFICANCE, MEDIUM_SIGNIFICANCE, MAJOR_SIGNIFICANCE,
+    TEMPLATE_TITLE_PREFIX)
 from kitsune.wiki.models import Document, HelpfulVoteMetadata, HelpfulVote
 from kitsune.wiki.tests import (
     doc_rev, document, helpful_vote, new_document_data, revision,
@@ -287,7 +288,7 @@ class DocumentEditingTests(TestCase):
         d = TemplateDocumentFactory()
         RevisionFactory(document=d)
         eq_(d.category, TEMPLATES_CATEGORY)
-        assert d.title.startswith('Template:')
+        assert d.title.startswith(TEMPLATE_TITLE_PREFIX)
 
         # First try and change the category without also changing the title. It should fail.
         data = new_document_data()

--- a/kitsune/wiki/tests/test_views.py
+++ b/kitsune/wiki/tests/test_views.py
@@ -15,12 +15,11 @@ from kitsune.sumo.tests import SkipTest, TestCase, LocalizingClient, MobileTestC
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.users.tests import user, add_permission
 from kitsune.wiki.config import (
-    TEMPLATES_CATEGORY, TYPO_SIGNIFICANCE,
-    MEDIUM_SIGNIFICANCE, MAJOR_SIGNIFICANCE)
+    CATEGORIES, TEMPLATES_CATEGORY, TYPO_SIGNIFICANCE, MEDIUM_SIGNIFICANCE, MAJOR_SIGNIFICANCE)
 from kitsune.wiki.models import Document, HelpfulVoteMetadata, HelpfulVote
 from kitsune.wiki.tests import (
     doc_rev, document, helpful_vote, new_document_data, revision,
-    translated_revision)
+    translated_revision, TemplateDocumentFactory, RevisionFactory)
 from kitsune.wiki.views import (
     _document_lock_check, _document_lock_clear, _document_lock_steal)
 
@@ -241,7 +240,7 @@ class DocumentEditingTests(TestCase):
                      'slug': d.slug,
                      'form': 'doc'})
         self.client.post(reverse('wiki.edit_document', args=[d.slug]), data)
-        eq_(new_title, Document.objects.get(slug=d.slug).title)
+        eq_(new_title, Document.objects.get(id=d.id).title)
         assert Document.objects.get(title=old_title).redirect_url()
 
     def test_retitling_accent(self):
@@ -253,7 +252,63 @@ class DocumentEditingTests(TestCase):
                      'slug': d.slug,
                      'form': 'doc'})
         self.client.post(reverse('wiki.edit_document', args=[d.slug]), data)
-        eq_(new_title, Document.objects.get(slug=d.slug).title)
+        eq_(new_title, Document.objects.get(id=d.id).title)
+
+    def test_retitling_template(self):
+        d = TemplateDocumentFactory()
+        RevisionFactory(document=d)
+
+        old_title = d.title
+        new_title = 'Not a template'
+
+        # First try and change the title without also changing the category. It should fail.
+        data = new_document_data()
+        data.update({
+            'title': new_title,
+            'category': d.category,
+            'slug': d.slug,
+            'form': 'doc'
+        })
+        url = reverse('wiki.edit_document', args=[d.slug])
+        res = self.client.post(url, data, follow=True)
+        eq_(Document.objects.get(id=d.id).title, old_title)
+        # This message gets HTML encoded.
+        assert ('Documents in the Template category must have titles that start with '
+                '&#34;Template:&#34;.'
+                in res.content)
+
+        # Now try and change the title while also changing the category.
+        data['category'] = CATEGORIES[0][0]
+        url = reverse('wiki.edit_document', args=[d.slug])
+        self.client.post(url, data, follow=True)
+        eq_(Document.objects.get(id=d.id).title, new_title)
+
+    def test_removing_template_category(self):
+        d = TemplateDocumentFactory()
+        RevisionFactory(document=d)
+        eq_(d.category, TEMPLATES_CATEGORY)
+        assert d.title.startswith('Template:')
+
+        # First try and change the category without also changing the title. It should fail.
+        data = new_document_data()
+        data.update({
+            'title': d.title,
+            'category': CATEGORIES[0][0],
+            'slug': d.slug,
+            'form': 'doc'
+        })
+        url = reverse('wiki.edit_document', args=[d.slug])
+        res = self.client.post(url, data, follow=True)
+        eq_(Document.objects.get(id=d.id).category, TEMPLATES_CATEGORY)
+        # This message gets HTML encoded.
+        assert ('Documents with titles that start with &#34;Template:&#34; must be in the '
+                'templates category.' in res.content)
+
+        # Now try and change the title while also changing the category.
+        data['title'] = 'not a template'
+        url = reverse('wiki.edit_document', args=[d.slug])
+        self.client.post(url, data)
+        eq_(Document.objects.get(id=d.id).category, CATEGORIES[0][0])
 
     def test_changing_products(self):
         """Changing products works as expected."""
@@ -412,8 +467,8 @@ class VoteTests(TestCase):
         """
         Throw helpful_vote a document that is a template and see if it 400s.
         """
-        d = document(save=True, slug="somedoc", category=TEMPLATES_CATEGORY)
-        r = revision(save=True, document=d)
+        d = TemplateDocumentFactory()
+        r = RevisionFactory(document=d)
         response = self.client.post(reverse('wiki.document_vote', args=['hi']),
                                     {'revision_id': r.id})
         eq_(400, response.status_code)

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -390,8 +390,7 @@ def edit_document(request, document_slug, revision_id=None):
     if revision_id:
         rev = get_object_or_404(Revision, pk=revision_id, document=doc)
     else:
-        rev = doc.current_revision or doc.revisions.order_by('-created',
-                                                             '-id')[0]
+        rev = doc.current_revision or doc.revisions.order_by('-created', '-id')[0]
 
     disclose_description = bool(request.GET.get('opendescription'))
     doc_form = rev_form = None


### PR DESCRIPTION
This makes some important, but hopefully pretty straight forward changes to the Document model, and then changes a whole lot of tests to account for the model changes.

* Added FactoryBoy powered model factories. These have some niceties over model makers, and Fjord uses them too.
* Enforce that documents with a title like "Template:Foo" are in the Template category, and vice-versa.
* Update all the tests to be ok with that, generally by switching them from model makers to model Factories.
* Make renaming a template in such a way that it is no longer a template not create redirects. The automatic redirect creation logic doesn't work when templates are required to have "Template:" prefixes *and* be in the right category.

To test:

* Try and rename a template to not have the prefix (without changing the category). It should fail with a nice error message. (There is a test for this)
* Try and change the category of a template to something else (without changing the title). It should fail. (There is a test for this)
* Try and do both at once. It should work.  (There is a test for this)
* Try and do this for a localized article. This is where most of our real problems are. (I need to add a test for this).

TODO

I realized I have a few more things to do before I want to land this. But it should be ready to start review now.

* [x] Add test for localized articles.
* [x] Add tests for normal article -> templates
* [x] ~~Figure out if landing this on a DB full of title/category inconsistencies is going to be a bad idea. I suspect it will only be a problem if the document is edited, in which case it will give a nice error to a human. But maybe not? What else calls .save() on documents? Hunt these down.~~
* [x] Wait for the templates on the site to be renamed so landing this won't break everything.

(This isn't ready to merge yet, because of the above)

f?