### PR TITLE
[Bug 1201656] Use correct product_key for FxiOS in AAQ.

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -518,7 +518,7 @@ def aaq(request, product_key=None, category_key=None, showform=False,
             if 'firefox' in ua and 'android' not in ua:
                 product_key = 'firefox-os'
             elif 'fxios' in ua:
-                product_key = 'fxios'
+                product_key = 'ios'
             else:
                 product_key = 'mobile'
 


### PR DESCRIPTION
Take two. This is a simpler, and means we didn't screw up as much. Yay!

@willkg r?