### PR TITLE
Add pushstate handling to new AAQ.

### DIFF
--- a/kitsune/questions/static/questions/js/components/AAQStep.jsx
+++ b/kitsune/questions/static/questions/js/components/AAQStep.jsx
@@ -29,7 +29,7 @@ export default class AAQStep extends React.Component {
   }
 
   switchToNextStep() {
-    this.props.setStep(this.props.next);
+    this.props.setStep();
   }
 }
 AAQStep.propTypes = {

--- a/kitsune/sumo/static/sumo/js/actions/UrlActions.es6.js
+++ b/kitsune/sumo/static/sumo/js/actions/UrlActions.es6.js
@@ -1,0 +1,31 @@
+import Dispatcher from '../Dispatcher.es6.js';
+import {actionTypes} from '../constants/UrlConstants.es6.js';
+
+/**
+ * Update the query string, notify any listeners, and call history.pushState.
+ * @param  {object} params Variables to merge into the current query string state.
+ */
+export function updateQueryString(params) {
+  Dispatcher.dispatch({
+    type: actionTypes.UPDATE_QUERY_STRING,
+    params,
+  });
+}
+
+/**
+ * Set the query string defaults and notify listeners. If the query
+ * string does not have the given values, they will be set, otherwise
+ * the existing value will be kept. This will call history.replaceState.
+ * @param  {object} params Default values for querystrings.
+ */
+export function updateQueryStringDefaults(params) {
+  Dispatcher.dispatch({
+    type: actionTypes.UPDATE_QUERY_STRING_DEFAULTS,
+    params,
+  });
+}
+
+export default {
+  updateQueryString,
+  updateQueryStringDefaults,
+};

--- a/kitsune/sumo/static/sumo/js/constants/UrlConstants.es6.js
+++ b/kitsune/sumo/static/sumo/js/constants/UrlConstants.es6.js
@@ -1,0 +1,10 @@
+import constantMap from '../../../sumo/js/utils/constantMap.es6.js';
+
+export const actionTypes = constantMap([
+  'UPDATE_QUERY_STRING',
+  'UPDATE_QUERY_STRING_DEFAULTS',
+]);
+
+export default {
+  actionTypes
+};

--- a/kitsune/sumo/static/sumo/js/main.js
+++ b/kitsune/sumo/static/sumo/js/main.js
@@ -156,6 +156,10 @@ window.k = window.k || {};
     });
   });
 
+  window.addEventListener('popstate', function() {
+    setTimeout(layoutTweaks, 0);
+  });
+
   /*
    * Initialize some selects so that they auto-submit on change.
    */

--- a/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
+++ b/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
@@ -1,0 +1,52 @@
+/* globals _:false */
+
+/**
+ * A shim to treat the URL query string as a Store. Listens to actions
+ * to update the query string, including pushstate calls, and responds
+ * to popstate events from the browser, translating them into store
+ * update events.
+ */
+
+import BaseStore from './BaseStore.es6.js';
+import Dispatcher from '../Dispatcher.es6.js';
+import {actionTypes} from '../constants/UrlConstants.es6.js';
+import {getQueryParamsAsDict, queryParamStringFromDict} from '../utils/urls.es6.js';
+
+class _UrlStore extends BaseStore {
+  get(key) {
+    return getQueryParamsAsDict()[key];
+  }
+}
+
+// Stores are singletons.
+const UrlStore = new _UrlStore();
+
+UrlStore.dispatchToken = Dispatcher.register((action) => {
+  let params, qs;
+  switch (action.type) {
+    case actionTypes.UPDATE_QUERY_STRING:
+      params = _.extend({}, getQueryParamsAsDict(), action.params);
+      qs = queryParamStringFromDict(params);
+      window.history.pushState(params, null, qs);
+      UrlStore.emitChange();
+      break;
+
+    case actionTypes.UPDATE_QUERY_STRING_DEFAULTS:
+      params = _.extend({}, action.params, getQueryParamsAsDict());
+      qs = queryParamStringFromDict(params);
+      window.history.replaceState(params, null, qs);
+      UrlStore.emitChange();
+      break;
+
+    default:
+      // do nothing
+  }
+});
+
+/* When the user clicks back/forward, the store will return different
+ * values, so notify all listeners. */
+window.addEventListener('popstate', function() {
+  UrlStore.emitChange();
+});
+
+export default UrlStore;

--- a/kitsune/sumo/static/sumo/js/utils/index.js
+++ b/kitsune/sumo/static/sumo/js/utils/index.js
@@ -1,9 +1,11 @@
 import apiFetch from './apiFetch.es6';
 import constantMap from './constantMap.es6';
 import scrollTo from './scrollTo.es6';
+import urls from './urls.es6.js';
 
 export default {
   apiFetch,
   constantMap,
   scrollTo,
+  urls,
 };

--- a/kitsune/sumo/static/sumo/js/utils/urls.es6.js
+++ b/kitsune/sumo/static/sumo/js/utils/urls.es6.js
@@ -1,0 +1,19 @@
+/* Re-export utils from the old-style global `k` library related to urls.
+ * Includes sanity checks to make sure the right files were included.
+ */
+
+import '../main.js';
+
+const names = [
+  'getQueryParamsAsDict',
+  'queryParamStringFromDict',
+];
+
+for (let name of names) {
+  if (window.k[name] === undefined) {
+    throw new Error(`Shim validation error: Could not find ``k.${name}`` in global scope.`);
+  }
+}
+
+export const getQueryParamsAsDict = window.k.getQueryParamsAsDict;
+export const queryParamStringFromDict = window.k.queryParamStringFromDict;


### PR DESCRIPTION
1. Add an ES6-style shim for some functions in the old school `k` library.
2. Add a shim to treat the URL's query string as a Store.
3. Update the new AAQ to store it's current step in the `UrlStore`.

r?