### PR TITLE
[Bug 1193443] Add more metadata and autotagging to new AAQ.

### DIFF
--- a/kitsune/questions/api.py
+++ b/kitsune/questions/api.py
@@ -310,8 +310,7 @@ class QuestionViewSet(viewsets.ModelViewSet):
             serializer.save()
             return Response(serializer.data)
         else:
-            return Response(serializer.errors,
-                            status=status.HTTP_400_BAD_REQUEST)
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @action(methods=['POST', 'DELETE'])
     def delete_metadata(self, request, pk=None):
@@ -379,6 +378,12 @@ class QuestionViewSet(viewsets.ModelViewSet):
         for tag in tags:
             question.tags.remove(tag)
 
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(methods=['POST'], permission_classes=[permissions.IsAuthenticated])
+    def auto_tag(self, request, pk=None):
+        question = self.get_object()
+        question.auto_tag()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/kitsune/questions/tests/__init__.py
+++ b/kitsune/questions/tests/__init__.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 
 from nose.tools import eq_
+import factory
 
 from kitsune.questions.models import (
     Question, QuestionVote, Answer, AnswerVote, QuestionLocale)
-from kitsune.sumo.tests import LocalizingClient, TestCase, with_save
-from kitsune.users.tests import profile
+from kitsune.sumo.tests import LocalizingClient, TestCase, with_save, FuzzyUnicode
+from kitsune.users.tests import profile, UserFactory
 
 
 class TestCaseBase(TestCase):
@@ -17,6 +18,15 @@ def tags_eq(tagged_object, tag_names):
     """Assert that the names of the tags on tagged_object are tag_names."""
     eq_(sorted([t.name for t in tagged_object.tags.all()]),
         sorted(tag_names))
+
+
+class QuestionFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Question
+
+    title = FuzzyUnicode()
+    content = FuzzyUnicode()
+    creator = factory.SubFactory(UserFactory)
 
 
 def question(save=False, **kwargs):

--- a/kitsune/tags/tests/__init__.py
+++ b/kitsune/tags/tests/__init__.py
@@ -2,9 +2,18 @@ from datetime import datetime
 
 from django.template.defaultfilters import slugify
 
+import factory
 from taggit.models import Tag
 
-from kitsune.sumo.tests import with_save
+from kitsune.sumo.tests import with_save, FuzzyUnicode
+
+
+class TagFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Tag
+
+    name = FuzzyUnicode()
+    slug = factory.LazyAttribute(lambda o: slugify(o.name))
 
 
 @with_save


### PR DESCRIPTION
This makes the new AAQ collect and add metadata about user agent, browser version, etc, that the old AAQ did, and adds an API end point for auto tagging.

Originally, I wanted auto tagging to run every time that metadata was changed so that BuddyUp would be able to take advantage of this, to reduce the number of requests the new AAQ had to make, and to make sure that future clients wouldn't have to think about auto tagging. Unfortunately, there is [a race condition in Taggit](https://github.com/alex/django-taggit/issues/349) that makes that not work. In particular, both BuddyUp and the new AAQ set metadata items in parallel. This causes a tag to be applied to a question multiple times because Taggit didn't make the DB constraints needed to make `get_or_create` atomic. So no auto-auto-tagging for us.

> Note: we should probably make sure we are using `get_or_create` in an atomic way in the rest of Kitsune.

r?