### PR TITLE
Make sure Travis is using npm lockdown

### DIFF
--- a/lockdown.json
+++ b/lockdown.json
@@ -4,14 +4,14 @@
   },
   "JSONStream": {
     "0.10.0": "74349d0d89522b71f30f0a03ff9bd20ca6f12ac0",
-    "0.7.4": "734290e41511eea7c2cfe151fbf9a563a97b9786",
-    "0.8.4": "91657dfe6ff857483066132b4618b62e8f4887bd"
+    "1.0.4": "aa86d6a89c8e77f206cd542581b563e7eee32459"
   },
   "abbrev": {
-    "1.0.5": "5d8257bd9ebe435e698b2fa431afde4fe7b10b03"
+    "1.0.5": "5d8257bd9ebe435e698b2fa431afde4fe7b10b03",
+    "1.0.6": "b6d632b859b3fa2d6f7e4b195472461b9e32dc30"
   },
   "acorn": {
-    "0.9.0": "67728e0acad6cc61dfb901c121837694db5b926b"
+    "1.2.1": "ae46ed295eea4e175a376634a8825eb6710f8058"
   },
   "acorn-babel": {
     "0.11.1-38": "6cf7b0c0791a11a05ef6020bf06ef34b30086768"
@@ -20,6 +20,7 @@
     "0.1.0": "3ca9735cf1dde0edf7a4bf6641709c8024f9b227"
   },
   "ansi-regex": {
+    "0.1.0": "55ca60db6900857c423ae9297980026f941ed903",
     "0.2.1": "0d8e946967a3d8143f93e24e298525fc1b2235f9",
     "1.1.1": "41c847194646375e6a1a5d10c3ca054ef9fc980d"
   },
@@ -53,10 +54,7 @@
     "0.1.11": "559be18376d08a4ec4dbe80877d27818639b2df7"
   },
   "asn1.js": {
-    "1.0.3": "281ba3ec1f2448fe765f92a4eecf883fe1364b54"
-  },
-  "asn1.js-rfc3280": {
-    "1.0.0": "4bb2013a7c9bdb4930c077b1b60d936186f4f4a7"
+    "2.0.3": "bc6104b08208770cd200fccc2ad71f921e821b57"
   },
   "assert": {
     "1.3.0": "03939a622582a812cc202320a0b9a56c9b815849"
@@ -69,11 +67,11 @@
     "0.7.2": "73b4535e995e7d8c533fb4f9a05a3ca6f33a4290"
   },
   "astw": {
-    "1.1.0": "f394778ab01c4ea467e64a614ed896ace0321a34"
+    "2.0.0": "08121ac8288d35611c0ceec663f6cd545604897d"
   },
   "async": {
     "0.2.10": "b6bbe0b0674b9d719708ca38de8c237cb526c3d1",
-    "0.9.0": "ac3613b1da9bed1b47510bb4651b8931e47146c7"
+    "0.9.2": "aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   },
   "autoprefixer-core": {
     "5.1.8": "19224f57d77bf3953dc026bbd1c3b8907319f049"
@@ -103,16 +101,18 @@
     "2.9.24": "14a2e75f0548323dc35aa440d92007ca154e967c"
   },
   "bn.js": {
-    "1.3.0": "0db4cbf96f8f23b742f5bcb9d1aa7a9994a05e83"
+    "2.0.5": "5f4b12a26ec4eb8ac895a9349980a254cfd3eb65"
   },
   "boom": {
     "0.4.2": "7a636e9ded4efcefb19cef4947a3c67dfaee911b",
-    "2.7.1": "fb165c348d337977c61d4363c21e9e1abf526705"
+    "2.7.2": "dad628d897f7fd2e32cc82197f13307971cf8354"
   },
   "bower": {
+    "1.3.12": "37de0edb3904baf90aee13384a1a379a05ee214c",
     "1.4.1": "a18be39d030792754f30f1c5b32d37b0156ba8dd"
   },
   "bower-config": {
+    "0.5.2": "1f7d2e899e99b70c29a613e70d4c64590414b22e",
     "0.6.1": "7093155688bef44079bf4cb32d189312c87ded60"
   },
   "bower-endpoint-parser": {
@@ -125,6 +125,7 @@
     "0.2.2": "39be07e979b2fc8e03a94634205ed9422373d381"
   },
   "bower-registry-client": {
+    "0.2.4": "269fc7e898b627fb939d1144a593254d7fbbeebc",
     "0.3.0": "f5adcfdeda771a84be088ef1310d9756e58ebe74"
   },
   "brace-expansion": {
@@ -134,23 +135,22 @@
     "1.0.5": "07b54ca30286abd1718a0e2a830803efdc9bfa04"
   },
   "browser-pack": {
-    "4.0.1": "7f4ab2b3a11c36a9274141fb7912122fc974e5f6"
+    "4.0.4": "8dae95a20ca43b3fea201faa6cfaa84ff4a0d484"
   },
   "browser-resolve": {
-    "1.8.2": "a00b06c871bee21b50d450ff94c2a423bc787729"
+    "1.9.0": "a3ab60185582063f8317fe48a1380f2ea81425ec"
   },
   "browserify": {
-    "9.0.4": "e58da3d5fe415bafa5734d1cb8e8c9d0ddb27d43"
+    "9.0.3": "f2f742b82ec5631c64b8c98a9788db0017c6517c"
   },
   "browserify-aes": {
-    "1.0.0": "582efc30561166f89855fcdc945b686919848b62"
+    "1.0.1": "796543bab86b84688cb58db1dee164bd1bb2af27"
   },
   "browserify-rsa": {
-    "1.1.1": "d7c952e12e44192680613ea7f3baa83af585c8ad",
-    "2.0.0": "b3e4f6d03a07db4408bfd9dbc0fef323bfe1bdcb"
+    "2.0.1": "9e6ec3e5bca3fdd11c9a93c14d2bb146470083bc"
   },
   "browserify-sign": {
-    "2.8.0": "655975c12006d02b59181da9ab73f856c63c9aa4"
+    "3.0.2": "751ced7ac76e7b719efa6fc3f04ecfa6ea7de88d"
   },
   "browserify-zlib": {
     "0.1.4": "bb35f8a519f600e0fa6b8485241c979d0141fb2d"
@@ -159,7 +159,7 @@
     "0.2.0": "e5b7cf311cccb70772cd22d4f61c7bb80523ecd2"
   },
   "buffer": {
-    "3.1.2": "1c679611b961edf16b9c4daf44fb66beb9daa9f0"
+    "3.2.2": "15d3ead5b994e8170e228540d7ff1286c25aa53b"
   },
   "buffers": {
     "0.1.1": "b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
@@ -177,9 +177,11 @@
     "1.0.30000113": "743519484426deacfc3895c8753e74143c828bde"
   },
   "cardinal": {
+    "0.4.0": "7d10aafb20837bde043c45e43a0c8c28cdaae45e",
     "0.4.4": "ca5bb68a5b511b90fe93b9acea49bdee5c32bfe2"
   },
   "caseless": {
+    "0.6.0": "8167c1ab8397fb5bb95f96d28e5a81c50f247ac4",
     "0.8.0": "5bca2881d41437f54b2407ebe34888c7b9ad4f7d",
     "0.9.0": "b7b65ce6bf1413886539cfd533f0b30effa9cf88"
   },
@@ -187,6 +189,7 @@
     "0.1.0": "5eab50b28afe58074d0d58291388828b5e5fbc98"
   },
   "chalk": {
+    "0.5.0": "375dfccbc21c0a60a8b61bc5b78f3dc2a55c212f",
     "0.5.1": "663b3a648b68b55d04690d49167aa837858f2174",
     "1.0.0": "b3cf4ed0ff5397c99c75b8f679db2f52831f96dc"
   },
