### PR TITLE
 Remove extra setuptools from requirements.

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -278,10 +278,6 @@ requests==2.7.0
 # sha256: ngIjuJUY7axhqXtW_3jycQVs4IyKF8a2RK7yRPrIPyM
 requests-oauthlib==0.4.2
 
-# sha256: Qr9imks6STO7PPrPYAXJW3SU_YjNYqe60ajD5kZH6ww
-# sha256: v445sBLQFGpK6vVBNT9bm5Ywu8tawnUFhJrIlrz_L2o
-setuptools==0.9.8
-
 # sha256: Y9f3sUog8p90Mlpp5ttFkl6vbjoAPqtGwCNP0FCoyT8
 simplejson==3.7.3
 


### PR DESCRIPTION
This can't be good, and is probably bad. We already have one of these [at the top of the file](https://github.com/mythmon/kitsune/blob/b545e1004a36073fce3f5f8baa11755e76387263/requirements/default.txt#L1-L4) with a much newer version (18.3.2 vs 0.9.8).

r?