### PR TITLE
[Bug 1225507] Disable signout during AAQ

### DIFF
--- a/kitsune/questions/templates/questions/includes/question_editing_frame.html
+++ b/kitsune/questions/templates/questions/includes/question_editing_frame.html
@@ -15,7 +15,7 @@ we can compute the edit-title URL.
 {% from "questions/includes/aaq_macros.html" import troubleshooting_instructions with context %}
 {% from "upload/attachments.html" import attachments_form %}
 
-{% set hide_aaq_link = True %}
+{% set within_aaq_flow = True %}
 
 {% block content %}
   <div class="grid_12">

--- a/kitsune/questions/templates/questions/includes/question_editing_frame.html
+++ b/kitsune/questions/templates/questions/includes/question_editing_frame.html
@@ -15,7 +15,7 @@ we can compute the edit-title URL.
 {% from "questions/includes/aaq_macros.html" import troubleshooting_instructions with context %}
 {% from "upload/attachments.html" import attachments_form %}
 
-{% set within_aaq_flow = True %}
+{% set hide_aaq_link = True %}
 
 {% block content %}
   <div class="grid_12">

--- a/kitsune/questions/templates/questions/new_question_react.html
+++ b/kitsune/questions/templates/questions/new_question_react.html
@@ -6,6 +6,8 @@
 {% set title = _('Ask a Question') %}
 {% block breadcrumbs %}{% endblock %}
 
+{% set hide_signout_link = True %}
+
 {% block content %}
   {{ csrf() }}{# CSRF token for AJAX actions. #}
   <script type="application/json" class="data" name="products">{{ products_json|safe }}</script>

--- a/kitsune/questions/templates/questions/new_question_react.html
+++ b/kitsune/questions/templates/questions/new_question_react.html
@@ -6,6 +6,7 @@
 {% set title = _('Ask a Question') %}
 {% block breadcrumbs %}{% endblock %}
 
+{% set hide_aaq_link = True %}
 {% set hide_signout_link = True %}
 
 {% block content %}

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -135,7 +135,7 @@
       <div class="cf">
         <nav id="aux-nav" role="navigation">
           <ul>
-            {{ aux_nav(user, within_aaq_flow) }}
+            {{ aux_nav(user, hide_aaq_link, hide_signout_link) }}
             {% if not hide_locale_switcher %}
               <li><a href="{{ locale_picker_url }}" class="locale-picker">{{ settings.LANGUAGES_DICT[request.LANGUAGE_CODE.lower()] }}</a></li>
             {% endif %}

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -135,7 +135,7 @@
       <div class="cf">
         <nav id="aux-nav" role="navigation">
           <ul>
-            {{ aux_nav(user, hide_aaq_link) }}
+            {{ aux_nav(user, within_aaq_flow) }}
             {% if not hide_locale_switcher %}
               <li><a href="{{ locale_picker_url }}" class="locale-picker">{{ settings.LANGUAGES_DICT[request.LANGUAGE_CODE.lower()] }}</a></li>
             {% endif %}

--- a/kitsune/sumo/templates/includes/common_macros.html
+++ b/kitsune/sumo/templates/includes/common_macros.html
@@ -11,9 +11,9 @@
   </form>
 {% endmacro %}
 
-{% macro aux_nav(user, hide_aaq_link=False) %}
+{% macro aux_nav(user, within_aaq_flow=False) %}
   {% if not settings.READ_ONLY %}
-    {% if not hide_aaq_link %}
+    {% if not within_aaq_flow %}
       {% if request.LANGUAGE_CODE in AAQ_LANGUAGES %}
         {% set ask_url = url('questions.aaq_step1') %}
       {% else %}
@@ -34,12 +34,14 @@
           <li><a href="{{ url('search')|urlparams(asked_by=user.username, a=1, w=2) }}">{{ _('My Questions') }}</a></li>
           <li><a href="{{ profile_url(user, edit=True) }}">{{ _('Edit Profile') }}</a></li>
           <li><a href="{{ url('users.edit_settings') }}">{{ _('Settings') }}</a></li>
+          {% if not within_aaq_flow %}
           <li>
             <form id="sign-out" action="{{ url('users.logout') }}" method="post">
               {{ csrf() }}
             </form>
             <a class="sign-out" data-type="submit" data-form="sign-out" href="#sign-out">{{ _('Sign Out') }}</a>
           </li>
+          {% endif %}
         </ul>
       </li>
       <li>

--- a/kitsune/sumo/templates/includes/common_macros.html
+++ b/kitsune/sumo/templates/includes/common_macros.html
@@ -11,9 +11,9 @@
   </form>
 {% endmacro %}
 
-{% macro aux_nav(user, within_aaq_flow=False) %}
+{% macro aux_nav(user, hide_aaq_link=False, hide_signout_link=False) %}
   {% if not settings.READ_ONLY %}
-    {% if not within_aaq_flow %}
+    {% if not hide_aaq_link %}
       {% if request.LANGUAGE_CODE in AAQ_LANGUAGES %}
         {% set ask_url = url('questions.aaq_step1') %}
       {% else %}
@@ -34,13 +34,13 @@
           <li><a href="{{ url('search')|urlparams(asked_by=user.username, a=1, w=2) }}">{{ _('My Questions') }}</a></li>
           <li><a href="{{ profile_url(user, edit=True) }}">{{ _('Edit Profile') }}</a></li>
           <li><a href="{{ url('users.edit_settings') }}">{{ _('Settings') }}</a></li>
-          {% if not within_aaq_flow %}
-          <li>
-            <form id="sign-out" action="{{ url('users.logout') }}" method="post">
-              {{ csrf() }}
-            </form>
-            <a class="sign-out" data-type="submit" data-form="sign-out" href="#sign-out">{{ _('Sign Out') }}</a>
-          </li>
+          {% if not hide_signout_link %}
+            <li>
+              <form id="sign-out" action="{{ url('users.logout') }}" method="post">
+                {{ csrf() }}
+              </form>
+              <a class="sign-out" data-type="submit" data-form="sign-out" href="#sign-out">{{ _('Sign Out') }}</a>
+            </li>
           {% endif %}
         </ul>
       </li>


### PR DESCRIPTION
This hides the signout button which wasn't working during the AAQ flow (https://bugzilla.mozilla.org/show_bug.cgi?id=1225507) 

I also renamed the `hide_aaq_link` variable to something a bit more generic, as it's responsible for a little more now.