### PR TITLE
[bug 1211961] Fix opensearch

### DIFF
--- a/kitsune/search/templates/search/plugin.html
+++ b/kitsune/search/templates/search/plugin.html
@@ -5,15 +5,15 @@
 <Description>{{ _('Search the Mozilla Support Knowledge Base and Support Forum.') }}</Description>
 <InputEncoding>UTF-8</InputEncoding>
 <Image width="16" height="16" type="image/png">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAARCAYAAAA7bUf6AAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9kDEQYMLMwA8jAAAAI1SURBVDjLhZNdSFNhGMd/G2NYMNPIEULhJjkXahaMglbEopvo8y63KHfRdasI7AOtiyAsMIMu6qYVeqhuMomgC71aDJ3gREqP66wlqTEtTkg1lvh2sXPGPvWB9+I873t+7/t/nv9jEEJQLuod3lagClAVWYqWO2cohNQ7vHVAF3BKA+ihAgPAbUWWEmUh9Q5vAOhh/bikyNKDIkghwLrZgudAC7W1NSzMLxIemyYx96MkyCCE0LWP67sXfEfo6PQXXd/39B3dva/4/Tetp3YrshQ1aR8X9eyZk/vp6PQzPJsilEwTWV7BZTHhtpo56z8KQNfdPnL+8+svEbqEcPgxw7Mp7n/+Q0orV2zaB8Cz46/xbK/gxLGrfIzNAaDIksGoSQGgybENgFAyzeSUD4P4lycnlMzIaNlZl2cDY24brTXVAESWVzAbzajzjwDY0difzQM0Om257CojkO15/OsCAC6LifRqmuRyJO8lLkumhGORqdx0wqgZJwEwOhFnMhrDbTXT7OzPAzQ7+3FbzQCMjM9kDajIUsIEsHVLZe/qqujZuMHMjZtPGHx7L1ODypfZ7lTEP+Hx7KOltT23xcE8sy18SwqApaVfOJtsLH7/yaZqC0PvRzno2UP3nee8GPxAwRjYFFlSdZ/gPhwI7t1lb792/TznvLcYmYivZXsVOK3IklpqdnqAQGgoMxZXLj8sBUtogOh6U/ylxO0DwBtFloJFO0KIssve0FZlb2g7tNYZIQT/AV1CFURmrsy6AAAAAElFTkSuQmCC</Image>
-<Url type="text/html" method="get" template="https://{{ site }}/{{ locale }}/search">
+<Url type="text/html" method="get" template="{{ host }}{{ url('search', locale=locale) }}">
   <Param name="q" value="{searchTerms}"/>
   <Param name="w" value="3"/>
   <Param name="qs" value="plugin"/>
 </Url>
 <Url type="application/opensearchdescription+xml"
      rel="self"
-     template="https://{{ site }}/{{ locale }}/search/xml"/>
+     template="{{ host }}{{ url('search.plugin', locale=locale) }}"/>
 <Url type="application/x-suggestions+json"
-     template="https://{{ site }}/{{ locale }}/search/suggestions?q={searchTerms}"/>
-<moz:SearchForm>https://{{ site }}/{{ locale }}/search</moz:SearchForm>
+     template="{{ host }}{{ url('search.suggestions', locale=locale) }}?q={searchTerms}"/>
+<moz:SearchForm>{{ host }}{{ url('search', locale=locale) }}</moz:SearchForm>
 </OpenSearchDescription>

--- a/kitsune/search/urls.py
+++ b/kitsune/search/urls.py
@@ -5,6 +5,6 @@ urlpatterns = patterns(
     'kitsune.search.views',
     url(r'^$', 'simple_search', name='search'),
     url(r'^/advanced$', 'advanced_search', name='search.advanced'),
-    url(r'^/xml$', 'plugin', name='search.plugin'),
-    url(r'^/suggestions$', 'suggestions', name='search.suggestions'),
+    url(r'^/xml$', 'opensearch_plugin', name='search.plugin'),
+    url(r'^/suggestions$', 'opensearch_suggestions', name='search.suggestions'),
 )


### PR DESCRIPTION
opensearch was totally busted. Partially from a lint-fixing round in
2014 and partially from upgrading to a new ElasticUtils that "dealt"
with array values.

I fixed those two issues and also redid the template so that it's not
using the Site framework because that makes things difficult to test.

However, it's still got problems:

1. it builds a different search than simple search does and since it's
   in a different place in the code, it's been unmaintained and thus
   things like templates pop up in the results; we should merge the
   two

2. none of the tests test the results of the opensearch search
   suggestions so when it breaks, we have no idea--further, there's
   a bunch of other stuff that should get tested

I didn't want to do either of those now. Instead I tested it manually
with curl. I'll look into doing them later as I work through refactoring
all the Elasticsearch code.

Relatedly, I think we should nix the opensearch altogether since few
people use it (as evidenced by the fact it was busted for sooooo long).

r?