### PR TITLE
[Bug 1169416] Added support to show full locale name like "English (en-US)" in the show_translations page.

### DIFF
--- a/kitsune/wiki/templates/wiki/show_translations.html
+++ b/kitsune/wiki/templates/wiki/show_translations.html
@@ -11,13 +11,13 @@
       <h3>{{ _('This document has been translated to the following locales:') }}</h3>
       <ul class="locales">
         {% for locale in translated_locales %}
-          <li><a class="translated_locale" href="{{ url("wiki.document", locale=locale, document_slug=document.slug) }}">{{ locale }}</a></li>
+          <li><a class="translated_locale" href="{{ url("wiki.document", locale=locale[0], document_slug=document.slug) }}">{{ locale[1] }} ({{ locale[0] }}) </a></li>
         {% endfor %}
       </ul>
       <h3>{{ _('This document is missing translations for the following locales:') }}</h3>
       <ul class="locales">
         {% for locale in untranslated_locales %}
-          <li>{{ locale }}</li>
+          <li>{{ locale[1] }} ({{ locale[0] }})</li>
         {% endfor %}
       </ul>
     </article>

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -2103,8 +2103,8 @@ class TranslateTests(TestCaseBase):
         doc = pq(r.content)
         translated_locales = doc(".translated_locale")
         eq_(translated_locales.length, 2)
-        eq_("en-US", doc(".translated_locale").first().text())
-        eq_("de", doc(".translated_locale:eq(1)").text())
+        eq_("English (en-US)", doc(".translated_locale").first().text())
+        eq_("Deutsch (de)", doc(".translated_locale:eq(1)").text())
 
     def test_keywords_dont_require_permission(self):
         """Test keywords don't require permission when translating."""

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -25,6 +25,7 @@ from tower import ugettext_lazy as _lazy
 from tower import ugettext as _
 
 from kitsune.access.decorators import login_required
+from kitsune.lib.sumo_locales import LOCALES
 from kitsune.products.models import Product, Topic
 from kitsune.sumo.decorators import ratelimit
 from kitsune.sumo.helpers import urlparams
@@ -1353,13 +1354,18 @@ def show_translations(request, document_slug):
     translated_locales = []
     untranslated_locales = []
 
-    translated_locales.append(document.locale)
-    translated_locales.extend(document.translations.all().values_list(
-        'locale', flat=True))
+    # Makes sure "English (en-US)" is always on top!
+    translated_locales.append((document.locale, LOCALES[document.locale].native))
+
+    # Gets all the locale code "ONLY" for translated locales
+    # Note: en-US is not a translated locale, it's the default
+    translated_locales_code = document.translations.all().values_list('locale', flat=True)
 
     for locale in settings.LANGUAGE_CHOICES:
-        if not locale[0] in translated_locales:
-            untranslated_locales.append(locale[0])
+        if locale[0] in translated_locales_code:
+            translated_locales.append(locale)
+        else:
+            untranslated_locales.append(locale)
 
     return render(request, 'wiki/show_translations.html', {
         'document': document,


### PR DESCRIPTION
[Bug 1169416] Updated contents of `<li>` elements under 'locales' class to show full locale name

[Bug 1169416] Updated test_show_translations_page() to test for full locale like 'English (en-US)' instead of only 'en-US', test order or the actual test is not changed

[Bug 1169416] Updated show_translations() to display full locale name, imported LOCALES