### PR TITLE
Bumping requests to 2.5.3

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -271,8 +271,8 @@ https://github.com/getsentry/raven-python/archive/ab53d276262a0fa2932588b34de4e6
 # sha256: pKrx7rUrWH9IbMYyT2MF62gW_bVPony2JPDx0TecNP0
 https://github.com/andymccurdy/redis-py/archive/43aa23146ad287959369161038a4e5cda985a259.tar.gz#egg=redis
 
-# sha256: e3c179Ox4jI9yfzvBgs4DQX18YvQ8kf16edKYoJ53mY
-requests==2.5.1
+# sha256: Vdf1YZ2q6U7Enuge2Mhl5aKkfwu_jgbPlGNr7hA-r2U
+requests==2.5.3
 
 # sha256: ngIjuJUY7axhqXtW_3jycQVs4IyKF8a2RK7yRPrIPyM
 requests-oauthlib==0.4.2


### PR DESCRIPTION
Fixes bug with SSL in urllib3

```
Traceback (most recent call last):
  File "/home/nikola/projects/mozilla/kitsune/venv/bin/pip", line 7, in <module>
    from pip import main
  File "/home/nikola/projects/mozilla/kitsune/venv/local/lib/python2.7/site-packages/pip/__init__.py", line 11, in <module>
    from pip.vcs import git, mercurial, subversion, bazaar  # noqa
  File "/home/nikola/projects/mozilla/kitsune/venv/local/lib/python2.7/site-packages/pip/vcs/mercurial.py", line 9, in <module>
    from pip.download import path_to_url
  File "/home/nikola/projects/mozilla/kitsune/venv/local/lib/python2.7/site-packages/pip/download.py", line 22, in <module>
    from pip._vendor import requests, six
  File "/home/nikola/projects/mozilla/kitsune/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py", line 53, in <module>
    from .packages.urllib3.contrib import pyopenssl
  File "/home/nikola/projects/mozilla/kitsune/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/contrib/pyopenssl.py", line 70, in <module>
    ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD,
AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'
```