### PR TITLE
[Bug 1183428] Add about:support troubleshooting data to new AAQ.

### DIFF
--- a/kitsune/questions/static/questions/js/actions/AAQActions.es6.js
+++ b/kitsune/questions/static/questions/js/actions/AAQActions.es6.js
@@ -87,6 +87,15 @@ export function setTroubleshootingOptIn(optIn) {
   }
 }
 
+export function checkTroubleshootingAvailable() {
+  remoteTroubleshooting.available(available => {
+    Dispatcher.dispatch({
+      type: actionTypes.TROUBLESHOOTING_AVAILABLE,
+      available: available
+    });
+  });
+}
+
 function getTroubleshootingInfo() {
   return new Promise((resolve, reject) => {
     remoteTroubleshooting.available(function (yesno) {
@@ -182,5 +191,6 @@ export default {
   setTitle,
   setContent,
   setTroubleshootingOptIn,
+  checkTroubleshootingAvailable,
   submitQuestion,
 };

--- a/kitsune/questions/static/questions/js/actions/AAQActions.es6.js
+++ b/kitsune/questions/static/questions/js/actions/AAQActions.es6.js
@@ -3,6 +3,10 @@ import apiFetch from '../../../sumo/js/utils/apiFetch.es6.js';
 import Dispatcher from '../../../sumo/js/Dispatcher.es6.js';
 import {actionTypes} from '../constants/AAQConstants.es6.js';
 import QuestionEditStore from '../stores/QuestionEditStore.es6.js';
+import TroubleshootingDataStore from '../stores/TroubleshootingDataStore.es6.js';
+import '../../../sumo/js/remote.js';
+
+const remoteTroubleshooting = window.remoteTroubleshooting;
 
 export function setProduct(product) {
   Dispatcher.dispatch({
@@ -70,6 +74,47 @@ export function setContent(content) {
   });
 }
 
+export function setTroubleshootingOptIn(optIn) {
+  if (optIn) {
+    Dispatcher.dispatch({
+      type: actionTypes.TROUBLESHOOTING_OPT_IN,
+    });
+    getTroubleshootingInfo();
+  } else {
+    Dispatcher.dispatch({
+      type: actionTypes.TROUBLESHOOTING_OPT_OUT,
+    });
+  }
+}
+
+function getTroubleshootingInfo() {
+  return new Promise((resolve, reject) => {
+    remoteTroubleshooting.available(function (yesno) {
+      if (yesno) {
+        remoteTroubleshooting.getData(function (data) {
+          resolve(data);
+        });
+      } else {
+        resolve(null);
+      }
+    });
+  })
+  .then(data => {
+    // Clean out the verbose and not very useful print preferences.
+    var modifiedPreferences = data.modifiedPreferences;
+    data.modifiedPreferences = {};
+    for (var key in modifiedPreferences) {
+      if (key.indexOf('print.') !== 0) {
+        data.modifiedPreferences[key] = modifiedPreferences[key];
+      }
+    }
+    Dispatcher.dispatch({
+      type: actionTypes.TROUBLESHOOTING_SET_DATA,
+      data,
+    });
+  });
+}
+
 export function submitQuestion() {
   Dispatcher.dispatch({
     type: actionTypes.QUESTION_SUBMIT_OPTIMISTIC,
@@ -95,6 +140,10 @@ export function submitQuestion() {
     },
   })
   .then(question => {
+    if (TroubleshootingDataStore.getOptedIn()) {
+      metadata.troubleshooting = JSON.stringify(TroubleshootingDataStore.getData());
+    }
+
     questionUrl = `/${locale}/questions/${question.id}`;
 
     let promises = [];
@@ -126,10 +175,12 @@ export function submitQuestion() {
   });
 }
 
+
 export default {
   setProduct,
   setTopic,
   setTitle,
   setContent,
+  setTroubleshootingOptIn,
   submitQuestion,
 };

--- a/kitsune/questions/static/questions/js/components/AAQApp.jsx
+++ b/kitsune/questions/static/questions/js/components/AAQApp.jsx
@@ -7,20 +7,29 @@ import TopicSelector from './TopicSelector.jsx';
 import TitleContentEditor from './TitleContentEditor.jsx';
 import UserAuth from './UserAuth.jsx';
 import SubmitQuestion from './SubmitQuestion.jsx';
+import TroubleshootingDataStore from '../stores/TroubleshootingDataStore.es6.js';
 
 export default class AAQApp extends React.Component {
   constructor(props) {
     super(props);
     this.state = this.getStateFromStores();
+    this.onChange = this.onChange.bind(this);
   }
 
   componentDidMount() {
-    QuestionEditStore.addChangeListener(() => {
-      this.setState(this.getStateFromStores());
-    });
-    UserAuthStore.addChangeListener(() => {
-      this.setState(this.getStateFromStores());
-    });
+    QuestionEditStore.addChangeListener(this.onChange);
+    UserAuthStore.addChangeListener(this.onChange);
+    TroubleshootingDataStore.addChangeListener(this.onChange);
+  }
+
+  componentWillUnmount() {
+    QuestionEditStore.removeChangeListener(this.onChange);
+    UserAuthStore.removeChangeListener(this.onChange);
+    TroubleshootingDataStore.removeChangeListener(this.onChange);
+  }
+
+  onChange() {
+    this.setState(this.getStateFromStores());
   }
 
   getStateFromStores() {
@@ -30,6 +39,7 @@ export default class AAQApp extends React.Component {
       validationErrors: QuestionEditStore.getValidationErrors(),
       questionState: QuestionEditStore.getState(),
       userAuth: UserAuthStore.getAll(),
+      troubleshooting: TroubleshootingDataStore.getAll(),
     };
   }
 

--- a/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
+++ b/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
@@ -14,6 +14,10 @@ export default class TitleContentEditor extends AAQStep {
     }
   }
 
+  componentDidMount() {
+    AAQActions.checkTroubleshootingAvailable();
+  }
+
   shouldExpand() {
     return (this.props.question.topic !== null &&
             this.props.question.product !== null);
@@ -49,9 +53,11 @@ export default class TitleContentEditor extends AAQStep {
           <SuggestionList suggestions={this.props.suggestions}/>
         </div>
 
-        <div className="row">
-          <TroubleshootingData {...this.props.troubleshooting}/>
-        </div>
+        {this.props.troubleshooting.available
+          ? <div className="row">
+              <TroubleshootingData {...this.props.troubleshooting}/>
+            </div>
+          : null}
       </div>
     );
   }

--- a/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
+++ b/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
@@ -26,26 +26,32 @@ export default class TitleContentEditor extends AAQStep {
   body() {
     return (
       <div className="AAQApp__TitleContentEditor">
-        <div className="AAQApp__TitleContentEditor__Editor">
-          <div className="AAQApp__TitleContentEditor__Editor__Title">
-            <label>Subject</label>
-            <input
-              type="text"
-              name="title"
-              value={this.props.question.title}
-              onChange={this.handleChange.bind(this)}
-              ref="title"/>
+        <div className="row">
+          <div className="AAQApp__TitleContentEditor__Editor">
+            <div className="AAQApp__TitleContentEditor__Editor__Title">
+              <label>Subject</label>
+              <input
+                type="text"
+                name="title"
+                value={this.props.question.title}
+                onChange={this.handleChange.bind(this)}
+                ref="title"/>
+            </div>
+            <div className="AAQApp__TitleContentEditor__Editor__Content">
+              <label>More Details</label>
+              <textarea
+                name="content"
+                value={this.props.question.content}
+                onChange={this.handleChange.bind(this)}
+                ref="content"/>
+            </div>
           </div>
-          <div className="AAQApp__TitleContentEditor__Editor__Content">
-            <label>More Details</label>
-            <textarea
-              name="content"
-              value={this.props.question.content}
-              onChange={this.handleChange.bind(this)}
-              ref="content"/>
-          </div>
+          <SuggestionList suggestions={this.props.suggestions}/>
         </div>
-        <SuggestionList suggestions={this.props.suggestions}/>
+
+        <div className="row">
+          <TroubleshootingData {...this.props.troubleshooting}/>
+        </div>
       </div>
     );
   }
@@ -54,8 +60,8 @@ TitleContentEditor.propTypes = {
   className: React.PropTypes.string,
   question: React.PropTypes.object.isRequired,
   suggestions: React.PropTypes.array.isRequired,
+  troubleshooting: React.PropTypes.object.isRequired,
 };
-
 
 class SuggestionList extends React.Component {
   render() {
@@ -74,7 +80,6 @@ SuggestionList.propTypes = {
   suggestions: React.PropTypes.array.isRequired,
 };
 
-
 class SuggestionItem extends React.Component {
   render() {
     let suggestion = this.props.suggestion;
@@ -89,3 +94,57 @@ class SuggestionItem extends React.Component {
 SuggestionItem.propTypes = {
   suggestion: React.PropTypes.object.isRequired,
 };
+
+class TroubleshootingData extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      expand: false,
+    };
+  }
+
+  handleOpt({target: {checked}}) {
+    AAQActions.setTroubleshootingOptIn(checked);
+  }
+
+  toggleExpand(ev) {
+    ev.preventDefault();
+    this.setState(state => ({expand: !this.state.expand}));
+  }
+
+  render() {
+    return (
+      <div className="AAQApp__TroubleshootingData">
+        <h3>Troubleshooting Information</h3>
+        <p>
+          This information gives details about the internal workings of
+          your browser that will help in answering your question.
+        </p>
+        <p>
+          <input type="checkbox"
+                 name="troubleshootingDataOptIn"
+                 checked={this.props.optIn}
+                 onChange={this.handleOpt.bind(this)}>
+            <label>Share data</label>
+          </input>
+          <a href="#" onClick={this.toggleExpand.bind(this)}>
+            {this.props.optIn
+              ? (this.state.expand
+                ? 'Hide'
+                : "Show the data I'm sharing")
+              : null}
+          </a>
+        </p>
+        {this.state.expand && this.props.optIn
+          ? <pre className="AAQApp__TroubleshootingData__dataView">
+              {JSON.stringify(this.props.data, null, 2)}
+            </pre>
+          : null}
+      </div>
+    );
+  }
+}
+TroubleshootingData.propTypes = {
+  optIn: React.PropTypes.bool.isRequired,
+  data: React.PropTypes.object.isRequired,
+}

--- a/kitsune/questions/static/questions/js/constants/AAQConstants.es6.js
+++ b/kitsune/questions/static/questions/js/constants/AAQConstants.es6.js
@@ -9,6 +9,9 @@ export const actionTypes = constantMap([
   'QUESTION_SUBMIT_OPTIMISTIC',
   'QUESTION_SUBMIT_SUCCESS',
   'QUESTION_SUBMIT_FAILURE',
+  'TROUBLESHOOTING_OPT_IN',
+  'TROUBLESHOOTING_OPT_OUT',
+  'TROUBLESHOOTING_SET_DATA',
 ]);
 
 export const questionEditState = constantMap([

--- a/kitsune/questions/static/questions/js/constants/AAQConstants.es6.js
+++ b/kitsune/questions/static/questions/js/constants/AAQConstants.es6.js
@@ -12,6 +12,7 @@ export const actionTypes = constantMap([
   'TROUBLESHOOTING_OPT_IN',
   'TROUBLESHOOTING_OPT_OUT',
   'TROUBLESHOOTING_SET_DATA',
+  'TROUBLESHOOTING_AVAILABLE',
 ]);
 
 export const questionEditState = constantMap([

--- a/kitsune/questions/static/questions/js/stores/TroubleshootingDataStore.es6.js
+++ b/kitsune/questions/static/questions/js/stores/TroubleshootingDataStore.es6.js
@@ -1,0 +1,67 @@
+import BaseStore from '../../../sumo/js/stores/BaseStore.es6.js';
+import Dispatcher from '../../../sumo/js/Dispatcher.es6.js';
+import {actionTypes, questionEditState} from '../constants/AAQConstants.es6.js';
+
+let troubleshootingInfo = {
+  optIn: false,
+  data: null,
+  available: false,
+};
+
+class _TroubleshootingDataStore extends BaseStore {
+  getData() {
+    if (troubleshootingInfo.optIn) {
+      return troubleshootingInfo.data;
+    } else {
+      return null;
+    }
+  }
+
+  getOptedIn() {
+    return troubleshootingInfo.optIn;
+  }
+
+  getAvailable() {
+    return troubleshootingInfo.available;
+  }
+
+  getAll() {
+    return {
+      data: this.getData(),
+      optIn: this.getOptedIn(),
+      available: this.getAvailable(),
+    };
+  }
+}
+
+// Stores are singletons.
+const TroubleshootingDataStore = new _TroubleshootingDataStore();
+
+TroubleshootingDataStore.dispatchToken = Dispatcher.register((action) => {
+  switch (action.type) {
+    case actionTypes.TROUBLESHOOTING_OPT_IN:
+      troubleshootingInfo.optIn = true;
+      TroubleshootingDataStore.emitChange();
+      break;
+
+    case actionTypes.TROUBLESHOOTING_OPT_OUT:
+      troubleshootingInfo.optIn = false;
+      TroubleshootingDataStore.emitChange();
+      break;
+
+    case actionTypes.TROUBLESHOOTING_SET_DATA:
+      troubleshootingInfo.data = action.data;
+      TroubleshootingDataStore.emitChange();
+      break;
+
+    case actionTypes.TROUBLESHOOTING_AVAILABLE:
+      troubleshootingInfo.available = action.available;
+      TroubleshootingDataStore.emitChange();
+      break;
+
+    default:
+      // do nothing
+  }
+});
+
+export default TroubleshootingDataStore;

--- a/kitsune/questions/static/questions/less/questions.aaq.react.less
+++ b/kitsune/questions/static/questions/less/questions.aaq.react.less
@@ -24,8 +24,8 @@
       display: flex;
 
       .AAQApp__TitleContentEditor__Editor {
-        flex: 0 0 50%;
         display: flex;
+        flex: 0 0 50%;
         flex-direction: column;
 
        > div:not(:last-child) {

--- a/kitsune/questions/static/questions/less/questions.aaq.react.less
+++ b/kitsune/questions/static/questions/less/questions.aaq.react.less
@@ -20,38 +20,56 @@
   }
 
   &__TitleContentEditor {
-    display: flex;
-
-    &__Editor {
-      flex: 0 0 50%;
+    .row {
       display: flex;
-      flex-direction: column;
 
-     > div:not(:last-child) {
-       margin-bottom: 10px;
-     }
+      .AAQApp__TitleContentEditor__Editor {
+        flex: 0 0 50%;
+        display: flex;
+        flex-direction: column;
 
-      &__Title {
-        flex: 0 0;
-      }
+       > div:not(:last-child) {
+         margin-bottom: 10px;
+       }
 
-      &__Content {
-        flex: 1 1 100%;
+        &__Title {
+          flex: 0 0;
+        }
 
+        &__Content {
+          flex: 1 1 100%;
+
+          textarea {
+            height: 90%;
+            min-height: 350px;
+          }
+        }
+
+        label {
+          display: block;
+        }
+
+        input,
         textarea {
-          height: 90%;
-          min-height: 350px;
+          width: 100%;
         }
       }
+    }
+  }
 
-      label {
-        display: block;
-      }
+  &__TroubleshootingData {
+    width: 100%;
 
-      input,
-      textarea {
-        width: 100%;
-      }
+    label {
+      margin-right: 10px;
+    }
+
+    &__dataView {
+      background: #eee;
+      border: 1px solid #888;
+      border-radius: 3px;
+      max-height: 200px;
+      overyflow-y: auto;
     }
   }
 


### PR DESCRIPTION
This update the new AAQ to include UI and behavior to collect about:support data from users using the UITour libraries exposed to us.

To test this, you'll need to run kitsune with https, and flip an extra flag in your browser console. [The docs have a section about this](http://kitsune.readthedocs.org/en/latest/notes.html?highlight=ssl#about-support-api). 

When the UITour libraries aren't available, for whatever reason (not Firefox, old Firefox, not SSL, etc), the UI for this not included on the page.

@lonnen This touches privacy related things. Policies and data retention haven't changed. The UI has changed slightly. Pedantically, the way the data gets from the browser to the server has changed, but I don't think it is significantly different.

r?

Here are some screen shots of the old and the new flow:

## The old AAQ

1. Have not opted in
  ![shot_2065](https://cloud.githubusercontent.com/assets/305049/9284371/2652aa82-4290-11e5-915a-a5e695a833aa.png)
2. Opted In
  ![shot_2264](https://cloud.githubusercontent.com/assets/305049/9284367/26505d04-4290-11e5-9577-1ae5f203d73c.png)
3. Opted in, data expanded
  ![shot_2451](https://cloud.githubusercontent.com/assets/305049/9284368/265144d0-4290-11e5-85a6-5503d9d7eba1.png)

## The new AAQ

1. Have not opted in
  ![shot_3328](https://cloud.githubusercontent.com/assets/305049/9284366/2650587c-4290-11e5-85b5-5e0712f7e7b9.png)
2. Opted in
  ![shot_3527](https://cloud.githubusercontent.com/assets/305049/9284370/265227f6-4290-11e5-89ee-5ed94d729dce.png)
3. Opted in, data expanded
  ![shot_3722](https://cloud.githubusercontent.com/assets/305049/9284369/2651b712-4290-11e5-843a-b5a166bdea59.png)


r?