### PR TITLE
[Bug 1173414] Fix url for product icons placeholder.

### DIFF
--- a/kitsune/questions/templates/questions/question_list.html
+++ b/kitsune/questions/templates/questions/question_list.html
@@ -172,7 +172,7 @@
                     {% set topic = question.topic %}
                     <li>
                       <a href="{{ url('questions.list', topic.product.slug)|urlparams(None, request.GET, topic=None) }}">
-                        <img src="/static/img/blank.png" class="logo-sprite-tiny logo-{{ topic.product.slug }}">
+                        <img src="{{ STATIC_URL }}sumo/img/blank.png" class="logo-sprite-tiny logo-{{ topic.product.slug }}">
                         {{ _(topic.product.title, 'DB: products.Product.title') }}
                       </a>
                     </li>


### PR DESCRIPTION
I missed this while doing the static rearrangement because it wasn't using `STATIC_URL`. I also grepped around for anything else with this pattern, but I didn't find anything.

r?