### PR TITLE
[Bug 1215226] Don't fail silently when sending emails.

### DIFF
--- a/kitsune/questions/cron.py
+++ b/kitsune/questions/cron.py
@@ -210,5 +210,4 @@ def report_employee_answers():
 
     email_addresses = [u.email for u in report_recipients]
 
-    send_mail(email_subject, email_body, settings.TIDINGS_FROM_ADDRESS, email_addresses,
-              fail_silently=False)
+    send_mail(email_subject, email_body, settings.TIDINGS_FROM_ADDRESS, email_addresses)

--- a/kitsune/sumo/email_utils.py
+++ b/kitsune/sumo/email_utils.py
@@ -22,11 +22,13 @@ def send_messages(messages):
     if not messages:
         return
 
-    conn = mail.get_connection(fail_silently=True)
-    conn.open()
-
-    for msg in messages:
-        conn.send_messages([msg])
+    try:
+        conn = mail.get_connection()
+        conn.open()
+        for msg in messages:
+            conn.send_messages([msg])
+    finally:
+        conn.close()
 
 
 def safe_translation(f):


### PR DESCRIPTION
Cyliang pointed out that we make sending email fail silently. That sounds like a bad thing, and makes it really hard to track down when we aren't sending notifications to users.

r?