### PR TITLE
[Bug 1064335] Added space between left and right columns in questions.

### DIFF
--- a/kitsune/sumo/static/sumo/less/questions.less
+++ b/kitsune/sumo/static/sumo/less/questions.less
@@ -1117,6 +1117,7 @@ h2 {
   .total {
     float: right;
     margin: 0 6px;
+    padding-left: 50px;
   }
 }
 


### PR DESCRIPTION
This adds space between the text 
"xx questions in the last 24 hours have no reply. Help solve them!"  which is little longer in other language like french that it goes to next line that is fine but the problem is text "Total questions: xx" ( Right side ) which is floated to right and has no padding to its left side it makes appear like a single line if the text on right is long enough.

Here is how it looks in English:  https://support.mozilla.org/en-US/questions/thunderbird

xx questions in the last 24 hours have no reply. Help solve them!  ^^^^^^^^^  Total questions: xx
( Have enough space )
                                                                                                       
In French  https://support.mozilla.org/fr/questions/thunderbird
![screenshot from 2015-11-20 12 40 59](https://cloud.githubusercontent.com/assets/1151263/11293899/ad8a37f4-8f84-11e5-97e5-f8b498a40269.png)
Without space between the two words

![screenshot from 2015-11-20 12 40 16](https://cloud.githubusercontent.com/assets/1151263/11293907/bac4f60c-8f84-11e5-9b8f-437586981423.png)
With space.