### PR TITLE
[Bug 1198961] Fix post reply links

### DIFF
--- a/kitsune/sumo/static/sumo/js/markup.js
+++ b/kitsune/sumo/static/sumo/js/markup.js
@@ -156,7 +156,7 @@
         // IE/Opera
         selText = document.selection.createRange().text;
       } else if (this.textarea.selectionStart ||
-        this.textarea.selectionStart == '0') {
+        parseInt(this.textarea.selectionStart) === 0) {
         // Firefox/Safari/Chrome/etc.
         selText = this.textarea.value.substring(
           this.textarea.selectionStart, this.textarea.selectionEnd);
@@ -204,7 +204,7 @@
         }
 
         range.select();
-      } else if (textarea.selectionStart || textarea.selectionStart == '0') { // yes, this is really a string.
+      } else if (textarea.selectionStart || parseInt(textarea.selectionStart) === 0) {
         // Firefox/Safari/Chrome/etc.
         selStart = textarea.selectionStart;
         selEnd = textarea.selectionEnd;

--- a/kitsune/sumo/static/sumo/js/markup.js
+++ b/kitsune/sumo/static/sumo/js/markup.js
@@ -156,7 +156,7 @@
         // IE/Opera
         selText = document.selection.createRange().text;
       } else if (this.textarea.selectionStart ||
-        this.textarea.selectionStart === '0') {
+        this.textarea.selectionStart == '0') {
         // Firefox/Safari/Chrome/etc.
         selText = this.textarea.value.substring(
           this.textarea.selectionStart, this.textarea.selectionEnd);
@@ -204,7 +204,7 @@
         }
 
         range.select();
-      } else if (textarea.selectionStart || textarea.selectionStart === '0') { // yes, this is really a string.
+      } else if (textarea.selectionStart || textarea.selectionStart == '0') { // yes, this is really a string.
         // Firefox/Safari/Chrome/etc.
         selStart = textarea.selectionStart;
         selEnd = textarea.selectionEnd;


### PR DESCRIPTION
This [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1198961) was caused by the `selectionStart` property being represented as an integer rather than a string. I originally changed the strict equals to compare against an integer, but I think it might be better to just do a `==` as I wasn't really able to determine when that property started being represented as an integer...I imagine there are scenarios where it may still be represented as a string.

I'm writing some tests for the Marky tool this code is a part of, but figured this was a harmless enough of a change to not be blocked by those. 

Thoughts?
