### PR TITLE
[bug 1116489] Tweak manage.py to be more helpful on errors

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import traceback
 
 # Now we can import from third-party libraries.
 
@@ -10,8 +11,15 @@ os.environ.setdefault('CELERY_CONFIG_MODULE', 'kitsune.settings_local')
 # MONKEYPATCH! WOO HOO!
 # Need this so we patch before running Django-specific commands which
 # import Jingo and then result in a circular import.
-from kitsune.sumo.monkeypatch import patch  # noqa
-patch()
+try:
+    from kitsune.sumo.monkeypatch import patch  # noqa
+    patch()
+except ImportError:
+    print 'OH NOES! There was an import error:'
+    print ''
+    print ''.join(traceback.format_exception(*sys.exc_info()))
+    print 'Have you activated your virtual environment?'
+    sys.exit(1)
 
 # Import for side-effect: configures our logging handlers.
 from kitsune import log_settings  # noqa

--- a/manage.py
+++ b/manage.py
@@ -18,7 +18,10 @@ except ImportError:
     print 'OH NOES! There was an import error:'
     print ''
     print ''.join(traceback.format_exception(*sys.exc_info()))
-    print 'Have you activated your virtual environment?'
+    if 'VIRTUAL_ENV' in os.environ:
+        print 'Have you installed requirements? Are they up-to-date?'
+    else:
+        print 'Have you activated your virtual environment?'
     sys.exit(1)
 
 # Import for side-effect: configures our logging handlers.


### PR DESCRIPTION
If you don't have your virtualenv activated, then manage.py sputters and
squawks and between muscle spasms of its right eye rants about
conspiracies involving django.forms which is unintelligible gibberish,
not helpful and not friendly to kitsune developers.

This fixes that by catching the ImportError and giving you a more
helpful hint.

r?