### PR TITLE
[bug 1175531] Fix the screen sharing message formatting

### DIFF
--- a/kitsune/questions/templates/questions/message/screen_share.ltxt
+++ b/kitsune/questions/templates/questions/message/screen_share.ltxt
@@ -1,21 +1,29 @@
 Hi {{ asker }},
 
-I’m {{ contributor }}, from the Mozilla support forums.
+I'm {{ contributor }}, from the Mozilla support forums.
+
 We are offering screen sharing sessions for issues that are otherwise hard to solve such as in this case. If you are interested, please follow the instructions below to start a screen sharing session and I’ll join to help out with your issue.
 
 1. Start Firefox and click the Hello button (the smiley face in the Firefox tool bar).
+
 2. Click "Start a conversation", and in the new conversation window, click on "Copy link".
-3. Send me the link you've just copied by using one of the following methods: 
-   a. If you are reading this on the Mozilla support website, click "reply" below this message and paste the link you just copied. 
-   b. If you are reading this in your email program, please click on "View this message on the web". From there, click "reply".
-4. The Hello button will turn blue when I join the session. Just click the Hello button and click on the conversation link to join me. 
+
+3. Send me the link you've just copied by using one of the following methods:
+
+a. If you are reading this on the Mozilla support website, click "reply" below this message and paste the link you just copied.
+
+b. If you are reading this in your email program, please click on "View this message on the web". From there, click "reply".
+
+4. The Hello button will turn blue when I join the session. Just click the Hello button and click on the conversation link to join me.
 
 In case we miss each other right now, here’s when I’ll be available over the next 2 days.
 
 June 2nd, 9am - 11am PST
+
 June 3rd, 9am - 11am PST
 
 Just pick a time and reply together with the link you copied above. I’ll get back to you as soon as possible.
 
 Best,
+
 {{ contributor }}


### PR DESCRIPTION
the way we parse messages it doesn't like single line breaks or nested lists. we may want to switch to markdown? this should fix the formatting for now.

r?