### PR TITLE
[Bug 1187070] Don't use repr for Documents in DocumentLink.

### DIFF
--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -1182,7 +1182,7 @@ class DocumentLink(ModelBase):
         unique_together = ('linked_from', 'linked_to', 'kind')
 
     def __unicode__(self):
-        return (u'<DocumentLink: %s from %r to %r>' %
+        return (u'<DocumentLink: %s from %s to %s>' %
                 (self.kind, self.linked_from, self.linked_to))
 
 


### PR DESCRIPTION
I'm not sure why, but this causes some Django templates to get very confused and throw unicode decode errors. In particular, when trying to delete documents, if the document is linked to another document and one of those two documents has unicode in the title, the '%r' in the format string throws an error. Changing these to %s fixes the delete page.

I still don't know what is going on here. I tried and failed to reproduce it.

r?