### PR TITLE
Add eslint file to tweak.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,44 @@
+ecmaFeatures:
+  arrowFunctions: true
+  binaryLiterals: true
+  blockBindings: true
+  classes: true
+  defaultParams: true
+  destructuring: true
+  forOf: true
+  generators: true
+  modules: true
+  objectLiteralComputedProperties: true
+  objectLiteralDuplicateProperties: true
+  objectLiteralShorthandMethods: true
+  objectLiteralShorthandProperties: true
+  octalLiterals: true
+  regexUFlag: true
+  regexYFlag: true
+  spread: true
+  superInFunctions: true
+  templateStrings: true
+  unicodeCodePointEscapes: true
+  jsx: true
+
+rules:
+  quotes: [2, single, avoid-escape]
+  no-shadow: [2, {hoist: all}]
+  no-alert: [2]
+  no-console: [0]
+  no-unused-vars: [0]
+  no-var: [0]
+  comma-dangle: [0]
+  new-cap: [0]
+  no-underscore-dangle: [0]
+  no-use-before-define: [2, nofunc]
+  camelcase: [0]
+
+env:
+  es6: true
+  browser: true
+
+settings:
+  resolve.root:
+    - node_modules
+    - src


### PR DESCRIPTION
This is what I've been using for es6/jsx code, which is supported when we use Babel. I'd like to figure out how to only enable es6 on a per-file basis (or file globs). I haven't  looked into exactly how to do that though. I like these options, but I'm not set in stone on any of them, we can tweak these for sure.

Note: I'm not adding any pre-commit or CI for this. There are a lot of errors by these standards in our code base. Some day we will have to fix that.

@rehandalal r?