### PR TITLE
[Bug 1180947] SUMO Universal Download Button for Non-Firefox Users

### DIFF
--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -44,17 +44,12 @@ def product_landing(request, template, slug):
         else:
             latest_version = 0
 
-    user_agent = request.META.get('HTTP_USER_AGENT', '')
-    browser = get_browser(user_agent)
-    show_fx_download = (product.slug == 'thunderbird' and browser != 'Firefox')
-
     return render(request, template, {
         'product': product,
         'products': Product.objects.filter(visible=True),
         'topics': topics_for(product=product, parent=None),
         'search_params': {'product': slug},
-        'latest_version': latest_version,
-        'show_fx_download': show_fx_download
+        'latest_version': latest_version
     })
 
 
@@ -79,6 +74,10 @@ def document_listing(request, template, product_slug, topic_slug,
 
     documents, fallback_documents = documents_for(**doc_kw)
 
+    user_agent = request.META.get('HTTP_USER_AGENT', '')
+    browser = get_browser(user_agent)
+    show_fx_download = (product.slug == 'thunderbird' and browser != 'Firefox')
+
     return render(request, template, {
         'product': product,
         'topic': topic,
@@ -87,4 +86,5 @@ def document_listing(request, template, product_slug, topic_slug,
         'subtopics': topics_for(product=product, parent=topic),
         'documents': documents,
         'fallback_documents': fallback_documents,
-        'search_params': {'product': product_slug}})
+        'search_params': {'product': product_slug},
+        'show_fx_download': show_fx_download})


### PR DESCRIPTION
This should fix the workaround of the Bug. It was misunderstood that the download button should be shown in Thunderbid product page. Actually it should work like below
* The button **should not** show in thunderbird product page
* But the button **Should Show** in any of the **Topic Page** of Thunderbird Product

r?