### PR TITLE
[Bug 1175880] Replace exit survey with SurveyGizmo Beacon.

### DIFF
--- a/kitsune/sumo/static/sumo/js/surveygizmo.js
+++ b/kitsune/sumo/static/sumo/js/surveygizmo.js
@@ -1,23 +1,23 @@
-;(function() {
+/* globals $:false */
+(function() {
     function launchWindow(url) {
-        var sg_div = document.createElement("div");
+        var sg_div = document.createElement('div');
         sg_div.innerHTML = (
             '<h1>You have been selected for a survey</h1>' +
             '<p>We appreciate your feedback!</p><p><a href="' + url + '">Please click here to start it now.</a></p>' +
             '<a href="#" onclick="document.getElementById(\'sg-popup\').style.display = \'none\';return false;">No, thank you.</a>'
         );
-        sg_div.id = "sg-popup";
+        sg_div.id = 'sg-popup';
         document.body.appendChild(sg_div);
     }
 
     var surveys = {
         site_survey: function() {
-            var surveyGizmoURL = $('body').data('surveygizmo-url') ||
-                "https://www.surveygizmo.com/s3/popup/1002970/46488f9ad4eb";
-            // This is adapted from a snipptet given by Survey Gizmo.
+            // This is adapted from a snippet given by Survey Gizmo.
             // It has been formatted to fit your screen. Bug 782809.
-            if (!$.cookie('hasSurveyed')) {
-                window.addEventListener("load", function(e) {
+            var surveyGizmoURL = $('body').data('surveygizmo-url');
+            if (surveyGizmoURL && !$.cookie('hasSurveyed')) {
+                window.addEventListener('load', function(e) {
                     launchWindow(surveyGizmoURL);
                     $.cookie('hasSurveyed', '1', {expires: 365});
                 });
@@ -27,7 +27,7 @@
         firefox_refresh: function() {
             var surveyGizmoURL = 'https://www.surveygizmo.com/s3/2010802/69cc2a79f50b';
             if ($.cookie('showFirefoxResetSurvey') === '1' && !$.cookie('hasEverFirefoxResetSurvey')) {
-                window.addEventListener("load", function(e) {
+                window.addEventListener('load', function(e) {
                     launchWindow(surveyGizmoURL);
                     $.cookie('showFirefoxResetSurvey', '0', {expires: 365});
                     $.cookie('hasEverFirefoxResetSurvey', '1', {expires: 365});
@@ -39,10 +39,32 @@
     $(function() {
         var surveyList = $('body').data('survey-gizmos') || [];
         for (var i = 0; i < surveyList.length; i++) {
-            survey = surveys[surveyList[i]];
+            var survey = surveys[surveyList[i]];
             if (survey) {
                 survey();
             }
         }
     });
+
+    /* This sets up a couple of globals that SurveyGizmo can use to  hook
+     * into the UI and provide surveys to users.
+     *
+     * This code was derived from the minified version of code posted in bug 1175880
+     */
+    // set up temp SG reciever, until the main script loads
+    window.SurveyGizmoBeacon = 'sg_beacon';
+    window.sg_beacon = window.sg_beacon || function() {
+        window.sg_beacon.q = window.sg_beacon.q || [];
+        window.sg_beacon.q.push(arguments);
+    };
+
+    // load SG beacon script
+    var beaconScript = document.createElement('script');
+    beaconScript.async = 1;
+    beaconScript.src = '//d2bnxibecyz4h5.cloudfront.net/runtimejs/intercept/intercept.js';
+    var lastScriptTag = document.getElementsByTagName('script')[0];
+    lastScriptTag.parentNode.insertBefore(beaconScript, lastScriptTag);
+
+    // Initialize
+    window.sg_beacon('init', 'MjgwNDktQUYyRDQ3ODk0MjY1NEVFNUIwNTI3MjhFMDk2QTE3RDU=');
 })();


### PR DESCRIPTION
This is a less ambitious version of #2589 which only removes the exit survey, like specified in the bug.

There isn't a great way yet to target the other kind of surveys we have (like product surveys) in the beacon, so we will need to do more work if we want to kill the rest of the surveys.

r?