### PR TITLE
Correcting missing macros of mobile and minimal

### DIFF
--- a/kitsune/wiki/templates/wiki/mobile/document-minimal.html
+++ b/kitsune/wiki/templates/wiki/mobile/document-minimal.html
@@ -21,7 +21,7 @@
   <div class="title-bar">{{ document_title(document) }}</div>
   <article id="wiki-doc">
     {{ document_messages(document, redirected_from) }}
-    {{ document_content(document, fallback_reason, request, settings) }}
+    {{ document_content(document, fallback_reason, request, settings, document_css_class, any_localizable_revision, full_locale_name) }}
 
     {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
     {% if share_link %}

--- a/kitsune/wiki/templates/wiki/mobile/document.html
+++ b/kitsune/wiki/templates/wiki/mobile/document.html
@@ -39,7 +39,7 @@
   <article id="wiki-doc">
     {{ document_title(document) }}
     {{ document_messages(document, redirected_from) }}
-    {{ document_content(document, fallback_reason, request, settings, full_locale_name) }}
+    {{ document_content(document, fallback_reason, request, settings, document_css_class, any_localizable_revision, full_locale_name) }}
 
     {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
     {% if share_link %}


### PR DESCRIPTION
This was missing from the Mobile template which cause not showing the locale name correctly and rest other thing.
r?