### PR TITLE
[Bug 1090363] Fixes issue with navigation due to fixedheader

### DIFF
--- a/kitsune/sumo/static/sumo/js/ui.js
+++ b/kitsune/sumo/static/sumo/js/ui.js
@@ -276,11 +276,11 @@
     }
   }
 
-  function correctFixedHeader(){
+  function correctFixedHeader() {
     var headerHeight = document.querySelector('header');
     var scrollHeight = headerHeight.scrollHeight;
-    if(window.location.hash && document.querySelector(window.location.hash)){
-      window.scrollBy(0,-scrollHeight);
+    if (window.location.hash && document.querySelector(window.location.hash)) {
+      window.scrollBy(0, -scrollHeight);
     }
   }
 
@@ -372,6 +372,7 @@
 
   $(document).on('keyup', '[data-validate-url] input', _.throttle(validate_field_cb, 200));
   $(document).on('change', '[data-validate-url] input', _.throttle(validate_field_cb, 200));
+  $(window).on('hashchange', correctFixedHeader);
 
   $(document).on('click', '[data-mozilla-ui-reset]', function(ev) {
     ev.preventDefault();

--- a/kitsune/sumo/static/sumo/js/ui.js
+++ b/kitsune/sumo/static/sumo/js/ui.js
@@ -192,6 +192,7 @@
   });
 
   $(window).load(function() {
+    correctFixedHeader();
     $('[data-ui-type="carousel"]').each(function() {
       var $this = $(this);
       var $container = $(this).children().first()
@@ -272,6 +273,14 @@
           }
         }
       });
+    }
+  }
+
+  function correctFixedHeader(){
+    var headerHeight = document.querySelector('header');
+    var scrollHeight = headerHeight.scrollHeight;
+    if(window.location.hash && document.querySelector(window.location.hash)){
+      window.scrollBy(0,-scrollHeight);
     }
   }
 


### PR DESCRIPTION
The problem was the fixedheader overlays the navigation done by browser using the hash in end of URL.

This can be solved by adding a function on page load which does the following
1. Check if hash is present in URL.
2. If yes check if a valid element with that hash exist in the page. This is done so that we don't end up scrolling the page without any requirement.
3. if element exists we need to scroll the page a little down ( Scroll to the height of fixed header) so that the contents are not under the menu. 

