### PR TITLE
[Bug 1210975] Document.related_documents may be blank.

### DIFF
--- a/kitsune/wiki/migrations/0005_auto_20151002_1359.py
+++ b/kitsune/wiki/migrations/0005_auto_20151002_1359.py
@@ -1,0 +1,22 @@
+"""Make related_documents optional on Document."""
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import kitsune.sumo.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0004_change_locale_sr_Cyrl_to_sr'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='document',
+            name='related_documents',
+            field=models.ManyToManyField(related_name='related_documents_rel_+', to='wiki.Document', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -128,7 +128,7 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin,
     display_order = models.IntegerField(default=1, db_index=True)
 
     # List of related documents
-    related_documents = models.ManyToManyField('self')
+    related_documents = models.ManyToManyField('self', blank=True)
 
     # firefox_versions,
     # operating_systems:


### PR DESCRIPTION
I couldn't figure out how to write a failing test case for this. Any ideas? @willkg ?

r?