### PR TITLE
[bug 1206918] Nix SQLAlchemy

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -286,9 +286,6 @@ setuptools==0.9.8
 # sha256: 4kBSQR_E-9H2cmNVN8P8IzDZSBsYwDF2lbRiWVEskdU
 six==1.9.0
 
-# sha256: xDk0Lw5v1G9WRDHJrksEoAiIlyFCZeLRjUGugY09b_E
-sqlalchemy==0.6.4
-
 # sha256: YEk4WnAyYoyam8KsV4zhgm5BebCoqfM7U18CL6vY0-o
 sqlparse==0.1.1
 


### PR DESCRIPTION
This removes sqlalchemy from the requirements file. As near as I can
tell, it's not used by kitsune at all.

Quick r?