### PR TITLE
[bug 1207323] Update setuptools to 18.3.2

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,8 @@
+# Note: This has to be listed first so it gets installed first and
+# thus affects the rest of the installs.
+# sha256: jEqwxPIncwUZ3B4CD4dbPvl-ZDyPQ6mKT6DEb7rRJFA
+setuptools==18.3.2
+
 # sha256: HegYoUcr9iVxLF06QwEw03dJz4qUE8th6UEeLr4X2ok
 amqp==1.4.2
 


### PR DESCRIPTION
If Travis is Green, that's cool. However, the bigger concern is that this touches deployments and it's possible that our admin nodes are using something something that doesn't work with this version of setuptools. Ergo, we'll kind of be testing this by pushing it to -stage.

Anyhow.... r?