### PR TITLE
[Bug 1175880] Change survey gizmo code to use SG's Beacon.

### DIFF
--- a/kitsune/products/templates/products/documents.html
+++ b/kitsune/products/templates/products/documents.html
@@ -9,11 +9,6 @@
 {% set styles = ('products',) %}
 {% set search_params = {'product': product.slug} %}
 
-{% if product.slug == 'mobile' %}
-  {# Firefox for Android has a special separate survey. #}
-  {% set extra_body_attrs = {'data-surveygizmo-url': 'http://qsurvey.mozilla.com/s3/63ac9fdb1ce1'} %}
-{% endif %}
-
 {% block title %}{{ _(topic.title, 'DB: products.Topic.title') }} | {{ _('{product} Help')|f(product=_(product.title, 'DB: products.Product.title')) }}{% endblock %}
 
 {% block content %}

--- a/kitsune/products/templates/products/product.html
+++ b/kitsune/products/templates/products/product.html
@@ -7,12 +7,7 @@
 {% set classes = 'product-landing' %}
 {% set search_params = {'product': product.slug} %}
 
-{% if product.slug == 'mobile' %}
-  {# Firefox for Android has a special separate survey. #}
-  {% set extra_body_attrs = {'data-surveygizmo-url': 'http://qsurvey.mozilla.com/s3/63ac9fdb1ce1', 'data-product-slug': product.slug} %}
-{% else %}
-  {% set extra_body_attrs = {'data-product-slug': product.slug} %}
-{% endif %}
+{% set extra_body_attrs = {'data-product-slug': product.slug} %}
 
 {% block title %}{{ _('{product} Help')|f(product=_(product.title, 'DB: products.Product.title')) }}{% endblock %}
 

--- a/kitsune/questions/templates/questions/base.html
+++ b/kitsune/questions/templates/questions/base.html
@@ -5,5 +5,3 @@
 {% if not scripts %}
   {% set scripts = ('questions', 'jqueryui') %}
 {% endif %}
-
-{% set extra_body_attrs = {'data-surveygizmo-url': 'http://www.surveygizmo.com/s3/1717268/SUMO-Survey-candidate-collection-forum'} %}

--- a/kitsune/sumo/static/sumo/js/surveygizmo.js
+++ b/kitsune/sumo/static/sumo/js/surveygizmo.js
@@ -4,14 +4,20 @@
  * This code was derived from the minified version of code posted in bug 1175880
  */
 (function() {
+    // set up temp SG reciever, until script loads
     window.SurveyGizmoBeacon = 'sg_beacon';
     window.sg_beacon = window.sg_beacon || function() {
         window.sg_beacon.q = window.sg_beacon.q || [];
         window.sg_beacon.q.push(arguments);
     };
+
+    // load SG beacon script
     var beaconScript = document.createElement('script');
     beaconScript.async = 1;
     beaconScript.src = '//d2bnxibecyz4h5.cloudfront.net/runtimejs/intercept/intercept.js';
     var lastScriptTag = document.getElementsByTagName('script')[0];
     lastScriptTag.parentNode.insertBefore(beaconScript, lastScriptTag);
+
+    // Initialize
+    window.sg_beacon('init', 'MjgwNDktQUYyRDQ3ODk0MjY1NEVFNUIwNTI3MjhFMDk2QTE3RDU=');
 })();

--- a/kitsune/sumo/static/sumo/js/surveygizmo.js
+++ b/kitsune/sumo/static/sumo/js/surveygizmo.js
@@ -1,48 +1,17 @@
-;(function() {
-    function launchWindow(url) {
-        var sg_div = document.createElement("div");
-        sg_div.innerHTML = (
-            '<h1>You have been selected for a survey</h1>' +
-            '<p>We appreciate your feedback!</p><p><a href="' + url + '">Please click here to start it now.</a></p>' +
-            '<a href="#" onclick="document.getElementById(\'sg-popup\').style.display = \'none\';return false;">No, thank you.</a>'
-        );
-        sg_div.id = "sg-popup";
-        document.body.appendChild(sg_div);
-    }
-
-    var surveys = {
-        site_survey: function() {
-            var surveyGizmoURL = $('body').data('surveygizmo-url') ||
-                "https://www.surveygizmo.com/s3/popup/1002970/46488f9ad4eb";
-            // This is adapted from a snipptet given by Survey Gizmo.
-            // It has been formatted to fit your screen. Bug 782809.
-            if (!$.cookie('hasSurveyed')) {
-                window.addEventListener("load", function(e) {
-                    launchWindow(surveyGizmoURL);
-                    $.cookie('hasSurveyed', '1', {expires: 365});
-                });
-            }
-        },
-
-        firefox_refresh: function() {
-            var surveyGizmoURL = 'https://www.surveygizmo.com/s3/2010802/69cc2a79f50b';
-            if ($.cookie('showFirefoxResetSurvey') === '1' && !$.cookie('hasEverFirefoxResetSurvey')) {
-                window.addEventListener("load", function(e) {
-                    launchWindow(surveyGizmoURL);
-                    $.cookie('showFirefoxResetSurvey', '0', {expires: 365});
-                    $.cookie('hasEverFirefoxResetSurvey', '1', {expires: 365});
-                });
-            }
-        }
+/* This sets up a couple of globals that SurveyGizmo can use to  hook
+ * into the UI and provide surveys to users.
+ *
+ * This code was derived from the minified version of code posted in bug 1175880
+ */
+(function() {
+    window.SurveyGizmoBeacon = 'sg_beacon';
+    window.sg_beacon = window.sg_beacon || function() {
+        window.sg_beacon.q = window.sg_beacon.q || [];
+        window.sg_beacon.q.push(arguments);
     };
-
-    $(function() {
-        var surveyList = $('body').data('survey-gizmos') || [];
-        for (var i = 0; i < surveyList.length; i++) {
-            survey = surveys[surveyList[i]];
-            if (survey) {
-                survey();
-            }
-        }
-    });
+    var beaconScript = document.createElement('script');
+    beaconScript.async = 1;
+    beaconScript.src = '//d2bnxibecyz4h5.cloudfront.net/runtimejs/intercept/intercept.js';
+    var lastScriptTag = document.getElementsByTagName('script')[0];
+    lastScriptTag.parentNode.insertBefore(beaconScript, lastScriptTag);
 })();

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -1,7 +1,4 @@
 {% from 'includes/common_macros.html' import announcement_bar, search_box, aux_nav, favicon with context %}
-{% if request.LANGUAGE_CODE == settings.WIKI_DEFAULT_LANGUAGE and waffle.flag('surveygizmo') %}
-  {% set SURVEY_GIZMOS = (SURVEY_GIZMOS or []) + ['site_survey', 'firefox_refresh'] %}
-{% endif %}
 {% if request.LANGUAGE_CODE == 'xx' %}
   {% set meta = [('robots', 'noindex')] %}
 {% endif %}
@@ -66,11 +63,6 @@
       data-usernames-api="{{ url('users.api.usernames') }}"
       data-static-url="{{ STATIC_URL }}"
       data-media-url="{{ MEDIA_URL }}"
-      {% if SURVEY_GIZMOS %}
-        data-survey-gizmos="{{ SURVEY_GIZMOS|json }}"
-      {% else %}
-        data-survey-gizmos="[]"
-      {% endif %}
       data-ga-push="{{ ga_push_attribute() }}"
       {% if ga_alternate_url %}
         data-ga-alternate-url="{{ ga_alternate_url }}"

--- a/kitsune/wiki/templates/wiki/document.html
+++ b/kitsune/wiki/templates/wiki/document.html
@@ -30,11 +30,6 @@
   {% set meta = meta + [('description', document.current_revision.summary)] %}
 {% endif %}
 
-{% if product.slug == 'mobile' %}
-  {# Firefox for Android has a special separate survey. #}
-  {% set extra_body_attrs = {'data-surveygizmo-url': 'http://qsurvey.mozilla.com/s3/63ac9fdb1ce1'} %}
-{% endif %}
-
 {% block breadcrumbs %}
   {{ breadcrumbs(breadcrumb_items, id='main-breadcrumbs') }}
 {% endblock %}


### PR DESCRIPTION
Now all Survey Gizmo surveys will be controlled from Survey Gizmo, instead of us having to put code on each page for each survey.

r?