### PR TITLE
Allow lint jobs to fail in Travis temporarily.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
   - TEST_SUITE=django ELASTICSEARCH_VERSION=1.2.4
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: TEST_SUITE=lint
 cache:
   directories:
   - /home/travis/virtualenv


### PR DESCRIPTION
pre-commit is broken right now, so just skip it.

r?