### PR TITLE
Home during deploys

### DIFF
--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -14,10 +14,13 @@ from commander.deploy import task, hostgroups  # noqa
 import commander_settings as settings  # noqa
 
 
-# Setup virtualenv path.
+# Setup environment
 venv_bin_path = os.path.join(settings.SRC_DIR, 'virtualenv', 'bin')
 os.environ['PATH'] = venv_bin_path + os.pathsep + os.environ['PATH']
 os.environ['DJANGO_SETTINGS_MODULE'] = 'kitsune.settings_local'
+if 'HOME' not in os.environ:
+    print 'Setting HOME to "{}" (wtf?)'.format(settings.SRC_DIR)
+    os.environ['HOME'] = settings.SRC_DIR
 
 
 @task

--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -19,7 +19,7 @@ venv_bin_path = os.path.join(settings.SRC_DIR, 'virtualenv', 'bin')
 os.environ['PATH'] = venv_bin_path + os.pathsep + os.environ['PATH']
 os.environ['DJANGO_SETTINGS_MODULE'] = 'kitsune.settings_local'
 if 'HOME' not in os.environ:
-    print 'Setting HOME to "{}" (wtf?)'.format(settings.SRC_DIR)
+    print 'Setting HOME to "{0}" (wtf?)'.format(settings.SRC_DIR)
     os.environ['HOME'] = settings.SRC_DIR
 
 


### PR DESCRIPTION
Adding jsdom to the NPM dependencies, which I did in #2647, revealed an oddity in our deployment infrastructure. We don't have the `$HOME` environment variable set during deploys. node-gyp needs this to work, for some reason, and jsdom uses node-gyp to build compiled dependencies.

Without this patch, stage doesn't deploy. With this patch, it does.

I'm also game for other ways we might fix this. I just can't think of any right now.

r?