### PR TITLE
[Bug 1223565] Use of QUERY_PARAMETERS in DRF apis.

### DIFF
--- a/kitsune/gallery/api.py
+++ b/kitsune/gallery/api.py
@@ -41,7 +41,7 @@ class ImageList(LocaleNegotiationMixin, generics.ListAPIView):
         # locale may come from the Accept-language header, but it can be
         # overridden via the query string.
         locale = self.get_locale()
-        locale = self.request.QUERY_PARAMS.get('locale', locale)
+        locale = self.request.query_params.get('locale', locale)
         if locale is not None:
             queryset = queryset.filter(locale=locale)
 

--- a/kitsune/gallery/urls_api.py
+++ b/kitsune/gallery/urls_api.py
@@ -6,6 +6,6 @@ from kitsune.gallery import api
 # API urls
 urlpatterns = patterns(
     '',
-    url(r'^image/?$', api.ImageList.as_view()),
-    url(r'^image/(?P<pk>\d+)/?$', api.ImageDetail.as_view()),
+    url(r'^image/?$', api.ImageList.as_view(), name='image-list'),
+    url(r'^image/(?P<pk>\d+)/?$', api.ImageDetail.as_view(), name='image-detail'),
 )

--- a/kitsune/products/api.py
+++ b/kitsune/products/api.py
@@ -101,6 +101,6 @@ class TopicList(LocaleNegotiationMixin, generics.ListAPIView):
 
     def get_queryset(self):
         queryset = self.queryset.filter(product__slug=self.kwargs['product'])
-        visible = bool(self.request.QUERY_PARAMS.get('visible', True))
+        visible = bool(self.request.query_params.get('visible', True))
         queryset = queryset.filter(visible=visible)
         return queryset

--- a/kitsune/products/tests/test_api.py
+++ b/kitsune/products/tests/test_api.py
@@ -1,8 +1,9 @@
 from nose.tools import eq_
 
 from kitsune.sumo.tests import TestCase
+from kitsune.sumo.urlresolvers import reverse
 from kitsune.products import api
-from kitsune.products.tests import ProductFactory
+from kitsune.products.tests import ProductFactory, TopicFactory
 
 
 class TestProductSerializerSerialization(TestCase):
@@ -19,3 +20,37 @@ class TestProductSerializerSerialization(TestCase):
         serializer = api.ProductSerializer()
         data = serializer.to_representation(p)
         eq_(data['image'], p.image.url)
+
+
+class TestTopicListView(TestCase):
+
+    def test_it_works(self):
+        p = ProductFactory()
+        url = reverse('topic-list', kwargs={'product': p.slug})
+        res = self.client.get(url)
+        eq_(res.status_code, 200)
+
+    def test_expected_output(self):
+        p = ProductFactory()
+        t1 = TopicFactory(product=p, visible=True, display_order=1)
+        t2 = TopicFactory(product=p, visible=True, display_order=2)
+
+        url = reverse('topic-list', kwargs={'product': p.slug})
+        res = self.client.get(url)
+        eq_(res.status_code, 200)
+
+        eq_(res.data, {
+            'count': 2,
+            'next': None,
+            'previous': None,
+            'results': [
+                {
+                    'title': t1.title,
+                    'slug': t1.slug,
+                },
+                {
+                    'title': t2.title,
+                    'slug': t2.slug,
+                },
+            ],
+        })

--- a/kitsune/products/urls_api.py
+++ b/kitsune/products/urls_api.py
@@ -6,8 +6,9 @@ from kitsune.products import api
 # API urls
 urlpatterns = patterns(
     '',
-    url(r'^$', api.ProductList.as_view()),
-    url(r'^(?P<product>[^/]+)/topic/?$', api.TopicList.as_view()),
+    url(r'^$', api.ProductList.as_view(), name='product-list'),
+    url(r'^(?P<product>[^/]+)/topic/?$', api.TopicList.as_view(), name='topic-list'),
     url(r'^(?P<product>[^/]+)/topic/(?P<topic>[^/]+)/?$',
-        api.TopicDetail.as_view()),
+        api.TopicDetail.as_view(),
+        name='topic-detail'),
 )

--- a/kitsune/sumo/api_utils.py
+++ b/kitsune/sumo/api_utils.py
@@ -192,7 +192,7 @@ class InequalityFilterBackend(BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         filter_fields = getattr(view, 'filter_fields', [])
 
-        for key, value in request.QUERY_PARAMS.items():
+        for key, value in request.query_params.items():
             splits = key.split('__')
             if len(splits) != 2:
                 continue

--- a/kitsune/sumo/tests/test_api_utils.py
+++ b/kitsune/sumo/tests/test_api_utils.py
@@ -41,14 +41,14 @@ class TestInequalityFilterBackend(TestCase):
         self.view.filter_fields = ['x']
         # `x` should be filtered, but `y` should not, since it is not in
         # `filter_fields`
-        self.request.QUERY_PARAMS = {'x__gt': 10, 'y': 5}
+        self.request.query_params = {'x__gt': 10, 'y': 5}
         self.backend.filter_queryset(self.request, self.queryset, self.view)
         self.queryset.filter.assert_called_with(x__gt=10)
 
     def test_lt_gte_multiple(self):
         """multiple fields, gte, and lt."""
         self.view.filter_fields = ['x', 'y']
-        self.request.QUERY_PARAMS = {'x__gte': 10, 'y__lt': 5}
+        self.request.query_params = {'x__gte': 10, 'y__lt': 5}
         self.backend.filter_queryset(self.request, self.queryset, self.view)
         calls = sorted(self.queryset.method_calls)
         # Since both variables are in `filter_fields`, they both get processed.

--- a/kitsune/wiki/api.py
+++ b/kitsune/wiki/api.py
@@ -45,11 +45,11 @@ class DocumentList(LocaleNegotiationMixin, generics.ListAPIView):
                                    current_revision__isnull=False)
 
         locale = self.get_locale()
-        product = self.request.QUERY_PARAMS.get('product')
-        topic = self.request.QUERY_PARAMS.get('topic')
-        is_template = bool(self.request.QUERY_PARAMS.get('is_template', False))
-        is_archived = bool(self.request.QUERY_PARAMS.get('is_archived', False))
-        is_redirect = bool(self.request.QUERY_PARAMS.get('is_redirect', False))
+        product = self.request.query_params.get('product')
+        topic = self.request.query_params.get('topic')
+        is_template = bool(self.request.query_params.get('is_template', False))
+        is_archived = bool(self.request.query_params.get('is_archived', False))
+        is_redirect = bool(self.request.query_params.get('is_redirect', False))
 
         if locale is not None:
             queryset = queryset.filter(locale=locale)

--- a/kitsune/wiki/urls_api.py
+++ b/kitsune/wiki/urls_api.py
@@ -6,6 +6,6 @@ from kitsune.wiki import api
 # API urls
 urlpatterns = patterns(
     '',
-    url(r'^$', api.DocumentList.as_view()),
-    url(r'^(?P<slug>[^/]+)$', api.DocumentDetail.as_view()),
+    url(r'^$', api.DocumentList.as_view(), name='document-list'),
+    url(r'^(?P<slug>[^/]+)$', api.DocumentDetail.as_view(), name='document-detail'),
 )


### PR DESCRIPTION
In DRF 3.0, `QUERY_PARAMETERS` was deprecated in favor of the lowercase `query_parameters`. In DRF 3.2 it was removed entirely. We updated from DRF 2.x straight to DRF 3.3.

We had poor test coverage that allowed this to slip through the upgrade.

r?