### PR TITLE
[Bug 919867] Add date started feature to profiles

### DIFF
--- a/kitsune/users/forms.py
+++ b/kitsune/users/forms.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 
 from django import forms
 from django.conf import settings
@@ -20,6 +21,7 @@ from kitsune.upload.forms import clean_image_extension
 from kitsune.upload.utils import check_file_size, FileTooLargeError
 from kitsune.users.models import Profile
 from kitsune.users.widgets import FacebookURLWidget
+from kitsune.users.widgets import MonthYearWidget
 
 
 USERNAME_INVALID = _lazy(u'Username may contain only English letters, '
@@ -175,11 +177,17 @@ class AuthenticationForm(auth_forms.AuthenticationForm):
 class ProfileForm(forms.ModelForm):
     """The form for editing the user's profile."""
 
+    involved_from = forms.DateField(
+        required=False,
+        label=_lazy(u'Involved with Mozilla from'),
+        widget=MonthYearWidget(years=range(1998, datetime.today().year + 1),
+                               required=False))
+
     class Meta(object):
         model = Profile
         fields = ('name', 'public_email', 'bio', 'website', 'twitter',
                   'facebook', 'mozillians', 'irc_handle', 'timezone', 'country', 'city',
-                  'locale')
+                  'locale', 'involved_from')
         widgets = {
             'facebook': FacebookURLWidget,
         }

--- a/kitsune/users/migrations/0008_auto_20150610_2214.py
+++ b/kitsune/users/migrations/0008_auto_20150610_2214.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import kitsune.sumo.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0007_auto_add_screen_share_permission'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='involved_from',
+            field=models.DateField(null=True, verbose_name='Involved with Mozilla from', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='profile',
+            name='locale',
+            field=kitsune.sumo.models.LocaleField(default=b'en-US', max_length=7, verbose_name='Preferred language', choices=[(b'af', 'Afrikaans'), (b'ar', '\u0639\u0631\u0628\u064a'), (b'az', 'Az\u0259rbaycanca'), (b'bg', '\u0411\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438'), (b'bn-BD', '\u09ac\u09be\u0982\u09b2\u09be (\u09ac\u09be\u0982\u09b2\u09be\u09a6\u09c7\u09b6)'), (b'bn-IN', '\u09ac\u09be\u0982\u09b2\u09be (\u09ad\u09be\u09b0\u09a4)'), (b'bs', 'Bosanski'), (b'ca', 'catal\xe0'), (b'cs', '\u010ce\u0161tina'), (b'da', 'Dansk'), (b'de', 'Deutsch'), (b'ee', '\xc8\u028begbe'), (b'el', '\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac'), (b'en-US', 'English'), (b'es', 'Espa\xf1ol'), (b'et', 'eesti keel'), (b'eu', 'Euskara'), (b'fa', '\u0641\u0627\u0631\u0633\u06cc'), (b'fi', 'suomi'), (b'fr', 'Fran\xe7ais'), (b'fy-NL', 'Frysk'), (b'ga-IE', 'Gaeilge (\xc9ire)'), (b'gl', 'Galego'), (b'gu-IN', '\u0a97\u0ac1\u0a9c\u0ab0\u0abe\u0aa4\u0ac0'), (b'ha', '\u0647\u064e\u0631\u0652\u0634\u064e\u0646 \u0647\u064e\u0648\u0652\u0633\u064e'), (b'he', '\u05e2\u05d1\u05e8\u05d9\u05ea'), (b'hi-IN', '\u0939\u093f\u0928\u094d\u0926\u0940 (\u092d\u093e\u0930\u0924)'), (b'hr', 'Hrvatski'), (b'hu', 'Magyar'), (b'id', 'Bahasa Indonesia'), (b'ig', 'As\u1ee5s\u1ee5 Igbo'), (b'it', 'Italiano'), (b'ja', '\u65e5\u672c\u8a9e'), (b'km', '\u1781\u17d2\u1798\u17c2\u179a'), (b'kn', '\u0c95\u0ca8\u0ccd\u0ca8\u0ca1'), (b'ko', '\ud55c\uad6d\uc5b4'), (b'ln', 'Ling\xe1la'), (b'lt', 'lietuvi\u0173 kalba'), (b'ml', '\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02'), (b'ne-NP', '\u0928\u0947\u092a\u093e\u0932\u0940'), (b'nl', 'Nederlands'), (b'no', 'Norsk'), (b'pl', 'Polski'), (b'pt-BR', 'Portugu\xeas (do Brasil)'), (b'pt-PT', 'Portugu\xeas (Europeu)'), (b'ro', 'rom\xe2n\u0103'), (b'ru', '\u0420\u0443\u0441\u0441\u043a\u0438\u0439'), (b'si', '\u0dc3\u0dd2\u0d82\u0dc4\u0dbd'), (b'sk', 'sloven\u010dina'), (b'sl', 'sloven\u0161\u010dina'), (b'sq', 'Shqip'), (b'sr-Cyrl', '\u0421\u0440\u043f\u0441\u043a\u0438'), (b'sw', 'Kiswahili'), (b'sv', 'Svenska'), (b'ta', '\u0ba4\u0bae\u0bbf\u0bb4\u0bcd'), (b'ta-LK', '\u0ba4\u0bae\u0bbf\u0bb4\u0bcd (\u0b87\u0bb2\u0b99\u0bcd\u0b95\u0bc8)'), (b'te', '\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41'), (b'th', '\u0e44\u0e17\u0e22'), (b'tn', 'Setswana'), (b'tr', 'T\xfcrk\xe7e'), (b'uk', '\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430'), (b'ur', '\u0627\u064f\u0631\u062f\u0648'), (b'vi', 'Ti\u1ebfng Vi\u1ec7t'), (b'wo', 'Wolof'), (b'xh', 'isiXhosa'), (b'yo', '\xe8d\xe8 Yor\xf9b\xe1'), (b'zh-CN', '\u4e2d\u6587 (\u7b80\u4f53)'), (b'zh-TW', '\u6b63\u9ad4\u4e2d\u6587 (\u7e41\u9ad4)'), (b'zu', 'isiZulu')]),
+            preserve_default=True,
+        ),
+    ]

