### PR TITLE
[bug 1212476] Refactor simple search to share code

### DIFF
--- a/kitsune/search/simple_search.py
+++ b/kitsune/search/simple_search.py
@@ -1,0 +1,113 @@
+from itertools import chain
+
+from django.conf import settings
+
+from kitsune import search as constants
+from kitsune.questions.models import QuestionMappingType
+from kitsune.search import es_utils
+from kitsune.wiki.models import DocumentMappingType
+
+
+def generate_simple_search(search_form, language, with_highlights=False):
+    """Generates an S given a form
+
+    :arg search_form: a SimpleSearch form that's already had ``.is_valid()``
+        called on it
+    :arg language: the language code
+    :arg with_highlights: whether or not to ask for highlights
+
+    :returns: a fully formed S
+
+    """
+    # We use a regular S here because we want to search across
+    # multiple doctypes.
+    searcher = (
+        es_utils.AnalyzerS().es(urls=settings.ES_URLS)
+        .indexes(es_utils.read_index('default'))
+    )
+
+    cleaned = search_form.cleaned_data
+
+    doctypes = []
+    final_filter = es_utils.F()
+    cleaned_q = cleaned['q']
+    products = cleaned['product']
+
+    # Handle wiki filters
+    if cleaned['w'] & constants.WHERE_WIKI:
+        wiki_f = es_utils.F(model='wiki_document',
+                            document_category__in=settings.SEARCH_DEFAULT_CATEGORIES,
+                            document_locale=language,
+                            document_is_archived=False)
+
+        for p in products:
+            wiki_f &= es_utils.F(product=p)
+
+        doctypes.append(DocumentMappingType.get_mapping_type_name())
+        final_filter |= wiki_f
+
+    # Handle question filters
+    if cleaned['w'] & constants.WHERE_SUPPORT:
+        question_f = es_utils.F(model='questions_question',
+                                question_is_archived=False,
+                                question_has_helpful=True)
+
+        for p in products:
+            question_f &= es_utils.F(product=p)
+
+        doctypes.append(QuestionMappingType.get_mapping_type_name())
+        final_filter |= question_f
+
+    # Build a filter for those filters and add the other bits to
+    # finish the search
+    searcher = searcher.doctypes(*doctypes)
+    searcher = searcher.filter(final_filter)
+
+    if cleaned['explain']:
+        searcher = searcher.explain()
+
+    if with_highlights:
+        # Set up the highlights. Show the entire field highlighted.
+        searcher = searcher.highlight(
+            'question_content',  # support forum
+            'document_summary',  # kb
+            pre_tags=['<b>'],
+            post_tags=['</b>'],
+            number_of_fragments=0
+        )
+
+    # Set up boosts
+    searcher = searcher.boost(
+        question_title=4.0,
+        question_content=3.0,
+        question_answer_content=3.0,
+        document_title=6.0,
+        document_content=1.0,
+        document_keywords=8.0,
+        document_summary=2.0,
+
+        # Text phrases in document titles and content get an extra
+        # boost.
+        document_title__match_phrase=10.0,
+        document_content__match_phrase=8.0
+    )
+
+    # Build the query
+    query_fields = chain(*[
+        cls.get_query_fields() for cls in [
+            DocumentMappingType,
+            QuestionMappingType
+        ]
+    ])
+    query = {}
+    # Create match and match_phrase queries for every field
+    # we want to search.
+    for field in query_fields:
+        for query_type in ['match', 'match_phrase']:
+            query['%s__%s' % (field, query_type)] = cleaned_q
+
+    # Transform the query to use locale aware analyzers.
+    query = es_utils.es_query_with_analyzer(query, language)
+
+    searcher = searcher.query(should=True, **query)
+    return searcher

--- a/kitsune/search/tests/test_search_simple.py
+++ b/kitsune/search/tests/test_search_simple.py
@@ -75,8 +75,8 @@ class SimpleSearchTests(ElasticTestCase):
         eq_(200, response.status_code)
         eq_(1, json.loads(response.content)['total'])
 
-    def test_clean_excerpt(self):
-        """Ensure we clean html out of excerpts."""
+    def test_clean_question_excerpt(self):
+        """Ensure we clean html out of question excerpts."""
         q = question(title='audio',
                      content='<script>alert("hacked");</script>', save=True)
         a = answer(question=q, save=True)

