### PR TITLE
[Bug 1201265] Fix 404 for fennec and b2g

### DIFF
--- a/kitsune/dashboards/templates/dashboards/contributors.html
+++ b/kitsune/dashboards/templates/dashboards/contributors.html
@@ -58,7 +58,7 @@
           {% include 'dashboards/includes/kb_overview.html' %}
         </table>
         <div class="table-footer">
-          <a href="{{ url('dashboards.contributors_overview')|urlparams(product=product, category=category) }}">{{ _('Complete overview...') }}</a>
+          <a href="{{ url('dashboards.contributors_overview')|urlparams(product=product.slug, category=category) }}">{{ _('Complete overview...') }}</a>
         </div>
       </details>
     </article>


### PR DESCRIPTION
[Bug 1201265](https://bugzilla.mozilla.org/show_bug.cgi?id=1201265) - "Page not found" error when trying to view all articles for Firefox for Android or Firefox OS in the KB dashboard