### PR TITLE
[Bug 1186697] Enable Bambara and Malagasy

### DIFF
--- a/kitsune/lib/languages.json
+++ b/kitsune/lib/languages.json
@@ -589,6 +589,11 @@
         "english": "Yoruba",
         "native": "èdè Yorùbá"
     },
+    "bm": {
+        "iso639_1": "bm",
+        "english": "Bambara",
+        "native": "Bamanankan"
+    },
     "xx": {
         "iso639_1": "xx",
         "english": "Pirate",

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -97,6 +97,7 @@ SUMO_LANGUAGES = (
     'ar',
     'az',
     'bg',
+    'bm',
     'bn-BD',
     'bn-IN',
     'bs',
@@ -133,6 +134,7 @@ SUMO_LANGUAGES = (
     'ko',
     'ln',
     'lt',
+    'mg',
     'mk',
     'ml',
     'ne-NP',
@@ -172,6 +174,7 @@ SUMO_LANGUAGES = (
 # to add content.
 FXOS_LANGUAGES = [
     'af',
+    'bm',
     'bn-BD',
     'bn-IN',
     'cs',
@@ -188,6 +191,7 @@ FXOS_LANGUAGES = [
     'ig',
     'it',
     'ln',
+    'mg',
     'nl',
     'pl',
     'pt-BR',


### PR DESCRIPTION
This should enable Bambara (bm) and Malagasy (mg) on SUMO.