@@ -226,7 +229,7 @@
     "0.0.1": "d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   },
   "concat-stream": {
-    "1.4.7": "0ceaa47b87a581d2a7a782b92b81d5020c3f9925"
+    "1.4.8": "e8325bb89e55000e52b626d97466fde1a28cfe5d"
   },
   "config-chain": {
     "1.1.8": "0943d0b7227213a20d4eaff4434f4a1c0a052cad"
@@ -251,7 +254,7 @@
     "1.0.1": "6b07085aef9a3ccac6ee53bf9d3df0c1521a5538"
   },
   "create-ecdh": {
-    "2.0.0": "59a11dbd3af8de5acbc8d005b624ccf7136f2a78"
+    "2.0.1": "94ba1ae3a96a0e522d143633f556a1adbad98f56"
   },
   "create-hash": {
     "1.1.1": "a55424f97b5369bfb2a97e53bd9b7a1aa6dd3a17"
@@ -264,7 +267,7 @@
     "2.0.4": "09ea1775b9e1c7de7e60a99d42ab6f08ce1a1285"
   },
   "crypto-browserify": {
-    "3.9.13": "07b829716685101dcd73f0bbcc95d16aa73fedf1"
+    "3.9.14": "d69925252c845392714aed1460c54b56605314ab"
   },
   "cssmin": {
     "0.4.3": "c9194077e0ebdacd691d5f59015b9d819f38d015"
@@ -291,6 +294,7 @@
     "1.0.1": "aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   },
   "decompress-zip": {
+    "0.0.8": "4a265b22c7b209d7b24fa66f2b2dfbced59044f3",
     "0.1.0": "bce60c11664f2d660fca4bcf634af6de5d6c14c7"
   },
   "deep-equal": {
@@ -306,7 +310,8 @@
     "1.0.2": "6902e25aa047649a501e19ef9e98f3e8365c109a"
   },
   "defined": {
-    "0.0.0": "f35eea7d705e933baf13b2f03b3f83d921403b3e"
+    "0.0.0": "f35eea7d705e933baf13b2f03b3f83d921403b3e",
+    "1.0.0": "c98d9bcef75674188e110969151199e39b1fa693"
   },
   "delayed-stream": {
     "0.0.5": "d4b1f43a93e8296dfe02694f4680bc37a313c73f"
@@ -315,19 +320,19 @@
     "0.0.1": "f9c9af5464afa1e7a971458a8bdef2aa94d5bb19"
   },
   "deps-sort": {
-    "1.3.5": "89dc3c323504080558f9909bf57df1f7837c5c6f"
+    "1.3.9": "29dfff53e17b36aecae7530adbbbf622c2ed1a71"
   },
   "detect-indent": {
     "3.0.1": "9dc5e5ddbceef8325764b9451b02bc6d54084f75"
   },
   "detective": {
-    "4.0.0": "9ffdb5555ddb1571fdbdc6f4ceac08e5e4cf8467"
+    "4.1.0": "7e8c5189bfb429bf392041e94ebe0599382aecac"
   },
   "dezalgo": {
     "1.0.1": "12bde135060807900d5a7aebb607c2abb7c76937"
   },
   "diffie-hellman": {
-    "3.0.1": "13be8fc4ad657278408cd796b554a93e586ed66a"
+    "3.0.2": "2a565afb1e03589cd284c010d6ebf8077b2886d7"
   },
   "domain-browser": {
     "1.1.4": "90b42769333e909ce3f13bf3e1023ba4a6d6b723"
@@ -339,10 +344,10 @@
     "0.0.2": "c614dcf67e2fb14995a91711e5a617e8a60a31db"
   },
   "duplexify": {
-    "3.3.0": "f5025c4b1f49f998b7399cd2d008e2895d18d247"
+    "3.4.1": "eb0e8a2040e27e2db9ff8d8d36d3a1b4427fc502"
   },
   "elliptic": {
-    "1.0.1": "d180376b66a17d74995c837796362ac4d22aefe3"
+    "3.0.3": "865c9b420bfbe55006b9f969f97a0d2c44966595"
   },
   "end-of-stream": {
     "0.1.5": "8e177206c3c80837d85632e8b9359dfe8b2f6eaf",
@@ -377,8 +382,7 @@
   },
   "esprima-fb": {
     "10001.1.0-dev-harmony-fb": "f7efb452d3c8006dde6b3c59678604f7114a882c",
-    "13001.1001.0-dev-harmony-fb": "633acdb40d9bd4db8a1c1d68c06a942959fad2b0",
-    "3001.1.0-dev-harmony-fb": "b77d37abcd38ea0b77426bb8bc2922ce6b426411"
+    "13001.1001.0-dev-harmony-fb": "633acdb40d9bd4db8a1c1d68c06a942959fad2b0"
   },
   "estraverse": {
     "1.9.3": "af67f2dc922582415950926091a4005d29c9bb44"
@@ -418,6 +422,7 @@
     "0.6.0": "1f9b9aff11eddb1c789c751f974ba7b15454ac5d"
   },
   "form-data": {
+    "0.1.4": "91abd788aba9702b1aabfa8bc01031a2ac9e3b12",
     "0.2.0": "26f8bc26da6440e299cbdcfb69035c4f77a6e466"
   },
   "from": {
@@ -456,6 +461,7 @@
   "glob": {
     "3.1.21": "d29e0a055dea5138f4d07ed40e8982e83c2066cd",
     "3.2.11": "4a973f635b9190f715d10987d5c00fd2815ebe3d",
+    "4.0.6": "695c50bdd4e2fb5c5d370b091f388d3707e291a7",
     "4.2.2": "ad2b047653a58c387e15deb43a19497f83fd2a80",
     "4.5.3": "c6cb73d3226c1efef04de3c56d012f03377ee15f"
   },
@@ -475,12 +481,14 @@
     "0.1.0": "d9c8edde1da79d125a151b79533b978676346ae5"
   },
   "got": {
+    "0.3.0": "888ec66ca4bc735ab089dbe959496d0f79485493",
     "2.9.2": "2e1ee58ea1e8d201e25ae580b96e63c15fefd4ee"
   },
   "graceful-fs": {
     "1.2.3": "15a4806a57547cb2d2dbf27f42e89a8c3451b364",
     "2.0.3": "7cd2cdb228a4a3f36e95efa6cc142de7d1a136d0",
-    "3.0.6": "dce3a18351cb94cdc82e688b2e3dd2842d1b09bb"
+    "3.0.6": "dce3a18351cb94cdc82e688b2e3dd2842d1b09bb",
+    "3.0.7": "e935be4b3e57892d289dc3bef7be8c02779d2b54"
   },
   "graceful-readlink": {
     "1.0.1": "4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
@@ -514,7 +522,7 @@
     "1.0.3": "c0b5b1615d9e382b0ff67169d967b425e48ca538"
   },
   "hash.js": {
-    "1.0.2": "bc7d601f4e0d05a32f3526d11fe39f7a5eb8c187"
+    "1.0.3": "1332ff00156c0a0ffdd8236013d07b77a0451573"
   },
   "hawk": {
     "1.1.1": "87cd491f9b46e4e2aeaca335416766885d2d1ed9",
@@ -522,7 +530,7 @@
   },
   "hoek": {
     "0.9.1": "3d322462badf07716ea7eb85baf88079cddce505",
-    "2.13.0": "cc86b5c1c344b41a7271be449e232fac8d6f450c"
+    "2.14.0": "81211691f52a5a835ae49edbf1e89c9003476aa4"
   },
   "http-browserify": {
     "1.7.0": "33795ade72df88acfbfd36773cefeda764735b20"
@@ -537,7 +545,7 @@
     "0.4.7": "89d32fec821bf8597f44609b4bc09bed5c209a23"
   },
   "ieee754": {
-    "1.1.4": "e3ec65200d4ad531d359aabdb6d3ec812699a30b"
+    "1.1.5": "2ddd7b4e3e48bcc67a32eed6abe9eeb18c5159e8"
   },
   "image-size": {
     "0.3.5": "83240eab2fb5b00b04aab8c74b0471e9cba7ad8c"
@@ -565,12 +573,15 @@
     "0.3.1": "a528b514e689fce90db3089e870d92f527acb5eb"
   },
   "inquirer": {
+    "0.6.0": "614d7bb3e48f9e6a8028e94a0c38f23ef29823d3",
+    "0.7.1": "b8acf140165bd581862ed1198fb6d26430091fac",
     "0.8.0": "525d4dd827d4f3d506b453726068f90deb99b443"
   },
   "insert-module-globals": {
-    "6.2.1": "95b8ec9ef8da579ceee827255a6a00e5b5cabaea"
+    "6.5.0": "e554008c41d6cb186ebe062fea4d779810e3c837"
   },
   "insight": {
+    "0.4.3": "76d653c5c0d8048b03cdba6385a6948f74614af0",
     "0.5.3": "353626c1b86b12c7bdfecb0a54ef80cd7e6f89e0"
   },
   "install": {
@@ -634,7 +645,7 @@
     "1.0.0": "278b2e6b68dfa4c8416af11370a55ea401bf4cde"
   },
   "js-yaml": {
-    "3.3.0": "cb6422d39168dbde419fecb7fd06fbe27ad56210"
+    "3.3.1": "ca1acd3423ec275d12140a7bab51db015ba0b3c0"
   },
   "jsesc": {
     "0.5.0": "e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
@@ -646,13 +657,15 @@
     "0.0.1": "611c23e814db375527df851193db59dd2af27f45"
   },
   "json-stringify-safe": {
-    "5.0.0": "4c1f228b5050837eba9d21f50c2e6e320624566e"
+    "5.0.0": "4c1f228b5050837eba9d21f50c2e6e320624566e",
+    "5.0.1": "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   },
   "jsonify": {
     "0.0.0": "2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   },
   "jsonparse": {
-    "0.0.5": "330542ad3f0a654665b778f3eb2d9a9fa507ac64"
+    "0.0.5": "330542ad3f0a654665b778f3eb2d9a9fa507ac64",
+    "1.0.0": "2622f4e66c08e1aac7edbeb76053c9b7e1211f76"
   },
   "jsonpointer": {
     "1.1.0": "c3c72efaed3b97154163dc01dd349e1cfe0f80fc"
@@ -664,6 +677,7 @@
     "1.0.2": "4615331537784981e8fd264e1f3a434c4e0ddd65"
   },
   "latest-version": {
+    "0.2.0": "adaf898d5f22380d3f9c45386efdff0a1b5b7501",
     "1.0.0": "84f40e5c90745c7e4f7811624d6152c381d931d9"
   },
   "left-pad": {
@@ -682,7 +696,7 @@
     "0.2.5": "ba8d339d0ca4a610e3a3f145b9caf48807155054"
   },
   "lexical-scope": {
-    "1.1.0": "899f36c4ec9c5af19736361aae290a6ef2af0800"
+    "1.1.1": "debac1067435f1359d90fcfd9e94bcb2ee47b2bf"
   },
   "liftoff": {
     "0.12.1": "bcaa49759c68396b83b984ad0b2d8cc226f9526d"
@@ -691,23 +705,25 @@
     "0.2.0": "6bc028149440e570d495ab509692aa08bd779c6e"
   },
   "lockdown": {
-    "0.0.8-dev": "075c0c1852e7cf746e4e85ccab8113b381f0b6e0"
+    "0.0.8-dev": "e6213cc58f76c4f7b62bf64189462367a87ba112"
   },
   "lockfile": {
-    "1.0.0": "b3a7609dda6012060083bacb0ab0ecbca58e9203"
+    "1.0.1": "9d353ecfe3f54d150bb57f89d51746935a39c4f5"
   },
   "lodash": {
     "1.0.2": "8f57560c83b59fc270bd3d561b690043430e2551",
-    "2.4.1": "5b7723034dda4d262e5a46fb2c58d7cc22f71420",
     "2.4.2": "fadd834b9683073da179b3eae6d9c0d15053f73e",
-    "3.6.0": "5266a8f49dd989be4f9f681b6f2a0c55285d0d9a",
-    "3.8.0": "376eb98bdcd9382a9365c33c4cb8250de1325b91"
+    "3.8.0": "376eb98bdcd9382a9365c33c4cb8250de1325b91",
+    "3.9.3": "0159e86832feffc6d61d852b12a953b99496bd32"
   },
   "lodash._escapehtmlchar": {
     "2.4.1": "df67c3bb6b7e8e1e831ab48bfa0795b92afe899d"
   },
   "lodash._escapestringchar": {
     "2.4.1": "ecfe22618a2ade50bfeea43937e51df66f0edb72"
+  },
+  "lodash._getnative": {
+    "3.9.0": "a478f0b87dd17d75b4311ffca2f551b2623977d9"
   },
   "lodash._htmlescapes": {
     "2.4.1": "32d14bf0844b6de6f8b62a051b4f67c228b624cb"
@@ -728,7 +744,8 @@
     "2.4.1": "6e9cc9666ff081f0b5a6c978b83e242e6949d203"
   },
   "lodash.debounce": {
-    "3.0.3": "f696762aedfa649c937c05a64e8a013ffd219c67"
+    "2.4.1": "d8cead246ec4b926e8b85678fc396bfeba8cc6fc",
+    "3.1.0": "f6731d72c739f29bd38e5803b208c9f640868b78"
   },
   "lodash.defaults": {
     "2.4.1": "a7e8885f05e68851144b6e12a8f3678026bc4c54"
@@ -736,14 +753,17 @@
   "lodash.escape": {
     "2.4.1": "2ce12c5e084db0a57dda5e5d1eeeb9f5d175a3b4"
   },
-  "lodash.isnative": {
-    "3.0.2": "7fefcd1af13f1bd2bcb6b45a4597337a22b32ce1"
+  "lodash.isfunction": {
+    "2.4.1": "2cfd575c73e498ab57e319b77fa02adef13a94d1"
   },
   "lodash.isobject": {
     "2.4.1": "5a2e47fe69953f1ee631a7eba1fe64d2d06558f5"
   },
   "lodash.keys": {
     "2.4.1": "48dea46df8ff7632b10d706b8acb26591e2b3727"
+  },
+  "lodash.now": {
+    "2.4.1": "6872156500525185faf96785bb7fe7fe15b562c6"
   },
   "lodash.template": {
     "2.4.1": "9e611007edf629129a974ab3c48b817b3e1cf20d"
@@ -759,8 +779,9 @@
   },
   "lru-cache": {
     "2.3.1": "b3adf6b3d856e954e2c390e6cef22081245a53d6",
-    "2.5.0": "d82388ae9c960becbea0c73bb9eb79b6c6ce9aeb",
-    "2.6.2": "77741638c6dc972e503dbe41dcb6bfdfba499a38"
+    "2.5.2": "1fddad938aae1263ce138680be1b3f591c0ab41c",
+    "2.6.2": "77741638c6dc972e503dbe41dcb6bfdfba499a38",
+    "2.6.4": "2675190ccd1b0701ec2f652a4d0d3d400d76c0dd"
   },
   "lru-queue": {
     "0.1.0": "2738bd9f0d3cf4f84490c5736c48699ac632cda3"
@@ -778,19 +799,20 @@
     "3.1.0": "5974708a0fe0dcbf27e0e6a49120b4c5e82c3cea"
   },
   "miller-rabin": {
-    "1.1.5": "41f506bed994b97e7c184a658ae107dad980526e"
+    "2.0.1": "8c0e07fef1bc24900a78895434d39ce4024d4648"
   },
   "mime": {
+    "1.2.11": "58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10",
     "1.3.4": "115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
   },
   "mime-db": {
-    "1.8.0": "82a9b385f22b0f5954dec4d445faba0722c4ad25",
+    "1.10.0": "e6308063c758ebd12837874c3d1ea9170766b03b",
     "1.9.1": "1431049a71791482c29f37bafc8ea2cb3a6dd3e8"
   },
   "mime-types": {
     "1.0.2": "995ae1392ab8affcbfcb2641dd054e943c0d5dce",
-    "2.0.10": "eacd81bb73cab2a77447549a078d4f2018c67b4d",
-    "2.0.11": "bf3449042799d877c815c29929d1e74760e72007"
+    "2.0.11": "bf3449042799d877c815c29929d1e74760e72007",
+    "2.0.12": "87ae9f124e94f8e440c93d1a72d0dccecdb71135"
   },
   "minimalistic-assert": {
     "1.0.0": "702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -799,8 +821,8 @@
     "0.2.14": "c74e780574f63c6f9a090e90efbe6ef53a6a756a",
     "0.3.0": "275d8edaac4f1bb3326472089e7949c8394699dd",
     "1.0.0": "e0dd2120b49e1b724ce8d714c520822a9438576d",
-    "2.0.4": "83bea115803e7a097a78022427287edb762fafed",
-    "2.0.7": "d23652ab10e663e7d914602e920e21f9f66492be"
+    "2.0.7": "d23652ab10e663e7d914602e920e21f9f66492be",
+    "2.0.8": "0bc20f6bf3570a698ef0ddff902063c6cabda6bf"
   },
   "minimist": {
     "0.0.10": "de3f98543dbf96082be48ad1a0c7cda836301dcf",
@@ -816,7 +838,7 @@
     "0.1.0": "7554a6f8d871834cc97b5462b122c4c124d6de91"
   },
   "module-deps": {
-    "3.7.5": "47222f17c6669225cee79a9824f71047a873e51d"
+    "3.8.0": "b45f8b135bd58d4b15b30c181a7561b19e884534"
   },
   "mout": {
     "0.11.0": "93cdf0791ac8a24873ceeb42a5b016b7c867abee",
@@ -829,7 +851,8 @@
     "0.1.2": "2a8f2ddf70eed564dff2d57f1e1a137d9f05078b"
   },
   "mute-stream": {
-    "0.0.4": "a9219960a6d5d5d046597aee51252c6655f7177e"
+    "0.0.4": "a9219960a6d5d5d046597aee51252c6655f7177e",
+    "0.0.5": "8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
   },
   "nested-error-stacks": {
     "1.0.0": "3bd2785bb1fa9ebbf608e293e9ccb9ea765254c7"
@@ -842,13 +865,16 @@
   },
   "nopt": {
     "1.0.10": "6ddd21bd2a31417b92727dd585f8a6f37608ebee",
-    "3.0.1": "bce5c42446a3291f47622a370abbf158fbbacbfd"
+    "2.2.1": "2aa09b7d1768487b3b89a9c5aa52335bff0baea7",
+    "3.0.1": "bce5c42446a3291f47622a370abbf158fbbacbfd",
+    "3.0.2": "a82a87f9d8c3df140fe78fb29657a7a774403b5e"
   },
   "normalize-package-data": {
     "1.0.3": "8be955b8907af975f1a4584ea8bb9b41492312f5"
   },
   "npmconf": {
-    "1.1.5": "07777bea48d78eed75a4258962a09f3dc7b6b916"
+    "1.1.5": "07777bea48d78eed75a4258962a09f3dc7b6b916",
+    "2.1.2": "66606a4a736f1e77a059aa071a79c94ab781853a"
   },
   "num2fraction": {
     "1.0.1": "addc0cad817e1a8686584a303ff244cbd336c531"
@@ -857,18 +883,21 @@
     "1.0.5": "8e3f4e7cdd5a311a6e2f8038aa31f4f97eb4ca52"
   },
   "oauth-sign": {
+    "0.4.0": "f22956f31ea7151a821e5f2fb32c113cad8b9f69",
     "0.5.0": "d767f5169325620eab2e087ef0c472e773db6461",
     "0.6.0": "7dbeae44f6ca454e1f168451d630746735813ce3"
   },
   "object-assign": {
     "0.2.2": "e0a78bc56af9c092051167f6b8f23249e7dde1a6",
+    "0.3.1": "060e2a2a27d7c0d77ec77b78f11aa47fd88008d2",
+    "1.0.0": "e65dc8766d3b47b4b8307465c8311da030b070a6",
     "2.0.0": "f8309b09083b01261ece3ef7373f2b57b8dd7042"
   },
   "object-keys": {
     "0.4.0": "28a6aae7428dd2c3a92f3d95f21335dd204e0336"
   },
   "once": {
-    "1.3.1": "f3f3e4da5b7d27b5c732969ee3e67e729457b31f",
+    "1.2.0": "de1905c636af874a8fba862d9aabddd1f920461c",
     "1.3.2": "d8feeca93b039ec1dcdee7741c92bdac5e28081b"
   },
   "opn": {
@@ -901,7 +930,8 @@
   },
   "osenv": {
     "0.0.3": "cd6ad8ddb290915ad9e22765576025d411f29cb6",
-    "0.1.0": "61668121eec584955030b9f470b1d2309504bfcb"
+    "0.1.0": "61668121eec584955030b9f470b1d2309504bfcb",
+    "0.1.1": "ddc7c4bb86c64a3022e95f030ee028e9a5996c07"
   },
   "osx-release": {
     "1.0.0": "02bee80f3b898aaa88922d2f86e178605974beac"
@@ -910,9 +940,11 @@
     "1.1.0": "b10dc60893f83de85e5d553a76327059295ff8d6"
   },
   "p-throttler": {
+    "0.1.0": "1b16907942c333e6f1ddeabcb3479204b8c417c4",
     "0.1.1": "15246409d225d3eefca85c50de710a83a78cca6a"
   },
   "package-json": {
+    "0.2.0": "0316e177b8eb149985d34f706b4a5543b274bec5",
     "1.1.0": "32b427c626385ccce180dc73a66d94f35f545e4b"
   },
   "pako": {
@@ -922,8 +954,7 @@
     "1.0.1": "fedd4d2bf193a77745fe71e371d73c3307d9c751"
   },
   "parse-asn1": {
-    "2.0.0": "c8cbc588abc91ade087c02ecbdfd7b66d9a8405f",
-    "3.0.0": "36ea30eb2ad99084e738e92801647910cdbf1ee4"
+    "3.0.1": "a0ef5aa6fc6747f4166cd18432bd67bd8dc438b5"
   },
   "path-browserify": {
     "0.0.0": "a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -937,17 +968,14 @@
   "pause-stream": {
     "0.0.11": "fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
   },
-  "pbkdf2-compat": {
-    "3.0.2": "0b207887e7d45467e9dd1027bbf1414e1f165291"
-  },
-  "pemstrip": {
-    "0.0.1": "39f7071720cfa13d542c9bde75f1fa5bf9d08806"
+  "pbkdf2": {
+    "3.0.4": "12c8bfaf920543786a85150b03f68d5f1aa982fc"
   },
   "postcss": {
     "4.0.6": "1bd1e8a99f73efdb46d11bf5c206079e2d306538"
   },
   "prelude-ls": {
-    "1.1.1": "c0b86c1ffd151ad3cc75e7e3fe38d7a1bf33728a"
+    "1.1.2": "21932a549f5e52ffd9a827f570e04be62a97da54"
   },
   "prepend-http": {
     "1.0.1": "5f13dad9a434fa4f346aa51cf03f3cea15fe4eb3"
@@ -960,7 +988,7 @@
   },
   "process": {
     "0.10.1": "842457cc51cfed72dc775afeeafb8c6034372725",
-    "0.6.0": "7dd9be80ffaaedd4cb628f1827f1cbab6dc0918f"
+    "0.11.1": "ee3becb4335edf3c8b14ccbf7e17a1125a4431ae"
   },
   "promise": {
     "6.1.0": "2ce729f6b94b45c26891ad0602c5c90e04c6eef6"
@@ -969,15 +997,16 @@
     "0.2.0": "73ef200fa8329d5d3a8df41798950b8646ca46d9"
   },
   "proto-list": {
-    "1.2.3": "6235554a1bca1f0d15e3ca12ca7329d5def42bd9"
+    "1.2.4": "212d5bfe1318306a420f6402b8e26ff39647a849"
   },
   "prr": {
     "0.0.0": "1a84b85908325501411853d0081ee3fa86e2926a"
   },
   "public-encrypt": {
-    "2.0.0": "9e49010bf021d33f6597c77abd939612a82767fc"
+    "2.0.1": "ef150418728a93e70700fa5c6a94016e0e596493"
   },
   "pump": {
+    "0.3.5": "ae5ff8c1f93ed87adc6530a97565b126f585454b",
     "1.0.0": "f0250fe282742492e4dea170e5ed3f7bc8a5e32c"
   },
   "punycode": {
@@ -986,10 +1015,12 @@
   },
   "q": {
     "0.9.7": "4de2e6cb3b29088c9e4cbc03bf9d42fb96ce2f75",
+    "1.0.1": "11872aeedee89268110b10a718448ffb10112a14",
     "1.1.2": "6357e291206701d99f197ab84e57e8ad196f2a89",
-    "1.4.0": "7913d541e50583c2f90c66a47979c93fcd764ae3"
+    "1.4.1": "55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
   },
   "qs": {
+    "1.2.2": "19b57ff24dc2a99ce1f8bdf6afcda59f8ef61f88",
     "2.3.3": "e9e85adbe75da0bbe4c8e0476a086290f863b404",
     "2.4.1": "68cbaea971013426a80c1404fad6b1a6b1175245"
   },
@@ -1003,10 +1034,10 @@
     "2.0.1": "18f4a9ba0dd07bdb1580bc9156091fcf90eabc6f"
   },
   "rc": {
-    "1.0.1": "f919c25e804cb0aa60f6fd92d929fc86b45013e8"
+    "1.0.3": "51bf28d21f13a9324528a9633460161ad9a39f77"
   },
   "read": {
-    "1.0.5": "007a3d169478aa710a491727e453effb92e76203"
+    "1.0.6": "09873c14ecc114d063fad43b8ca5a33d304721c8"
   },
   "read-all-stream": {
     "2.1.2": "0e80070eadd99712383e9f3c26762310900bda0a"
@@ -1050,6 +1081,7 @@
     "1.1.2": "472fedd80ebfac9f07513b4aa17e40fdaf5c8605"
   },
   "registry-url": {
+    "0.1.1": "1739427b81b110b302482a1c7cd727ffcc82d5be",
     "3.0.3": "c9f5102e0fd9c9f250522a7f19f68672c84ccc96"
   },
   "regjsgen": {
@@ -1062,11 +1094,13 @@
     "1.1.2": "dcced290c4d22df9818746eb5257679d27fe0283"
   },
   "request": {
+    "2.42.0": "572bd0148938564040ac7ab148b96423a063304a",
     "2.51.0": "35d00bbecc012e55f907b1bd9e0dbd577bfef26e",
     "2.53.0": "180a3ae92b7b639802e4f9545dd8fcdeb71d760c",
     "2.54.0": "a13917cd8e8fa73332da0bf2f84a30181def1953"
   },
   "request-progress": {
+    "0.3.0": "bdf2062bfc197c5d492500d44cb3aff7865b492e",
     "0.3.1": "0721c105d8a96ac6b2ce8b2c89ae2d5ecfcf6b3a"
   },
   "request-replay": {
@@ -1077,14 +1111,15 @@
     "1.1.6": "d3492ad054ca800f5befa612e61beac1eec98f8f"
   },
   "retry": {
+    "0.6.0": "1c010713279a6fd1e8def28af0c3ff1871caa537",
     "0.6.1": "fdc90eed943fde11b893554b8cc63d0e899ba918"
   },
   "rimraf": {
     "2.2.8": "e439be2aaee327321952730f99a8929e4fc50582",
-    "2.3.3": "d0073d8b3010611e8f3ad377b08e9a3c18b98f06"
+    "2.3.4": "82d9bc1b2fcf31e205ac7b28138a025d08e9159a"
   },
   "ripemd160": {
-    "1.0.0": "15fd251d56e58848840f3d5864a5cfbb259114c7"
+    "1.0.1": "93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
   },
   "rx": {
     "2.5.2": "52f236b5a6d24e538aa1fba88152909322a02886"
@@ -1095,13 +1130,15 @@
     "4.3.4": "bf43a1aae304de040e12a13f84200ca7aeab7589"
   },
   "semver-diff": {
+    "0.1.0": "4f6057ca3eba23cc484b51f64aaf88b131a3855d",
     "2.0.0": "d43024f91aa7843937dc1379002766809f7480d2"
   },
   "sequencify": {
     "0.0.7": "90cff19d02e07027fd767f5ead3e7b95d1e7380c"
   },
   "sha.js": {
-    "2.3.6": "10585a3f7fd8f1da715adac6f9d54516da0670cc"
+    "2.3.6": "10585a3f7fd8f1da715adac6f9d54516da0670cc",
+    "2.4.1": "b7daae383cc8deefddbc07780247fafce4328f5b"
   },
   "shallow-copy": {
     "0.0.1": "415f42702d73d810330292cc5ee86eae1a11a170"
@@ -1164,6 +1201,7 @@
     "1.3.1": "87737a08777aa00d6a27d92562e7bc88070c081d"
   },
   "string-length": {
+    "0.1.2": "ab04bb33867ee74beed7fb89bb7f089d392780f2",
     "1.0.0": "5f0564b174feb299595a763da71513266370d3a9"
   },
   "string_decoder": {
@@ -1176,6 +1214,7 @@
     "0.0.4": "0f0e3423f942960b5692ac324a57dd093bc41a92"
   },
   "strip-ansi": {
+    "0.2.2": "854d290c981525fc8c397a910b025ae2d54ffc08",
     "0.3.0": "25f48ea22ca79187f3174a4db8759347bb126220",
     "2.0.1": "df62c1aa94ed2f114e1d0f21fd1d50482b79a60e"
   },
@@ -1186,7 +1225,6 @@
     "0.1.3": "164c64e370a8a3cc00c9e01b539e569823f0ee54"
   },
   "subarg": {
-    "0.0.1": "3d56b07dacfbc45bbb63f7672b43b63e46368e3a",
     "1.0.0": "f62cf17581e996b48fc965699f54c06ae268b8d2"
   },
   "supports-color": {
@@ -1194,20 +1232,21 @@
     "1.3.1": "15758df09d8ff3b4acc307539fabe27095e1042d"
   },
   "syntax-error": {
-    "1.1.2": "660f025b170b7eb944efc2a889d451312bcef451"
+    "1.1.4": "1ad035e1b4f72fe16186510ac24f055c48002f6d"
   },
   "tar-fs": {
-    "1.5.0": "461da12f3a756adcfe781afbc0c13694d9c5d613"
+    "0.5.2": "0f59424be7eeee45232316e302f66d3f6ea6db3e",
+    "1.5.1": "5fc6744cf79c1331330112cbdc290aa6ebf0eda8"
   },
   "tar-stream": {
-    "1.1.4": "e6c3ffc4305f7d537b6ec697823dd86e4d61ca63"
+    "0.4.7": "1f1d2ce9ebc7b42765243ca0e8f1b7bfda0aadcd",
+    "1.1.5": "be9218c130c20029e107b0f967fb23de0579d13c"
   },
   "throttleit": {
     "0.0.2": "cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
   },
   "through": {
     "2.3.4": "495e40e8d8a8eaebc7c275ea88c2b8fc14c56455",
-    "2.3.6": "26681c0f524671021d4e29df7c36bce2d0ecf2e8",
     "2.3.7": "5fcc3690fed2fdf98c6fc88b4d207a4624ac3b87"
   },
   "through2": {
@@ -1223,23 +1262,26 @@
     "2.0.0": "f38b0ae81d3747d628001f41dafc652ace671c0a"
   },
   "timers-browserify": {
-    "1.4.0": "6b424b07688cd1978c2a3333ee618c46036d6ddb"
+    "1.4.1": "bf8afeb7b50d6c500e2b3e0a5d759c4005e985d7"
   },
   "timers-ext": {
     "0.1.0": "00345a2ca93089d1251322054389d263e27b77e2"
   },
   "tmp": {
+    "0.0.23": "de874aa5e974a85f0a32cdfdbd74663cb3bd9c74",
     "0.0.24": "d6a5e198d14a9835cc6f2d7c3d9e302428c8cf12"
   },
   "to-fast-properties": {
     "1.0.1": "4a41554d2b2f4bbe2d794060dc47396b10bb48a8"
   },
   "touch": {
+    "0.0.2": "a65a777795e5cbbe1299499bdc42281ffb21b5f4",
     "0.0.3": "51aef3d449571d4f287a5d87c9c8b49181a0db1d"
   },
   "tough-cookie": {
     "0.12.1": "8220c7e21abd5b13d96804254bd5a81ebf2c7d62",
-    "1.1.0": "126d2490e66ae5286b6863debd4a341076915954"
+    "1.1.0": "126d2490e66ae5286b6863debd4a341076915954",
+    "1.2.0": "9b7e9d98e769e80b5aa899d944fe44e02ebf82ad"
   },
   "traverse": {
     "0.3.9": "717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
@@ -1270,12 +1312,13 @@
     "0.0.5": "5a3db23ef5dbd55b81fce0ec9a2ac6fccdebb81e"
   },
   "umd": {
-    "3.0.0": "328de29bf1004abb4d6309d7fff1b84b9f823b83"
+    "3.0.1": "8ae556e11011f63c2596708a8837259f01b3d60e"
   },
   "unique-stream": {
     "1.0.0": "d59a4a75427447d9aa6c91e70263f8d26a4b104b"
   },
   "update-notifier": {
+    "0.2.0": "a010c928adcf02090b8e0ce7fef6fb0a7cacc34a",
     "0.3.2": "22a8735baadef3320e2db928f693da898dc87777"
   },
   "url": {
@@ -1304,13 +1347,13 @@
     "0.0.4": "5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   },
   "which": {
+    "1.0.9": "460c1da0f810103d0321a9b633af9e575e64486f",
     "1.1.1": "9ce512459946166e12c083f08ec073380fc8cbbb"
   },
   "win-release": {
     "1.0.0": "8993308dedbd8d30ad5594b6b7382a8c1d96ae5a"
   },
   "wordwrap": {
-    "0.0.2": "b79669bb42ecb409f83d583cad52ca17eaa1643f",
     "0.0.3": "a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
   },
   "wrappy": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "url": "git://github.com/mozilla/kitsune.git"
   },
   "scripts": {
-    "preinstall": "./scripts/lockdown.js"
   },
   "devDependencies": {
     "gulp": "3.8.6",
@@ -15,11 +14,11 @@
     "lockdown": "mozilla/npm-lockdown#c7ceb9ca37fab4ba2639b89f94b88703d4e4d0d2"
   },
   "dependencies": {
-    "babelify": "^5.0.4",
+    "babelify": "5.0.4",
     "bower": "1.4.1",
-    "browserify": "^9.0.3",
+    "browserify": "9.0.3",
     "cssmin": "0.4.3",
-    "debowerify": "^1.2.0",
+    "debowerify": "1.2.0",
     "less": "2.4.0",
     "less-plugin-autoprefix": "1.4.1",
     "nunjucks": "1.0.5",

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -16,20 +16,14 @@ if [[ $TEST_SUITE == "lint" ]]; then
 fi
 
 ./peep.sh install -r "requirements/default.txt"
-# Print the installed packages for the world to see.
-pip freeze
 echo
-
 
 echo "Installing Node.js dependencies"
-npm install > /dev/null 2> /dev/null
-npm list
+./scripts/lockdown.js
 echo
 
-
-echo "Intalling front end dependencies"
-./node_modules/.bin/bower install > /dev/null 2> /dev/null
-./node_modules/.bin/bower list -o
+echo "Installing front end dependencies"
+./node_modules/.bin/bower install
 echo
 
 


### PR DESCRIPTION
The test failure in #2550 makes me think Travis isn't using lockdown correctly, and we are hiding that from the install process. This will make it a little easier to debug.

This is mainly to get Travis to run, it isn't for review just yet.