### PR TITLE
[bug 702276] Upgrade lxml to 3.4.4 and pyquery to 1.2.9

### DIFF
--- a/kitsune/forums/tests/test_templates.py
+++ b/kitsune/forums/tests/test_templates.py
@@ -1,13 +1,13 @@
 from django.contrib.contenttypes.models import ContentType
 
 from nose.tools import eq_
-from pyquery import PyQuery as pq
 
 from kitsune.access.tests import permission
 from kitsune.forums.models import Post
 from kitsune.forums.tests import (
     ForumTestCase, forum, thread, post as forum_post)
 from kitsune.sumo.tests import get, post
+from kitsune.sumo.tests import SumoPyQuery as pq
 from kitsune.users.tests import user, group
 
 
@@ -365,7 +365,7 @@ class ForumsTemplateTests(ForumTestCase):
         r = get(self.client, 'forums.forums')
         eq_(200, r.status_code)
         doc = pq(r.content)
-        eq_(forum1.name, doc('ol.forums > li a:first').text())
+        eq_(forum1.name, doc('ol.forums > li a').first().text())
 
         forum1.display_order = 3
         forum1.save()
@@ -374,7 +374,7 @@ class ForumsTemplateTests(ForumTestCase):
         r = get(self.client, 'forums.forums')
         eq_(200, r.status_code)
         doc = pq(r.content)
-        eq_(forum2.name, doc('ol.forums > li a:first').text())
+        eq_(forum2.name, doc('ol.forums > li a').first().text())
 
     def test_is_listed(self):
         """Verify is_listed is respected."""

--- a/kitsune/messages/tests/test_templates.py
+++ b/kitsune/messages/tests/test_templates.py
@@ -54,11 +54,6 @@ class SendMessageTestCase(TestCase):
         eq_(self.user2.username,
             pq(response.content)('#id_to')[0].attrib['value'])
 
-    def test_no_markup_in_message_list(self):
-        response = self._test_send_message_to(self.user2.username)
-        eq_(pq(response.content)('read').text(),
-            pq(response.content)('read').html())
-
     def test_send_message_ratelimited(self):
         """Verify that after 50 messages, no more are sent."""
         # Try to send 53 messages.

--- a/kitsune/sumo/tests/__init__.py
+++ b/kitsune/sumo/tests/__init__.py
@@ -17,6 +17,7 @@ from django.utils.translation import trans_real
 import django_nose
 import factory.fuzzy
 from nose.tools import eq_
+from pyquery import PyQuery
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.firefox import firefox_binary
@@ -276,3 +277,10 @@ class set_waffle_flag(object):
         if self.origflag is not None:
             self.origflag.id = self.origid
             self.origflag.save()
+
+
+class SumoPyQuery(PyQuery):
+    """Extends PyQuery with some niceties to alleviate its bugs"""
+    def first(self):
+        """:first doesn't work, so this is a meh substitute"""
+        return self.items().next()

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -11,12 +11,12 @@ from django.utils.encoding import smart_str
 import mock
 from bleach import clean
 from nose.tools import eq_
-from pyquery import PyQuery as pq
 from wikimarkup.parser import ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 
 from kitsune.products.tests import product, topic
 from kitsune.sumo.helpers import urlparams
 from kitsune.sumo.tests import post, get, attrs_eq, MobileTestCase
+from kitsune.sumo.tests import SumoPyQuery as pq
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.users.tests import user, add_permission
 from kitsune.wiki.events import (
@@ -436,7 +436,7 @@ class RevisionTests(TestCaseBase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_('Revision id: %s' % r.id,
-            doc('div.revision-info li:first').text())
+            doc('div.revision-info li').first().text())
         eq_(d.title, doc('h1.title').text())
         eq_(pq(r.content_parsed)('div').text(),
             doc('#doc-content div').text())
@@ -1195,7 +1195,7 @@ class DocumentRevisionsTests(TestCaseBase):
         # Verify there is no Review link
         eq_(0, len(doc('#revision-list div.status a')))
         eq_('Unreviewed',
-            doc('#revision-list li:not(.header) div.status:first').text())
+            doc('#revision-list li:not(.header) div.status').first().text())
 
         # Log in as user with permission to review
         u = user(save=True)
