### PR TITLE
[Bug 1218459] Improve SimplePush error handling.

### DIFF
--- a/kitsune/notifications/tasks.py
+++ b/kitsune/notifications/tasks.py
@@ -4,6 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 
 import actstream.registry
+import simplejson
 import requests
 from actstream.models import Action, Follow
 from celery import task
@@ -48,7 +49,10 @@ def _send_simple_push(endpoint, version):
         # If something does wrong, the SimplePush server will give back
         # json encoded error messages.
         if r.status_code != 200:
-            logger.error('SimplePush error: %s %s', r.status_code, r.json())
+            try:
+                logger.error('SimplePush error: %s %s', r.status_code, r.json())
+            except simplejson.scanner.JSONDecodeError:
+                logger.error('SimplePush error (also not JSON?!): %s %s', r.status_code, r.text)
     except RequestException as e:
         # This will go to Sentry.
         logger.error('SimplePush PUT failed: %s', e)

--- a/kitsune/notifications/tasks.py
+++ b/kitsune/notifications/tasks.py
@@ -38,24 +38,46 @@ def _full_ct_query(action, actor_only=None):
     return query
 
 
-def _send_simple_push(endpoint, version):
+def _send_simple_push(endpoint, version, max_retries=3, _retry_count=0):
     """
     Hit a simple push endpoint to send a notification to a user.
 
-    Handles and record any HTTP errors.
+    Handles and record any HTTP errors. May retry up to ``max_retries``
+    times by recursing.
+
+    This function tries hard to handle any potential errors, so it may
+    be used in a loop that iterates over many actions to send, without
+    the loop needing to contain error handling logic.
+
+    @param endpoint: The url to PUT to.
+    @param version: The version to include in the push. Should be an integer
+        greater than the version used every other time this endpoint has
+        been called. Timestamps and DB auto increment fields work well.
+    @param max_retries: The maximum number of times to try again.
     """
+
     try:
         r = requests.put(endpoint, 'version={}'.format(version))
-        # If something does wrong, the SimplePush server will give back
-        # json encoded error messages.
-        if r.status_code != 200:
-            try:
-                logger.error('SimplePush error: %s %s', r.status_code, r.json())
-            except simplejson.scanner.JSONDecodeError:
-                logger.error('SimplePush error (also not JSON?!): %s %s', r.status_code, r.text)
     except RequestException as e:
-        # This will go to Sentry.
-        logger.error('SimplePush PUT failed: %s', e)
+        # This is something like connection error, not a server error.
+        if _retry_count < max_retries:
+            return _send_simple_push(endpoint, version, max_retries, _retry_count + 1)
+        else:
+            logger.error('SimplePush PUT failed: %s', e)
+            return
+
+    # If something does wrong, the SimplePush server should give back json encoded error messages.
+    if r.status_code >= 400:
+        try:
+            data = r.json()
+        except simplejson.scanner.JSONDecodeError:
+            logger.error('SimplePush error (also not JSON?!): %s %s', r.status_code, r.text)
+            return
+
+        if r.status_code == 503 and data['errno'] == 202 and _retry_count < max_retries:
+            return _send_simple_push(endpoint, version, max_retries, _retry_count + 1)
+        else:
+            logger.error('SimplePush error: %s %s', r.status_code, r.json())
 
 
 @task(bind=True)

--- a/kitsune/notifications/tasks.py
+++ b/kitsune/notifications/tasks.py
@@ -85,7 +85,7 @@ def _send_simple_push(endpoint, version, max_retries=3, _retry_count=0):
 @use_master
 def add_notification_for_action(action_id):
     action = Action.objects.get(id=action_id)
-    
+
     query = _full_ct_query(action, actor_only=False)
     # Don't send notifications to a user about actions they take.
     query &= ~Q(user=action.actor)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -282,6 +282,9 @@ requests-oauthlib==0.4.2
 # sha256: v445sBLQFGpK6vVBNT9bm5Ywu8tawnUFhJrIlrz_L2o
 setuptools==0.9.8
 
+# sha256: Y9f3sUog8p90Mlpp5ttFkl6vbjoAPqtGwCNP0FCoyT8
+simplejson==3.7.3
+
 # sha256: 4kBSQR_E-9H2cmNVN8P8IzDZSBsYwDF2lbRiWVEskdU
 six==1.9.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -57,9 +57,6 @@ PyYAML==3.11
 # sha256: a_c6l7D-RUKn7i2KYnoTs4KegdERvidVGzag36DCkJk
 q==2.4
 
-# sha256: Y9f3sUog8p90Mlpp5ttFkl6vbjoAPqtGwCNP0FCoyT8
-simplejson==3.7.3
-
 # sha256: lJM7ZOL-CAfaBhLFdKAhwNrCjHvTxKI3I65aOeqPPQQ
 Sphinx==1.2.3
 


### PR DESCRIPTION
We found out that some times the SimplePush server *doesn't* send back JSON errors (Even though it is supposed to). This should handle that and still print out the errors.

I'm deploying this to stage now to do some testing with Marcia and Kadir. I'll update this PR once that has gone through.