### PR TITLE
[Bug 1201656] Fix slug of Firefox iOS in AAQ.

### DIFF
--- a/kitsune/questions/config.py
+++ b/kitsune/questions/config.py
@@ -158,12 +158,12 @@ products = SortedDict([
             }),
         ])
     }),
-    ('ios', {
+    ('fxios', {
         'name': _lazy(u'Firefox for iOS'),
         'subtitle': '',
         'extra_fields': ['ff_version', 'os', 'plugins'],
-        'tags': ['ios'],
-        'product': 'ios',
+        'tags': ['fxios'],
+        'product': 'fxios',
         'categories': SortedDict([
             ('install-and-update-firefox-ios', {
                 'name': _lazy(u'Install and Update'),

--- a/kitsune/questions/migrations/0006_ios_questionlocale.py
+++ b/kitsune/questions/migrations/0006_ios_questionlocale.py
@@ -1,30 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
-
-def create_questionlocale(apps, schema_editor):
-    Product = apps.get_model('products', 'Product')
-    QuestionLocale = apps.get_model('questions', 'QuestionLocale')
-
-    p, created = Product.objects.get_or_create(slug='ios', defaults={
-        'title': 'Firefox for iOS',
-        'description': 'Firefox for iPhone, iPad and iPod touch devices',
-        'display_order': 0,
-        'visible': False})
-
-    ql, created = QuestionLocale.objects.get_or_create(locale='en-US')
-    ql.products.add(p)
+# This migration used to create a ios product for the aaq. It was
+# incorrect. Since it was deployed, it can't be deleted. So instead it
+# is empty.
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
         ('questions', '0005_change_locale_sr_Cyrl_to_sr'),
-        ('products', '0001_initial'),
     ]
 
-    operations = [
-        migrations.RunPython(create_questionlocale),
-    ]
+    operations = []

--- a/kitsune/questions/tests/test_templates.py
+++ b/kitsune/questions/tests/test_templates.py
@@ -1528,7 +1528,7 @@ class ProductForumTemplateTestCase(TestCaseBase):
         response = self.client.get(reverse('questions.home'))
         eq_(200, response.status_code)
         doc = pq(response.content)
-        eq_(5, len(doc('.product-list .product')))
+        eq_(4, len(doc('.product-list .product')))
         product_list_html = doc('.product-list').html()
         assert firefox.title in product_list_html
         assert android.title in product_list_html


### PR DESCRIPTION
The slug of the Firefox for iOS product that was created in the DB was `fxios`, not `ios` like we expected. This updates the AAQ to deal with that.

There is also another problem: the data migration that created the `ios` product. Options I thought of

1. ~~Delete it.~~ Can't delete it, because it has been deployed.
2. Nullify it. That is, leave it in place but make it a no-op.
3. Add another migration to move the `ios` product to be `fxios`, but only if `fxios` doesn't exist and otherwise delete the `ios` product.

3 sounds better in theory. It also sounds hard and not very useful. I picked 2 instead.

@willkg r?