--- a/kitsune/users/models.py
+++ b/kitsune/users/models.py
@@ -73,6 +73,8 @@ class Profile(ModelBase, SearchMixin):
         default=False, help_text=_lazy(u'Has been sent a first answer contribution email.'))
     first_l10n_email_sent = models.BooleanField(
         default=False, help_text=_lazy(u'Has been sent a first revision contribution email.'))
+    involved_from = models.DateField(null=True, blank=True,
+                                     verbose_name=_lazy(u'Involved with Mozilla from'))
 
     class Meta(object):
         permissions = (('view_karma_points', 'Can view karma points'),

--- a/kitsune/users/templates/users/profile.html
+++ b/kitsune/users/templates/users/profile.html
@@ -64,10 +64,15 @@
         {% endif %}
       {% endif %}
 
-      {% if num_answers or num_questions or num_solutions or num_documents %}
+      {% if num_answers or num_questions or num_solutions or num_documents or profile.involved_from %}
         <section class="contributions">
           <h2>Contributions</h2>
           <ul>
+            {% if profile.involved_from %}
+              <li>
+                {{ _('Involved with Mozilla since {date}')|f(date=profile.involved_from.strftime('%b %Y')) }}
+              </li>
+            {% endif %}
             {% if num_questions %}
               <li>
                 <a href="{{ url('search')|urlparams(asked_by=profile.user.username, sortby=1, a=1, w=2) }}">

--- a/kitsune/users/widgets.py
+++ b/kitsune/users/widgets.py
@@ -1,4 +1,86 @@
+import re
+from datetime import datetime
+
+from django.forms.widgets import Widget, Select
+from django.utils.dates import MONTHS
+from django.utils.safestring import mark_safe
 from kitsune.sumo.monkeypatch import URLWidget
+
+RE_DATE = re.compile(r'(\d{4})-(\d\d?)-(\d\d?)$')
+
+
+class MonthYearWidget(Widget):
+    """
+    A Widget that splits date input into two <select> boxes for month and year,
+    with 'day' defaulting to the first of the month ( 01 ).
+    Based on SelectDateWidget, in
+    http://djangosnippets.org/snippets/1688/
+    """
+    none_value = (0, '---')
+    month_field = '%s_month'
+    year_field = '%s_year'
+
+    def __init__(self, attrs=None, years=None, required=True):
+        # years is an optional list/tuple of years to use in the "year" select box.
+        self.attrs = attrs or {}
+        self.required = required
+        if years:
+            self.years = years
+        else:
+            this_year = datetime.date.today().year
+            self.years = range(this_year, this_year + 10)
+
+    def render(self, name, value, attrs=None):
+        try:
+            year_val, month_val = value.year, value.month
+        except AttributeError:
+            year_val = month_val = None
+            if isinstance(value, basestring):
+                match = RE_DATE.match(value)
+                if match:
+                    year_val, month_val, day_val = [int(v) for v in match.groups()]
+
+        output = []
+
+        if 'id' in self.attrs:
+            id_ = self.attrs['id']
+        else:
+            id_ = 'id_%s' % name
+
+        month_choices = MONTHS.items()
+        if not (self.required and value):
+            month_choices.append(self.none_value)
+        month_choices.sort()
+        local_attrs = self.build_attrs(id=self.month_field % id_)
+        s = Select(choices=month_choices)
+        select_html = s.render(self.month_field % name, month_val, local_attrs)
+        output.append(select_html)
+
+        year_choices = [(i, i) for i in self.years]
+        if not (self.required and value):
+            year_choices.insert(0, self.none_value)
+        local_attrs['id'] = self.year_field % id_
+        s = Select(choices=year_choices)
+        select_html = s.render(self.year_field % name, year_val, local_attrs)
+        output.append(select_html)
+
+        return mark_safe(u'\n'.join(output))
+
+    def id_for_label(self, id_):
+        return '%s_month' % id_
+    id_for_label = classmethod(id_for_label)
+
+    def value_from_datadict(self, data, files, name):
+        y = data.get(self.year_field % name)
+        m = data.get(self.month_field % name)
+
+        if not y or not m or y == m == '0':
+            return None
+
+        try:
+            return datetime.date(int(y), int(m), 1)
+        except (TypeError, ValueError):
+            return '%s-%s-%s' % (y, m, 1)
 
 
 class PatternURLWidget(URLWidget):


### PR DESCRIPTION
Added function for user to add when did they get involved with sumo data to profile.

Label used for filed is "Involved with SUMO from", it will allow user to select a month and year ( starting from 1998, start year in mozillians.org) 

I don't it would serve any good to have "Involved with SUMO or Mozilla from".
  1. The Label is too long.
  2. The field already exist in Mozillians.org
