### PR TITLE
[Bug 998806] Changed 'Edit this thread' button to 'Edit Thread Title'

### DIFF
--- a/kitsune/forums/templates/forums/posts.html
+++ b/kitsune/forums/templates/forums/posts.html
@@ -23,7 +23,7 @@
     <ul id="thread-actions" class="sidebar-nav">
       {% if not thread.is_locked and
         has_perm_or_owns('forums_forum.thread_edit_forum', thread, forum) %}
-        <li><a href="{{ url('forums.edit_thread', forum.slug, thread.id) }}">{{ _('Edit this thread') }}</a></li>
+        <li><a href="{{ url('forums.edit_thread', forum.slug, thread.id) }}">{{ _('Edit Thread Title') }}</a></li>
       {% endif %}
       {% if has_perm('forums_forum.thread_delete_forum', forum) %}
         <li><a href="{{ url('forums.delete_thread', forum.slug, thread.id) }}">{{ _('Delete this thread') }}</a></li>


### PR DESCRIPTION
Changed to 'Edit this title' because that button just give option to edit the title of thread.