### PR TITLE
Expand section if deeplinked to, on pageload

### DIFF
--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -772,6 +772,9 @@
     $('#doc-content').on('click', 'h1', function() {
       $(this).closest('.wiki-section').toggleClass('collapsed');
     });
+
+    // Expand section if deeplinked to it
+    $(window.location.hash).closest('.wiki-section').removeClass('collapsed');
   };
 
   if ($('#doc-content').is('.collapsible')) {


### PR DESCRIPTION
Problem:
* User 1 visits a wiki article with collapsable content.
* User 1 finds the id of a section and share that fragment in URL (eg: https://support.mozilla.org/en-US/kb/how-stop-firefox-making-automatic-connections#w_speculative-pre-connections )
* User 2 loads the URL
* User 2 finds that all the sections are collapsed and thus do not get what User 1 pointed to

Solution:
Remove the collapsed class on the section that contains the element with the hash in the URL.

Possible improvement (is this required?):
Check if window.location.hash exists and is valid before calling remove class [I tested with no hash and invalid hash, but it appears to fail safely]