### PR TITLE
[Bug 800880] Correction to show correct message to mobile

### DIFF
--- a/kitsune/wiki/templates/wiki/mobile/document.html
+++ b/kitsune/wiki/templates/wiki/mobile/document.html
@@ -39,7 +39,7 @@
   <article id="wiki-doc">
     {{ document_title(document) }}
     {{ document_messages(document, redirected_from) }}
-    {{ document_content(document, fallback_reason, request, settings) }}
+    {{ document_content(document, fallback_reason, request, settings, full_locale_name) }}
 
     {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
     {% if share_link %}


### PR DESCRIPTION
It was missed during #2573. The ``full_locale_name`` was added in the document template, but missed at Mobile template.(1). So while user view the article from mobile, they can not see the proper locale name
r?
1. https://github.com/mozilla/kitsune/pull/2573/files#diff-a193392a22b60ae6502da2147debf34cR55