### PR TITLE
[Bug 1223230] Changed Firefox Affiliates to Firefox Friends

### DIFF
--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -214,7 +214,7 @@
       <ul>
         <li><a href="http://www.twitter.com/mozilla">{{ _('Twitter') }}</a></li>
         <li><a href="http://www.facebook.com/mozilla">{{ _('Facebook') }}</a></li>
-        <li><a href="http://affiliates.mozilla.org/">{{ _('Firefox Affiliates') }}</a></li>
+        <li><a href="http://friends.mozilla.org/">{{ _('Firefox Friends') }}</a></li>
         <li><a href="?{{ request.QUERY_STRING }}&amp;mobile=1">{{ _('Switch to mobile site') }}</a></li>
       </ul>
     </div>


### PR DESCRIPTION
Changing of Affiliates to Friends due to the phase out of Affiliates