### PR TITLE
[Bug 1199555] RTL Locales out of view

### DIFF
--- a/kitsune/sumo/static/sumo/less/questions.less
+++ b/kitsune/sumo/static/sumo/less/questions.less
@@ -409,7 +409,8 @@ h2 {
 
     textarea {
       margin-top: 10px;
-      width: 510px;
+      width: 500px;
+      padding: 0 5px;
     }
 
     .editor-tools {

--- a/kitsune/sumo/static/sumo/less/questions.less
+++ b/kitsune/sumo/static/sumo/less/questions.less
@@ -409,8 +409,8 @@ h2 {
 
     textarea {
       margin-top: 10px;
-      width: 500px;
       padding: 0 5px;
+      width: 500px;
     }
 
     .editor-tools {


### PR DESCRIPTION
Adding some padding to the textarea prevents the RTL locales from being cut off when you type (as noted in bugzilla [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1199555). I could add some specificity to this by wrapping it in the `body.html-rtl` selector as well, but it seems a minimal enough change that applying it at all times shouldn't hurt. 

Screenshot attached. 
<img width="586" alt="rtl-locales" src="https://cloud.githubusercontent.com/assets/856935/11254173/4d1d4726-8e0d-11e5-8342-02dd16c6de1f.png">
