### PR TITLE
[bug 1085618] Use bulk_create in badge tests.

### DIFF
--- a/kitsune/customercare/tests/test_badges.py
+++ b/kitsune/customercare/tests/test_badges.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 from kitsune.customercare.badges import AOA_BADGE
+from kitsune.customercare.models import Reply
 from kitsune.customercare.tests import reply
 from kitsune.kbadge.tests import badge
 from kitsune.sumo.tests import TestCase
@@ -21,8 +22,13 @@ class TestAOABadges(TestCase):
             save=True)
 
         # Create 49 replies.
-        for i in range(49):
-            reply(user=u, save=True)
+        replies = []
+        for i in range(48):
+            replies.append(reply(user=u))
+        Reply.objects.bulk_create(replies)
+
+        # Create the 49th reply separately so the signals are triggered.
+        reply(user=u, save=True)
 
         # User should NOT have the badge yet.
         assert not b.is_awarded_to(u)

--- a/kitsune/questions/tests/test_badges.py
+++ b/kitsune/questions/tests/test_badges.py
@@ -1,8 +1,9 @@
 from datetime import date
 
 from kitsune.kbadge.tests import badge
+from kitsune.questions.models import Answer
 from kitsune.questions.badges import QUESTIONS_BADGES
-from kitsune.questions.tests import answer
+from kitsune.questions.tests import answer, question
 from kitsune.sumo.tests import TestCase
 from kitsune.users.tests import profile
 
@@ -21,9 +22,15 @@ class TestQuestionsBadges(TestCase):
             description=badge_template['description'].format(year=year),
             save=True)
 
-        # Create 29 answer.
-        for i in range(29):
-            answer(creator=u, save=True)
+        # Create 29 answers.
+        q = question(save=True)
+        answers = []
+        for i in range(28):
+            answers.append(answer(question=q, creator=u))
+        Answer.objects.bulk_create(answers)
+
+        # Create the 29th answer separately so the signals are triggered.
+        answer(creator=u, save=True)
 
         # User should NOT have the badge yet.
         assert not b.is_awarded_to(u)

--- a/kitsune/wiki/tests/test_badges.py
+++ b/kitsune/wiki/tests/test_badges.py
@@ -6,6 +6,7 @@ from kitsune.kbadge.tests import badge
 from kitsune.sumo.tests import TestCase
 from kitsune.users.tests import profile
 from kitsune.wiki.badges import WIKI_BADGES
+from kitsune.wiki.models import Revision
 from kitsune.wiki.tests import revision, document
 
 
@@ -25,8 +26,13 @@ class TestWikiBadges(TestCase):
 
         # Create 9 approved en-US revisions.
         d = document(locale=settings.WIKI_DEFAULT_LANGUAGE, save=True)
-        for i in range(9):
-            revision(creator=u, document=d, is_approved=True, save=True)
+        revisions = []
+        for i in range(8):
+            revisions.append(revision(creator=u, document=d, is_approved=True))
+        Revision.objects.bulk_create(revisions)
+
+        # Create the 9th revision separately so signals get triggered.
+        revision(creator=u, document=d, is_approved=True, save=True)
 
         # User should NOT have the badge yet
         assert not b.is_awarded_to(u)
@@ -51,8 +57,13 @@ class TestWikiBadges(TestCase):
 
         # Create 9 approved es revisions.
         d = document(locale='es', save=True)
-        for i in range(9):
-            revision(creator=u, document=d, is_approved=True, save=True)
+        revisions = []
+        for i in range(8):
+            revisions.append(revision(creator=u, document=d, is_approved=True))
+        Revision.objects.bulk_create(revisions)
+
+        # Create the 9th revision separately so signals get triggered.
+        revision(creator=u, document=d, is_approved=True, save=True)
 
         # User should NOT have the badge yet
         assert not b.is_awarded_to(u)


### PR DESCRIPTION
I was looking at test performance for like an hour last week. I didnt find anything groundbreaking but... This is a decent speedup for only 4 tests. So it's only like 5 seconds, not much in the grand scheme of things but I figured it doesnt hurt. Might add up to that hour I spent over the next year or decade.

r?