### PR TITLE
[Bug 1175880] Style Survey Gizmo bottom bar.

### DIFF
--- a/kitsune/sumo/static/sumo/less/main.less
+++ b/kitsune/sumo/static/sumo/less/main.less
@@ -1905,6 +1905,11 @@ input[type=button],
   z-index: 1000;
 }
 
+/* Survey Gizmo bottom bar */
+.sg-b-bar {
+  box-shadow: 0px -3px 3px rgba(0, 0, 0, 0.1);
+}
+
 .html-rtl {
   > .breadcrumbs {
     > .container_12 {


### PR DESCRIPTION
This adds a little shadow above the survey gizmo beacon UI (which is just an unstyled white box). It makes it look a lot better on the site.

To test: Visit a page like /en-US/kb/install-older-version-of-firefox?SGINTTEST=2645123 . That will force the survey gizmo beacon to trigger, showing the UI that this patches.

r?