### PR TITLE
[Bug 1180947] SUMO Universal Download Button for Non-Firefox Users

### DIFF
--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -7,6 +7,7 @@ from mobility.decorators import mobile_template
 from product_details import product_details
 
 from kitsune.products.models import Product, Topic
+from kitsune.sumo.utils import get_browser
 from kitsune.wiki.decorators import check_simple_wiki_locale
 from kitsune.wiki.facets import topics_for, documents_for
 
@@ -43,12 +44,17 @@ def product_landing(request, template, slug):
         else:
             latest_version = 0
 
+    user_agent = request.META.get('HTTP_USER_AGENT', '')
+    browser = get_browser(user_agent)
+    show_fx_download = (product.slug == 'thunderbird' and browser != 'Firefox')
+
     return render(request, template, {
         'product': product,
         'products': Product.objects.filter(visible=True),
         'topics': topics_for(product=product, parent=None),
         'search_params': {'product': slug},
-        'latest_version': latest_version
+        'latest_version': latest_version,
+        'show_fx_download': show_fx_download
     })
 
 

--- a/kitsune/sumo/static/sumo/less/main.less
+++ b/kitsune/sumo/static/sumo/less/main.less
@@ -121,7 +121,7 @@ body {
       }
 
       #aux-nav {
-        margin-right: 302px;
+        margin-right: 290px;
 
         > ul {
           margin-top: 4px;
@@ -1229,6 +1229,29 @@ input[type=button],
     position: relative;
     top: -2px;
   }
+
+  .firefox-download-button {
+    background: #81BC2E;
+    background: linear-gradient(to bottom, #81BC2E, #659324);
+    border-radius: 5px;
+    box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.2), 0 -1px 0 0 rgba(0, 0, 0, 0.3) inset;
+    display: inline-block;
+    line-height: 25px;
+    margin: 6px 15px 0px 15px;
+    position: relative;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+    transition: all 0.5s;
+    width: 130px;
+
+    .download-title {
+      color: #FFFFFF;
+      display: inline-block;
+      font-family: "Open Sans",Arial,Helvetica,sans-serif;
+      padding: 1px 6px 1px 12px;
+      text-align: center;
+      text-transform: capitalize;
+    }
+  }
 }
 
 .html-rtl {
@@ -1395,7 +1418,7 @@ input[type=button],
   margin: 35px 0 0 0;
 
   .searchbox {
-    width: 240px;
+    width: 200px;
   }
 }
 

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -137,6 +137,12 @@
             {% if not hide_locale_switcher %}
               <li><a href="{{ locale_picker_url }}" class="locale-picker">{{ settings.LANGUAGES_DICT[request.LANGUAGE_CODE.lower()] }}</a></li>
             {% endif %}
+            {% if show_fx_download and not user.is_authenticated() %}
+              <a href="https://www.mozilla.org/en-US/firefox/new/?scene=2&utm_source=support.mozilla.org&utm_medium=referral&utm_campaign=non-fx-button#download-fx"
+                class="firefox-download-button" data-ga-click="_trackEvent | Download Button | Firefox button on Thunderbird article">
+                <strong class="download-title">{{ _('Download Firefox') }}</strong>
+              </a>
+            {% endif %}
           </ul>
         </nav>
       </div>

--- a/kitsune/sumo/tests/test_utils.py
+++ b/kitsune/sumo/tests/test_utils.py
@@ -9,7 +9,7 @@ from nose.tools import eq_
 
 from kitsune.journal.models import Record
 from kitsune.sumo.utils import (
-    chunked, get_next_url, is_ratelimited, smart_int, truncated_json_dumps)
+    chunked, get_next_url, is_ratelimited, smart_int, truncated_json_dumps, get_browser)
 from kitsune.sumo.tests import TestCase
 from kitsune.users.tests import profile
 
@@ -170,3 +170,40 @@ class IsRatelimitedTest(TestCase):
         is_ratelimited(request, 'test-ratelimited', '1/min')
 
         eq_(Record.objects.count(), 1)
+
+
+class GetBrowserNameTest(TestCase):
+
+    def test_firefox(self):
+        """Test with User Agent of Firefox"""
+
+        user_agent = 'Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0'
+        # Check Firefox is returning
+        eq_(get_browser(user_agent), 'Firefox')
+
+    def test_chrome(self):
+        """Test with User Agent of Chrome"""
+
+        user_agent = ('Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) '
+                      'Chrome/41.0.2228.0 Safari/537.36')
+        # Check Chrome is returning
+        eq_(get_browser(user_agent), 'Chrome')
+
+    def test_internet_explorer(self):
+        """Test with User Agent of Internet Explorer"""
+
+        # Check with default User Agent of IE 11
+        user_agent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko'
+        eq_(get_browser(user_agent), 'Trident')
+        # Check with Compatibility View situation user Agent of IE11
+        user_agent = ('Mozilla/5.0 (compatible, MSIE 11, Windows NT 6.3; '
+                      'Trident/7.0;  rv:11.0) like Gecko')
+        eq_(get_browser(user_agent), 'MSIE')
+
+    def test_safari(self):
+        """Test with User Agent of Safari"""
+
+        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14'
+                      '(KHTML, like Gecko) Version/7.0.3 Safari/7046A194A')
+        # Check Safari is returning
+        eq_(get_browser(user_agent), 'Safari')

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sys
 from contextlib import contextmanager
 from datetime import datetime
@@ -328,3 +329,14 @@ def is_ratelimited(request, name, rate, method=['POST'], skip_if=lambda r: False
             Record.objects.info('sumo.ratelimit', '{key} hit the rate limit for {name}',
                                 key=key, name=name)
     return request.limited
+
+
+def get_browser(user_agent):
+    """Get Browser Name from User Agent"""
+
+    match = re.search(r'(?i)(firefox|msie|chrome|safari|trident)', user_agent, re.IGNORECASE)
+    if match:
+        browser = match.group(1)
+    else:
+        browser = None
+    return browser

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -30,7 +30,7 @@ from kitsune.sumo.decorators import ratelimit
 from kitsune.sumo.helpers import urlparams
 from kitsune.sumo.redis_utils import redis_client, RedisError
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.sumo.utils import paginate, smart_int, get_next_url, truncated_json_dumps
+from kitsune.sumo.utils import paginate, smart_int, get_next_url, truncated_json_dumps, get_browser
 from kitsune.wiki.config import (
     CATEGORIES, MAJOR_SIGNIFICANCE, TEMPLATES_CATEGORY, DOCUMENTS_PER_PAGE,
     COLLAPSIBLE_DOCUMENTS)
@@ -203,6 +203,10 @@ def document(request, document_slug, template=None, document=None):
     # The list above was built backwards, so flip this.
     breadcrumbs.reverse()
 
+    user_agent = request.META.get('HTTP_USER_AGENT', '')
+    browser = get_browser(user_agent)
+    show_fx_download = (product.slug == 'thunderbird' and browser != 'Firefox')
+
     data = {
         'document': doc,
         'redirected_from': redirected_from,
@@ -217,6 +221,7 @@ def document(request, document_slug, template=None, document=None):
         'breadcrumb_items': breadcrumbs,
         'document_css_class': document_css_class,
         'any_localizable_revision': any_localizable_revision,
+        'show_fx_download': show_fx_download,
     }
 
     response = render(request, template, data)


### PR DESCRIPTION
I think this should work as expected. mentioned in the bug
* User who are **not using Firefox** browser will see Firefox Download Button in Thunderbird product Page and Thunderbird articles
* User will see the button only if he is **not logged in**

r?