### PR TITLE
[Bug 1149559] Show "No one has helped..." notification only on articles marked Ready For L10n

### DIFF
--- a/kitsune/wiki/templates/wiki/document.html
+++ b/kitsune/wiki/templates/wiki/document.html
@@ -52,7 +52,7 @@
     <article class="wiki-doc">
       {{ document_title(document) }}
       {{ document_messages(document, redirected_from) }}
-      {{ document_content(document, fallback_reason, request, settings, document_css_class) }}
+      {{ document_content(document, fallback_reason, request, settings, document_css_class, any_localizable_revision) }}
 
     {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
     {% if share_link %}

--- a/kitsune/wiki/templates/wiki/includes/document_macros.html
+++ b/kitsune/wiki/templates/wiki/includes/document_macros.html
@@ -41,12 +41,12 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro document_content(document, fallback_reason, request, settings, css_class='') -%}
+{% macro document_content(document, fallback_reason, request, settings, css_class='', any_localizable_revision) -%}
   <section id="doc-content" class="{{ css_class }}">
     {% if not fallback_reason %}
       {{ document.html|safe }}
     {% elif fallback_reason == 'no_translation' %}
-      {% if not document.is_archived %}
+      {% if document.is_localizable and any_localizable_revision and not document.is_archived %}
         <div id="doc-pending-fallback" class="warning-box">
           {% trans help_link=url('wiki.document', 'localize-firefox-help'), document_trans_link=url('wiki.translate', document.slug) %}
             No one has helped translate this article yet. If you already know how localizing for SUMO works,

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -209,10 +209,8 @@ class DocumentTests(TestCaseBase):
         # Marking the document and the revision ready for localization
         r2 = revision(save=True, document=r.document, content='Some text.',
                       is_approved=True, is_ready_for_localization=True)
-        r2.document.current_revision = r2
-        r2.document.is_localizable = True
-        r2.document.save()
 
+        url = reverse('wiki.document', args=[r.document.slug], locale='de')
         response = self.client.get(url)
         doc = pq(response.content)
 

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -192,20 +192,38 @@ class DocumentTests(TestCaseBase):
 
     def test_document_fallback_no_translation(self):
         """The document template falls back to English if no translation
-        exists."""
+        exists. The fallback message is only shown when there is any revision
+        ready for localization"""
         r = revision(save=True, content='Some text.', is_approved=True)
         url = reverse('wiki.document', args=[r.document.slug], locale='fr')
         response = self.client.get(url)
         doc = pq(response.content)
         eq_(r.document.title, doc('article h1.title').text())
 
+        # Fallback message is not shown because the revision is not ready for
+        # localization.
+        eq_(0, len(doc('#doc-pending-fallback')))
+        # Included content is English.
+        eq_(pq(r.document.html)('div').text(), doc('#doc-content div').text())
+
+        # Marking the document and the revision ready for localization
+        r2 = revision(save=True, document=r.document, content='Some text.',
+                      is_approved=True, is_ready_for_localization=True)
+        r2.document.current_revision = r2
+        r2.document.is_localizable = True
+        r2.document.save()
+
+        response = self.client.get(url)
+        doc = pq(response.content)
+
+        eq_(r2.document.title, doc('article h1.title').text())
         # Fallback message is shown.
         eq_(1, len(doc('#doc-pending-fallback')))
         # Removing this as it shows up in text(), and we don't want to depend
         # on its localization.
         doc('#doc-pending-fallback').remove()
         # Included content is English.
-        eq_(pq(r.document.html)('div').text(), doc('#doc-content div').text())
+        eq_(pq(r2.document.html)('div').text(), doc('#doc-content div').text())
 
     def test_redirect(self):
         """Make sure documents with REDIRECT directives redirect properly.

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -125,6 +125,9 @@ def document(request, document_slug, template=None, document=None):
             # and OK to fall back to parent (parent is approved).
             fallback_reason = 'no_translation'
 
+    any_localizable_revision = doc.revisions.filter(is_approved=True,
+                                                    is_ready_for_localization=True).exists()
+
     # Obey explicit redirect pages:
     # Don't redirect on redirect=no (like Wikipedia), so we can link from a
     # redirected-to-page back to a "Redirected from..." link, so you can edit
@@ -213,6 +216,7 @@ def document(request, document_slug, template=None, document=None):
         'ga_push': ga_push,
         'breadcrumb_items': breadcrumbs,
         'document_css_class': document_css_class,
+        'any_localizable_revision': any_localizable_revision,
     }
 
     response = render(request, template, data)


### PR DESCRIPTION
[Show the "No one has helped translate this article yet..." notification only on articles that are marked Ready For Localization](https://bugzilla.mozilla.org/show_bug.cgi?id=1149559)