### PR TITLE
Remove django_qunit from settings_local.py.dist

### DIFF
--- a/kitsune/settings_local.py.dist
+++ b/kitsune/settings_local.py.dist
@@ -57,8 +57,6 @@ NUNJUCKS_PRECOMPILE_BIN = path('node_modules/.bin/nunjucks-precompile')
 # Tells django-axes we aren't behind a reverse proxy.
 AXES_BEHIND_REVERSE_PROXY = False
 
-INSTALLED_APPS += ['django_qunit']
-
 # Enable this to add more debugging in all pages. You'll also need to install
 # the developer packages, listed in ``requirements/dev.txt``.
 USE_DEBUG_TOOLBAR = False


### PR DESCRIPTION
We stopped using qunit recently. This removes it from
settings_local.py.dist so it doesn't throw errors in new development
environments.

Quick r?

Also, we should send an email to the developer list telling people about the switch to the new JS test system and also that they should update their `settings_local.py` and remove references to `django-qunit`.