@@ -1208,7 +1208,7 @@ class DocumentRevisionsTests(TestCaseBase):
         # Verify there are Review links now
         eq_(2, len(doc('#revision-list div.status a')))
         eq_('Review',
-            doc('#revision-list li:not(.header) div.status:first').text())
+            doc('#revision-list li:not(.header) div.status').first().text())
         # Verify edit revision link
         eq_('/en-US/kb/test-document/edit/{r}'.format(r=r2.id),
             doc('#revision-list div.edit a')[0].attrib['href'])
@@ -2103,7 +2103,7 @@ class TranslateTests(TestCaseBase):
         doc = pq(r.content)
         translated_locales = doc(".translated_locale")
         eq_(translated_locales.length, 2)
-        eq_("en-US", doc(".translated_locale:first").text())
+        eq_("en-US", doc(".translated_locale").first().text())
         eq_("de", doc(".translated_locale:eq(1)").text())
 
     def test_keywords_dont_require_permission(self):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -34,6 +34,9 @@ cffi==0.8.6
 # sha256: k9gjEUXUPKAuHsPO41UzOvqOcq25z4FXZ-F1lXSXdNQ
 https://github.com/jsocol/commonware/archive/b5544185b2d24adc1eb512735990752400ce9cbd.tar.gz#egg=commonware
 
+# sha256: BTWn4nAUh0snrjpNM-h0njRb36YnZhlSCLeZa_EQBoI
+cssselect==0.9.1
+
 # sha256: -rf83eNg7GYURC0DIdzQ7_XkNUTLMNl16ddakUpM33g
 cryptography==0.7.2
 
@@ -187,8 +190,8 @@ Jinja2==2.5.2
 # sha256: uf8EN2BxE66nAf1RIsKvpAwF3_bx2k9YsvHqGNnyv40
 kombu==3.0.24
 
-# sha256: f9NuSlY2DNXXMZ41ewSpDixrg26iIMiPlFHDAK4zzF4
-lxml==2.2.6
+# sha256: s9NiusRxFydHzaNRMjjxFcvWxfi45jGb9ql6eJJyQJk
+lxml==3.4.4
 
 # sha256: U0_2_u_hzQOYT0ROZBWqzHnAqF87ho7EGi_VADAEwx4
 mimeparse==0.1.3
@@ -231,8 +234,8 @@ pyOpenSSL==0.14
 # sha256: 0XVN8IAYcdBalvHO9QpPMuXUDUnqJKocbKlSnL1WIAU
 pyparsing==1.5.5
 
-# sha256: KXcQ12LNo5YUC-xKy4cfHWUxs3Dy0phjoEnPMHZDD9o
-pyquery==0.5
+# sha256: RsUeuHi3h-gU7o-XN7CmIREDSutNHAZFCsWo6lpw5gI
+pyquery==1.2.9
 
 # sha256: bxlzSLRvuM358_z8Kn1al9qV2z4uhmfPZXIWJ0_hsAk
 python-dateutil==1.5


### PR DESCRIPTION
This upgrades lxml to 3.4.4. In order to do that, I also had to upgrade
pyquery and pull in cssselect.

I think there's a bug in the cssselect handling for the :first
pseudo-element. That breaks a few of our tests. It kind of looks like
both pyquery and cssselect are dead-ish projects and aren't being
actively maintained, so at some point we might want to look at replacing
pyquery with something else like BeautifulSoup4.

I talked with Rehan about this a bit and decided that since it's just a
few tests that are busted, I'd just subclass PyQuery and provide a
.first() method.

The other thing I discovered when doing this is that the messages page
has changed significantly since 2011 and one of the tests not only fails
now, but it doesn't appear to be a valid test anyhow, so I removed it.

r?