### PR TITLE
Upgrade dev requirements to match requires.io.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,53 +1,56 @@
 # These requirements are used for the development and testing of
 # Kitsune, but they are not required for running it on servers.
 
-# sha256: s6eaI9N7WgL6pVC5LLu-vrSqHXfmScPrOcGav1Ji2gQ
-argparse==1.3.0
+# sha256: YrCJpVvh2JSc0rx-DfC9254Cj678jDIDjMhIYq791uQ
+argparse==1.4.0
 
 # sha256: qRNwGDrqY8h9hIfns5ntLZmnwvFLEI0nwLyK2e9ZXZo
 aspy.yaml==0.2.1
 
-# sha256: BBpgphbVmxMCbJi44fK4K39OoEm8_0SobUoCU7oeJ2g
-cached-property==1.0.0
+# sha256: 4wgagYLT1LcoPuredsOCvP1N_WRMqABZginC73mKu1M
+cached-property==1.2.0
 
 # sha256: yfS7goDAxl8gqd_IQRV_y0eUYeyuaXKoozNj52k6qRc
 chief-james==1.0.0
 
-# sha256: 6U6syZbt8Rq7o3Lw3APp2PHQCIn9KeiTXE6bvZuir9w
-django-debug-toolbar==1.2.2
+# sha256: DLrodg9IUdSApwtyrOWwdfgZHs-Jm8l0J3FeUPsOkLk
+django-debug-toolbar==1.4.0
 
-# sha256: Y6KG6ssDzV9kPX60WMbGK3DBEbRjT9jVnyfMrKS3yDo
-django-sslserver==0.14
+# sha256: rWInLeCyFLq6vMM5d7CWQlS8BsPcHOaN0-6FNcOdICg
+django-sslserver==0.16
 
 # sha256: x9txeBCraWX2bIzwOYqYydjfmC2jm0zX8WKRHriVlvo
 docutils==0.12
 
-# sha256: KF6L1zDAtv374jwy0pNr_7pAHyPKsTLocixovoDW8YI
-flake8==2.2.5
+# sha256: ghbIxu4JKuk9UfibyRBFZIyIzZvnfWDPR998om7k-Iw
+flake8==2.5.0
 
-# sha256: Epii8bL0xKe5IczNFZ5OQvbXsPt1yGwM3s_HHwYYM_o
-jsonschema==2.4.0
+# sha256: 9iU9--BTitLjh72P39kpPJJdY1U_WBPE5Yd0VBZQHm0
+functools32==3.2.3-2
 
-# sha256: WioXDkfeVZOmq_rh6VQr0sOSSsYrvk5u2WyVPANSJDo
-mccabe==0.2.1
+# sha256: Nmc6w3j-7T2qWVYnaoKWmQVlI9eWECeRHwZLUiVerUE
+jsonschema==2.5.1
+
+# sha256: X36m-zqpr-FG0H_W1c7feIdH2LDCnkRzJFPCstsePRY
+mccabe==0.3.1
 
 # sha256: e5YBIl0vUwZjVn0DMm8o8ipKZCPlasGBLWH9IEEmM_I
 ndg-httpsclient==0.3.3
 
-# sha256: z-plZ1KzlnhB98MAocl1ZSYBPuGfOsR9srdxNP84tQk
-nodeenv==0.13.1
+# sha256: _qr7BIbXdjYO-Tm9hbo0z_m2IwE7EygNHjdw04HuK38
+nodeenv==0.13.6
 
 # sha256: ku47hrXBkhwtnawhe--JkMX4Usi8TZAYyv4PPzuBzTo
 nosenicedots==0.5
 
-# sha256: VzZ3y4X_CJJEsPma-VX3bC43RWYyYQtt7aYWcTnOFVo
-pep8==1.6.1
+# sha256: uLfjVjC1U54moZffxgBb6eHpoTVJazd3I6jrwBuby_8
+pep8==1.6.2
 
-# sha256: AYZpifnJp_6ZrQamhb9qj41LDZpA6AHm_zXSHLpxYzk
-pre-commit==0.5.2
+# sha256: wapVuGj_cYauuuwMQDlL2MHHiGdXK3J-WpxzS56oL9I
+pre-commit==0.6.2
 
-# sha256: P6gKELNtUWhr93RPXcmWIs1cmM6O1kAi5imGiq_Bd2k
-pyflakes==0.8.1
+# sha256: 854zpMA77q2HdPAFvT7PDD8vJk-gIB3pZfzgr_HTQmM
+pyflakes==1.0.0
 
 # sha256: cyCRkITm2sj0VAY4pGRHo71zD8oXKvwX0sA-7SLPT1E
 Pygments==2.0.2
@@ -55,8 +58,8 @@ Pygments==2.0.2
 # sha256: w2yTiocuX_SUk4szsUqqFWy0OexnVI_Ks1Nbt4sIRug
 PyYAML==3.11
 
-# sha256: a_c6l7D-RUKn7i2KYnoTs4KegdERvidVGzag36DCkJk
-q==2.4
+# sha256: 3g_PWkOXVJdd2AIsO_JjdLiC0P5CZaq4gT9Oh-BX7tU
+q==2.6
 
 # sha256: lJM7ZOL-CAfaBhLFdKAhwNrCjHvTxKI3I65aOeqPPQQ
 Sphinx==1.2.3
@@ -70,5 +73,5 @@ tabulate==0.7.5
 # sha256: lM7ehUx4i_w1KArTvkn85vNiWTgp_YuOPKwe0RL-yFc
 testfixtures==4.5.0
 
-# sha256: PIjPffEUwyzwZR0S-Xm421VtmS1kdJPlvbvigovkAAc
-virtualenv==12.1.1
+# sha256: qryO8YzdvYoqnH-SvEPi_qVLEUczDWXbkg7zzpgS49w
+virtualenv==13.1.2


### PR DESCRIPTION
Eventually I'd like to get to a point where everything on requires.io is up to date. That's a big project though. Upgrading the dev requirements should be pretty easy though. I updated anything that requires.io complained about, except Sphinx, and added `functools32` because precommit wouldn't run without it.

I didn't upgrade Sphinx because it would require us to upgrade Babel, which is not a dev dependency. Maybe it would be easy to do, but I didn't want to touch that file right now.

Things that should work:

* tests locally
* tests in travis
* making the docs
* pre-commit hooks
* ./manage.py runserver
* any normal debugging workflow you care to test

These all work for me locally

r?