### PR TITLE
[Bug 1224267] Redirect warnings to logging infra.

### DIFF
--- a/kitsune/log_settings.py
+++ b/kitsune/log_settings.py
@@ -84,3 +84,4 @@ else:
     )
 
 dictConfig(config)
+logging.captureWarnings(True)

--- a/scripts/crontab/gen-crons.py
+++ b/scripts/crontab/gen-crons.py
@@ -14,7 +14,7 @@ def main():
                       help="Location of kitsune (required)")
     parser.add_option("-u", "--user",
                       help=("Prefix cron with this user. "
-                           "Only define for cron.d style crontabs"))
+                            "Only define for cron.d style crontabs"))
     parser.add_option("-p", "--python", default="python",
                       help="Python interpreter to use")
 
@@ -24,7 +24,7 @@ def main():
         parser.error("-k must be defined")
 
     ctx = {
-        'django': 'cd %s; source virtualenv/bin/activate; %s -W ignore::DeprecationWarning manage.py' % (
+        'django': 'cd %s; source virtualenv/bin/activate; %s manage.py' % (
             opts.kitsune, opts.python),
         'scripts': 'cd %s; source virtualenv/bin/activate; %s' % (
             opts.kitsune, opts.python),


### PR DESCRIPTION
This should do two things

* Make collect_tweets stop spamming my inbox
* In the future we can more easily deal with these kind of warnings via logging instead of ad-hoc dumping of them to stdout.

r?