--- a/kitsune/search/tests/test_simple_search.py
+++ b/kitsune/search/tests/test_simple_search.py
@@ -1,0 +1,55 @@
+from nose.tools import ok_
+
+from kitsune.search.forms import SimpleSearchForm
+from kitsune.search.simple_search import generate_simple_search
+from kitsune.sumo.tests import TestCase
+
+
+class SimpleSearchTests(TestCase):
+    def test_language_en_us(self):
+        form = SimpleSearchForm({'q': 'foo'})
+        ok_(form.is_valid())
+
+        s = generate_simple_search(form, 'en-US', with_highlights=False)
+
+        # NB: Comparing bits of big trees is hard, so we serialize it
+        # and look for strings.
+        s_string = str(s.build_search())
+        # Verify locale
+        ok_("{'term': {'document_locale': 'en-US'}}" in s_string)
+        # Verify en-US has the right synonym-enhanced analyzer
+        ok_("'analyzer': 'snowball-english-synonyms'" in s_string)
+
+    def test_language_fr(self):
+        form = SimpleSearchForm({'q': 'foo'})
+        ok_(form.is_valid())
+
+        s = generate_simple_search(form, 'fr', with_highlights=False)
+
+        s_string = str(s.build_search())
+        # Verify locale
+        ok_("{'term': {'document_locale': 'fr'}}" in s_string)
+        # Verify fr has right synonym-less analyzer
+        ok_("'analyzer': 'snowball-french'" in s_string)
+
+    def test_language_zh_cn(self):
+        form = SimpleSearchForm({'q': 'foo'})
+        ok_(form.is_valid())
+
+        s = generate_simple_search(form, 'zh-CN', with_highlights=False)
+
+        s_string = str(s.build_search())
+        # Verify locale
+        ok_("{'term': {'document_locale': 'zh-CN'}}" in s_string)
+        # Verify standard analyzer is used
+        ok_("'analyzer': 'chinese'" in s_string)
+
+    def test_with_highlights(self):
+        form = SimpleSearchForm({'q': 'foo'})
+        ok_(form.is_valid())
+
+        s = generate_simple_search(form, 'en-US', with_highlights=True)
+        ok_('highlight' in s.build_search())
+
+        s = generate_simple_search(form, 'en-US', with_highlights=False)
+        ok_('highlight' not in s.build_search())

--- a/kitsune/search/views.py
+++ b/kitsune/search/views.py
@@ -121,9 +121,6 @@ def simple_search(request, template=None):
     searcher = searcher[:settings.SEARCH_MAX_RESULTS]
 
     try:
-        # paginator = Paginator(searcher, settings.SEARCH_RESULTS_PER_PAGE)
-        # page = paginator.page(page_num)
-        # offset = page.start_index()
         pages = paginate(request, searcher, settings.SEARCH_RESULTS_PER_PAGE)
         offset = pages.start_index()
 
@@ -164,12 +161,10 @@ def simple_search(request, template=None):
             elif doc['model'] == 'questions_question':
                 summary = _build_es_excerpt(doc)
                 if not summary:
-                    # We're excerpting only question_content, so if
-                    # the query matched question_title or
-                    # question_answer_content, then there won't be any
-                    # question_content excerpts. In that case, just
-                    # show the question--but only the first 500
-                    # characters.
+                    # We're excerpting only question_content, so if the query matched
+                    # question_title or question_answer_content, then there won't be any
+                    # question_content excerpts. In that case, just show the question--but
+                    # only the first 500 characters.
                     summary = bleach.clean(doc['question_content'], strip=True)[:500]
 
                 result = {
@@ -206,8 +201,7 @@ def simple_search(request, template=None):
         'product_titles': product_titles,
         'q': cleaned['q'],
         'w': cleaned['w'],
-        'lang_name': lang_name
-    }
+        'lang_name': lang_name}
 
     if is_json:
         # Models are not json serializable.
@@ -326,7 +320,7 @@ def advanced_search(request, template=None):
     offset = (page - 1) * settings.SEARCH_RESULTS_PER_PAGE
 
     lang = language.lower()
-    lang_name = settings.LANGUAGES_DICT.get(lang, '') or ''
+    lang_name = settings.LANGUAGES_DICT.get(lang) or ''
 
     # We use a regular S here because we want to search across
     # multiple doctypes.
@@ -744,9 +738,8 @@ def opensearch_suggestions(request):
         )
 
     def titleize(r):
-        # NB: Elasticsearch returns an array of strings as the value,
-        # so we mimic that and then pull out the first (and only)
-        # string.
+        # NB: Elasticsearch returns an array of strings as the value, so we mimic that and
+        # then pull out the first (and only) string.
         return r.get('document_title', r.get('question_title', [_('No title')]))[0]
 
     try:
@@ -757,8 +750,7 @@ def opensearch_suggestions(request):
             [urlize(r) for r in results]
         ]
     except ES_EXCEPTIONS:
-        # If we have Elasticsearch problems, we just send back an empty
-        # set of results.
+        # If we have Elasticsearch problems, we just send back an empty set of results.
         data = []
 
     return HttpResponse(json.dumps(data), content_type=content_type)


### PR DESCRIPTION
* moves some things over to the SimpleSearchForm
* extracts S building code into simple_search.py:generate_simple_search
  so that it can be re-used between simple_search and
  opensearch_suggestions
* redoes opensearch_suggestions to use the new generate_simple_search

One thing this does is changes how opensearch_suggestions works.
Previously, it would do a search and show the top 5 kb articles followed
by the top 5 questions. That's what simple search used to do eons ago.

This changes that so that it does what simple search does and shows the
top 10 mixed results. This reduces the number of different kinds of
search we're doing by 1 and reduces the likelihood that
opensearch_suggestions gets totally out of sync with the other searches
like it did.

r?