### PR TITLE
[Bug 1175880] Replace exit survey with Beacon on pages with no other survey.

### DIFF
--- a/kitsune/products/templates/products/documents.html
+++ b/kitsune/products/templates/products/documents.html
@@ -11,7 +11,7 @@
 
 {% if product.slug == 'mobile' %}
   {# Firefox for Android has a special separate survey. #}
-  {% set extra_body_attrs = {'data-surveygizmo-url': 'http://qsurvey.mozilla.com/s3/63ac9fdb1ce1'} %}
+  {% set SURVEY_GIZMOS = ['mobile'] %}
 {% endif %}
 
 {% block title %}{{ _(topic.title, 'DB: products.Topic.title') }} | {{ _('{product} Help')|f(product=_(product.title, 'DB: products.Product.title')) }}{% endblock %}

--- a/kitsune/products/templates/products/product.html
+++ b/kitsune/products/templates/products/product.html
@@ -9,10 +9,9 @@
 
 {% if product.slug == 'mobile' %}
   {# Firefox for Android has a special separate survey. #}
-  {% set extra_body_attrs = {'data-surveygizmo-url': 'http://qsurvey.mozilla.com/s3/63ac9fdb1ce1', 'data-product-slug': product.slug} %}
-{% else %}
-  {% set extra_body_attrs = {'data-product-slug': product.slug} %}
+  {% set SURVEY_GIZMOS = ['mobile'] %}
 {% endif %}
+{% set extra_body_attrs = {'data-product-slug': product.slug} %}
 
 {% block title %}{{ _('{product} Help')|f(product=_(product.title, 'DB: products.Product.title')) }}{% endblock %}
 

--- a/kitsune/questions/templates/questions/base.html
+++ b/kitsune/questions/templates/questions/base.html
@@ -6,4 +6,4 @@
   {% set scripts = ('questions', 'jqueryui') %}
 {% endif %}
 
-{% set extra_body_attrs = {'data-surveygizmo-url': 'http://www.surveygizmo.com/s3/1717268/SUMO-Survey-candidate-collection-forum'} %}
+{% set SURVEY_GIZMOS = ['questions'] %}

--- a/kitsune/sumo/static/sumo/js/surveygizmo.js
+++ b/kitsune/sumo/static/sumo/js/surveygizmo.js
@@ -1,4 +1,5 @@
-;(function() {
+/* globals $:false */
+(function() {
     function launchWindow(url) {
         var sg_div = document.createElement("div");
         sg_div.innerHTML = (
@@ -10,36 +11,71 @@
         document.body.appendChild(sg_div);
     }
 
+    function basicSurvey(surveyGizmoURL) {
+        // This is adapted from a snipptet given by Survey Gizmo.
+        // It has been formatted to fit your screen. Bug 782809.
+        if (!$.cookie('hasSurveyed')) {
+            window.addEventListener('load', function(e) {
+                launchWindow(surveyGizmoURL);
+                $.cookie('hasSurveyed', '1', {expires: 365});
+            });
+        }
+    }
+
     var surveys = {
         site_survey: function() {
-            var surveyGizmoURL = $('body').data('surveygizmo-url') ||
-                "https://www.surveygizmo.com/s3/popup/1002970/46488f9ad4eb";
-            // This is adapted from a snipptet given by Survey Gizmo.
-            // It has been formatted to fit your screen. Bug 782809.
-            if (!$.cookie('hasSurveyed')) {
-                window.addEventListener("load", function(e) {
-                    launchWindow(surveyGizmoURL);
-                    $.cookie('hasSurveyed', '1', {expires: 365});
-                });
-            }
+            basicSurvey('https://www.surveygizmo.com/s3/popup/1002970/46488f9ad4eb');
+        },
+
+        mobile: function() {
+            basicSurvey('http://qsurvey.mozilla.com/s3/63ac9fdb1ce1');
+        },
+
+        questions: function() {
+            basicSurvey('http://www.surveygizmo.com/s3/1717268/SUMO-Survey-candidate-collection-forum');
         },
 
         firefox_refresh: function() {
             var surveyGizmoURL = 'https://www.surveygizmo.com/s3/2010802/69cc2a79f50b';
             if ($.cookie('showFirefoxResetSurvey') === '1' && !$.cookie('hasEverFirefoxResetSurvey')) {
-                window.addEventListener("load", function(e) {
+                window.addEventListener('load', function(e) {
                     launchWindow(surveyGizmoURL);
                     $.cookie('showFirefoxResetSurvey', '0', {expires: 365});
                     $.cookie('hasEverFirefoxResetSurvey', '1', {expires: 365});
                 });
             }
+        },
+
+        /* This sets up a couple of globals that SurveyGizmo can use to  hook
+         * into the UI and provide surveys to users.
+         *
+         * This code was derived from the minified version of code posted in bug 1175880
+         */
+        beacon: function() {
+            // set up temp SG reciever, until the main script loads
+            window.SurveyGizmoBeacon = 'sg_beacon';
+            window.sg_beacon = window.sg_beacon || function() {
+                window.sg_beacon.q = window.sg_beacon.q || [];
+                window.sg_beacon.q.push(arguments);
+            };
+
+            // load SG beacon script
+            var beaconScript = document.createElement('script');
+            beaconScript.async = 1;
+            beaconScript.src = '//d2bnxibecyz4h5.cloudfront.net/runtimejs/intercept/intercept.js';
+            var lastScriptTag = document.getElementsByTagName('script')[0];
+            lastScriptTag.parentNode.insertBefore(beaconScript, lastScriptTag);
+
+            // Initialize
+            window.sg_beacon('init', 'MjgwNDktQUYyRDQ3ODk0MjY1NEVFNUIwNTI3MjhFMDk2QTE3RDU=');
         }
     };
+
 
     $(function() {
         var surveyList = $('body').data('survey-gizmos') || [];
         for (var i = 0; i < surveyList.length; i++) {
-            survey = surveys[surveyList[i]];
+            var survey = surveys[surveyList[i]];
             if (survey) {
                 survey();
             }

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -1,6 +1,6 @@
 {% from 'includes/common_macros.html' import announcement_bar, search_box, aux_nav, favicon with context %}
 {% if request.LANGUAGE_CODE == settings.WIKI_DEFAULT_LANGUAGE and waffle.flag('surveygizmo') %}
-  {% set SURVEY_GIZMOS = (SURVEY_GIZMOS or []) + ['site_survey', 'firefox_refresh'] %}
+  {% set SURVEY_GIZMOS = (SURVEY_GIZMOS or ['beacon']) + ['firefox_refresh'] %}
 {% endif %}
 {% if request.LANGUAGE_CODE == 'xx' %}
   {% set meta = [('robots', 'noindex')] %}

--- a/kitsune/wiki/templates/wiki/document.html
+++ b/kitsune/wiki/templates/wiki/document.html
@@ -32,7 +32,7 @@
 
 {% if product.slug == 'mobile' %}
   {# Firefox for Android has a special separate survey. #}
-  {% set extra_body_attrs = {'data-surveygizmo-url': 'http://qsurvey.mozilla.com/s3/63ac9fdb1ce1'} %}
+  {% set SURVEY_GIZMOS = ['mobile'] %}
 {% endif %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
The logic is now

1. A template can ask for a custom survey by name (not by URL).
2. If no survey is provided, the survey named `beacon` is used.
3. The refresh survey is added to the list from (1) and (2). (It is always included).
4. Each survey has custom rules for if it gets shown (generally cookie and waffle based). These didn't change.

The beacon code is a copy and paste from the other two PRs for this bug. The interesting part is the change to the logic for how the survey is selected. Two things should be true:

1. All pages should have at least two surveys.
2. If a page has the beacon survey, it should have no other survey except the refresh survey.
3. All pages should have the refresh survey.

r?