### PR TITLE
[Bug 1173526] Replace all model makers with factoryboy classes.

### DIFF
--- a/kitsune/access/tests/test_decorators.py
+++ b/kitsune/access/tests/test_decorators.py
@@ -7,7 +7,7 @@ from nose.tools import eq_
 from kitsune.access.decorators import (
     logout_required, login_required, permission_required)
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 def simple_view(request):
@@ -24,14 +24,14 @@ class LogoutRequiredTestCase(TestCase):
 
     def test_logged_in_default(self):
         request = RequestFactory().get('/foo')
-        request.user = user(save=True)
+        request.user = UserFactory()
         view = logout_required(simple_view)
         response = view(request)
         eq_(302, response.status_code)
 
     def test_logged_in_argument(self):
         request = RequestFactory().get('/foo')
-        request.user = user(save=True)
+        request.user = UserFactory()
         view = logout_required('/bar')(simple_view)
         response = view(request)
         eq_(302, response.status_code)
@@ -41,7 +41,7 @@ class LogoutRequiredTestCase(TestCase):
         """Ajax requests should not redirect."""
         request = RequestFactory().get('/foo')
         request.META['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
-        request.user = user(save=True)
+        request.user = UserFactory()
         view = logout_required(simple_view)
         response = view(request)
         eq_(403, response.status_code)
@@ -58,7 +58,7 @@ class LoginRequiredTestCase(TestCase):
     def test_logged_in_default(self):
         """Active user login."""
         request = RequestFactory().get('/foo')
-        request.user = user(save=True)
+        request.user = UserFactory()
         view = login_required(simple_view)
         response = view(request)
         eq_(200, response.status_code)
@@ -66,7 +66,7 @@ class LoginRequiredTestCase(TestCase):
     def test_logged_in_inactive(self):
         """Inactive user login not allowed by default."""
         request = RequestFactory().get('/foo')
-        request.user = user(is_active=False, save=True)
+        request.user = UserFactory(is_active=False)
         view = login_required(simple_view)
         response = view(request)
         eq_(302, response.status_code)
@@ -74,7 +74,7 @@ class LoginRequiredTestCase(TestCase):
     def test_logged_in_inactive_allow(self):
         """Inactive user login explicitly allowed."""
         request = RequestFactory().get('/foo')
-        request.user = user(is_active=False, save=True)
+        request.user = UserFactory(is_active=False)
         view = login_required(simple_view, only_active=False)
         response = view(request)
         eq_(200, response.status_code)
@@ -99,7 +99,7 @@ class PermissionRequiredTestCase(TestCase):
 
     def test_logged_in_default(self):
         request = RequestFactory().get('/foo')
-        request.user = user(save=True)
+        request.user = UserFactory()
         view = permission_required('perm')(simple_view)
         response = view(request)
         eq_(403, response.status_code)
@@ -107,14 +107,14 @@ class PermissionRequiredTestCase(TestCase):
     def test_logged_in_inactive(self):
         """Inactive user is denied access."""
         request = RequestFactory().get('/foo')
-        request.user = user(is_active=False, save=True)
+        request.user = UserFactory(is_active=False)
         view = permission_required('perm')(simple_view)
         response = view(request)
         eq_(403, response.status_code)
 
     def test_logged_in_admin(self):
         request = RequestFactory().get('/foo')
-        request.user = user(is_staff=True, is_superuser=True, save=True)
+        request.user = UserFactory(is_staff=True, is_superuser=True)
         view = permission_required('perm')(simple_view)
         response = view(request)
         eq_(200, response.status_code)

--- a/kitsune/announcements/tests/test_models.py
+++ b/kitsune/announcements/tests/test_models.py
@@ -3,34 +3,35 @@ from datetime import datetime, timedelta
 from nose.tools import eq_
 
 from kitsune.announcements.models import Announcement
-from kitsune.announcements.tests import announcement
+from kitsune.announcements.tests import AnnouncementFactory
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import user, group, profile
-from kitsune.wiki.tests import locale
+from kitsune.users.tests import UserFactory, GroupFactory
+from kitsune.wiki.tests import LocaleFactory
 
 
 class AnnouncementModelTests(TestCase):
 
     def setUp(self):
         super(AnnouncementModelTests, self).setUp()
-        self.creator = user(save=True)
-        profile(user=self.creator)
-        self.group = group(save=True)
-        self.locale = locale(locale='es', save=True)
+        self.creator = UserFactory()
+        self.group = GroupFactory()
+        self.locale = LocaleFactory(locale='es')
         self.creator.groups.add(self.group)
 
     def test_active(self):
         """Active announcement shows."""
-        announcement(show_after=datetime.now() - timedelta(days=2),
-                     show_until=datetime.now() + timedelta(days=2)).save()
+        AnnouncementFactory(
+            show_after=datetime.now() - timedelta(days=2),
+            show_until=datetime.now() + timedelta(days=2))
         eq_(1, Announcement.get_site_wide().count())
 
     def test_always_visible(self):
         """Always visible announcements are shown."""
         # This one doesn't show
-        announcement(show_after=datetime.now() + timedelta(days=2)).save()
-        announcement(show_after=datetime.now() - timedelta(days=2),
-                     content='stardate 43125').save()
+        AnnouncementFactory(show_after=datetime.now() + timedelta(days=2))
+        AnnouncementFactory(
+            show_after=datetime.now() - timedelta(days=2),
+            content='stardate 43125')
 
         site_wide = Announcement.get_site_wide()
         eq_(1, site_wide.count())
@@ -38,15 +39,15 @@ class AnnouncementModelTests(TestCase):
 
     def test_group_excluded(self):
         """Announcements in a group are not shown."""
-        announcement(group=self.group).save()
+        AnnouncementFactory(group=self.group)
         eq_(0, Announcement.get_site_wide().count())
 
     def test_get_for_group_id(self):
         """If no groups are passed, nothing is returned."""
         # Site-wide announcement
-        announcement().save()
+        AnnouncementFactory()
         # Announcement in a group.
-        a = announcement(group=self.group, save=True)
+        a = AnnouncementFactory(group=self.group)
 
         group_ann = Announcement.get_for_group_id(self.group.id)
         eq_(1, len(group_ann))
@@ -55,9 +56,9 @@ class AnnouncementModelTests(TestCase):
     def test_get_for_locale_name(self):
         """Announcements for a specific locale are shown."""
         # Site-wide announcement
-        announcement(save=True)
+        AnnouncementFactory()
         # Announcement in a locale
-        a = announcement(locale=self.locale, save=True)
+        a = AnnouncementFactory(locale=self.locale)
 
         locale_ann = Announcement.get_for_locale_name(self.locale.locale)
         eq_(1, locale_ann.count())

--- a/kitsune/announcements/tests/test_views.py
+++ b/kitsune/announcements/tests/test_views.py
@@ -3,17 +3,17 @@ from datetime import datetime
 from nose.tools import eq_
 
 from kitsune.announcements.models import Announcement
-from kitsune.announcements.tests import announcement
+from kitsune.announcements.tests import AnnouncementFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import user, add_permission
-from kitsune.wiki.tests import locale
+from kitsune.users.tests import UserFactory, add_permission
+from kitsune.wiki.tests import LocaleFactory
 
 
 class TestCreateLocaleAnnouncement(TestCase):
 
     def setUp(self):
-        self.locale = locale(save=True, locale='es')
+        self.locale = LocaleFactory(locale='es')
 
     def _create_test(self, status, count):
         """Login, or other setup, then call this."""
@@ -26,25 +26,25 @@ class TestCreateLocaleAnnouncement(TestCase):
         eq_(Announcement.objects.count(), count)
 
     def test_create(self):
-        u = user(save=True, is_superuser=1)
+        u = UserFactory(is_superuser=1)
         self.client.login(username=u.username, password='testpass')
         self._create_test(200, 1)
 
     def test_leader(self):
-        u = user(save=True)
+        u = UserFactory()
         self.locale.leaders.add(u)
         self.locale.save()
         self.client.login(username=u.username, password='testpass')
         self._create_test(200, 1)
 
     def test_has_permission(self):
-        u = user(save=True)
+        u = UserFactory()
         add_permission(u, Announcement, 'add_announcement')
         self.client.login(username=u.username, password='testpass')
         self._create_test(200, 1)
 
     def test_no_perms(self):
-        u = user(save=True)
+        u = UserFactory()
         self.client.login(username=u.username, password='testpass')
         self._create_test(403, 0)
 
@@ -55,16 +55,18 @@ class TestCreateLocaleAnnouncement(TestCase):
 class TestDeleteAnnouncement(TestCase):
 
     def setUp(self):
-        self.locale = locale(save=True, locale='es')
+        self.locale = LocaleFactory(locale='es')
 
-        self.u = user(save=True)
+        self.u = UserFactory()
 
         self.locale.leaders.add(self.u)
         self.locale.save()
 
-        self.announcement = announcement(
-            creator=self.u, locale=self.locale, content="Look at me!",
-            show_after=datetime(2012, 01, 01, 0, 0, 0), save=True)
+        self.announcement = AnnouncementFactory(
+            creator=self.u,
+            locale=self.locale,
+            content="Look at me!",
+            show_after=datetime(2012, 1, 1, 0, 0, 0))
 
     def _delete_test(self, id, status, count):
         """Login, or other setup, then call this."""
@@ -74,7 +76,7 @@ class TestDeleteAnnouncement(TestCase):
         eq_(Announcement.objects.count(), count)
 
     def test_delete(self):
-        u = user(save=True, is_superuser=1)
+        u = UserFactory(is_superuser=1)
         self.client.login(username=u.username, password='testpass')
         self._delete_test(self.announcement.id, 204, 0)
 
@@ -84,13 +86,13 @@ class TestDeleteAnnouncement(TestCase):
         self._delete_test(self.announcement.id, 204, 0)
 
     def test_has_permission(self):
-        u = user(save=True)
+        u = UserFactory()
         add_permission(u, Announcement, 'add_announcement')
         self.client.login(username=u.username, password='testpass')
         self._delete_test(self.announcement.id, 204, 0)
 
     def test_no_perms(self):
-        u = user(save=True)
+        u = UserFactory()
         self.client.login(username=u.username, password='testpass')
         self._delete_test(self.announcement.id, 403, 1)
 

--- a/kitsune/community/tests/test_cron.py
+++ b/kitsune/community/tests/test_cron.py
@@ -9,10 +9,10 @@ import mock
 from nose.tools import eq_
 
 from kitsune.community import cron
-from kitsune.questions.tests import answer, question
+from kitsune.questions.tests import AnswerFactory, QuestionFactory
 from kitsune.sumo.tests import attrs_eq, TestCase
-from kitsune.users.tests import profile
-from kitsune.wiki.tests import document, revision
+from kitsune.users.tests import UserFactory
+from kitsune.wiki.tests import DocumentFactory, RevisionFactory
 
 
 class WelcomeEmailsTests(TestCase):
@@ -21,16 +21,16 @@ class WelcomeEmailsTests(TestCase):
     def test_answer_welcome_email(self, get_current):
         get_current.return_value.domain = 'testserver'
 
-        u1 = profile().user
-        u2 = profile(first_answer_email_sent=True).user
-        u3 = profile().user
+        u1 = UserFactory()
+        u2 = UserFactory(profile__first_answer_email_sent=True)
+        u3 = UserFactory()
 
         two_days = datetime.now() - timedelta(hours=48)
 
-        q = question(creator=u1, save=True)
-        answer(question=q, creator=u1, created=two_days, save=True)
-        answer(question=q, creator=u2, created=two_days, save=True)
-        answer(question=q, creator=u3, created=two_days, save=True)
+        q = QuestionFactory(creator=u1)
+        AnswerFactory(question=q, creator=u1, created=two_days)
+        AnswerFactory(question=q, creator=u2, created=two_days)
+        AnswerFactory(question=q, creator=u3, created=two_days)
 
         # Clear out the notifications that were sent
         mail.outbox = []
@@ -64,14 +64,14 @@ class WelcomeEmailsTests(TestCase):
     def test_l10n_welcome_email(self, get_current):
         get_current.return_value.domain = 'testserver'
 
-        u1 = profile().user
-        u2 = profile(first_l10n_email_sent=True).user
+        u1 = UserFactory()
+        u2 = UserFactory(profile__first_l10n_email_sent=True)
 
         two_days = datetime.now() - timedelta(hours=48)
 
-        d = document(locale='ru', save=True)
-        revision(document=d, creator=u1, created=two_days, save=True)
-        revision(document=d, creator=u2, created=two_days, save=True)
+        d = DocumentFactory(locale='ru')
+        RevisionFactory(document=d, creator=u1, created=two_days)
+        RevisionFactory(document=d, creator=u2, created=two_days)
 
         # Clear out the notifications that were sent
         mail.outbox = []

--- a/kitsune/community/tests/test_templates.py
+++ b/kitsune/community/tests/test_templates.py
@@ -1,18 +1,16 @@
 from nose.tools import eq_
 
-from django.contrib.auth.models import User
-
 from pyquery import PyQuery as pq
 
-from kitsune.customercare.tests import reply
-from kitsune.forums.tests import thread, forum
-from kitsune.questions.tests import answer
+from kitsune.customercare.tests import ReplyFactory
+from kitsune.forums.tests import ThreadFactory
+from kitsune.questions.tests import AnswerFactory
 from kitsune.search.tests.test_es import ElasticTestCase
 from kitsune.sumo.helpers import urlparams
 from kitsune.sumo.tests import LocalizingClient
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import user, profile
-from kitsune.wiki.tests import document, revision
+from kitsune.users.tests import UserFactory
+from kitsune.wiki.tests import DocumentFactory, RevisionFactory, ApprovedRevisionFactory
 
 
 class UserSearchTests(ElasticTestCase):
@@ -20,19 +18,15 @@ class UserSearchTests(ElasticTestCase):
     client_class = LocalizingClient
 
     def test_no_results(self):
-        profile(name='Foo Bar', user=user(username='foo', save=True))
-
+        UserFactory(username='foo', profile__name='Foo Bar')
         self.refresh()
-
-        response = self.client.get(
-            urlparams(reverse('community.search'), q='baz'))
-
+        response = self.client.get(urlparams(reverse('community.search'), q='baz'))
         eq_(response.status_code, 200)
         assert 'No users were found' in response.content
 
     def test_results(self):
-        profile(name='Foo Bar', user=user(username='foo', save=True))
-        profile(name='Bar Bam', user=user(username='bam', save=True))
+        UserFactory(username='foo', profile__name='Foo Bar')
+        UserFactory(username='bam', profile__name='Bar Bam')
 
         self.refresh()
 
@@ -59,21 +53,17 @@ class LandingTests(ElasticTestCase):
 
     def test_top_contributors(self):
         """Verify the top contributors appear."""
-        d = document(locale='en-US', save=True)
-        revision(document=d, save=True)
-        d = document(locale='es', save=True)
-        revision(document=d, save=True)
-        revision(document=d, save=True)
-        answer(save=True)
-        answer(save=True)
-        answer(save=True)
-        reply(user=user(save=True), save=True)
-        reply(user=user(save=True), save=True)
-        reply(user=user(save=True), save=True)
-        reply(user=user(save=True), save=True)
-
-        for u in User.objects.all():
-            profile(user=u)
+        RevisionFactory(document__locale='en-US')
+        d = DocumentFactory(locale='es')
+        RevisionFactory(document=d)
+        RevisionFactory(document=d)
+        AnswerFactory()
+        AnswerFactory()
+        AnswerFactory()
+        ReplyFactory()
+        ReplyFactory()
+        ReplyFactory()
+        ReplyFactory()
 
         self.refresh()
 
@@ -95,10 +85,8 @@ class LandingTests(ElasticTestCase):
         eq_(len(doc('#doc-content')), 0)
 
         # Create the "Mozilla News" article and verify it on home page.
-        d = document(
-            title='Community Hub News', slug='community-hub-news', save=True)
-        rev = revision(
-            document=d, content='splendid', is_approved=True, save=True)
+        d = DocumentFactory(title='Community Hub News', slug='community-hub-news')
+        rev = ApprovedRevisionFactory(document=d, content='splendid')
         d.current_revision = rev
         d.save()
         response = self.client.get(urlparams(reverse('community.home')))
@@ -110,8 +98,7 @@ class LandingTests(ElasticTestCase):
 
     def test_recent_threads(self):
         """Verify the Community Discussions section."""
-        f = forum(slug='contributors', save=True)
-        thread(forum=f, title='we are SUMO!!!!!!', save=True)
+        ThreadFactory(forum__slug='contributors', title='we are SUMO!!!!!!')
 
         self.refresh()
 
@@ -132,10 +119,8 @@ class TopContributorsTests(ElasticTestCase):
         eq_(404, response.status_code)
 
     def test_top_army_of_awesome(self):
-        r1 = reply(user=user(save=True), save=True)
-        r2 = reply(user=user(save=True), save=True)
-        profile(user=r1.user)
-        profile(user=r2.user)
+        r1 = ReplyFactory()
+        r2 = ReplyFactory()
 
         self.refresh()
 
@@ -144,14 +129,12 @@ class TopContributorsTests(ElasticTestCase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(2, len(doc('li.results-user')))
-        assert r1.user.username in response.content
-        assert r2.user.username in response.content
+        assert str(r1.user.username) in response.content
+        assert str(r2.user.username) in response.content
 
     def test_top_questions(self):
-        a1 = answer(save=True)
-        a2 = answer(save=True)
-        profile(user=a1.creator)
-        profile(user=a2.creator)
+        a1 = AnswerFactory()
+        a2 = AnswerFactory()
 
         self.refresh()
 
@@ -160,32 +143,27 @@ class TopContributorsTests(ElasticTestCase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(2, len(doc('li.results-user')))
-        assert a1.creator.username in response.content
-        assert a2.creator.username in response.content
+        assert str(a1.creator.username) in response.content
+        assert str(a2.creator.username) in response.content
 
     def test_top_kb(self):
-        d = document(locale='en-US', save=True)
-        r1 = revision(document=d, save=True)
-        r2 = revision(document=d, save=True)
-        profile(user=r1.creator)
-        profile(user=r2.creator)
+        d = DocumentFactory(locale='en-US')
+        r1 = RevisionFactory(document=d)
+        r2 = RevisionFactory(document=d)
 
         self.refresh()
 
-        response = self.client.get(urlparams(
-            reverse('community.top_contributors', args=['kb'])))
+        response = self.client.get(urlparams(reverse('community.top_contributors', args=['kb'])))
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(2, len(doc('li.results-user')))
-        assert r1.creator.username in response.content
-        assert r2.creator.username in response.content
+        assert str(r1.creator.username) in response.content
+        assert str(r2.creator.username) in response.content
 
     def test_top_l10n(self):
-        d = document(locale='es', save=True)
-        r1 = revision(document=d, save=True)
-        r2 = revision(document=d, save=True)
-        profile(user=r1.creator)
-        profile(user=r2.creator)
+        d = DocumentFactory(locale='es')
+        r1 = RevisionFactory(document=d)
+        r2 = RevisionFactory(document=d)
 
         self.refresh()
 
@@ -194,5 +172,5 @@ class TopContributorsTests(ElasticTestCase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(2, len(doc('li.results-user')))
-        assert r1.creator.username in response.content
-        assert r2.creator.username in response.content
+        assert str(r1.creator.username) in response.content
+        assert str(r2.creator.username) in response.content

--- a/kitsune/community/tests/test_templates.py
+++ b/kitsune/community/tests/test_templates.py
@@ -53,6 +53,7 @@ class LandingTests(ElasticTestCase):
 
     def test_top_contributors(self):
         """Verify the top contributors appear."""
+        # FIXME: Change this to batch creation
         RevisionFactory(document__locale='en-US')
         d = DocumentFactory(locale='es')
         RevisionFactory(document=d)

--- a/kitsune/community/tests/test_utils.py
+++ b/kitsune/community/tests/test_utils.py
@@ -21,7 +21,7 @@ class TopContributorTests(ElasticTestCase):
         r1 = RevisionFactory(document=d)
         RevisionFactory(document=d, creator=r1.creator)
         RevisionFactory(document=d)
-        r4 = RevisionFactory(document=d, created=date.today()-timedelta(days=91))
+        r4 = RevisionFactory(document=d, created=date.today() - timedelta(days=91))
 
         self.refresh()
 
@@ -96,7 +96,7 @@ class TopContributorTests(ElasticTestCase):
         a1 = AnswerFactory(question__product=firefox)
         AnswerFactory(creator=a1.creator)
         AnswerFactory(question__product=fxos)
-        a4 = AnswerFactory(created=datetime.now()-timedelta(days=91))
+        a4 = AnswerFactory(created=datetime.now() - timedelta(days=91))
         AnswerFactory(creator=a1.creator, question__product=fxos)
         AnswerFactory(creator=a4.question.creator, question=a4.question)
 

--- a/kitsune/customercare/tests/test_api.py
+++ b/kitsune/customercare/tests/test_api.py
@@ -3,10 +3,10 @@ import json
 from nose.tools import eq_
 
 from kitsune.customercare.models import TwitterAccount
-from kitsune.customercare.tests import twitter_account
+from kitsune.customercare.tests import TwitterAccountFactory
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import add_permission, user
+from kitsune.users.tests import add_permission, UserFactory
 
 
 class BanUser(TestCase):
@@ -15,15 +15,15 @@ class BanUser(TestCase):
         # Set up some banned users
         self.banned_usernames = ['deanj', 'r1cky', 'mythmon']
         for username in self.banned_usernames:
-            twitter_account(username=username, banned=True, save=True)
+            TwitterAccountFactory(username=username, banned=True)
 
         # Now a few normal users
         self.normal_usernames = ['willkg', 'marcell', 'ian']
         for username in self.normal_usernames:
-            twitter_account(username=username, banned=False, save=True)
+            TwitterAccountFactory(username=username, banned=False)
 
         # Create a user with permissions to ban
-        u = user(save=True)
+        u = UserFactory()
         add_permission(u, TwitterAccount, 'ban_account')
         self.client.login(username=u.username, password='testpass')
 
@@ -81,15 +81,15 @@ class IgnoreUser(TestCase):
         # Set up some ignored users
         self.ignored_usernames = ['deanj', 'r1cky', 'mythmon']
         for username in self.ignored_usernames:
-            twitter_account(username=username, ignored=True, save=True)
+            TwitterAccountFactory(username=username, ignored=True)
 
         # Now a few normal users
         self.normal_usernames = ['willkg', 'marcell', 'ian']
         for username in self.normal_usernames:
-            twitter_account(username=username, ignored=False, save=True)
+            TwitterAccountFactory(username=username, ignored=False)
 
         # Create a user with permissions to ignore
-        u = user(save=True)
+        u = UserFactory()
         add_permission(u, TwitterAccount, 'ignore_account')
         self.client.login(username=u.username, password='testpass')
 

--- a/kitsune/customercare/tests/test_badges.py
+++ b/kitsune/customercare/tests/test_badges.py
@@ -1,40 +1,38 @@
 from datetime import date
 
 from kitsune.customercare.badges import AOA_BADGE
-from kitsune.customercare.models import Reply
-from kitsune.customercare.tests import reply
-from kitsune.kbadge.tests import badge
+from kitsune.customercare.tests import ReplyFactory
+from kitsune.kbadge.tests import BadgeFactory
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import profile
+from kitsune.users.tests import UserFactory
+from kitsune.customercare.badges import register_signals
 
 
 class TestAOABadges(TestCase):
+
+    def setUp(self):
+        # Make sure the badges hear this.
+        register_signals()
 
     def test_aoa_badge(self):
         """Verify the KB Badge is awarded properly."""
         # Create the user and badge.
         year = date.today().year
-        u = profile().user
-        b = badge(
+        u = UserFactory()
+        b = BadgeFactory(
             slug=AOA_BADGE['slug'].format(year=year),
             title=AOA_BADGE['title'].format(year=year),
-            description=AOA_BADGE['description'].format(year=year),
-            save=True)
+            description=AOA_BADGE['description'].format(year=year))
 
         # Create 49 replies.
-        replies = []
-        for i in range(48):
-            replies.append(reply(user=u))
-        Reply.objects.bulk_create(replies)
-
-        # Create the 49th reply separately so the signals are triggered.
-        reply(user=u, save=True)
+        for _ in range(49):
+            ReplyFactory(user=u)
 
         # User should NOT have the badge yet.
         assert not b.is_awarded_to(u)
 
         # Create 1 more reply.
-        reply(user=u, save=True)
+        ReplyFactory(user=u)
 
         # User should have the badge now.
         assert b.is_awarded_to(u)

--- a/kitsune/customercare/tests/test_badges.py
+++ b/kitsune/customercare/tests/test_badges.py
@@ -25,6 +25,7 @@ class TestAOABadges(TestCase):
             description=AOA_BADGE['description'].format(year=year))
 
         # Create 49 replies.
+        # FIXME: Do this as a batch
         for _ in range(49):
             ReplyFactory(user=u)
 

--- a/kitsune/customercare/tests/test_cron.py
+++ b/kitsune/customercare/tests/test_cron.py
@@ -131,6 +131,7 @@ class TwitterCronTestCase(TestCase):
 class GetOldestTweetTestCase(TestCase):
 
     def setUp(self):
+        # FIXME: Do this as a batch
         TweetFactory(tweet_id=1, locale='en', created=datetime(2010, 9, 23, 13, 50, 0))
         TweetFactory(tweet_id=2, locale='en', created=datetime(2010, 9, 23, 13, 53, 0))
         TweetFactory(tweet_id=3, locale='en', created=datetime(2010, 9, 23, 13, 57, 0))

--- a/kitsune/customercare/tests/test_es.py
+++ b/kitsune/customercare/tests/test_es.py
@@ -1,9 +1,8 @@
 from nose.tools import eq_
 
 from kitsune.customercare.models import ReplyMetricsMappingType
-from kitsune.customercare.tests import reply
+from kitsune.customercare.tests import ReplyFactory
 from kitsune.search.tests.test_es import ElasticTestCase
-from kitsune.users.tests import user
 
 
 class AnswerMetricsTests(ElasticTestCase):
@@ -12,7 +11,7 @@ class AnswerMetricsTests(ElasticTestCase):
 
         Deleting should delete it.
         """
-        r = reply(save=True)
+        r = ReplyFactory()
         self.refresh()
         eq_(ReplyMetricsMappingType.search().count(), 1)
 
@@ -22,8 +21,7 @@ class AnswerMetricsTests(ElasticTestCase):
 
     def test_data_in_index(self):
         """Verify the data we are indexing."""
-        u = user(save=True)
-        r = reply(user=u, locale='de', save=True)
+        r = ReplyFactory(locale='de')
         self.refresh()
 
         eq_(ReplyMetricsMappingType.search().count(), 1)

--- a/kitsune/customercare/tests/test_models.py
+++ b/kitsune/customercare/tests/test_models.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_, raises
 
 from kitsune.customercare.models import Tweet
-from kitsune.customercare.tests import tweet
+from kitsune.customercare.tests import TweetFactory
 from kitsune.sumo.tests import TestCase
 
 
@@ -10,9 +10,8 @@ class TweetTests(TestCase):
 
     def test_latest(self):
         """Test the latest() class method when there is a latest tweet."""
-        NUM = 2
-        for x in xrange(NUM):
-            last = tweet(save=True)
+        TweetFactory()
+        last = TweetFactory()
         eq_(last.tweet_id, Tweet.latest().tweet_id)
 
     @raises(Tweet.DoesNotExist)

--- a/kitsune/customercare/tests/test_templates.py
+++ b/kitsune/customercare/tests/test_templates.py
@@ -9,7 +9,7 @@ from pyquery import PyQuery as pq
 from kitsune.customercare.replies import REPLIES_DOCUMENT_SLUG
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.wiki.tests import document, revision
+from kitsune.wiki.tests import DocumentFactory, RevisionFactory
 
 
 CANNED_RESPONSES_WIKI = """
@@ -56,13 +56,8 @@ class CannedResponsesTestCase(TestCase):
 
     def _create_doc(self, content):
         # Create the canned responses article.
-        doc = document(slug=REPLIES_DOCUMENT_SLUG, save=True)
-        rev = revision(
-            document=doc,
-            content=content,
-            is_approved=True,
-            save=True)
-
+        doc = DocumentFactory(slug=REPLIES_DOCUMENT_SLUG)
+        rev = RevisionFactory(document=doc, content=content, is_approved=True)
         doc.current_revision = rev
         doc.save()
 

--- a/kitsune/dashboards/models.py
+++ b/kitsune/dashboards/models.py
@@ -105,6 +105,6 @@ class WikiMetric(ModelBase):
         ordering = ['-date']
 
     def __unicode__(self):
-        return '[{date}][{locale}][{product}] {code}: {value}'.format(
+        return u'[{date}][{locale}][{product}] {code}: {value}'.format(
             date=self.date, code=self.code, locale=self.locale,
             value=self.value, product=self.product)

--- a/kitsune/dashboards/readouts.py
+++ b/kitsune/dashboards/readouts.py
@@ -186,8 +186,7 @@ def _format_row_with_out_of_dateness(readout_locale, eng_slug, eng_title, slug,
 
 
 def kb_overview_rows(mode=None, max=None, locale=None, product=None, category=None):
-    """Return the iterable of dicts needed to draw the new KB dashboard
-    overview"""
+    """Return the iterable of dicts needed to draw the new KB dashboard overview"""
 
     if mode is None:
         mode = LAST_30_DAYS

--- a/kitsune/dashboards/tests/__init__.py
+++ b/kitsune/dashboards/tests/__init__.py
@@ -1,17 +1,15 @@
 from datetime import date
 
+import factory
+
 from kitsune.dashboards.models import WikiMetric, METRIC_CODE_CHOICES
-from kitsune.sumo.tests import with_save
 
 
-@with_save
-def wikimetric(**kwargs):
-    """A model maker for WikiMetric."""
-    defaults = {'code': METRIC_CODE_CHOICES[0][0],
-                'locale': 'es',
-                'date': date.today(),
-                'value': 42.0}
+class WikiMetricFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = WikiMetric
 
-    defaults.update(kwargs)
-
-    return WikiMetric(**defaults)
+    code = METRIC_CODE_CHOICES[0][0]
+    locale = 'es'
+    date = date.today()
+    value = 42.0

--- a/kitsune/dashboards/tests/test_api.py
+++ b/kitsune/dashboards/tests/test_api.py
@@ -4,8 +4,8 @@ from datetime import date, timedelta
 from nose.tools import eq_
 
 from kitsune.dashboards.models import METRIC_CODE_CHOICES
-from kitsune.dashboards.tests import wikimetric
-from kitsune.products.tests import product
+from kitsune.dashboards.tests import WikiMetricFactory
+from kitsune.products.tests import ProductFactory
 from kitsune.sumo.helpers import urlparams
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
@@ -19,11 +19,10 @@ class WikiMetricAPITests(TestCase):
 
         # Create 10 wikimetrics.
         for i in range(10):
-            wikimetric(
+            WikiMetricFactory(
                 code=METRIC_CODE_CHOICES[i % len(METRIC_CODE_CHOICES)][0],
                 date=today - timedelta(days=i),
-                value=i,
-                save=True)
+                value=i)
 
         # Call the API.
         response = self.client.get(
@@ -46,21 +45,15 @@ class WikiMetricAPITests(TestCase):
         today = date.today()
 
         # Create products and associated wiki metrics.
-        p1 = product(save=True)
-        p2 = product(save=True)
+        p1 = ProductFactory()
+        p2 = ProductFactory()
 
         # Create 3 for each product:
         for i in range(3):
             for p in [p1, p2]:
-                wikimetric(
-                    date=today - timedelta(days=i),
-                    product=p,
-                    save=True)
+                WikiMetricFactory(date=today - timedelta(days=i), product=p)
         # Create one more for p2.
-        wikimetric(
-            date=today - timedelta(days=4),
-            product=p2,
-            save=True)
+        WikiMetricFactory(date=today - timedelta(days=4), product=p2)
 
         # Call and verify the API for product=p1.
         response = self.client.get(
@@ -86,13 +79,10 @@ class WikiMetricAPITests(TestCase):
 
         # Create 3 wikimetrics for es:
         for i in range(3):
-            wikimetric(
-                locale='es',
-                date=today - timedelta(days=i),
-                save=True)
+            WikiMetricFactory(locale='es', date=today - timedelta(days=i))
 
         # Create 1 for fr:
-        wikimetric(locale='fr', save=True)
+        WikiMetricFactory(locale='fr')
 
         # Call and verify the API for locale=es.
         response = self.client.get(
@@ -118,13 +108,10 @@ class WikiMetricAPITests(TestCase):
 
         # Create 3 wikimetrics for active_contributors:
         for i in range(3):
-            wikimetric(
-                code=METRIC_CODE_CHOICES[0][0],
-                date=today - timedelta(days=i),
-                save=True)
+            WikiMetricFactory(code=METRIC_CODE_CHOICES[0][0], date=today - timedelta(days=i))
 
         # Create 1 for percent_localized_all:
-        wikimetric(code=METRIC_CODE_CHOICES[1][0], save=True)
+        WikiMetricFactory(code=METRIC_CODE_CHOICES[1][0])
 
         # Call and verify the API for code=METRIC_CODE_CHOICES[0].
         response = self.client.get(

--- a/kitsune/dashboards/tests/test_cron.py
+++ b/kitsune/dashboards/tests/test_cron.py
@@ -44,7 +44,6 @@ class TopUnhelpfulArticlesTests(TestCase):
 
     def test_old_articles(self):
         """Returns unhelpful votes within time range"""
-        # FIXME: this changed from 90 to 10. why?
         r = _make_backdated_revision(10)
 
         # Add 4 no votes 1.5 weeks ago

--- a/kitsune/dashboards/tests/test_cron.py
+++ b/kitsune/dashboards/tests/test_cron.py
@@ -44,6 +44,7 @@ class TopUnhelpfulArticlesTests(TestCase):
 
     def test_old_articles(self):
         """Returns unhelpful votes within time range"""
+        # FIXME: this changed from 90 to 10. why?
         r = _make_backdated_revision(10)
 
         # Add 4 no votes 1.5 weeks ago

--- a/kitsune/dashboards/tests/test_models.py
+++ b/kitsune/dashboards/tests/test_models.py
@@ -6,7 +6,7 @@ from kitsune.dashboards import models
 from kitsune.dashboards.models import (
     WikiDocumentVisits, LAST_7_DAYS, googleanalytics)
 from kitsune.sumo.tests import TestCase
-from kitsune.wiki.tests import document, revision
+from kitsune.wiki.tests import ApprovedRevisionFactory
 
 
 class DocumentVisitsTests(TestCase):
@@ -25,10 +25,8 @@ class DocumentVisitsTests(TestCase):
         execute = _build_request.return_value.get.return_value.execute
         execute.return_value = PAGEVIEWS_BY_DOCUMENT_RESPONSE
 
-        d1 = revision(document=document(slug=u'hellỗ', save=True),
-                      is_approved=True, save=True).document
-        d2 = revision(document=document(slug=u'there', save=True),
-                      is_approved=True, save=True).document
+        d1 = ApprovedRevisionFactory(document__slug=u'hellỗ').document
+        d2 = ApprovedRevisionFactory(document__slug=u'there').document
 
         WikiDocumentVisits.reload_period_from_analytics(LAST_7_DAYS)
 

--- a/kitsune/dashboards/tests/test_templates.py
+++ b/kitsune/dashboards/tests/test_templates.py
@@ -3,7 +3,7 @@ from pyquery import PyQuery as pq
 
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.wiki.tests import translated_revision
+from kitsune.wiki.tests import TranslatedRevisionFactory
 
 
 class LocalizationDashTests(TestCase):
@@ -20,20 +20,18 @@ class LocalizationDashTests(TestCase):
     def _assert_readout_contains(doc, slug, contents):
         """Assert `doc` contains `contents` within the `slug` readout."""
         html = doc('a#' + slug).closest('details').html()
-        assert contents in html, \
-            "'" + contents + "' is not in the following: " + html
+        assert contents in html, "'" + contents + "' is not in the following: " + html
 
     def test_render(self):
         """Assert main dash and all the readouts render and don't crash."""
-        # Put some stuff in the DB so at least one row renders for each
-        # readout:
-        unreviewed = translated_revision(is_ready_for_localization=True)
-        unreviewed.save()
+        # Put some stuff in the DB so at least one row renders for each readout:
+        unreviewed = TranslatedRevisionFactory(
+            document__locale='de',
+            reviewed=None,
+            is_approved=False,
+            is_ready_for_localization=True)
 
-        response = self.client.get(reverse('dashboards.localization',
-                                           locale='de'),
-                                   follow=False)
+        response = self.client.get(reverse('dashboards.localization', locale='de'), follow=False)
         eq_(200, response.status_code)
         doc = pq(response.content)
-        self._assert_readout_contains(doc, 'unreviewed',
-                                      unreviewed.document.title)
+        self._assert_readout_contains(doc, 'unreviewed', unreviewed.document.title)

--- a/kitsune/dashboards/utils.py
+++ b/kitsune/dashboards/utils.py
@@ -22,8 +22,7 @@ from kitsune.wiki.events import (
 log = logging.getLogger('k.dashboards')
 
 
-def render_readouts(request, readouts, template, locale=None, extra_data=None,
-                    product=None):
+def render_readouts(request, readouts, template, locale=None, extra_data=None, product=None):
     """Render a readouts, possibly with overview page.
 
     Use the given template, pass the template the given readouts, limit the
@@ -53,27 +52,21 @@ def render_readouts(request, readouts, template, locale=None, extra_data=None,
                                for slug, class_ in readouts.iteritems()
                                if class_.should_show_to(request)),
         'default_locale': settings.WIKI_DEFAULT_LANGUAGE,
-        'default_locale_name': (
-            LOCALES[settings.WIKI_DEFAULT_LANGUAGE].native),
+        'default_locale_name': LOCALES[settings.WIKI_DEFAULT_LANGUAGE].native,
         'current_locale': current_locale,
         'current_locale_name': LOCALES[current_locale].native,
         'request_locale_name': LOCALES[request.LANGUAGE_CODE].native,
-        'is_watching_default_approved': (
-            ApproveRevisionInLocaleEvent.is_notifying(
-                request.user, **default_kwargs)),
+        'is_watching_default_approved':
+            ApproveRevisionInLocaleEvent.is_notifying(request.user, **default_kwargs),
         'is_watching_other_approved': (
             None if on_default_locale
-            else ApproveRevisionInLocaleEvent.is_notifying(
-                request.user, **locale_kwargs)),
+            else ApproveRevisionInLocaleEvent.is_notifying(request.user, **locale_kwargs)),
         'is_watching_default_locale': (
-            ReviewableRevisionInLocaleEvent.is_notifying(
-                request.user, **default_kwargs)),
+            ReviewableRevisionInLocaleEvent.is_notifying(request.user, **default_kwargs)),
         'is_watching_other_locale': (
             None if on_default_locale
-            else ReviewableRevisionInLocaleEvent.is_notifying(
-                request.user, **locale_kwargs)),
-        'is_watching_default_ready': (
-            ReadyRevisionEvent.is_notifying(request.user, **ready_kwargs)),
+            else ReviewableRevisionInLocaleEvent.is_notifying(request.user, **locale_kwargs)),
+        'is_watching_default_ready': ReadyRevisionEvent.is_notifying(request.user, **ready_kwargs),
         'on_default_locale': on_default_locale,
         'announce_form': AnnouncementForm(),
         'announcements': Announcement.get_for_locale_name(current_locale),

--- a/kitsune/flagit/tests/test_permissions.py
+++ b/kitsune/flagit/tests/test_permissions.py
@@ -3,14 +3,14 @@ from nose.tools import eq_
 from kitsune.flagit.models import FlaggedObject
 from kitsune.flagit.tests import TestCaseBase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import user, add_permission
+from kitsune.users.tests import UserFactory, add_permission
 
 
 class FlagitTestPermissions(TestCaseBase):
     """Test our new permission required decorator."""
     def setUp(self):
         super(FlagitTestPermissions, self).setUp()
-        self.user = user(save=True)
+        self.user = UserFactory()
 
     def test_permission_required(self):
         url = reverse('flagit.queue', force_locale=True)

--- a/kitsune/flagit/tests/test_templates.py
+++ b/kitsune/flagit/tests/test_templates.py
@@ -4,22 +4,19 @@ from pyquery import PyQuery as pq
 from kitsune.flagit.models import FlaggedObject
 from kitsune.flagit.tests import TestCaseBase
 from kitsune.questions.models import Answer
-from kitsune.questions.tests import question, answer
+from kitsune.questions.tests import AnswerFactory
 from kitsune.sumo.tests import post, get
-from kitsune.users.tests import user, add_permission
+from kitsune.users.tests import UserFactory, add_permission
 
 
 class FlaggedQueueTestCase(TestCaseBase):
     """Test the flagit queue."""
     def setUp(self):
         super(FlaggedQueueTestCase, self).setUp()
-        q = question(creator=user(save=True), save=True)
-        self.answer = answer(question=q,
-                             creator=user(save=True),
-                             save=True)
+        self.answer = AnswerFactory()
+        self.flagger = UserFactory()
 
-        self.flagger = user(save=True)
-        u = user(save=True)
+        u = UserFactory()
         add_permission(u, FlaggedObject, 'can_moderate')
 
         self.client.login(username=u.username, password='testpass')

--- a/kitsune/flagit/tests/test_views.py
+++ b/kitsune/flagit/tests/test_views.py
@@ -5,17 +5,17 @@ from nose.tools import eq_
 from kitsune.flagit.tests import TestCaseBase
 from kitsune.flagit.models import FlaggedObject
 from kitsune.questions.models import Question
-from kitsune.questions.tests import question
+from kitsune.questions.tests import QuestionFactory
 from kitsune.sumo.tests import post
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class FlagTestCase(TestCaseBase):
     """Test the flag view."""
     def setUp(self):
         super(FlagTestCase, self).setUp()
-        self.user = user(save=True)
-        self.question = question(creator=self.user, save=True)
+        self.user = UserFactory()
+        self.question = QuestionFactory(creator=self.user)
 
         self.client.login(username=self.user.username, password='testpass')
 

--- a/kitsune/forums/tests/__init__.py
+++ b/kitsune/forums/tests/__init__.py
@@ -1,85 +1,104 @@
 from datetime import datetime
-import uuid
 
 from django.contrib.contenttypes.models import ContentType
-
 from django.template.defaultfilters import slugify
 
-from kitsune.access.tests import permission
+import factory
+from nose.tools import eq_
+
+from kitsune.access.tests import PermissionFactory
 from kitsune.forums.models import Forum, Thread, Post
-from kitsune.users.tests import user
-from kitsune.sumo.tests import LocalizingClient, TestCase, with_save
+from kitsune.users.tests import UserFactory
+from kitsune.sumo.tests import FuzzyUnicode, LocalizingClient, TestCase
 
 
 class ForumTestCase(TestCase):
     client_class = LocalizingClient
 
 
-@with_save
-def forum(**kwargs):
-    if 'name' not in kwargs:
-        kwargs['name'] = str(uuid.uuid4())
-    if 'slug' not in kwargs:
-        kwargs['slug'] = slugify(kwargs['name'])
-    return Forum(**kwargs)
+class ForumFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Forum
+
+    name = FuzzyUnicode()
+    slug = factory.LazyAttribute(lambda o: slugify(o.name))
 
 
-def restricted_forum(**kwargs):
-    """Creates a restricted forum.
+class RestrictedForumFactory(ForumFactory):
 
-    :arg permission_code: Defaults to "forums_forum.view_in_forum"
-
-    Any additional arguments are passed to the created forum.
-
-    .. Note::
-
-       Always saves the forum it creates.
-
-    :returns: the created restricted forum
-
-    """
-    # Pop off the permission_code
-    permission_code = kwargs.pop(
-        'permission_code', 'forums_forum.view_in_forum')
-
-    # Remove save=True if it's there--we always save.
-    kwargs.pop('save', True)
-    new_forum = forum(save=True, **kwargs)
-
-    # Make it restricted.
-    ct = ContentType.objects.get_for_model(new_forum)
-    permission(codename=permission_code, content_type=ct,
-               object_id=new_forum.id, save=True)
-
-    return new_forum
+    @factory.post_generation
+    def permission_code(forum, created, extracted, **kwargs):
+        assert created
+        permission = extracted or 'forums_forum.view_in_forum'
+        ct = ContentType.objects.get_for_model(forum)
+        PermissionFactory(codename=permission, content_type=ct, object_id=forum.id)
 
 
-@with_save
-def thread(**kwargs):
-    defaults = dict(
-        created=datetime.now(),
-        title=str(uuid.uuid4()))
-    defaults.update(kwargs)
-    if 'creator' not in kwargs and 'creator_id' not in kwargs:
-        defaults['creator'] = user(save=True)
-    if 'forum' not in kwargs and 'forum_id' not in kwargs:
-        defaults['forum'] = forum(save=True)
-    return Thread(**defaults)
+class ThreadFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Thread
 
+    created = factory.LazyAttribute(lambda t: datetime.now())
+    creator = factory.SubFactory(UserFactory)
+    forum = factory.SubFactory(ForumFactory)
+    title = FuzzyUnicode()
 
-@with_save
-def post(**kwargs):
-    defaults = dict()
-    defaults.update(kwargs)
-    if 'author' not in kwargs and 'author_id' not in kwargs:
-        defaults['author'] = user(save=True)
-    if 'thread' not in kwargs and 'thread_id' not in kwargs:
-        # The thread creator should match the post author if the
-        # thread doesn't exist yet.
-        kw = {}
-        if 'author' in defaults:
-            kw['creator'] = defaults['author']
+    @factory.post_generation
+    def posts(obj, create, extracted, **kwargs):
+        defaults = {
+            'created': obj.created,
+            'author': obj.creator,
+            'thread': obj,
+        }
+        defaults.update(**kwargs)
+
+        if extracted is None:
+            posts = [PostFactory(**defaults)]
         else:
-            kw['creator_id'] = defaults['author_id']
-        defaults['thread'] = thread(save=True, **kw)
-    return Post(**defaults)
+            posts = []
+            for args in extracted:
+                args.update(defaults)
+                posts.append(PostFactory(**args))
+
+        for post in posts:
+            obj.post_set.add(post)
+
+
+class ThreadFactoryTests(TestCase):
+    def test_has_one_post(self):
+        t = ThreadFactory()
+        eq_(t.post_set.count(), 1)
+
+    def test_can_set_post_properties(self):
+        t = ThreadFactory(posts__content='lol')
+        eq_(t.post_set.get().content, 'lol')
+
+    def test_can_set_posts(self):
+        t = ThreadFactory(posts=[{'content': 'one'}, {'content': 'two'}])
+        contents = list(t.post_set.values_list('content', flat=True))
+        eq_(contents, [u'one', u'two'])
+
+    def test_posts_belong_to_the_thread(self):
+        t = ThreadFactory()
+        assert all(p.thread == t for p in t.post_set.all())
+        t = ThreadFactory(posts=[{}, {}, {}])
+        assert all(p.thread == t for p in t.post_set.all())
+        t = ThreadFactory(posts=[{'content': 'two'}, {'content': 'one'}])
+        assert all(p.thread == t for p in t.post_set.all())
+
+
+class PostFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Post
+
+    author = factory.SubFactory(UserFactory)
+    thread = factory.SubFactory(
+        ThreadFactory,
+        creator=factory.SelfAttribute('..author'),
+        posts=[])
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        obj = model_class(*args, **kwargs)
+        obj.save()
+        return obj

--- a/kitsune/forums/tests/test_es.py
+++ b/kitsune/forums/tests/test_es.py
@@ -1,27 +1,20 @@
 from nose.tools import eq_
 
 from kitsune.forums.models import ThreadMappingType
-from kitsune.forums.tests import thread, post
+from kitsune.forums.tests import ThreadFactory, PostFactory
 from kitsune.search.tests.test_es import ElasticTestCase
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class TestPostUpdate(ElasticTestCase):
     def test_added(self):
-        new_thread = thread()
+        # Nothing exists before the test starts
         eq_(ThreadMappingType.search().count(), 0)
 
-        # Saving a new Thread does create a new document in the
-        # index.
-        new_thread.save()
+        # Creating a new Thread does create a new document in the index.
+        new_thread = ThreadFactory()
         self.refresh()
         eq_(ThreadMappingType.search().count(), 1)
-
-        new_post = post(thread=new_thread)
-        eq_(ThreadMappingType.search().count(), 1)
-
-        new_post.save()
-        self.refresh()
 
         # Saving a new post in a thread doesn't create a new
         # document in the index.  Therefore, the count remains 1.
@@ -29,25 +22,20 @@ class TestPostUpdate(ElasticTestCase):
         # TODO: This is ambiguous: it's not clear whether we correctly
         # updated the document in the index or whether the post_save
         # hook didn't kick off.  Need a better test.
+        PostFactory(thread=new_thread)
+        self.refresh()
         eq_(ThreadMappingType.search().count(), 1)
 
     def test_deleted(self):
-        new_thread = thread()
+        # Nothing exists before the test starts
         eq_(ThreadMappingType.search().count(), 0)
 
-        # Saving a new Thread does create a new document in the
-        # index.
-        new_thread.save()
+        # Creating a new Thread does create a new document in the index.
+        new_thread = ThreadFactory()
         self.refresh()
         eq_(ThreadMappingType.search().count(), 1)
 
-        new_post = post(thread=new_thread)
-        eq_(ThreadMappingType.search().count(), 1)
-
-        new_post.save()
-        self.refresh()
-        eq_(ThreadMappingType.search().count(), 1)
-
+        # Deleting the thread deletes the document in the index.
         new_thread.delete()
         self.refresh()
         eq_(ThreadMappingType.search().count(), 0)
@@ -55,17 +43,14 @@ class TestPostUpdate(ElasticTestCase):
     def test_thread_is_reindexed_on_username_change(self):
         search = ThreadMappingType.search()
 
-        u = user(username='dexter', save=True)
+        u = UserFactory(username='dexter')
+        ThreadFactory(creator=u, title=u'Hello')
 
-        t = thread(creator=u, title=u'Hello', save=True)
-        post(author=u, thread=t, save=True)
         self.refresh()
-        eq_(search.query(post_title='hello')[0]['post_author_ord'],
-            [u'dexter'])
+        eq_(search.query(post_title='hello')[0]['post_author_ord'], [u'dexter'])
 
         # Change the username and verify the index.
         u.username = 'walter'
         u.save()
         self.refresh()
-        eq_(search.query(post_title='hello')[0]['post_author_ord'],
-            [u'walter'])
+        eq_(search.query(post_title='hello')[0]['post_author_ord'], [u'walter'])

--- a/kitsune/forums/tests/test_models.py
+++ b/kitsune/forums/tests/test_models.py
@@ -91,7 +91,7 @@ class ForumModelTestCase(ForumTestCase):
         t = orig_post.thread
 
         # add a new post, then check that last_post is updated
-        new_post = PostFactory(thread=t, content="test")
+        new_post = PostFactory(thread=t, content='test')
         f = Forum.objects.get(id=t.forum_id)
         t = Thread.objects.get(id=t.id)
         eq_(f.last_post.id, new_post.id)
@@ -176,7 +176,7 @@ class ForumModelTestCase(ForumTestCase):
     def test_last_post_creator_deleted(self):
         """Delete the creator of the last post and verify forum survives."""
         # Create a post and verify it is the last one in the forum.
-        post = PostFactory(content="test")
+        post = PostFactory(content='test')
         forum = post.thread.forum
         eq_(forum.last_post.id, post.id)
 
@@ -195,8 +195,8 @@ class ThreadModelTestCase(ForumTestCase):
         last_post = f.last_post
 
         # add a new thread and post, verify last_post updated
-        t = ThreadFactory(title="test", forum=f, posts=[])
-        p = PostFactory(thread=t, content="test", author=t.creator)
+        t = ThreadFactory(title='test', forum=f, posts=[])
+        p = PostFactory(thread=t, content='test', author=t.creator)
         f = Forum.objects.get(id=f.id)
         eq_(f.last_post.id, p.id)
 

--- a/kitsune/forums/tests/test_permissions.py
+++ b/kitsune/forums/tests/test_permissions.py
@@ -2,10 +2,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.test.client import RequestFactory
 
 from kitsune.access.helpers import has_perm, has_perm_or_owns
-from kitsune.access.tests import permission
-from kitsune.forums.tests import ForumTestCase, forum, thread
+from kitsune.access.tests import PermissionFactory
+from kitsune.forums.tests import ForumTestCase, ForumFactory, ThreadFactory
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import user, group
+from kitsune.users.tests import UserFactory, GroupFactory
 
 
 class ForumTestPermissions(ForumTestCase):
@@ -15,34 +15,30 @@ class ForumTestPermissions(ForumTestCase):
         url = reverse('forums.threads', args=[u'test-forum'])
         self.context = {'request': RequestFactory().get(url)}
 
-        self.group = group(save=True)
+        self.group = GroupFactory()
 
         # Set up forum_1
-        f = self.forum_1 = forum(save=True)
+        f = self.forum_1 = ForumFactory()
         ct = ContentType.objects.get_for_model(self.forum_1)
-        permission(codename='forums_forum.thread_edit_forum', content_type=ct,
-                   object_id=f.id, group=self.group, save=True)
-        permission(codename='forums_forum.post_edit_forum', content_type=ct,
-                   object_id=f.id, group=self.group, save=True)
-        permission(codename='forums_forum.post_delete_forum', content_type=ct,
-                   object_id=f.id, group=self.group, save=True)
-        permission(codename='forums_forum.thread_delete_forum',
-                   content_type=ct, object_id=f.id, group=self.group,
-                   save=True)
-        permission(codename='forums_forum.thread_sticky_forum',
-                   content_type=ct, object_id=f.id, group=self.group,
-                   save=True)
-        permission(codename='forums_forum.thread_move_forum', content_type=ct,
-                   object_id=f.id, group=self.group, save=True)
+        permission_names = [
+            'forums_forum.thread_edit_forum',
+            'forums_forum.post_edit_forum',
+            'forums_forum.post_delete_forum',
+            'forums_forum.thread_delete_forum',
+            'forums_forum.thread_sticky_forum',
+            'forums_forum.thread_move_forum',
+        ]
+        for name in permission_names:
+            PermissionFactory(codename=name, content_type=ct, object_id=f.id, group=self.group)
 
         # Set up forum_2
-        f = self.forum_2 = forum(save=True)
-        permission(codename='forums_forum.thread_move_forum', content_type=ct,
-                   object_id=f.id, group=self.group, save=True)
+        f = self.forum_2 = ForumFactory()
+        PermissionFactory(codename='forums_forum.thread_move_forum', content_type=ct,
+                          object_id=f.id, group=self.group)
 
     def test_has_perm_thread_edit(self):
         """User in group can edit thread in forum_1, but not in forum_2."""
-        u = user(save=True)
+        u = UserFactory()
         self.group.user_set.add(u)
 
         self.context['request'].user = u
@@ -53,9 +49,9 @@ class ForumTestPermissions(ForumTestCase):
 
     def test_has_perm_or_owns_thread_edit(self):
         """Users can edit their own threads."""
-        my_t = thread(save=True)
+        my_t = ThreadFactory()
         me = my_t.creator
-        other_t = thread(save=True)
+        other_t = ThreadFactory()
         self.context['request'].user = me
         perm = 'forums_forum.thread_edit_forum'
         assert has_perm_or_owns(self.context, perm, my_t, self.forum_1)
@@ -63,7 +59,7 @@ class ForumTestPermissions(ForumTestCase):
 
     def test_has_perm_thread_delete(self):
         """User in group can delete thread in forum_1, but not in forum_2."""
-        u = user(save=True)
+        u = UserFactory()
         self.group.user_set.add(u)
 
         self.context['request'].user = u
@@ -75,7 +71,7 @@ class ForumTestPermissions(ForumTestCase):
     def test_has_perm_thread_sticky(self):
         # User in group can change sticky status of thread in forum_1,
         # but not in forum_2.
-        u = user(save=True)
+        u = UserFactory()
         self.group.user_set.add(u)
 
         self.context['request'].user = u
@@ -87,7 +83,7 @@ class ForumTestPermissions(ForumTestCase):
     def test_has_perm_thread_locked(self):
         # Sanity check: user in group has no permission to change
         # locked status in forum_1.
-        u = user(save=True)
+        u = UserFactory()
         self.group.user_set.add(u)
 
         self.context['request'].user = u
@@ -96,7 +92,7 @@ class ForumTestPermissions(ForumTestCase):
 
     def test_has_perm_post_edit(self):
         """User in group can edit any post in forum_1, but not in forum_2."""
-        u = user(save=True)
+        u = UserFactory()
         self.group.user_set.add(u)
 
         self.context['request'].user = u
@@ -107,7 +103,7 @@ class ForumTestPermissions(ForumTestCase):
 
     def test_has_perm_post_delete(self):
         """User in group can delete posts in forum_1, but not in forum_2."""
-        u = user(save=True)
+        u = UserFactory()
         self.group.user_set.add(u)
 
         self.context['request'].user = u
@@ -118,7 +114,7 @@ class ForumTestPermissions(ForumTestCase):
 
     def test_no_perm_thread_delete(self):
         """User not in group cannot delete thread in any forum."""
-        self.context['request'].user = user(save=True)
+        self.context['request'].user = UserFactory()
         assert not has_perm(self.context, 'forums_forum.thread_delete_forum',
                             self.forum_1)
         assert not has_perm(self.context, 'forums_forum.thread_delete_forum',

--- a/kitsune/forums/tests/test_posts.py
+++ b/kitsune/forums/tests/test_posts.py
@@ -5,10 +5,10 @@ from django.conf import settings
 from nose.tools import eq_, raises
 
 from kitsune.forums.models import Thread, Forum, ThreadLockedError
-from kitsune.forums.tests import ForumTestCase, thread, post
+from kitsune.forums.tests import ForumTestCase, ThreadFactory, PostFactory
 from kitsune.forums.views import sort_threads
 from kitsune.sumo.tests import get
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class PostTestCase(ForumTestCase):
@@ -16,8 +16,8 @@ class PostTestCase(ForumTestCase):
     def test_new_post_updates_thread(self):
         # Saving a new post in a thread should update the last_post
         # key in that thread to point to the new post.
-        t = thread(save=True)
-        post(thread=t, save=True)
+        t = ThreadFactory()
+        PostFactory(thread=t)
         p = t.new_post(author=t.creator, content='an update')
         p.save()
         t = Thread.objects.get(id=t.id)
@@ -26,8 +26,8 @@ class PostTestCase(ForumTestCase):
     def test_new_post_updates_forum(self):
         # Saving a new post should update the last_post key in the
         # forum to point to the new post.
-        t = thread(save=True)
-        post(thread=t, save=True)
+        t = ThreadFactory()
+        PostFactory(thread=t)
         p = t.new_post(author=t.creator, content='another update')
         p.save()
         f = Forum.objects.get(id=t.forum_id)
@@ -36,9 +36,9 @@ class PostTestCase(ForumTestCase):
     def test_update_post_does_not_update_thread(self):
         # Updating/saving an old post in a thread should _not_ update
         # the last_post key in that thread.
-        t = thread(save=True)
-        old = post(thread=t, save=True)
-        last = post(thread=t, save=True)
+        t = ThreadFactory()
+        old = PostFactory(thread=t)
+        last = PostFactory(thread=t)
         old.content = 'updated content'
         old.save()
         eq_(last.id, old.thread.last_post_id)
@@ -46,9 +46,9 @@ class PostTestCase(ForumTestCase):
     def test_update_forum_does_not_update_thread(self):
         # Updating/saving an old post in a forum should _not_ update
         # the last_post key in that forum.
-        t = thread(save=True)
-        old = post(thread=t, save=True)
-        last = post(thread=t, save=True)
+        t = ThreadFactory()
+        old = PostFactory(thread=t)
+        last = PostFactory(thread=t)
         old.content = 'updated content'
         old.save()
         eq_(last.id, t.forum.last_post_id)
@@ -56,10 +56,7 @@ class PostTestCase(ForumTestCase):
     def test_replies_count(self):
         # The Thread.replies value should remain one less than the
         # number of posts in the thread.
-        t = thread(save=True)
-        post(thread=t, save=True)
-        post(thread=t, save=True)
-        post(thread=t, save=True)
+        t = ThreadFactory(posts=[{}, {}, {}])
         old = t.replies
         eq_(2, old)
         t.new_post(author=t.creator, content='test').save()
@@ -67,10 +64,9 @@ class PostTestCase(ForumTestCase):
 
     def test_sticky_threads_first(self):
         # Sticky threads should come before non-sticky threads.
-        t = post(save=True).thread
-        sticky = thread(forum=t.forum, is_sticky=True, save=True)
+        t = ThreadFactory()
         yesterday = datetime.now() - timedelta(days=1)
-        post(thread=sticky, created=yesterday, save=True)
+        sticky = ThreadFactory(forum=t.forum, is_sticky=True, posts=[{'created': yesterday}])
 
         # The older sticky thread shows up first.
         eq_(sticky.id, Thread.objects.all()[0].id)
@@ -80,10 +76,9 @@ class PostTestCase(ForumTestCase):
         # created date of the last post.
 
         # Make sure the datetimes are different.
-        post(created=datetime.now() - timedelta(days=1), save=True)
-        post(save=True)
-        t = thread(is_sticky=True, save=True)
-        post(thread=t, save=True)
+        PostFactory(created=datetime.now() - timedelta(days=1))
+        PostFactory()
+        Thread(is_sticky=True)
 
         threads = Thread.objects.filter(is_sticky=False)
         self.assert_(threads[0].last_post.created >
@@ -91,48 +86,36 @@ class PostTestCase(ForumTestCase):
 
     def test_post_sorting(self):
         """Posts should be sorted chronologically."""
-        t = thread(save=True)
-        post(thread=t, created=datetime.now() - timedelta(days=1), save=True)
-        post(thread=t, created=datetime.now() - timedelta(days=4), save=True)
-        post(thread=t, created=datetime.now() - timedelta(days=7), save=True)
-        post(thread=t, created=datetime.now() - timedelta(days=11), save=True)
-        post(thread=t, save=True)
+        now = datetime.now()
+        t = ThreadFactory(posts=[{'created': now - timedelta(days=n)} for n in [0, 1, 4, 7, 11]])
         posts = t.post_set.all()
         for i in range(len(posts) - 1):
             self.assert_(posts[i].created <= posts[i + 1].created)
 
     def test_sorting_creator(self):
         """Sorting threads by creator."""
-        thread(creator=user(username='aaa', save=True), save=True)
-        thread(creator=user(username='bbb', save=True), save=True)
+        ThreadFactory(creator__username='aaa')
+        ThreadFactory(creator__username='bbb')
         threads = sort_threads(Thread.objects, 3, 1)
-        self.assert_(threads[0].creator.username >=
-                     threads[1].creator.username)
+        self.assert_(threads[0].creator.username >= threads[1].creator.username)
 
     def test_sorting_replies(self):
         """Sorting threads by replies."""
-        t = thread(save=True)
-        post(thread=t, save=True)
-        post(thread=t, save=True)
-        post(thread=t, save=True)
-        post(save=True)
+        ThreadFactory(posts=[{}, {}, {}])
+        ThreadFactory()
         threads = sort_threads(Thread.objects, 4)
         self.assert_(threads[0].replies <= threads[1].replies)
 
     def test_sorting_last_post_desc(self):
         """Sorting threads by last_post descendingly."""
-        t = thread(save=True)
-        post(thread=t, save=True)
-        post(thread=t, save=True)
-        post(thread=t, save=True)
-        post(created=datetime.now() - timedelta(days=1), save=True)
+        ThreadFactory(posts=[{}, {}, {}])
+        PostFactory(created=datetime.now() - timedelta(days=1))
         threads = sort_threads(Thread.objects, 5, 1)
-        self.assert_(threads[0].last_post.created >=
-                     threads[1].last_post.created)
+        self.assert_(threads[0].last_post.created >= threads[1].last_post.created)
 
     def test_thread_last_page(self):
         """Thread's last_page property is accurate."""
-        t = post(save=True).thread
+        t = ThreadFactory()
         # Format: (# replies, # of pages to expect)
         test_data = ((t.replies, 1),  # Test default
                      (50, 3),  # Test a large number
@@ -145,20 +128,19 @@ class PostTestCase(ForumTestCase):
     @raises(ThreadLockedError)
     def test_locked_thread(self):
         """Trying to reply to a locked thread should raise an exception."""
-        locked = thread(is_locked=True, save=True)
-        user1 = user(save=True)
+        locked = ThreadFactory(is_locked=True)
+        user = UserFactory()
         # This should raise an exception
-        locked.new_post(author=user1, content='empty')
+        locked.new_post(author=user, content='empty')
 
     def test_unlocked_thread(self):
-        unlocked = thread(save=True)
-        user1 = user(save=True)
+        unlocked = ThreadFactory()
+        user = UserFactory()
         # This should not raise an exception
-        unlocked.new_post(author=user1, content='empty')
+        unlocked.new_post(author=user, content='empty')
 
     def test_post_no_session(self):
-        r = get(self.client, 'forums.new_thread',
-                kwargs={'forum_slug': 'test-forum'})
+        r = get(self.client, 'forums.new_thread', kwargs={'forum_slug': 'test-forum'})
         assert(settings.LOGIN_URL in r.redirect_chain[0][0])
         eq_(302, r.redirect_chain[0][1])
 

--- a/kitsune/forums/tests/test_urls.py
+++ b/kitsune/forums/tests/test_urls.py
@@ -2,11 +2,10 @@ from django.contrib.contenttypes.models import ContentType
 
 from nose.tools import eq_
 
-from kitsune.access.tests import permission
-from kitsune.forums.tests import (
-    ForumTestCase, forum, thread, post as forum_post)
+from kitsune.access.tests import PermissionFactory
+from kitsune.forums.tests import ForumTestCase, ForumFactory, ThreadFactory, PostFactory
 from kitsune.sumo.tests import get, post
-from kitsune.users.tests import user, group
+from kitsune.users.tests import UserFactory, GroupFactory
 
 
 class BelongsTestCase(ForumTestCase):
@@ -16,8 +15,8 @@ class BelongsTestCase(ForumTestCase):
 
     def test_posts_thread_belongs_to_forum(self):
         """Posts view - redirect if thread does not belong to forum."""
-        f = forum(save=True)
-        t = thread(save=True)  # Thread belongs to a different forum
+        f = ForumFactory()
+        t = ThreadFactory()  # Thread belongs to a different forum
 
         r = get(self.client, 'forums.posts', args=[f.slug, t.id])
         eq_(200, r.status_code)
@@ -26,9 +25,9 @@ class BelongsTestCase(ForumTestCase):
 
     def test_reply_thread_belongs_to_forum(self):
         """Reply action - thread belongs to forum."""
-        f = forum(save=True)
-        t = thread(save=True)  # Thread belongs to a different forum
-        u = user(save=True)
+        f = ForumFactory()
+        t = ThreadFactory()  # Thread belongs to a different forum
+        u = UserFactory()
 
         self.client.login(username=u.username, password='testpass')
         r = post(self.client, 'forums.reply', {}, args=[f.slug, t.id])
@@ -36,17 +35,17 @@ class BelongsTestCase(ForumTestCase):
 
     def test_locked_thread_belongs_to_forum(self):
         """Lock action - thread belongs to forum."""
-        f = forum(save=True)
-        t = thread(save=True)  # Thread belongs to a different forum
-        u = user(save=True)
+        f = ForumFactory()
+        t = ThreadFactory()  # Thread belongs to a different forum
+        u = UserFactory()
 
         # Give the user the permission to lock threads.
-        g = group(save=True)
+        g = GroupFactory()
         ct = ContentType.objects.get_for_model(f)
-        permission(codename='forums_forum.thread_locked_forum',
-                   content_type=ct, object_id=f.id, group=g, save=True)
-        permission(codename='forums_forum.thread_locked_forum',
-                   content_type=ct, object_id=t.forum.id, group=g, save=True)
+        PermissionFactory(codename='forums_forum.thread_locked_forum',
+                          content_type=ct, object_id=f.id, group=g)
+        PermissionFactory(codename='forums_forum.thread_locked_forum',
+                          content_type=ct, object_id=t.forum.id, group=g)
         g.user_set.add(u)
 
         self.client.login(username=u.username, password='testpass')
@@ -55,17 +54,17 @@ class BelongsTestCase(ForumTestCase):
 
     def test_sticky_thread_belongs_to_forum(self):
         """Sticky action - thread belongs to forum."""
-        f = forum(save=True)
-        t = thread(save=True)  # Thread belongs to a different forum
-        u = user(save=True)
+        f = ForumFactory()
+        t = ThreadFactory()  # Thread belongs to a different forum
+        u = UserFactory()
 
         # Give the user the permission to sticky threads.
-        g = group(save=True)
+        g = GroupFactory()
         ct = ContentType.objects.get_for_model(f)
-        permission(codename='forums_forum.thread_sticky_forum',
-                   content_type=ct, object_id=f.id, group=g, save=True)
-        permission(codename='forums_forum.thread_sticky_forum',
-                   content_type=ct, object_id=t.forum.id, group=g, save=True)
+        PermissionFactory(codename='forums_forum.thread_sticky_forum',
+                          content_type=ct, object_id=f.id, group=g)
+        PermissionFactory(codename='forums_forum.thread_sticky_forum',
+                          content_type=ct, object_id=t.forum.id, group=g)
         g.user_set.add(u)
 
         self.client.login(username=u.username, password='testpass')
@@ -74,8 +73,8 @@ class BelongsTestCase(ForumTestCase):
 
     def test_edit_thread_belongs_to_forum(self):
         """Edit thread action - thread belongs to forum."""
-        f = forum(save=True)
-        t = forum_post(save=True).thread  # Thread belongs to a different forum
+        f = ForumFactory()
+        t = ThreadFactory()  # Thread belongs to a different forum
         u = t.creator
 
         self.client.login(username=u.username, password='testpass')
@@ -84,17 +83,17 @@ class BelongsTestCase(ForumTestCase):
 
     def test_delete_thread_belongs_to_forum(self):
         """Delete thread action - thread belongs to forum."""
-        f = forum(save=True)
-        t = thread(save=True)  # Thread belongs to a different forum
-        u = user(save=True)
+        f = ForumFactory()
+        t = ThreadFactory()  # Thread belongs to a different forum
+        u = UserFactory()
 
         # Give the user the permission to delete threads.
-        g = group(save=True)
+        g = GroupFactory()
         ct = ContentType.objects.get_for_model(f)
-        permission(codename='forums_forum.thread_delete_forum',
-                   content_type=ct, object_id=f.id, group=g, save=True)
-        permission(codename='forums_forum.thread_delete_forum',
-                   content_type=ct, object_id=t.forum.id, group=g, save=True)
+        PermissionFactory(codename='forums_forum.thread_delete_forum',
+                          content_type=ct, object_id=f.id, group=g)
+        PermissionFactory(codename='forums_forum.thread_delete_forum',
+                          content_type=ct, object_id=t.forum.id, group=g)
         g.user_set.add(u)
 
         self.client.login(username=u.username, password='testpass')
@@ -104,10 +103,10 @@ class BelongsTestCase(ForumTestCase):
     def test_edit_post_belongs_to_thread_and_forum(self):
         # Edit post action - post belongs to thread and thread belongs
         # to forum.
-        f = forum(save=True)
-        t = thread(forum=f, save=True)
+        f = ForumFactory()
+        t = ThreadFactory(forum=f)
         # Post belongs to a different forum and thread.
-        p = forum_post(save=True)
+        p = PostFactory()
         u = p.author
 
         self.client.login(username=u.username, password='testpass')
@@ -125,20 +124,19 @@ class BelongsTestCase(ForumTestCase):
     def test_delete_post_belongs_to_thread_and_forum(self):
         # Delete post action - post belongs to thread and thread
         # belongs to forum.
-        f = forum(save=True)
-        t = thread(forum=f, save=True)
+        f = ForumFactory()
+        t = ThreadFactory(forum=f)
         # Post belongs to a different forum and thread.
-        p = forum_post(save=True)
+        p = PostFactory()
         u = p.author
 
         # Give the user the permission to delete posts.
-        g = group(save=True)
+        g = GroupFactory()
         ct = ContentType.objects.get_for_model(f)
-        permission(codename='forums_forum.post_delete_forum',
-                   content_type=ct, object_id=p.thread.forum_id, group=g,
-                   save=True)
-        permission(codename='forums_forum.post_delete_forum',
-                   content_type=ct, object_id=f.id, group=g, save=True)
+        PermissionFactory(codename='forums_forum.post_delete_forum',
+                          content_type=ct, object_id=p.thread.forum_id, group=g)
+        PermissionFactory(codename='forums_forum.post_delete_forum',
+                          content_type=ct, object_id=f.id, group=g)
         g.user_set.add(u)
 
         self.client.login(username=u.username, password='testpass')

--- a/kitsune/gallery/tests/__init__.py
+++ b/kitsune/gallery/tests/__init__.py
@@ -1,58 +1,25 @@
-from datetime import datetime
-
-from django.core.files import File
+import factory
 
 from kitsune.gallery.models import Image, Video
-from kitsune.users.tests import user
+from kitsune.sumo.tests import FuzzyUnicode
+from kitsune.users.tests import UserFactory
 
 
-def image(file_and_save=True, **kwargs):
-    """Return a saved image."""
-    u = None
-    if 'creator' not in kwargs:
-        u = user(save=True)
+class ImageFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Image
 
-    defaults = {'title': 'Some title %s' % str(datetime.now()),
-                'description': 'Some description %s' % str(datetime.now()),
-                'creator': u}
-    defaults.update(kwargs)
-
-    img = Image(**defaults)
-    if not file_and_save:
-        return img
-
-    if 'file' not in kwargs:
-        with open('kitsune/upload/tests/media/test.jpg') as f:
-            up_file = File(f)
-            img.file.save(up_file.name, up_file, save=True)
-
-    return img
+    creator = factory.SubFactory(UserFactory)
+    description = FuzzyUnicode()
+    file = factory.django.ImageField()
+    title = FuzzyUnicode()
 
 
-def video(file_and_save=True, **kwargs):
-    """Return a saved video."""
-    u = None
-    if 'creator' not in kwargs:
-        u = user(save=True)
+class VideoFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Video
 
-    defaults = {'title': 'Some title', 'description': 'Some description',
-                'creator': u}
-    defaults.update(kwargs)
-
-    vid = Video(**defaults)
-    if not file_and_save:
-        return vid
-
-    if 'file' not in kwargs:
-        with open('kitsune/gallery/tests/media/test.webm') as f:
-            up_file = File(f)
-            vid.webm.save(up_file.name, up_file, save=False)
-        with open('kitsune/gallery/tests/media/test.ogv') as f:
-            up_file = File(f)
-            vid.ogv.save(up_file.name, up_file, save=False)
-        with open('kitsune/gallery/tests/media/test.flv') as f:
-            up_file = File(f)
-            vid.flv.save(up_file.name, up_file, save=False)
-        vid.save()
-
-    return vid
+    creator = factory.SubFactory(UserFactory)
+    webm = factory.django.FileField(from_path='kitsune/gallery/tests/media/test.webm')
+    ogv = factory.django.FileField(from_path='kitsune/gallery/tests/media/test.ogv')
+    flv = factory.django.FileField(from_path='kitsune/gallery/tests/media/test.flv')

--- a/kitsune/gallery/tests/test_models.py
+++ b/kitsune/gallery/tests/test_models.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_
 
 from kitsune.gallery.models import Image
-from kitsune.gallery.tests import image
+from kitsune.gallery.tests import ImageFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.upload.tasks import generate_thumbnail
 
@@ -11,17 +11,10 @@ class ImageTestCase(TestCase):
         Image.objects.all().delete()
         super(ImageTestCase, self).tearDown()
 
-    def test_new_image(self):
-        """New Image is created and saved"""
-        img = image(title='Some title')
-        eq_('Some title', img.title)
-        eq_(150, img.file.width)
-        eq_(200, img.file.height)
-
     def test_thumbnail_url_if_set(self):
         """thumbnail_url_if_set() returns self.thumbnail if set, or else
         returns self.file"""
-        img = image()
+        img = ImageFactory()
         eq_(img.file.url, img.thumbnail_url_if_set())
 
         generate_thumbnail(img, 'file', 'thumbnail')

--- a/kitsune/gallery/tests/test_utils.py
+++ b/kitsune/gallery/tests/test_utils.py
@@ -4,19 +4,19 @@ from django.core.files import File
 from nose.tools import raises
 
 from kitsune.gallery.models import Image, Video
-from kitsune.gallery.tests import image, video
+from kitsune.gallery.tests import ImageFactory, VideoFactory
 from kitsune.gallery.utils import check_media_permissions, create_image
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.upload.tests import check_file_info
-from kitsune.users.tests import user, add_permission
+from kitsune.users.tests import UserFactory, add_permission
 
 
 class CheckPermissionsTestCase(TestCase):
 
     def setUp(self):
         super(CheckPermissionsTestCase, self).setUp()
-        self.user = user(save=True)
+        self.user = UserFactory()
 
     def tearDown(self):
         Image.objects.all().delete()
@@ -25,20 +25,20 @@ class CheckPermissionsTestCase(TestCase):
 
     def test_check_own_object(self):
         """tagger can edit a video s/he doesn't own."""
-        vid = video(creator=self.user)
+        vid = VideoFactory(creator=self.user)
         check_media_permissions(vid, self.user, 'change')
 
     @raises(PermissionDenied)
     def test_check_not_own_object(self):
         """tagger cannot delete an image s/he doesn't own."""
-        img = image()
+        img = ImageFactory()
         # This should raise
         check_media_permissions(img, self.user, 'delete')
 
     def test_check_has_perm(self):
         """User with django permission has perm to change video."""
-        vid = video(creator=self.user)
-        u = user(save=True)
+        vid = VideoFactory(creator=self.user)
+        u = UserFactory()
         add_permission(u, Video, 'change_video')
         check_media_permissions(vid, u, 'change')
 
@@ -47,7 +47,7 @@ class CreateImageTestCase(TestCase):
 
     def setUp(self):
         super(CreateImageTestCase, self).setUp()
-        self.user = user(save=True)
+        self.user = UserFactory()
 
     def tearDown(self):
         Image.objects.all().delete()

--- a/kitsune/groups/tests/__init__.py
+++ b/kitsune/groups/tests/__init__.py
@@ -1,7 +1,11 @@
+import factory
+
 from kitsune.groups.models import GroupProfile
-from kitsune.sumo.tests import with_save
+from kitsune.users.tests import GroupFactory
 
 
-@with_save
-def group_profile(**kwargs):
-    return GroupProfile(**kwargs)
+class GroupProfileFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = GroupProfile
+
+    group = factory.SubFactory(GroupFactory)

--- a/kitsune/groups/tests/test_helpers.py
+++ b/kitsune/groups/tests/test_helpers.py
@@ -6,20 +6,21 @@ from pyquery import PyQuery as pq
 
 from kitsune.groups.helpers import group_avatar, group_link
 from kitsune.groups.models import GroupProfile
+from kitsune.groups.tests import GroupProfileFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import group
+from kitsune.users.tests import GroupFactory
 
 
 class GroupHelperTests(TestCase):
 
     def test_group_link_no_profile(self):
-        g = group()
+        g = GroupFactory()
         text = group_link(g)
         eq_(g.name, text)
 
     def test_group_link_with_profile(self):
-        g = group()
+        g = GroupFactory()
         g.save()
         p = GroupProfile.objects.create(group=g, slug='foo')
         text = group_link(g)
@@ -30,19 +31,19 @@ class GroupHelperTests(TestCase):
 
     def test_right_group_profile(self):
         """Make sure we get the right group profile."""
-        g1 = group(pk=100)
+        g1 = GroupFactory(pk=100)
         g1.save()
         eq_(100, g1.pk)
-        g2 = group(pk=101)
+        g2 = GroupFactory(pk=101)
         g2.save()
         eq_(101, g2.pk)
-        p = GroupProfile.objects.create(pk=100, group=g2, slug='foo')
+        p = GroupProfileFactory(pk=100, group=g2, slug='foo')
         eq_(100, p.pk)
 
         eq_(group_link(g1), g1.name)
 
     def test_group_avatar(self):
-        g = group()
+        g = GroupFactory()
         g.save()
         p = GroupProfile.objects.create(group=g, slug='foo')
         url = group_avatar(p)

--- a/kitsune/groups/tests/test_views.py
+++ b/kitsune/groups/tests/test_views.py
@@ -5,18 +5,18 @@ from django.core.files import File
 from nose.tools import eq_
 
 from kitsune.groups.models import GroupProfile
-from kitsune.groups.tests import group_profile
+from kitsune.groups.tests import GroupProfileFactory
 from kitsune.sumo.helpers import urlparams
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import user, group, add_permission
+from kitsune.users.tests import UserFactory, GroupFactory, add_permission
 
 
 class EditGroupProfileTests(TestCase):
     def setUp(self):
         super(EditGroupProfileTests, self).setUp()
-        self.user = user(save=True)
-        self.group_profile = group_profile(group=group(save=True), save=True)
+        self.user = UserFactory()
+        self.group_profile = GroupProfileFactory()
         self.client.login(username=self.user.username, password='testpass')
 
     def _verify_get_and_post(self):
@@ -55,9 +55,9 @@ class EditGroupProfileTests(TestCase):
 class EditAvatarTests(TestCase):
     def setUp(self):
         super(EditAvatarTests, self).setUp()
-        self.user = user(save=True)
+        self.user = UserFactory()
         add_permission(self.user, GroupProfile, 'change_groupprofile')
-        self.group_profile = group_profile(group=group(save=True), save=True)
+        self.group_profile = GroupProfileFactory()
         self.client.login(username=self.user.username, password='testpass')
 
     def tearDown(self):
@@ -102,10 +102,10 @@ class EditAvatarTests(TestCase):
 class AddRemoveMemberTests(TestCase):
     def setUp(self):
         super(AddRemoveMemberTests, self).setUp()
-        self.user = user(save=True)
-        self.member = user(save=True)
+        self.user = UserFactory()
+        self.member = UserFactory()
         add_permission(self.user, GroupProfile, 'change_groupprofile')
-        self.group_profile = group_profile(group=group(save=True), save=True)
+        self.group_profile = GroupProfileFactory()
         self.client.login(username=self.user.username, password='testpass')
 
     def test_add_member(self):
@@ -131,10 +131,10 @@ class AddRemoveMemberTests(TestCase):
 class AddRemoveLeaderTests(TestCase):
     def setUp(self):
         super(AddRemoveLeaderTests, self).setUp()
-        self.user = user(save=True)
+        self.user = UserFactory()
         add_permission(self.user, GroupProfile, 'change_groupprofile')
-        self.leader = user(save=True)
-        self.group_profile = group_profile(group=group(save=True), save=True)
+        self.leader = UserFactory()
+        self.group_profile = GroupProfileFactory()
         self.client.login(username=self.user.username, password='testpass')
 
     def test_add_leader(self):
@@ -160,9 +160,9 @@ class AddRemoveLeaderTests(TestCase):
 class JoinContributorsTests(TestCase):
     def setUp(self):
         super(JoinContributorsTests, self).setUp()
-        self.user = user(save=True)
+        self.user = UserFactory()
         self.client.login(username=self.user.username, password='testpass')
-        group(name='Contributors', save=True)
+        GroupFactory(name='Contributors')
 
     def test_join_contributors(self):
         next = reverse('groups.list')

--- a/kitsune/inproduct/tests/__init__.py
+++ b/kitsune/inproduct/tests/__init__.py
@@ -1,11 +1,10 @@
+import factory
+
 from kitsune.inproduct.models import Redirect
-from kitsune.sumo.tests import with_save
 
 
-@with_save
-def redirect(**kwargs):
-    """Return an inproduct redirect."""
-    defaults = {'target': 'home'}
-    defaults.update(kwargs)
+class RedirectFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Redirect
 
-    return Redirect(**defaults)
+    target = 'home'

--- a/kitsune/inproduct/tests/test_views.py
+++ b/kitsune/inproduct/tests/test_views.py
@@ -6,7 +6,7 @@ import mock
 import waffle
 from nose.tools import eq_
 
-from kitsune.inproduct.tests import redirect
+from kitsune.inproduct.tests import RedirectFactory
 from kitsune.sumo.tests import TestCase
 
 
@@ -56,15 +56,13 @@ class RedirectTestCase(TestCase):
         super(RedirectTestCase, self).setUp()
 
         # Create redirects to test with.
-        redirect(target='kb/Applications', topic='prefs-applications',
-                 save=True)
-        redirect(target='', save=True)
-        redirect(product='mobile', target='products/mobile', save=True)
-        redirect(platform='iPhone', target='', save=True)
-        redirect(product='mobile', platform='Android', topic='foo',
-                 target='', save=True)
-        redirect(version='5.0', target='does-not-exist', save=True)
-        redirect(platform='martian', target='http://martian.com', save=True)
+        RedirectFactory(target='kb/Applications', topic='prefs-applications')
+        RedirectFactory(target='')
+        RedirectFactory(product='mobile', target='products/mobile')
+        RedirectFactory(platform='iPhone', target='')
+        RedirectFactory(product='mobile', platform='Android', topic='foo', target='')
+        RedirectFactory(version='5.0', target='does-not-exist')
+        RedirectFactory(platform='martian', target='http://martian.com')
 
     def test_target(self):
         """Test that we can vary on any parameter and targets work."""

--- a/kitsune/karma/tests/test_helpers.py
+++ b/kitsune/karma/tests/test_helpers.py
@@ -2,14 +2,14 @@ from nose.tools import eq_
 
 from kitsune.karma.helpers import karma_titles
 from kitsune.karma.models import Title
-from kitsune.users.tests import TestCase, user, group
+from kitsune.users.tests import TestCase, UserFactory, GroupFactory
 
 
 class KarmaTitleHelperTests(TestCase):
     def setUp(self):
         super(KarmaTitleHelperTests, self).setUp()
-        self.user = user(save=True)
-        self.group = group(name='group', save=True)
+        self.user = UserFactory()
+        self.group = GroupFactory(name='group')
         self.user.groups.add(self.group)
 
     def test_user_title(self):

--- a/kitsune/karma/tests/test_models.py
+++ b/kitsune/karma/tests/test_models.py
@@ -1,23 +1,23 @@
 from nose.tools import eq_
 
 from kitsune.karma.models import Title
-from kitsune.users.tests import TestCase, user
+from kitsune.users.tests import TestCase, UserFactory
 
 
 class KarmaTitleTests(TestCase):
     def test_top_contributors_title(self):
         # Set top 10 title to 3 users and verify
         title = 'Top 10 Contributor'
-        u1 = user(save=True)
-        u2 = user(save=True)
-        u3 = user(save=True)
+        u1 = UserFactory()
+        u2 = UserFactory()
+        u3 = UserFactory()
         Title.objects.set_top10_contributors([u1.id, u2.id, u3.id])
         top10_title = Title.objects.get(name=title)
         assert top10_title.is_auto
         eq_(3, len(top10_title.users.all()))
 
         # Update title to different list of users
-        u4 = user(save=True)
+        u4 = UserFactory()
         Title.objects.set_top10_contributors([u1.id, u3.id, u4.id])
         top10_title = Title.objects.get(name=title)
         assert top10_title.is_auto

--- a/kitsune/kbadge/tests/__init__.py
+++ b/kitsune/kbadge/tests/__init__.py
@@ -1,31 +1,23 @@
 from badger.models import Award, Badge
 
-from kitsune.sumo.tests import with_save
-from kitsune.users.tests import profile
+import factory
+
+from kitsune.sumo.tests import FuzzyUnicode
+from kitsune.users.tests import UserFactory
 
 
-@with_save
-def award(**kwargs):
-    defaults = {
-        'description': u'An award!',
-    }
-    defaults.update(kwargs)
+class BadgeFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Badge
 
-    if 'badge' not in defaults:
-        defaults['badge'] = badge(save=True)
-
-    if 'user' not in defaults:
-        defaults['user'] = profile().user
-
-    return Award(**defaults)
+    description = FuzzyUnicode()
+    title = FuzzyUnicode()
 
 
-@with_save
-def badge(**kwargs):
-    defaults = {
-        'title': u'BADGE!',
-        'description': u'A badge',
-    }
-    defaults.update(kwargs)
+class AwardFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Award
 
-    return Badge(**defaults)
+    badge = factory.SubFactory(BadgeFactory)
+    description = FuzzyUnicode()
+    user = factory.SubFactory(UserFactory)

--- a/kitsune/kbadge/tests/test_awards.py
+++ b/kitsune/kbadge/tests/test_awards.py
@@ -2,7 +2,7 @@ from django.core import mail
 
 from nose.tools import eq_
 
-from kitsune.kbadge.tests import award, badge
+from kitsune.kbadge.tests import AwardFactory, BadgeFactory
 from kitsune.sumo.tests import TestCase
 
 
@@ -14,13 +14,13 @@ class AwardNotificationTests(TestCase):
         # because badges gets loaded by django-badger in startup.
         from kitsune.kbadge import badges  # noqa
 
-        new_badge = badge(save=True)
+        new_badge = BadgeFactory()
 
         # Check the mail queue first.
         eq_(0, len(mail.outbox))
 
         # Create an award and save it. This triggers the notification.
-        award(description=u'yay!', badge=new_badge, save=True)
+        AwardFactory(description=u'yay!', badge=new_badge)
 
         eq_(1, len(mail.outbox))
 

--- a/kitsune/kbadge/tests/test_views.py
+++ b/kitsune/kbadge/tests/test_views.py
@@ -1,6 +1,6 @@
 from nose.tools import eq_
 
-from kitsune.kbadge.tests import award, badge
+from kitsune.kbadge.tests import AwardFactory, BadgeFactory
 from kitsune.sumo.tests import LocalizingClient, TestCase
 from kitsune.sumo.urlresolvers import reverse
 
@@ -13,10 +13,10 @@ class AwardsListTests(TestCase):
         eq_(200, resp.status_code)
 
     def test_list_with_awards(self):
-        b = badge(save=True)
-        a1 = award(description=u'A1 AWARD', badge=b, save=True)
-        a2 = award(description=u'A2 AWARD', badge=b, save=True)
-        a3 = award(description=u'A3 AWARD', badge=b, save=True)
+        b = BadgeFactory()
+        a1 = AwardFactory(description=u'A1 AWARD', badge=b)
+        a2 = AwardFactory(description=u'A2 AWARD', badge=b)
+        a3 = AwardFactory(description=u'A3 AWARD', badge=b)
 
         resp = self.client.get(reverse('badger.awards_list'), follow=True)
         eq_(200, resp.status_code)
@@ -31,8 +31,7 @@ class AwardsListTests(TestCase):
 class AwardDetailsTests(TestCase):
     def test_details_page(self):
         # This is a just basic test to make sure the template loads.
-        b = badge(save=True)
-        a1 = award(description=u'A1 AWARD', badge=b, save=True)
+        a1 = AwardFactory(description=u'A1 AWARD')
 
         resp = self.client.get(a1.get_absolute_url(), follow=True)
         eq_(200, resp.status_code)

--- a/kitsune/kbforums/tests/__init__.py
+++ b/kitsune/kbforums/tests/__init__.py
@@ -1,34 +1,29 @@
 from django.conf import settings
 
+import factory
 from nose.tools import eq_
 
 from kitsune.kbforums.models import Thread, Post, ThreadLockedError
 from kitsune.kbforums.views import sort_threads
-from kitsune.sumo.tests import get, LocalizingClient, TestCase, with_save
-from kitsune.users.tests import user
-from kitsune.wiki.tests import document
+from kitsune.sumo.tests import get, LocalizingClient, TestCase
+from kitsune.users.tests import UserFactory
+from kitsune.wiki.tests import DocumentFactory
 
 
-@with_save
-def thread(**kwargs):
-    defaults = {}
-    if 'document' not in kwargs:
-        defaults['document'] = document(save=True)
-    if 'creator' not in kwargs:
-        defaults['creator'] = user(save=True)
-    defaults.update(kwargs)
-    return Thread(**defaults)
+class ThreadFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Thread
+
+    creator = factory.SubFactory(UserFactory)
+    document = factory.SubFactory(DocumentFactory)
 
 
-@with_save
-def post(**kwargs):
-    defaults = {}
-    if 'creator' not in kwargs:
-        defaults['creator'] = user(save=True)
-    if 'thread' not in kwargs:
-        defaults['thread'] = thread(creator=defaults['creator'], save=True)
-    defaults.update(kwargs)
-    return Post(**defaults)
+class PostFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Post
+
+    creator = factory.SubFactory(UserFactory)
+    thread = factory.SubFactory(ThreadFactory)
 
 
 class KBForumTestCase(TestCase):
@@ -40,14 +35,14 @@ class PostTestCase(KBForumTestCase):
     def test_new_post_updates_thread(self):
         """Saving a new post in a thread should update the last_post key in
         that thread to point to the new post."""
-        t = thread(save=True)
+        t = ThreadFactory()
         post = t.new_post(creator=t.creator, content='an update')
         eq_(post.id, t.last_post_id)
 
     def test_update_post_does_not_update_thread(self):
         """Updating/saving an old post in a thread should _not_ update the
         last_post key in that thread."""
-        p = post(save=True)
+        p = PostFactory()
         old = p.thread.last_post_id
         p.content = 'updated content'
         eq_(old, p.thread.last_post_id)
@@ -55,30 +50,30 @@ class PostTestCase(KBForumTestCase):
     def test_replies_count(self):
         """The Thread.replies value should remain one less than the number of
         posts in the thread."""
-        t = thread(save=True)
+        t = ThreadFactory()
         old = t.replies
         t.new_post(creator=t.creator, content='test')
         eq_(old, t.replies)
 
     def test_sticky_threads_first(self):
         """Sticky threads should come before non-sticky threads."""
-        thread(save=True)
-        t2 = thread(is_sticky=True, save=True)
+        ThreadFactory()
+        t2 = ThreadFactory(is_sticky=True)
         s = Thread.objects.all()[0]
         eq_(t2.id, s.id)
 
     def test_thread_sorting(self):
         """After the sticky threads, threads should be sorted by the created
         date of the last post."""
-        t1 = thread(is_sticky=False, save=True)
+        t1 = ThreadFactory(is_sticky=False)
         t1.post_set.create(creator=t1.creator, content='foo')
-        t2 = thread(is_sticky=False, save=True)
+        t2 = ThreadFactory(is_sticky=False)
         t2.post_set.create(creator=t2.creator, content='bar')
         self.assertGreater(t2.last_post.created, t1.last_post.created)
 
     def test_post_sorting(self):
         """Posts should be sorted chronologically."""
-        t = thread(save=True)
+        t = ThreadFactory()
         t.post_set.create(creator=t.creator, content='foo')
         t.post_set.create(creator=t.creator, content='bar')
         posts = t.post_set.all()
@@ -88,19 +83,19 @@ class PostTestCase(KBForumTestCase):
 
     def test_sorting_creator(self):
         """Sorting threads by creator."""
-        u1 = user(username='foo', save=True)
-        u2 = user(username='bar', save=True)
-        thread(creator=u1, save=True)
-        thread(creator=u2, save=True)
+        u1 = UserFactory(username='foo')
+        u2 = UserFactory(username='bar')
+        ThreadFactory(creator=u1)
+        ThreadFactory(creator=u2)
         threads = sort_threads(Thread.objects, 3, 1)
         self.assertEqual(threads[0].creator.username, u1.username)
         self.assertEqual(threads[1].creator.username, u2.username)
 
     def test_sorting_replies(self):
         """Sorting threads by replies."""
-        t1 = thread(save=True)
+        t1 = ThreadFactory()
         t1.new_post(t1.creator, 'foo')
-        t2 = thread(save=True)
+        t2 = ThreadFactory()
         t2.new_post(t2.creator, 'bar')
         t2.new_post(t2.creator, 'baz')
         threads = sort_threads(Thread.objects, 4)
@@ -113,9 +108,9 @@ class PostTestCase(KBForumTestCase):
 
     def test_sorting_last_post_desc(self):
         """Sorting threads by last_post descendingly."""
-        t1 = thread(save=True)
+        t1 = ThreadFactory()
         t1.new_post(t1.creator, 'foo')
-        t2 = thread(save=True)
+        t2 = ThreadFactory()
         t2.new_post(t2.creator, 'bar')
         threads = sort_threads(Thread.objects, 5, 1)
         self.assertGreaterEqual(threads[0].last_post.created,
@@ -123,7 +118,7 @@ class PostTestCase(KBForumTestCase):
 
     def test_thread_last_page(self):
         """Thread's last_page property is accurate."""
-        t = thread(save=True)
+        t = ThreadFactory()
         t.new_post(t.creator, 'foo')
         # Format: (# replies, # of pages to expect)
         test_data = ((t.replies, 1),  # Test default
@@ -137,7 +132,7 @@ class PostTestCase(KBForumTestCase):
 
     def test_locked_thread(self):
         """Trying to reply to a locked thread should raise an exception."""
-        locked = thread(is_locked=True, save=True)
+        locked = ThreadFactory(is_locked=True)
         with self.assertRaises(ThreadLockedError):
             locked.new_post(creator=locked.creator, content='foo')
 

--- a/kitsune/kbforums/tests/test_feeds.py
+++ b/kitsune/kbforums/tests/test_feeds.py
@@ -4,26 +4,26 @@ from nose.tools import eq_
 from pyquery import PyQuery as pq
 
 from kitsune.kbforums.feeds import ThreadsFeed, PostsFeed
-from kitsune.kbforums.tests import KBForumTestCase, get, thread
-from kitsune.wiki.tests import document
+from kitsune.kbforums.tests import KBForumTestCase, get, ThreadFactory
+from kitsune.wiki.tests import DocumentFactory
 
 
 class FeedSortingTestCase(KBForumTestCase):
 
     def test_threads_sort(self):
         """Ensure that threads are being sorted properly by date/time."""
-        d = document(save=True)
-        t = thread(document=d, save=True)
+        d = DocumentFactory()
+        t = ThreadFactory(document=d)
         t.new_post(creator=t.creator, content='foo')
         time.sleep(1)
-        t2 = thread(document=d, save=True)
+        t2 = ThreadFactory(document=d)
         t2.new_post(creator=t2.creator, content='foo')
         given_ = ThreadsFeed().items(d)[0].id
         eq_(t2.id, given_)
 
     def test_posts_sort(self):
         """Ensure that posts are being sorted properly by date/time."""
-        t = thread(save=True)
+        t = ThreadFactory()
         t.new_post(creator=t.creator, content='foo')
         time.sleep(1)
         p2 = t.new_post(creator=t.creator, content='foo')
@@ -32,7 +32,7 @@ class FeedSortingTestCase(KBForumTestCase):
 
     def test_multi_feed_titling(self):
         """Ensure that titles are being applied properly to feeds."""
-        d = document(save=True)
+        d = DocumentFactory()
         response = get(self.client, 'wiki.discuss.threads', args=[d.slug])
         doc = pq(response.content)
         given_ = doc('link[type="application/atom+xml"]')[0].attrib['title']

--- a/kitsune/kbforums/tests/test_notifications.py
+++ b/kitsune/kbforums/tests/test_notifications.py
@@ -7,11 +7,11 @@ from nose.tools import eq_
 
 from kitsune.kbforums.events import NewPostEvent, NewThreadEvent
 from kitsune.kbforums.models import Thread, Post
-from kitsune.kbforums.tests import KBForumTestCase, thread
+from kitsune.kbforums.tests import KBForumTestCase, ThreadFactory
 from kitsune.sumo.tests import post, attrs_eq, starts_with
 from kitsune.users.models import Setting
-from kitsune.users.tests import user
-from kitsune.wiki.tests import document
+from kitsune.users.tests import UserFactory
+from kitsune.wiki.tests import DocumentFactory
 
 
 # Some of these contain a locale prefix on included links, while others don't.
@@ -19,7 +19,7 @@ from kitsune.wiki.tests import document
 # request. See the long explanation in questions.tests.test_notifications.
 REPLY_EMAIL = u"""Reply to thread: Sticky Thread
 
-jsocol has replied to a thread you're watching. Here is their reply:
+%(user)s has replied to a thread you're watching. Here is their reply:
 
 ========
 
@@ -30,15 +30,16 @@ a post
 To view this post on the site, click the following link, or paste it into \
 your browser's location bar:
 
-https://testserver/en-US/kb/%s/discuss/%s?utm_campaign=kbforums-post&\
-utm_medium=email&utm_source=notification#post-%s
+https://testserver/en-US/kb/%(document_slug)s/discuss/%(thread_id)s?utm_campaign=kbforums-post&\
+utm_medium=email&utm_source=notification#post-%(post_id)s
 
 --
 Unsubscribe from these emails:
 https://testserver/en-US/unsubscribe/"""
+
 NEW_THREAD_EMAIL = u"""New thread: a title
 
-jsocol has posted a new thread in a forum you're watching. Here is the \
+%(user)s has posted a new thread in a forum you're watching. Here is the \
 thread:
 
 ========
@@ -50,7 +51,7 @@ a post
 To view this post on the site, click the following link, or paste it into \
 your browser's location bar:
 
-https://testserver/en-US/kb/%s/discuss/%s?utm_campaign=kbforums-thread&\
+https://testserver/en-US/kb/%(document_slug)s/discuss/%(thread_id)s?utm_campaign=kbforums-thread&\
 utm_medium=email&utm_source=notification
 
 --
@@ -64,8 +65,8 @@ class NotificationsTests(KBForumTestCase):
     @mock.patch.object(NewPostEvent, 'fire')
     def test_fire_on_reply(self, fire):
         """The event fires when there is a reply."""
-        t = thread(save=True)
-        u = user(save=True)
+        t = ThreadFactory()
+        u = UserFactory()
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.reply', {'content': 'a post'},
              args=[t.document.slug, t.id])
@@ -75,8 +76,8 @@ class NotificationsTests(KBForumTestCase):
     @mock.patch.object(NewThreadEvent, 'fire')
     def test_fire_on_new_thread(self, fire):
         """The event fires when there is a new thread."""
-        d = document(save=True)
-        u = user(save=True)
+        d = DocumentFactory()
+        u = UserFactory()
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.new_thread',
              {'title': 'a title', 'content': 'a post'},
@@ -120,11 +121,10 @@ class NotificationsTests(KBForumTestCase):
     def test_watch_thread_then_reply(self, get_current):
         """The event fires and sends emails when watching a thread."""
         get_current.return_value.domain = 'testserver'
-        u = user(username='jsocol', save=True)
-        u_b = user(username='berkerpeksag', save=True)
-        d = document(title='an article title', save=True)
-        _t = thread(title='Sticky Thread', document=d, is_sticky=True,
-                    save=True)
+        u = UserFactory(username='jsocol')
+        u_b = UserFactory(username='berkerpeksag')
+        d = DocumentFactory(title='an article title')
+        _t = ThreadFactory(title='Sticky Thread', document=d, is_sticky=True)
         t = self._toggle_watch_thread_as(u_b.username, _t, turn_on=True)
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.reply', {'content': 'a post'},
@@ -133,18 +133,23 @@ class NotificationsTests(KBForumTestCase):
         p = Post.objects.all().order_by('-id')[0]
         attrs_eq(mail.outbox[0], to=[u_b.email],
                  subject='Re: an article title - Sticky Thread')
-        starts_with(mail.outbox[0].body, REPLY_EMAIL % (d.slug, t.id, p.id))
+        starts_with(mail.outbox[0].body, REPLY_EMAIL % {
+            'user': u.profile.name,
+            'document_slug': d.slug,
+            'thread_id': t.id,
+            'post_id': p.id,
+        })
 
         self._toggle_watch_thread_as(u_b.username, _t, turn_on=False)
 
     def test_watch_other_thread_then_reply(self):
         """Watching a different thread than the one we're replying to shouldn't
         notify."""
-        u_b = user(username='berkerpeksag', save=True)
-        _t = thread(save=True)
+        u_b = UserFactory(username='berkerpeksag')
+        _t = ThreadFactory()
         self._toggle_watch_thread_as(u_b.username, _t, turn_on=True)
-        u = user(save=True)
-        t2 = thread(save=True)
+        u = UserFactory()
+        t2 = ThreadFactory()
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.reply', {'content': 'a post'},
              args=[t2.document.slug, t2.id])
@@ -156,10 +161,10 @@ class NotificationsTests(KBForumTestCase):
         """Watching a forum and creating a new thread should send email."""
         get_current.return_value.domain = 'testserver'
 
-        u = user(save=True)
-        d = document(title='an article title', save=True)
+        u = UserFactory()
+        d = DocumentFactory(title='an article title')
         f = self._toggle_watch_kbforum_as(u.username, d, turn_on=True)
-        u2 = user(username='jsocol', save=True)
+        u2 = UserFactory(username='jsocol')
         self.client.login(username=u2.username, password='testpass')
         post(self.client, 'wiki.discuss.new_thread',
              {'title': 'a title', 'content': 'a post'}, args=[f.slug])
@@ -167,7 +172,11 @@ class NotificationsTests(KBForumTestCase):
         t = Thread.objects.all().order_by('-id')[0]
         attrs_eq(mail.outbox[0], to=[u.email],
                  subject=u'an article title - a title')
-        starts_with(mail.outbox[0].body, NEW_THREAD_EMAIL % (d.slug, t.id))
+        starts_with(mail.outbox[0].body, NEW_THREAD_EMAIL % {
+            'user': u2.profile.name,
+            'document_slug': d.slug,
+            'thread_id': t.id,
+        })
 
         self._toggle_watch_kbforum_as(u.username, d, turn_on=False)
 
@@ -177,8 +186,8 @@ class NotificationsTests(KBForumTestCase):
         send email."""
         get_current.return_value.domain = 'testserver'
 
-        u = user(save=True)
-        d = document(save=True)
+        u = UserFactory()
+        d = DocumentFactory()
         f = self._toggle_watch_kbforum_as(u.username, d, turn_on=True)
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.new_thread',
@@ -191,11 +200,11 @@ class NotificationsTests(KBForumTestCase):
         """Watching a forum and replying to a thread should send email."""
         get_current.return_value.domain = 'testserver'
 
-        u = user(save=True)
-        d = document(title='an article title', save=True)
+        u = UserFactory()
+        d = DocumentFactory(title='an article title')
         f = self._toggle_watch_kbforum_as(u.username, d, turn_on=True)
-        t = thread(title='Sticky Thread', document=d, save=True)
-        u2 = user(username='jsocol', save=True)
+        t = ThreadFactory(title='Sticky Thread', document=d)
+        u2 = UserFactory(username='jsocol')
         self.client.login(username=u2.username, password='testpass')
         post(self.client, 'wiki.discuss.reply', {'content': 'a post'},
              args=[f.slug, t.id])
@@ -203,17 +212,22 @@ class NotificationsTests(KBForumTestCase):
         p = Post.objects.all().order_by('-id')[0]
         attrs_eq(mail.outbox[0], to=[u.email],
                  subject='Re: an article title - Sticky Thread')
-        starts_with(mail.outbox[0].body, REPLY_EMAIL % (d.slug, t.id, p.id))
+        starts_with(mail.outbox[0].body, REPLY_EMAIL % {
+            'user': u2.profile.name,
+            'document_slug': d.slug,
+            'thread_id': t.id,
+            'post_id': p.id,
+        })
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_watch_forum_then_new_post_as_self(self, get_current):
         """Watching a forum and replying as myself should not send email."""
         get_current.return_value.domain = 'testserver'
 
-        u = user(save=True)
-        d = document(title='an article title', save=True)
+        u = UserFactory()
+        d = DocumentFactory(title='an article title')
         f = self._toggle_watch_kbforum_as(u.username, d, turn_on=True)
-        t = thread(document=d, save=True)
+        t = ThreadFactory(document=d)
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.reply', {'content': 'a post'},
              args=[f.slug, t.id])
@@ -225,12 +239,12 @@ class NotificationsTests(KBForumTestCase):
         """Watching both and replying to a thread should send ONE email."""
         get_current.return_value.domain = 'testserver'
 
-        u = user(save=True)
-        d = document(title='an article title', save=True)
+        u = UserFactory()
+        d = DocumentFactory(title='an article title')
         f = self._toggle_watch_kbforum_as(u.username, d, turn_on=True)
-        t = thread(title='Sticky Thread', document=d, save=True)
+        t = ThreadFactory(title='Sticky Thread', document=d)
         self._toggle_watch_thread_as(u.username, t, turn_on=True)
-        u2 = user(username='jsocol', save=True)
+        u2 = UserFactory(username='jsocol')
         self.client.login(username=u2.username, password='testpass')
         post(self.client, 'wiki.discuss.reply', {'content': 'a post'},
              args=[f.slug, t.id])
@@ -239,7 +253,12 @@ class NotificationsTests(KBForumTestCase):
         p = Post.objects.all().order_by('-id')[0]
         attrs_eq(mail.outbox[0], to=[u.email],
                  subject='Re: an article title - Sticky Thread')
-        starts_with(mail.outbox[0].body, REPLY_EMAIL % (d.slug, t.id, p.id))
+        starts_with(mail.outbox[0].body, REPLY_EMAIL % {
+            'user': u2.profile.name,
+            'document_slug': d.slug,
+            'thread_id': t.id,
+            'post_id': p.id,
+        })
 
         self._toggle_watch_kbforum_as(u.username, d, turn_on=False)
         self._toggle_watch_thread_as(u.username, t, turn_on=False)
@@ -249,14 +268,14 @@ class NotificationsTests(KBForumTestCase):
         """Watching locale and reply to a thread."""
         get_current.return_value.domain = 'testserver'
 
-        d = document(title='an article title', locale='en-US', save=True)
-        t = thread(document=d, title='Sticky Thread', save=True)
-        u = user(save=True)
+        d = DocumentFactory(title='an article title', locale='en-US')
+        t = ThreadFactory(document=d, title='Sticky Thread')
+        u = UserFactory()
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.watch_locale', {'watch': 'yes'})
 
         # Reply as jsocol to document d.
-        u2 = user(username='jsocol', save=True)
+        u2 = UserFactory(username='jsocol')
         self.client.login(username=u2.username, password='testpass')
         post(self.client, 'wiki.discuss.reply', {'content': 'a post'},
              args=[d.slug, t.id])
@@ -266,23 +285,28 @@ class NotificationsTests(KBForumTestCase):
         p = Post.objects.all().order_by('-id')[0]
         attrs_eq(mail.outbox[0], to=[u.email],
                  subject='Re: an article title - Sticky Thread')
-        starts_with(mail.outbox[0].body, REPLY_EMAIL % (d.slug, t.id, p.id))
+        starts_with(mail.outbox[0].body, REPLY_EMAIL % {
+            'user': u2.profile.name,
+            'document_slug': d.slug,
+            'thread_id': t.id,
+            'post_id': p.id,
+        })
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_watch_all_then_new_post(self, get_current):
         """Watching document + thread + locale and reply to thread."""
         get_current.return_value.domain = 'testserver'
 
-        u = user(save=True)
-        _d = document(title='an article title', save=True)
+        u = UserFactory()
+        _d = DocumentFactory(title='an article title')
         d = self._toggle_watch_kbforum_as(u.username, _d, turn_on=True)
-        t = thread(title='Sticky Thread', document=d, save=True)
+        t = ThreadFactory(title='Sticky Thread', document=d)
         self._toggle_watch_thread_as(u.username, t, turn_on=True)
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.watch_locale', {'watch': 'yes'})
 
         # Reply as jsocol to document d.
-        u2 = user(username='jsocol', save=True)
+        u2 = UserFactory(username='jsocol')
         self.client.login(username=u2.username, password='testpass')
         post(self.client, 'wiki.discuss.reply', {'content': 'a post'},
              args=[d.slug, t.id])
@@ -292,7 +316,12 @@ class NotificationsTests(KBForumTestCase):
         p = Post.objects.all().order_by('-id')[0]
         attrs_eq(mail.outbox[0], to=[u.email],
                  subject='Re: an article title - Sticky Thread')
-        starts_with(mail.outbox[0].body, REPLY_EMAIL % (d.slug, t.id, p.id))
+        starts_with(mail.outbox[0].body, REPLY_EMAIL % {
+            'user': u2.profile.name,
+            'document_slug': d.slug,
+            'thread_id': t.id,
+            'post_id': p.id,
+        })
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_watch_other_locale_then_new_thread(self, get_current):
@@ -300,13 +329,13 @@ class NotificationsTests(KBForumTestCase):
         notify."""
         get_current.return_value.domain = 'testserver'
 
-        d = document(locale='en-US', save=True)
-        u = user(username='berkerpeksag', save=True)
+        d = DocumentFactory(locale='en-US')
+        u = UserFactory(username='berkerpeksag')
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.watch_locale', {'watch': 'yes'},
              locale='ja')
 
-        u2 = user(save=True)
+        u2 = UserFactory()
         self.client.login(username=u2.username, password='testpass')
         post(self.client, 'wiki.discuss.new_thread',
              {'title': 'a title', 'content': 'a post'}, args=[d.slug])
@@ -319,12 +348,12 @@ class NotificationsTests(KBForumTestCase):
         """Watching locale and create a thread."""
         get_current.return_value.domain = 'testserver'
 
-        d = document(title='an article title', locale='en-US', save=True)
-        u = user(username='berkerpeksag', save=True)
+        d = DocumentFactory(title='an article title', locale='en-US')
+        u = UserFactory(username='berkerpeksag')
         self.client.login(username=u.username, password='testpass')
         post(self.client, 'wiki.discuss.watch_locale', {'watch': 'yes'})
 
-        u2 = user(username='jsocol', save=True)
+        u2 = UserFactory(username='jsocol')
         self.client.login(username=u2.username, password='testpass')
         post(self.client, 'wiki.discuss.new_thread',
              {'title': 'a title', 'content': 'a post'}, args=[d.slug])
@@ -333,22 +362,26 @@ class NotificationsTests(KBForumTestCase):
         t = Thread.objects.all().order_by('-id')[0]
         attrs_eq(mail.outbox[0], to=[u.email],
                  subject=u'an article title - a title')
-        starts_with(mail.outbox[0].body, NEW_THREAD_EMAIL % (d.slug, t.id))
+        starts_with(mail.outbox[0].body, NEW_THREAD_EMAIL % {
+            'user': u2.profile.name,
+            'document_slug': d.slug,
+            'thread_id': t.id,
+        })
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_autowatch_new_thread(self, get_current):
         """Creating a new thread should email responses"""
         get_current.return_value.domain = 'testserver'
 
-        d = document(save=True)
-        u = user(save=True)
+        d = DocumentFactory()
+        u = UserFactory()
         self.client.login(username=u.username, password='testpass')
         s = Setting.objects.create(user=u, name='kbforums_watch_new_thread',
                                    value='False')
         data = {'title': 'a title', 'content': 'a post'}
         post(self.client, 'wiki.discuss.new_thread', data, args=[d.slug])
 
-        t1 = thread(document=d, save=True)
+        t1 = ThreadFactory(document=d)
         assert not NewPostEvent.is_notifying(u, t1), (
             'NewPostEvent should not be notifying.')
 
@@ -363,9 +396,9 @@ class NotificationsTests(KBForumTestCase):
     def test_autowatch_reply(self, get_current):
         get_current.return_value.domain = 'testserver'
 
-        u = user(save=True)
-        t1 = thread(is_locked=False, save=True)
-        t2 = thread(is_locked=False, save=True)
+        u = UserFactory()
+        t1 = ThreadFactory(is_locked=False)
+        t2 = ThreadFactory(is_locked=False)
         assert not NewPostEvent.is_notifying(u, t1)
         assert not NewPostEvent.is_notifying(u, t2)
 

--- a/kitsune/kbforums/tests/test_urls.py
+++ b/kitsune/kbforums/tests/test_urls.py
@@ -1,9 +1,9 @@
 from nose.tools import eq_
 
-from kitsune.kbforums.tests import KBForumTestCase, thread
+from kitsune.kbforums.tests import KBForumTestCase, ThreadFactory
 from kitsune.sumo.tests import get, post
-from kitsune.users.tests import user, add_permission
-from kitsune.wiki.tests import document
+from kitsune.users.tests import UserFactory, add_permission
+from kitsune.wiki.tests import DocumentFactory
 
 
 class KBBelongsTestCase(KBForumTestCase):
@@ -13,19 +13,15 @@ class KBBelongsTestCase(KBForumTestCase):
 
     def setUp(self):
         super(KBBelongsTestCase, self).setUp()
-        u = user(save=True)
-        self.doc = document(title='spam', save=True)
-        self.doc_2 = document(title='eggs', save=True)
-        self.thread = thread(creator=u, document=self.doc, is_locked=False,
-                             save=True)
-        self.thread_2 = thread(creator=u, document=self.doc_2, is_locked=False,
-                               save=True)
-        permissions = ('sticky_thread', 'lock_thread', 'delete_thread',
-                       'delete_post')
+        u = UserFactory()
+        self.doc = DocumentFactory(title='spam')
+        self.doc_2 = DocumentFactory(title='eggs')
+        self.thread = ThreadFactory(creator=u, document=self.doc, is_locked=False)
+        self.thread_2 = ThreadFactory(creator=u, document=self.doc_2, is_locked=False)
+        permissions = ('sticky_thread', 'lock_thread', 'delete_thread', 'delete_post')
         for permission in permissions:
             add_permission(u, self.thread, permission)
-        self.post = self.thread.new_post(creator=self.thread.creator,
-                                         content='foo')
+        self.post = self.thread.new_post(creator=self.thread.creator, content='foo')
         self.client.login(username=u.username, password='testpass')
 
     def test_posts_thread_belongs_to_document(self):

--- a/kitsune/kpi/tests/__init__.py
+++ b/kitsune/kpi/tests/__init__.py
@@ -1,20 +1,23 @@
 from datetime import date
 
+import factory
+
 from kitsune.kpi.models import MetricKind, Metric
-from kitsune.sumo.tests import with_save
+from kitsune.sumo.tests import FuzzyUnicode
 
 
-@with_save
-def metric_kind(**kwargs):
-    return MetricKind(code=kwargs.get('code', 'something'))
+class MetricKindFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = MetricKind
+
+    code = FuzzyUnicode()
 
 
-@with_save
-def metric(**kwargs):
-    defaults = {'start': date(1980, 02, 16),
-                'end': date(1980, 02, 23),
-                'value': 33}
-    if 'kind' not in kwargs:
-        defaults['kind'] = metric_kind(save=True)
-    defaults.update(kwargs)
-    return Metric(**defaults)
+class MetricFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Metric
+
+    start = date(1980, 2, 16)
+    end = date(1980, 2, 23)
+    value = 33
+    kind = factory.SubFactory(MetricKindFactory)

--- a/kitsune/kpi/tests/test_api.py
+++ b/kitsune/kpi/tests/test_api.py
@@ -5,36 +5,34 @@ from django.core.cache import cache
 
 from nose.tools import eq_
 
-from kitsune.customercare.tests import reply
+from kitsune.customercare.tests import ReplyFactory
 from kitsune.kpi.cron import update_contributor_metrics
 from kitsune.kpi.models import (
     Metric, AOA_CONTRIBUTORS_METRIC_CODE, KB_ENUS_CONTRIBUTORS_METRIC_CODE,
     KB_L10N_CONTRIBUTORS_METRIC_CODE, L10N_METRIC_CODE,
     SUPPORT_FORUM_CONTRIBUTORS_METRIC_CODE, VISITORS_METRIC_CODE,
     EXIT_SURVEY_YES_CODE, EXIT_SURVEY_NO_CODE, EXIT_SURVEY_DONT_KNOW_CODE)
-from kitsune.kpi.tests import metric, metric_kind
-from kitsune.products.tests import product
+from kitsune.kpi.tests import MetricFactory, MetricKindFactory
+from kitsune.products.tests import ProductFactory
 from kitsune.sumo.helpers import urlparams
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.questions.tests import answer, answervote, question
-from kitsune.users.tests import user
-from kitsune.wiki.tests import document, revision, helpful_vote
+from kitsune.questions.tests import AnswerFactory, AnswerVoteFactory, QuestionFactory
+from kitsune.users.tests import UserFactory
+from kitsune.wiki.tests import DocumentFactory, RevisionFactory, HelpfulVoteFactory
 
 
 class KpiApiTests(TestCase):
     def _make_elastic_metric_kinds(self):
-        click_kind = metric_kind(code='search clickthroughs:elastic:clicks',
-                                 save=True)
-        search_kind = metric_kind(code='search clickthroughs:elastic:searches',
-                                  save=True)
+        click_kind = MetricKindFactory(code='search clickthroughs:elastic:clicks')
+        search_kind = MetricKindFactory(code='search clickthroughs:elastic:searches')
         return click_kind, search_kind
 
     def _make_contributor_metric_kinds(self):
-        metric_kind(code=AOA_CONTRIBUTORS_METRIC_CODE, save=True)
-        metric_kind(code=KB_ENUS_CONTRIBUTORS_METRIC_CODE, save=True)
-        metric_kind(code=KB_L10N_CONTRIBUTORS_METRIC_CODE, save=True)
-        metric_kind(code=SUPPORT_FORUM_CONTRIBUTORS_METRIC_CODE, save=True)
+        MetricKindFactory(code=AOA_CONTRIBUTORS_METRIC_CODE)
+        MetricKindFactory(code=KB_ENUS_CONTRIBUTORS_METRIC_CODE)
+        MetricKindFactory(code=KB_L10N_CONTRIBUTORS_METRIC_CODE)
+        MetricKindFactory(code=SUPPORT_FORUM_CONTRIBUTORS_METRIC_CODE)
 
     def _get_api_result(self, name, **kwargs):
         """Helper to make API calls, parse the json and return the result."""
@@ -47,15 +45,15 @@ class KpiApiTests(TestCase):
     def test_questions(self):
         """Test questions API call."""
         # A question with a solution:
-        a = answer(save=True)
+        a = AnswerFactory()
         a.question.solution = a
         a.question.save()
         # A question with an answer:
-        answer(save=True)
+        AnswerFactory()
         # A question without answers:
-        question(save=True)
+        QuestionFactory()
         # A locked question that shouldn't be counted for anything
-        question(is_locked=True, save=True)
+        QuestionFactory(is_locked=True)
 
         r = self._get_api_result('api.kpi.questions')
         eq_(r['objects'][0]['solved'], 1)
@@ -66,18 +64,18 @@ class KpiApiTests(TestCase):
     def test_questions_by_locale(self):
         """Test locale filtering of questions API call."""
         # An en-US question with a solution:
-        q = question(locale='en-US', save=True)
-        a = answer(question=q, save=True)
+        q = QuestionFactory(locale='en-US')
+        a = AnswerFactory(question=q)
         q.solution = a
         q.save()
         # An en-US question with an answer:
-        q = question(locale='en-US', save=True)
-        answer(question=q, save=True)
+        q = QuestionFactory(locale='en-US')
+        AnswerFactory(question=q)
         # An en-US question without answers:
-        question(locale='en-US', save=True)
+        QuestionFactory(locale='en-US')
 
         # A pt-BR question without answers:
-        question(locale='pt-BR', save=True)
+        QuestionFactory(locale='pt-BR')
 
         # Verify no locale filtering:
         r = self._get_api_result('api.kpi.questions')
@@ -102,24 +100,24 @@ class KpiApiTests(TestCase):
 
     def test_questions_by_product(self):
         """Test product filtering of questions API call."""
-        firefox_os = product(slug='firefox-os', save=True)
-        firefox = product(slug='firefox', save=True)
+        firefox_os = ProductFactory(slug='firefox-os')
+        firefox = ProductFactory(slug='firefox')
 
         # A Firefox OS question with a solution:
-        q = question(product=firefox_os, save=True)
-        a = answer(question=q, save=True)
+        q = QuestionFactory(product=firefox_os)
+        a = AnswerFactory(question=q)
         q.solution = a
         q.save()
 
         # A Firefox OS question with an answer:
-        q = question(product=firefox_os, save=True)
-        answer(question=q, save=True)
+        q = QuestionFactory(product=firefox_os)
+        AnswerFactory(question=q)
 
         # A Firefox OS question without answers:
-        q = question(product=firefox_os, save=True)
+        q = QuestionFactory(product=firefox_os)
 
         # A Firefox question without answers:
-        q = question(product=firefox, locale='pt-BR', save=True)
+        q = QuestionFactory(product=firefox, locale='pt-BR')
 
         # Verify no product filtering:
         r = self._get_api_result('api.kpi.questions')
@@ -146,9 +144,9 @@ class KpiApiTests(TestCase):
         """Verify questions from inactive users aren't counted."""
         # Two questions for an inactive user.
         # They shouldn't show up in the count.
-        u = user(is_active=False, save=True)
-        question(creator=u, save=True)
-        question(creator=u, save=True)
+        u = UserFactory(is_active=False)
+        QuestionFactory(creator=u)
+        QuestionFactory(creator=u)
 
         r = self._get_api_result('api.kpi.questions')
         eq_(len(r['objects']), 0)
@@ -166,15 +164,15 @@ class KpiApiTests(TestCase):
 
     def test_vote(self):
         """Test vote API call."""
-        r = revision(save=True)
-        helpful_vote(revision=r, save=True)
-        helpful_vote(revision=r, save=True)
-        helpful_vote(revision=r, helpful=True, save=True)
+        r = RevisionFactory()
+        HelpfulVoteFactory(revision=r)
+        HelpfulVoteFactory(revision=r)
+        HelpfulVoteFactory(revision=r, helpful=True)
 
-        a = answer(save=True)
-        answervote(answer=a, save=True)
-        answervote(answer=a, helpful=True, save=True)
-        answervote(answer=a, helpful=True, save=True)
+        a = AnswerFactory()
+        AnswerVoteFactory(answer=a)
+        AnswerVoteFactory(answer=a, helpful=True)
+        AnswerVoteFactory(answer=a, helpful=True)
 
         r = self._get_api_result('api.kpi.votes')
         eq_(r['objects'][0]['kb_helpful'], 1)
@@ -184,17 +182,17 @@ class KpiApiTests(TestCase):
 
     def test_kb_vote(self):
         """Test vote API call."""
-        r1 = revision(document=document(locale='en-US', save=True), save=True)
-        r2 = revision(document=document(locale='es', save=True), save=True)
-        r3 = revision(document=document(locale='es', save=True), save=True)
+        r1 = RevisionFactory(document__locale='en-US')
+        r2 = RevisionFactory(document__locale='es')
+        r3 = RevisionFactory(document__locale='es')
         for r in [r1, r2, r3]:
-            helpful_vote(revision=r, save=True)
-            helpful_vote(revision=r, save=True)
-            helpful_vote(revision=r, helpful=True, save=True)
+            HelpfulVoteFactory(revision=r)
+            HelpfulVoteFactory(revision=r)
+            HelpfulVoteFactory(revision=r, helpful=True)
 
         # Assign 2 documents to Firefox OS and 1 to Firefox
-        firefox_os = product(slug='firefox-os', save=True)
-        firefox = product(slug='firefox', save=True)
+        firefox_os = ProductFactory(slug='firefox-os')
+        firefox = ProductFactory(slug='firefox')
         r1.document.products.add(firefox_os)
         r2.document.products.add(firefox_os)
         r3.document.products.add(firefox)
@@ -233,27 +231,30 @@ class KpiApiTests(TestCase):
     def test_active_contributors(self):
         """Test active contributors API call."""
         # 2 en-US revisions by 2 contributors:
-        r1 = revision(creator=user(save=True), save=True)
-        r2 = revision(creator=user(save=True), save=True)
+        r1 = RevisionFactory()
+        r2 = RevisionFactory()
         # A translation with 2 contributors (translator + reviewer):
-        d = document(parent=r1.document, locale='es', save=True)
-        revision(document=d, reviewed=datetime.now(),
-                 reviewer=r1.creator, creator=r2.creator, save=True)
+        d = DocumentFactory(parent=r1.document, locale='es')
+        RevisionFactory(
+            document=d,
+            reviewed=datetime.now(),
+            reviewer=r1.creator,
+            creator=r2.creator)
         # 1 active support forum contributor:
         # A user with 10 answers
-        u1 = user(save=True)
+        u1 = UserFactory()
         for x in range(10):
-            answer(save=True, creator=u1)
+            AnswerFactory(creator=u1)
         # A user with 9 answers
-        u2 = user(save=True)
+        u2 = UserFactory()
         for x in range(9):
-            answer(save=True, creator=u2)
+            AnswerFactory(creator=u2)
         # A user with 1 answer
-        u3 = user(save=True)
-        answer(save=True, creator=u3)
+        u3 = UserFactory()
+        AnswerFactory(creator=u3)
 
         # An AoA reply (1 contributor):
-        reply(save=True)
+        ReplyFactory()
 
         # Create metric kinds and update metrics for tomorrow (today's
         # activity shows up tomorrow).
@@ -274,10 +275,9 @@ class KpiApiTests(TestCase):
         a contributor.
         """
         # A user with 10 answers to own question.
-        q = question(save=True)
+        q = QuestionFactory()
         u = q.creator
-        for x in range(10):
-            answer(creator=u, question=q, save=True)
+        AnswerFactory.create_batch(10, creator=u, question=q)
 
         # Create metric kinds and update metrics for tomorrow (today's
         # activity shows up tomorrow).
@@ -288,7 +288,7 @@ class KpiApiTests(TestCase):
         eq_(r['objects'][0]['support_forum'], 0)
 
         # Change the question creator, now we should have 1 contributor.
-        q.creator = user(save=True)
+        q.creator = UserFactory()
         q.save()
         cache.clear()  # We need to clear the cache for new results.
 
@@ -301,22 +301,10 @@ class KpiApiTests(TestCase):
     def test_elastic_clickthrough_get(self):
         """Test elastic clickthrough read API."""
         click_kind, search_kind = self._make_elastic_metric_kinds()
-        metric(kind=click_kind,
-               start=date(2000, 1, 1),
-               value=1,
-               save=True)
-        metric(kind=search_kind,
-               start=date(2000, 1, 1),
-               value=10,
-               save=True)
-        metric(kind=click_kind,
-               start=date(2000, 1, 9),
-               value=2,
-               save=True)
-        metric(kind=search_kind,
-               start=date(2000, 1, 9),
-               value=20,
-               save=True)
+        MetricFactory(kind=click_kind, start=date(2000, 1, 1), value=1)
+        MetricFactory(kind=search_kind, start=date(2000, 1, 1), value=10)
+        MetricFactory(kind=click_kind, start=date(2000, 1, 9), value=2)
+        MetricFactory(kind=search_kind, start=date(2000, 1, 9), value=20)
 
         url = reverse('api.kpi.search-ctr')
         response = self.client.get(url + '?format=json')
@@ -336,9 +324,8 @@ class KpiApiTests(TestCase):
     def test_visitors(self):
         """Test unique visitors API call."""
         # Create the metric.
-        kind = metric_kind(code=VISITORS_METRIC_CODE, save=True)
-        metric(kind=kind, start=date.today(), end=date.today(), value=42,
-               save=True)
+        kind = MetricKindFactory(code=VISITORS_METRIC_CODE)
+        MetricFactory(kind=kind, start=date.today(), end=date.today(), value=42)
 
         # There should be 42 visitors.
         r = self._get_api_result('api.kpi.visitors')
@@ -347,9 +334,8 @@ class KpiApiTests(TestCase):
     def test_l10n_coverage(self):
         """Test l10n coverage API call."""
         # Create the metrics
-        kind = metric_kind(code=L10N_METRIC_CODE, save=True)
-        metric(kind=kind, start=date.today(), end=date.today(), value=56,
-               save=True)
+        kind = MetricKindFactory(code=L10N_METRIC_CODE)
+        MetricFactory(kind=kind, start=date.today(), end=date.today(), value=56)
 
         # The l10n coverage should be 56%.
         r = self._get_api_result('api.kpi.l10n-coverage')
@@ -358,15 +344,12 @@ class KpiApiTests(TestCase):
     def test_exit_survey_results(self):
         """Test the exist survey results API call."""
         # Create the metrics
-        kind = metric_kind(code=EXIT_SURVEY_YES_CODE, save=True)
-        metric(kind=kind, start=date.today(), end=date.today(), value=1337,
-               save=True)
-        kind = metric_kind(code=EXIT_SURVEY_NO_CODE, save=True)
-        metric(kind=kind, start=date.today(), end=date.today(), value=42,
-               save=True)
-        kind = metric_kind(code=EXIT_SURVEY_DONT_KNOW_CODE, save=True)
-        metric(kind=kind, start=date.today(), end=date.today(), value=777,
-               save=True)
+        kind = MetricKindFactory(code=EXIT_SURVEY_YES_CODE)
+        MetricFactory(kind=kind, start=date.today(), end=date.today(), value=1337)
+        kind = MetricKindFactory(code=EXIT_SURVEY_NO_CODE)
+        MetricFactory(kind=kind, start=date.today(), end=date.today(), value=42)
+        kind = MetricKindFactory(code=EXIT_SURVEY_DONT_KNOW_CODE)
+        MetricFactory(kind=kind, start=date.today(), end=date.today(), value=777)
 
         # Verify the results returned from the API
         r = self._get_api_result('api.kpi.exit-survey')

--- a/kitsune/kpi/tests/test_api.py
+++ b/kitsune/kpi/tests/test_api.py
@@ -247,6 +247,7 @@ class KpiApiTests(TestCase):
             AnswerFactory(creator=u1)
         # A user with 9 answers
         u2 = UserFactory()
+        # FIXME: create_batch?
         for x in range(9):
             AnswerFactory(creator=u2)
         # A user with 1 answer

--- a/kitsune/landings/tests/test_templates.py
+++ b/kitsune/landings/tests/test_templates.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_
 from pyquery import PyQuery as pq
 
-from kitsune.products.tests import product
+from kitsune.products.tests import ProductFactory
 from kitsune.search.tests.test_es import ElasticTestCase
 from kitsune.sumo.urlresolvers import reverse
 
@@ -11,8 +11,7 @@ class HomeTestCase(ElasticTestCase):
         """Verify that home page renders products."""
 
         # Create some topics and products
-        for i in range(4):
-            product(save=True)
+        ProductFactory.create_batch(4)
 
         # GET the home page and verify the content
         r = self.client.get(reverse('home'), follow=True)

--- a/kitsune/messages/tests/test_context_processors.py
+++ b/kitsune/messages/tests/test_context_processors.py
@@ -7,7 +7,7 @@ from nose.tools import eq_
 from kitsune.messages import context_processors
 from kitsune.messages.context_processors import unread_message_count
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class UnreadCountTests(TestCase):
@@ -29,6 +29,6 @@ class UnreadCountTests(TestCase):
         unread_count_for.return_value = 3
         rf = RequestFactory()
         request = rf.get('/')
-        request.user = user(save=True)
+        request.user = UserFactory()
         eq_(3, unread_message_count(request)['unread_message_count'])
         assert unread_count_for.called

--- a/kitsune/messages/tests/test_internal_api.py
+++ b/kitsune/messages/tests/test_internal_api.py
@@ -3,15 +3,15 @@ from nose.tools import eq_
 from kitsune.messages.models import InboxMessage, OutboxMessage
 from kitsune.messages.utils import send_message
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class SendTests(TestCase):
     """Tests for the internal send API."""
 
     def test_send_message(self):
-        to = [user(save=True), user(save=True)]
-        sender = user(save=True)
+        to = UserFactory.create_batch(2)
+        sender = UserFactory()
         msg_text = "hi there!"
         send_message(to=to, text=msg_text, sender=sender)
 

--- a/kitsune/messages/tests/test_notifications.py
+++ b/kitsune/messages/tests/test_notifications.py
@@ -6,9 +6,9 @@ import mock
 from kitsune.kbforums.tests import KBForumTestCase
 from kitsune.sumo.tests import post, attrs_eq, starts_with
 from kitsune.users.models import Setting
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
-PRIVATE_MESSAGE_EMAIL = '{sender} sent you the following'
+PRIVATE_MESSAGE_EMAIL = u'{sender} sent you the following'
 
 
 class NotificationsTests(KBForumTestCase):
@@ -17,8 +17,8 @@ class NotificationsTests(KBForumTestCase):
     def setUp(self):
         super(NotificationsTests, self).setUp()
 
-        self.sender = user(username=u'Alice', save=True)
-        self.to = user(username=u'Bob', save=True)
+        self.sender = UserFactory()
+        self.to = UserFactory()
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_private_message_sends_email(self, get_current):
@@ -28,8 +28,7 @@ class NotificationsTests(KBForumTestCase):
         """
         get_current.return_value.domain = 'testserver'
 
-        s, c = Setting.objects.get_or_create(user=self.to,
-                                             name='email_private_messages')
+        s, c = Setting.objects.get_or_create(user=self.to, name='email_private_messages')
         s.value = True
         s.save()
         # User has setting, and should recieve notification email.
@@ -42,9 +41,9 @@ class NotificationsTests(KBForumTestCase):
         subject = u'[SUMO] You have a new private message from [{sender}]'
 
         attrs_eq(mail.outbox[0], to=[self.to.email],
-                 subject=subject.format(sender=self.sender.username))
+                 subject=subject.format(sender=self.sender.profile.name))
         starts_with(mail.outbox[0].body,
-                    PRIVATE_MESSAGE_EMAIL.format(sender=self.sender.username))
+                    PRIVATE_MESSAGE_EMAIL.format(sender=self.sender.profile.name))
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_private_message_not_sends_email(self, get_current):

--- a/kitsune/messages/tests/test_templates.py
+++ b/kitsune/messages/tests/test_templates.py
@@ -5,15 +5,15 @@ from kitsune.messages.models import OutboxMessage
 from kitsune.sumo.helpers import urlparams
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class SendMessageTestCase(TestCase):
     def setUp(self):
         super(SendMessageTestCase, self).setUp()
-        self.user1 = user(save=True)
-        self.user2 = user(save=True)
-        self.user3 = user(save=True)
+        self.user1 = UserFactory()
+        self.user2 = UserFactory()
+        self.user3 = UserFactory()
         self.client.login(username=self.user1.username, password='testpass')
 
     def test_send_message_page(self):
@@ -70,7 +70,7 @@ class MessagePreviewTests(TestCase):
     """Tests for preview."""
     def setUp(self):
         super(MessagePreviewTests, self).setUp()
-        self.user = user(save=True)
+        self.user = UserFactory()
         self.client.login(username=self.user.username, password='testpass')
 
     def test_preview(self):

--- a/kitsune/messages/tests/test_views.py
+++ b/kitsune/messages/tests/test_views.py
@@ -4,15 +4,15 @@ from nose.tools import eq_
 from kitsune.messages.models import InboxMessage, OutboxMessage
 from kitsune.sumo.tests import TestCase, LocalizingClient
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class ReadMessageTests(TestCase):
 
     def setUp(self):
         super(ReadMessageTests, self).setUp()
-        self.user1 = user(save=True)
-        self.user2 = user(save=True)
+        self.user1 = UserFactory()
+        self.user2 = UserFactory()
         self.client.login(username=self.user1.username, password='testpass')
 
     def test_mark_bulk_message_read(self):
@@ -70,8 +70,8 @@ class ReadMessageTests(TestCase):
 class DeleteMessageTests(TestCase):
     def setUp(self):
         super(DeleteMessageTests, self).setUp()
-        self.user1 = user(save=True)
-        self.user2 = user(save=True)
+        self.user1 = UserFactory()
+        self.user2 = UserFactory()
         self.client.login(username=self.user1.username, password='testpass')
 
     def test_delete_inbox_message(self):
@@ -121,8 +121,8 @@ class OutboxTests(TestCase):
 
     def setUp(self):
         super(OutboxTests, self).setUp()
-        self.user1 = user(save=True)
-        self.user2 = user(save=True)
+        self.user1 = UserFactory()
+        self.user2 = UserFactory()
         self.client.login(username=self.user1.username, password='testpass')
 
     def test_message_without_recipients(self):

--- a/kitsune/notifications/tests/__init__.py
+++ b/kitsune/notifications/tests/__init__.py
@@ -1,21 +1,21 @@
+import factory
 from actstream.models import Action
 
 from kitsune.notifications.models import Notification
-from kitsune.users.tests import profile
-from kitsune.sumo.tests import with_save
+from kitsune.users.tests import UserFactory
 
 
-@with_save
-def notification(**kwargs):
-    """Create and return a notification."""
-    defaults = {
-        'read_at': None,
-    }
-    defaults.update(kwargs)
+class ActionFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Action
 
-    if 'owner' not in defaults:
-        defaults['owner'] = profile().user
-    if 'action' not in defaults:
-        defaults['action'] = Action.objects.create(actor=profile().user, verb='looked at')
+    actor = factory.SubFactory(UserFactory)
+    verb = 'looked at'
 
-    return Notification(**defaults)
+
+class NotificationFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Notification
+
+    owner = factory.SubFactory(UserFactory)
+    action = factory.SubFactory(ActionFactory)

--- a/kitsune/notifications/tests/test_models.py
+++ b/kitsune/notifications/tests/test_models.py
@@ -2,26 +2,26 @@ from datetime import datetime
 
 from nose.tools import eq_
 
-from kitsune.notifications.tests import notification
+from kitsune.notifications.tests import NotificationFactory
 from kitsune.sumo.tests import TestCase
 
 
 class TestNotificationModel(TestCase):
 
     def test_is_read_false(self):
-        n = notification(read_at=None, save=True)
+        n = NotificationFactory(read_at=None)
         eq_(n.is_read, False)
 
     def test_is_read_true(self):
-        n = notification(read_at=datetime.now(), save=True)
+        n = NotificationFactory(read_at=datetime.now())
         eq_(n.is_read, True)
 
     def test_set_is_read_true(self):
-        n = notification(read_at=None, save=True)
+        n = NotificationFactory(read_at=None)
         n.is_read = True
         assert n.read_at is not None
 
     def test_set_is_read_false(self):
-        n = notification(read_at=datetime.now(), save=True)
+        n = NotificationFactory(read_at=datetime.now())
         n.is_read = False
         assert n.read_at is None

--- a/kitsune/postcrash/tests/__init__.py
+++ b/kitsune/postcrash/tests/__init__.py
@@ -1,0 +1,13 @@
+import factory
+
+from kitsune.postcrash.models import Signature
+from kitsune.sumo.tests import FuzzyUnicode
+from kitsune.wiki.tests import DocumentFactory
+
+
+class SignatureFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Signature
+
+    document = factory.SubFactory(DocumentFactory)
+    signature = FuzzyUnicode()

--- a/kitsune/postcrash/tests/test_models.py
+++ b/kitsune/postcrash/tests/test_models.py
@@ -1,13 +1,10 @@
 from nose.tools import eq_
 
-from kitsune.postcrash.models import Signature
+from kitsune.postcrash.tests import SignatureFactory
 from kitsune.sumo.tests import TestCase
-from kitsune.wiki.tests import document
 
 
 class SignatureTests(TestCase):
     def test_get_absolute_url(self):
-        doc = document(slug='foo-bar')
-        doc.save()
-        sig = Signature(signature='baz', document=doc)
+        sig = SignatureFactory(document__slug='foo-bar')
         eq_('/kb/foo-bar', sig.get_absolute_url())

--- a/kitsune/postcrash/tests/test_views.py
+++ b/kitsune/postcrash/tests/test_views.py
@@ -1,10 +1,9 @@
 from nose.tools import eq_
 
-from kitsune.postcrash.models import Signature
+from kitsune.postcrash.tests import SignatureFactory
 from kitsune.sumo.helpers import urlparams
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.wiki.tests import document
 
 
 class ApiTests(TestCase):
@@ -22,13 +21,9 @@ class ApiTests(TestCase):
         eq_('text/plain', response['content-type'])
 
     def test_known_signature(self):
-        slug = 'foo'
-        doc = document(slug=slug)
-        doc.save()
-        sig = Signature(signature=slug, document=doc)
-        sig.save()
-        url = urlparams(reverse('postcrash.api'), s=slug)
+        sig = SignatureFactory()
+        url = urlparams(reverse('postcrash.api'), s=sig.signature)
         response = self.client.get(url)
         eq_(200, response.status_code)
-        eq_('https://example.com/kb/%s' % slug, response.content)
+        eq_('https://example.com/kb/%s' % sig.document.slug, response.content)
         eq_('text/plain', response['content-type'])

--- a/kitsune/products/tests/test_models.py
+++ b/kitsune/products/tests/test_models.py
@@ -1,6 +1,6 @@
 from nose.tools import eq_
 
-from kitsune.products.tests import product, topic
+from kitsune.products.tests import ProductFactory, TopicFactory
 from kitsune.sumo.tests import TestCase
 
 
@@ -8,26 +8,26 @@ class TopicModelTests(TestCase):
 
     def test_path(self):
         """Verify that the path property works."""
-        p = product(slug='p', save=True)
-        t1 = topic(product=p, slug='t1', save=True)
-        t2 = topic(product=p, slug='t2', parent=t1, save=True)
-        t3 = topic(product=p, slug='t3', parent=t2, save=True)
+        p = ProductFactory(slug='p')
+        t1 = TopicFactory(product=p, slug='t1')
+        t2 = TopicFactory(product=p, slug='t2', parent=t1)
+        t3 = TopicFactory(product=p, slug='t3', parent=t2)
 
         eq_(t1.path, [t1.slug])
         eq_(t2.path, [t1.slug, t2.slug])
         eq_(t3.path, [t1.slug, t2.slug, t3.slug])
 
     def test_absolute_url(self):
-        p = product(save=True)
-        t = topic(product=p, save=True)
+        p = ProductFactory()
+        t = TopicFactory(product=p)
         expected = '/products/{p}/{t}'.format(p=p.slug, t=t.slug)
         actual = t.get_absolute_url()
         eq_(actual, expected)
 
     def test_absolute_url_subtopic(self):
-        p = product(save=True)
-        t1 = topic(product=p, save=True)
-        t2 = topic(parent=t1, product=p, save=True)
+        p = ProductFactory()
+        t1 = TopicFactory(product=p)
+        t2 = TopicFactory(parent=t1, product=p)
         expected = '/products/{p}/{t1}/{t2}'.format(p=p.slug, t1=t1.slug, t2=t2.slug)
         actual = t2.get_absolute_url()
         eq_(actual, expected)
@@ -36,7 +36,7 @@ class TopicModelTests(TestCase):
 class ProductModelTests(TestCase):
 
     def test_absolute_url(self):
-        p = product(save=True)
+        p = ProductFactory()
         expected = '/products/{p}'.format(p=p.slug)
         actual = p.get_absolute_url()
         eq_(actual, expected)

--- a/kitsune/products/tests/test_templates.py
+++ b/kitsune/products/tests/test_templates.py
@@ -5,11 +5,11 @@ from nose.tools import eq_
 from pyquery import PyQuery as pq
 
 from kitsune.products.models import HOT_TOPIC_SLUG
-from kitsune.products.tests import product, topic
+from kitsune.products.tests import ProductFactory, TopicFactory
 from kitsune.questions.models import QuestionLocale
 from kitsune.search.tests.test_es import ElasticTestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.wiki.tests import revision, helpful_vote
+from kitsune.wiki.tests import DocumentFactory, ApprovedRevisionFactory, HelpfulVoteFactory
 
 
 class ProductViewsTestCase(ElasticTestCase):
@@ -18,7 +18,7 @@ class ProductViewsTestCase(ElasticTestCase):
         """Verify that /products page renders products."""
         # Create some products.
         for i in range(3):
-            p = product(save=True)
+            p = ProductFactory(visible=True)
             l = QuestionLocale.objects.get(locale=settings.LANGUAGE_CODE)
             p.questions_locales.add(l)
 
@@ -31,21 +31,17 @@ class ProductViewsTestCase(ElasticTestCase):
     def test_product_landing(self):
         """Verify that /products/<slug> page renders topics."""
         # Create a product.
-        p = product(save=True)
+        p = ProductFactory()
         l = QuestionLocale.objects.get(locale=settings.LANGUAGE_CODE)
         p.questions_locales.add(l)
 
         # Create some topics.
-        topic(slug=HOT_TOPIC_SLUG, product=p, save=True)
-        topics = []
-        for i in range(11):
-            topics.append(topic(product=p, save=True))
+        TopicFactory(slug=HOT_TOPIC_SLUG, product=p, visible=True)
+        topics = TopicFactory.create_batch(11, product=p, visible=True)
 
         # Create a document and assign the product and 10 topics.
-        doc = revision(is_approved=True, save=True).document
-        doc.products.add(p)
-        for i in range(10):
-            doc.topics.add(topics[i])
+        d = DocumentFactory(products=[p], topics=topics[:10])
+        ApprovedRevisionFactory(document=d)
 
         self.refresh()
 
@@ -60,16 +56,12 @@ class ProductViewsTestCase(ElasticTestCase):
     def test_document_listing(self):
         """Verify /products/<product slug>/<topic slug> renders articles."""
         # Create a topic and product.
-        p = product(save=True)
-        t1 = topic(product=p, save=True)
+        p = ProductFactory()
+        t1 = TopicFactory(product=p)
 
         # Create 3 documents with the topic and product and one without.
-        for i in range(3):
-            doc = revision(is_approved=True, save=True).document
-            doc.topics.add(t1)
-            doc.products.add(p)
-
-        doc = revision(is_approved=True, save=True).document
+        ApprovedRevisionFactory.create_batch(3, document__products=[p], document__topics=[t1])
+        ApprovedRevisionFactory()
 
         self.refresh()
 
@@ -84,13 +76,12 @@ class ProductViewsTestCase(ElasticTestCase):
     def test_document_listing_order(self):
         """Verify documents are sorted by display_order and number of helpful votes."""
         # Create topic, product and documents.
-        p = product(save=True)
-        t = topic(product=p, save=True)
+        p = ProductFactory()
+        t = TopicFactory(product=p)
         docs = []
         for i in range(3):
-            doc = revision(is_approved=True, save=True).document
-            doc.topics.add(t)
-            doc.products.add(p)
+            doc = DocumentFactory(products=[p], topics=[t])
+            ApprovedRevisionFactory(document=doc)
             docs.append(doc)
 
         # Add a lower display order to the second document. It should be first now.
@@ -106,7 +97,7 @@ class ProductViewsTestCase(ElasticTestCase):
 
         # Add a helpful vote to the third document. It should be second now.
         rev = docs[2].current_revision
-        helpful_vote(revision=rev, helpful=True, save=True)
+        HelpfulVoteFactory(revision=rev, helpful=True)
         docs[2].save()  # Votes don't trigger a reindex.
         self.refresh()
         cache.clear()  # documents_for() is cached
@@ -119,8 +110,8 @@ class ProductViewsTestCase(ElasticTestCase):
 
         # Add 2 helpful votes the first document. It should be second now.
         rev = docs[0].current_revision
-        helpful_vote(revision=rev, helpful=True, save=True)
-        helpful_vote(revision=rev, helpful=True, save=True)
+        HelpfulVoteFactory(revision=rev, helpful=True)
+        HelpfulVoteFactory(revision=rev, helpful=True)
         docs[0].save()  # Votes don't trigger a reindex.
         self.refresh()
         cache.clear()  # documents_for() is cached
@@ -133,13 +124,12 @@ class ProductViewsTestCase(ElasticTestCase):
     def test_subtopics(self):
         """Verifies subtopics appear on document listing page."""
         # Create a topic and product.
-        p = product(save=True)
-        t = topic(product=p, save=True)
+        p = ProductFactory()
+        t = TopicFactory(product=p, visible=True)
 
         # Create a documents with the topic and product
-        doc = revision(is_approved=True, save=True).document
-        doc.topics.add(t)
-        doc.products.add(p)
+        doc = DocumentFactory(products=[p], topics=[t])
+        ApprovedRevisionFactory(document=doc)
 
         self.refresh()
 
@@ -152,7 +142,7 @@ class ProductViewsTestCase(ElasticTestCase):
 
         # Create a subtopic, it still shouldn't show up because no
         # articles are assigned.
-        subtopic = topic(parent=t, product=p, save=True)
+        subtopic = TopicFactory(parent=t, product=p, visible=True)
         r = self.client.get(url, follow=True)
         eq_(200, r.status_code)
         pqdoc = pq(r.content)

--- a/kitsune/products/tests/test_templates.py
+++ b/kitsune/products/tests/test_templates.py
@@ -79,6 +79,8 @@ class ProductViewsTestCase(ElasticTestCase):
         p = ProductFactory()
         t = TopicFactory(product=p)
         docs = []
+        # FIXME: Can't we do this with create_batch and build the document
+        # in the approvedrevisionfactory
         for i in range(3):
             doc = DocumentFactory(products=[p], topics=[t])
             ApprovedRevisionFactory(document=doc)

--- a/kitsune/questions/tests/test_badges.py
+++ b/kitsune/questions/tests/test_badges.py
@@ -1,11 +1,10 @@
 from datetime import date
 
-from kitsune.kbadge.tests import badge
-from kitsune.questions.models import Answer
+from kitsune.kbadge.tests import BadgeFactory
 from kitsune.questions.badges import QUESTIONS_BADGES
-from kitsune.questions.tests import answer, question
+from kitsune.questions.tests import AnswerFactory
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import profile
+from kitsune.users.tests import UserFactory
 
 
 class TestQuestionsBadges(TestCase):
@@ -14,29 +13,21 @@ class TestQuestionsBadges(TestCase):
         """Verify the Support Forum Badge is awarded properly."""
         # Create the user and badge.
         year = date.today().year
-        u = profile().user
+        u = UserFactory()
         badge_template = QUESTIONS_BADGES['answer-badge']
-        b = badge(
+        b = BadgeFactory(
             slug=badge_template['slug'].format(year=year),
             title=badge_template['title'].format(year=year),
-            description=badge_template['description'].format(year=year),
-            save=True)
+            description=badge_template['description'].format(year=year))
 
         # Create 29 answers.
-        q = question(save=True)
-        answers = []
-        for i in range(28):
-            answers.append(answer(question=q, creator=u))
-        Answer.objects.bulk_create(answers)
-
-        # Create the 29th answer separately so the signals are triggered.
-        answer(creator=u, save=True)
+        AnswerFactory.create_batch(29, creator=u)
 
         # User should NOT have the badge yet.
         assert not b.is_awarded_to(u)
 
         # Create 1 more answer.
-        answer(creator=u, save=True)
+        AnswerFactory(creator=u)
 
         # User should have the badge now.
         assert b.is_awarded_to(u)

--- a/kitsune/questions/tests/test_cron.py
+++ b/kitsune/questions/tests/test_cron.py
@@ -5,14 +5,14 @@ from django.core import mail
 import mock
 from nose.tools import eq_
 
-from kitsune.products.tests import product
 import kitsune.questions.tasks
+from kitsune.products.tests import ProductFactory
 from kitsune.questions import config
 from kitsune.questions.cron import escalate_questions, report_employee_answers
-from kitsune.questions.tests import answer, question
+from kitsune.questions.tests import AnswerFactory, QuestionFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.users.models import Group
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class TestEscalateCron(TestCase):
@@ -23,71 +23,49 @@ class TestEscalateCron(TestCase):
 
         questions_to_escalate = [
             # Questions over 24 hours old without an answer.
-            question(
-                created=datetime.now() - timedelta(hours=24, minutes=10),
-                save=True),
-            question(
-                created=datetime.now() - timedelta(hours=24, minutes=50),
-                save=True),
+            QuestionFactory(created=datetime.now() - timedelta(hours=24, minutes=10)),
+            QuestionFactory(created=datetime.now() - timedelta(hours=24, minutes=50)),
         ]
 
         # Question about Firefox OS
-        fxos = product(slug='firefox-os', save=True)
-        q = question(
-            created=datetime.now() - timedelta(hours=24, minutes=10),
-            product=fxos,
-            save=True)
+        fxos = ProductFactory(slug='firefox-os')
+        q = QuestionFactory(created=datetime.now() - timedelta(hours=24, minutes=10), product=fxos)
         questions_to_escalate.append(q)
 
         # Questions not to escalate
 
         # Questions newer than 24 hours without an answer.
-        question(save=True)
-        question(created=datetime.now() - timedelta(hours=11), save=True)
-        question(created=datetime.now() - timedelta(hours=21), save=True)
+        QuestionFactory()
+        QuestionFactory(created=datetime.now() - timedelta(hours=11))
+        QuestionFactory(created=datetime.now() - timedelta(hours=21))
 
         # Questions older than 25 hours (The cronjob runs once an hour)
-        question(created=datetime.now() - timedelta(hours=26), save=True)
+        QuestionFactory(created=datetime.now() - timedelta(hours=26))
 
         # Question in the correct time range, but not in the default language.
-        question(created=datetime.now() - timedelta(hours=24, minutes=10), locale='de', save=True)
+        QuestionFactory(created=datetime.now() - timedelta(hours=24, minutes=10), locale='de')
 
         # Question older than 24 hours with a recent answer.
-        q = question(
-            created=datetime.now() - timedelta(hours=24, minutes=10),
-            save=True)
-        answer(created=datetime.now() - timedelta(hours=10), question=q,
-               save=True)
-        answer(created=datetime.now() - timedelta(hours=1), creator=q.creator,
-               question=q, save=True)
+        q = QuestionFactory(created=datetime.now() - timedelta(hours=24, minutes=10))
+        AnswerFactory(created=datetime.now() - timedelta(hours=10), question=q)
+        AnswerFactory(created=datetime.now() - timedelta(hours=1), creator=q.creator, question=q)
 
         # Question older than 24 hours with a recent answer by the asker.
-        q = question(
-            created=datetime.now() - timedelta(hours=24, minutes=10),
-            save=True)
-        answer(
-            created=datetime.now() - timedelta(hours=15), creator=q.creator,
-            question=q, save=True)
+        q = QuestionFactory(created=datetime.now() - timedelta(hours=24, minutes=10))
+        AnswerFactory(created=datetime.now() - timedelta(hours=15), creator=q.creator, question=q)
 
         # Question older than 24 hours without an answer already escalated.
-        q = question(
-            created=datetime.now() - timedelta(hours=24, minutes=10),
-            save=True)
+        q = QuestionFactory(created=datetime.now() - timedelta(hours=24, minutes=10))
         q.tags.add(config.ESCALATE_TAG_NAME)
 
         # Question with an inactive user.
-        q = question(
-            created=datetime.now() - timedelta(hours=24, minutes=10),
-            save=True)
-        q.creator.is_active = False
-        q.creator.save()
+        q = QuestionFactory(
+            creator__is_active=False,
+            created=datetime.now() - timedelta(hours=24, minutes=10))
 
         # Question about Thunderbird, which is one of the products we exclude.
-        tb = product(slug='thunderbird', save=True)
-        q = question(
-            created=datetime.now() - timedelta(hours=24, minutes=10),
-            product=tb,
-            save=True)
+        tb = ProductFactory(slug='thunderbird')
+        q = QuestionFactory(created=datetime.now() - timedelta(hours=24, minutes=10), product=tb)
 
         # Run the cron job and verify only 3 questions were escalated.
         eq_(len(questions_to_escalate), escalate_questions())
@@ -101,30 +79,30 @@ class TestEmployeeReportCron(TestCase):
         # two groups here: 'Support Forum Tracked', 'Support Forum Metrics'
 
         tracked_group = Group.objects.get(name='Support Forum Tracked')
-        tracked_user = user(save=True)
+        tracked_user = UserFactory()
         tracked_user.groups.add(tracked_group)
 
         report_group = Group.objects.get(name='Support Forum Metrics')
-        report_user = user(save=True)
+        report_user = UserFactory()
         report_user.groups.add(report_group)
 
         # An unanswered question that should get reported
-        question(created=datetime.now() - timedelta(days=2), save=True)
+        QuestionFactory(created=datetime.now() - timedelta(days=2))
 
         # An answered question that should get reported
-        q = question(created=datetime.now() - timedelta(days=2), save=True)
-        answer(question=q, save=True)
+        q = QuestionFactory(created=datetime.now() - timedelta(days=2))
+        AnswerFactory(question=q)
 
         # A question answered by a tracked user that should get reported
-        q = question(created=datetime.now() - timedelta(days=2), save=True)
-        answer(creator=tracked_user, question=q, save=True)
+        q = QuestionFactory(created=datetime.now() - timedelta(days=2))
+        AnswerFactory(creator=tracked_user, question=q)
 
         # More questions that shouldn't get reported
-        q = question(created=datetime.now() - timedelta(days=3), save=True)
-        answer(creator=tracked_user, question=q, save=True)
-        q = question(created=datetime.now() - timedelta(days=1), save=True)
-        answer(question=q, save=True)
-        question(save=True)
+        q = QuestionFactory(created=datetime.now() - timedelta(days=3))
+        AnswerFactory(creator=tracked_user, question=q)
+        q = QuestionFactory(created=datetime.now() - timedelta(days=1))
+        AnswerFactory(question=q)
+        QuestionFactory()
 
         report_employee_answers()
 

--- a/kitsune/questions/tests/test_feeds.py
+++ b/kitsune/questions/tests/test_feeds.py
@@ -7,20 +7,20 @@ from pyquery import PyQuery as pq
 
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.sumo.helpers import urlparams
-from kitsune.products.tests import product, topic
+from kitsune.products.tests import ProductFactory, TopicFactory
 from kitsune.questions.feeds import QuestionsFeed, TaggedQuestionsFeed
 from kitsune.questions.models import Question
-from kitsune.questions.tests import TestCaseBase, question
-from kitsune.tags.tests import tag
-from kitsune.users.tests import user
+from kitsune.questions.tests import TestCaseBase, QuestionFactory
+from kitsune.tags.tests import TagFactory
+from kitsune.users.tests import UserFactory
 
 
 class ForumTestFeeds(TestCaseBase):
 
     def test_tagged_feed(self):
         """Test the tagged feed."""
-        t = tag(name='green', slug='green', save=True)
-        q = question(save=True)
+        t = TagFactory(name='green', slug='green')
+        q = QuestionFactory()
         q.tags.add('green')
         items = TaggedQuestionsFeed().items(t)
         eq_(1, len(items))
@@ -28,7 +28,7 @@ class ForumTestFeeds(TestCaseBase):
 
         cache.clear()
 
-        q = question(save=True)
+        q = QuestionFactory()
         q.tags.add('green')
         q.updated = datetime.now() + timedelta(days=1)
         q.save()
@@ -38,7 +38,7 @@ class ForumTestFeeds(TestCaseBase):
 
     def test_tagged_feed_link(self):
         """Make sure the tagged feed is discoverable on the questions page."""
-        tag(name='green', slug='green', save=True)
+        TagFactory(name='green', slug='green')
         url = urlparams(reverse('questions.list', args=['all']),
                         tagged='green')
         response = self.client.get(url)
@@ -55,7 +55,7 @@ class ForumTestFeeds(TestCaseBase):
 
     def test_no_inactive_users(self):
         """Ensure that inactive users' questions don't appear in the feed."""
-        u = user(is_active=False, save=True)
+        u = UserFactory(is_active=False)
 
         q = Question(title='Test Question', content='Lorem Ipsum Dolor',
                      creator_id=u.id)
@@ -64,7 +64,7 @@ class ForumTestFeeds(TestCaseBase):
 
     def test_question_feed_with_product(self):
         """Test that questions feeds with products work."""
-        p = product(save=True)
+        p = ProductFactory()
         url = reverse('questions.list', args=[p.slug])
         res = self.client.get(url)
         eq_(200, res.status_code)
@@ -79,8 +79,8 @@ class ForumTestFeeds(TestCaseBase):
 
     def test_question_feed_with_product_and_topic(self):
         """Test that questions feeds with products and topics work."""
-        p = product(save=True)
-        t = topic(product=p, save=True)
+        p = ProductFactory()
+        t = TopicFactory(product=p)
         url = urlparams(reverse('questions.list', args=[p.slug]), topic=t.slug)
         res = self.client.get(url)
         eq_(200, res.status_code)

--- a/kitsune/questions/tests/test_forms.py
+++ b/kitsune/questions/tests/test_forms.py
@@ -4,7 +4,7 @@ from nose.tools import eq_
 
 from kitsune.questions.forms import NewQuestionForm, WatchQuestionForm
 from kitsune.questions.tests import TestCaseBase
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class WatchQuestionFormTests(TestCaseBase):
@@ -22,13 +22,14 @@ class WatchQuestionFormTests(TestCaseBase):
         eq_('Please provide an email.', form.errors['email'][0])
 
     def test_registered_watch_with_email(self):
-        form = WatchQuestionForm(user(), data={'email': 'wo@ot.com',
-                                               'event_type': 'reply'})
+        form = WatchQuestionForm(
+            UserFactory(),
+            data={'email': 'wo@ot.com', 'event_type': 'reply'})
         assert form.is_valid()
         assert not form.cleaned_data['email']
 
     def test_registered_watch_without_email(self):
-        form = WatchQuestionForm(user(), data={'event_type': 'reply'})
+        form = WatchQuestionForm(UserFactory(), data={'event_type': 'reply'})
         assert form.is_valid()
 
 

--- a/kitsune/questions/tests/test_managers.py
+++ b/kitsune/questions/tests/test_managers.py
@@ -2,9 +2,9 @@ from nose.tools import eq_
 
 from kitsune.questions import config
 from kitsune.questions.models import Question
-from kitsune.questions.tests import answer, question
+from kitsune.questions.tests import AnswerFactory, QuestionFactory
 from kitsune.sumo.tests import TestCase
-from kitsune.tags.tests import tag
+from kitsune.tags.tests import TagFactory
 
 
 class QuestionManagerTestCase(TestCase):
@@ -12,11 +12,11 @@ class QuestionManagerTestCase(TestCase):
     def test_done(self):
         """Verify the done queryset."""
         # Create a question, there shouldn't be any done yet.
-        q = question(save=True)
+        q = QuestionFactory()
         eq_(0, Question.objects.done().count())
 
         # Add an answer, there shouldn't be any done yet.
-        a = answer(question=q, save=True)
+        a = AnswerFactory(question=q)
         eq_(0, Question.objects.done().count())
 
         # Make it the solution, there should be one done.
@@ -25,25 +25,25 @@ class QuestionManagerTestCase(TestCase):
         eq_(1, Question.objects.done().count())
 
         # Create a locked questions, there should be two done.
-        question(is_locked=True, save=True)
+        QuestionFactory(is_locked=True)
         eq_(2, Question.objects.done().count())
 
     def test_responded(self):
         """Verify the responded queryset."""
         # Create a question, there shouldn't be any responded yet.
-        q = question(save=True)
+        q = QuestionFactory()
         eq_(0, Question.objects.responded().count())
 
         # Add an answer, there should be one responded.
-        a = answer(question=q, save=True)
+        a = AnswerFactory(question=q)
         eq_(1, Question.objects.responded().count())
 
         # Add an answer by the creator, there should be none responded.
-        a = answer(creator=q.creator, question=q, save=True)
+        a = AnswerFactory(creator=q.creator, question=q)
         eq_(0, Question.objects.responded().count())
 
         # Add another answer, there should be one responded.
-        a = answer(question=q, save=True)
+        a = AnswerFactory(question=q)
         eq_(1, Question.objects.responded().count())
 
         # Lock it, there should be none responded.
@@ -60,15 +60,15 @@ class QuestionManagerTestCase(TestCase):
     def test_needs_attention(self):
         """Verify the needs_attention queryset."""
         # Create a question, there shouldn't be one needs_attention.
-        q = question(save=True)
+        q = QuestionFactory()
         eq_(1, Question.objects.needs_attention().count())
 
         # Add an answer, there should be no needs_attention.
-        a = answer(question=q, save=True)
+        a = AnswerFactory(question=q)
         eq_(0, Question.objects.needs_attention().count())
 
         # Add an answer by the creator, there should be one needs_attention.
-        a = answer(creator=q.creator, question=q, save=True)
+        a = AnswerFactory(creator=q.creator, question=q)
         eq_(1, Question.objects.needs_attention().count())
 
         # Lock it, there should be none responded.
@@ -84,7 +84,7 @@ class QuestionManagerTestCase(TestCase):
 
     def test_needs_info(self):
         """Verify the needs_info queryset."""
-        q = question(save=True)
+        q = QuestionFactory()
 
         # There should be no needs_info questions yet.
         eq_(0, Question.objects.needs_info().count())
@@ -99,11 +99,8 @@ class QuestionManagerTestCase(TestCase):
 
     def test_escalated(self):
         """Verify the escalated queryset."""
-        t = tag(
-            name=config.ESCALATE_TAG_NAME,
-            slug=config.ESCALATE_TAG_NAME,
-            save=True)
-        q = question(save=True)
+        t = TagFactory(name=config.ESCALATE_TAG_NAME, slug=config.ESCALATE_TAG_NAME)
+        q = QuestionFactory()
 
         # There should be no escalated questions yet.
         eq_(0, Question.objects.escalated().count())

--- a/kitsune/questions/tests/test_marketplace.py
+++ b/kitsune/questions/tests/test_marketplace.py
@@ -7,7 +7,7 @@ import kitsune.questions.forms
 from kitsune import questions
 from kitsune.questions.marketplace import submit_ticket
 from kitsune.sumo.tests import TestCase, LocalizingClient, get, post
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class MarketplaceAaqTests(TestCase):
@@ -16,7 +16,7 @@ class MarketplaceAaqTests(TestCase):
     def setUp(self):
         super(MarketplaceAaqTests, self).setUp()
 
-        self.user = user(email='s@s.com', save=True)
+        self.user = UserFactory(email='s@s.com')
         self.client.login(username=self.user.username, password='testpass')
 
     def test_aaq_page(self):

--- a/kitsune/questions/tests/test_tasks.py
+++ b/kitsune/questions/tests/test_tasks.py
@@ -5,7 +5,7 @@ from nose.tools import eq_
 from kitsune.questions.models import (
     Question, QuestionVote, send_vote_update_task)
 from kitsune.questions.tasks import update_question_vote_chunk
-from kitsune.questions.tests import question, questionvote
+from kitsune.questions.tests import QuestionFactory, QuestionVoteFactory
 from kitsune.sumo.tests import TestCase
 
 
@@ -20,19 +20,19 @@ class QuestionVoteTestCase(TestCase):
     def test_update_question_vote_chunk(self):
         # Reset the num_votes_past_week counts, I suspect the data gets
         # loaded before I disconnect the signal and they get zeroed out.
-        q1 = question(save=True)
-        questionvote(question=q1, save=True)
+        q1 = QuestionFactory()
+        QuestionVoteFactory(question=q1)
         q1.num_votes_past_week = 1
         q1.save()
 
-        q2 = question(save=True)
+        q2 = QuestionFactory()
 
         # Actually test the task.
         qs = Question.objects.all().order_by('-num_votes_past_week')
         eq_(q1.pk, qs[0].pk)
 
-        questionvote(question=q2, save=True)
-        questionvote(question=q2, save=True)
+        QuestionVoteFactory(question=q2)
+        QuestionVoteFactory(question=q2)
         qs = Question.objects.all().order_by('-num_votes_past_week')
         eq_(q1.pk, qs[0].pk)
 

--- a/kitsune/questions/tests/test_utils.py
+++ b/kitsune/questions/tests/test_utils.py
@@ -1,23 +1,23 @@
 from nose.tools import eq_
 
 from kitsune.questions.models import Question, Answer
-from kitsune.questions.tests import question, answer
+from kitsune.questions.tests import QuestionFactory, AnswerFactory
 from kitsune.questions.utils import (
     num_questions, num_answers, num_solutions, mark_content_as_spam)
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class ContributionCountTestCase(TestCase):
     def test_num_questions(self):
         """Answers are counted correctly on a user."""
-        u = user(save=True)
+        u = UserFactory()
         eq_(num_questions(u), 0)
 
-        q1 = question(creator=u, save=True)
+        q1 = QuestionFactory(creator=u)
         eq_(num_questions(u), 1)
 
-        q2 = question(creator=u, save=True)
+        q2 = QuestionFactory(creator=u)
         eq_(num_questions(u), 2)
 
         q1.delete()
@@ -27,14 +27,14 @@ class ContributionCountTestCase(TestCase):
         eq_(num_questions(u), 0)
 
     def test_num_answers(self):
-        u = user(save=True)
-        q = question(save=True)
+        u = UserFactory()
+        q = QuestionFactory()
         eq_(num_answers(u), 0)
 
-        a1 = answer(creator=u, question=q, save=True)
+        a1 = AnswerFactory(creator=u, question=q)
         eq_(num_answers(u), 1)
 
-        a2 = answer(creator=u, question=q, save=True)
+        a2 = AnswerFactory(creator=u, question=q)
         eq_(num_answers(u), 2)
 
         a1.delete()
@@ -44,11 +44,11 @@ class ContributionCountTestCase(TestCase):
         eq_(num_answers(u), 0)
 
     def test_num_solutions(self):
-        u = user(save=True)
-        q1 = question(save=True)
-        q2 = question(save=True)
-        a1 = answer(creator=u, question=q1, save=True)
-        a2 = answer(creator=u, question=q2, save=True)
+        u = UserFactory()
+        q1 = QuestionFactory()
+        q2 = QuestionFactory()
+        a1 = AnswerFactory(creator=u, question=q1)
+        a2 = AnswerFactory(creator=u, question=q2)
         eq_(num_solutions(u), 0)
 
         q1.solution = a1
@@ -71,12 +71,12 @@ class FlagUserContentAsSpamTestCase(TestCase):
 
     def test_flag_content_as_spam(self):
         # Create some questions and answers by the user.
-        u = user(save=True)
-        question(creator=u, save=True)
-        question(creator=u, save=True)
-        answer(creator=u, save=True)
-        answer(creator=u, save=True)
-        answer(creator=u, save=True)
+        u = UserFactory()
+        QuestionFactory(creator=u)
+        QuestionFactory(creator=u)
+        AnswerFactory(creator=u)
+        AnswerFactory(creator=u)
+        AnswerFactory(creator=u)
 
         # Verify they are not marked as spam yet.
         eq_(2, Question.objects.filter(is_spam=False, creator=u).count())
@@ -85,7 +85,7 @@ class FlagUserContentAsSpamTestCase(TestCase):
         eq_(0, Answer.objects.filter(is_spam=True, creator=u).count())
 
         # Flag content as spam and verify it is updated.
-        mark_content_as_spam(u, user(save=True))
+        mark_content_as_spam(u, UserFactory())
         eq_(0, Question.objects.filter(is_spam=False, creator=u).count())
         eq_(2, Question.objects.filter(is_spam=True, creator=u).count())
         eq_(0, Answer.objects.filter(is_spam=False, creator=u).count())

--- a/kitsune/questions/tests/test_votes.py
+++ b/kitsune/questions/tests/test_votes.py
@@ -1,7 +1,7 @@
 from nose.tools import eq_
 
 from kitsune.questions.models import Question, QuestionMappingType
-from kitsune.questions.tests import TestCaseBase, question, questionvote
+from kitsune.questions.tests import TestCaseBase, QuestionFactory, QuestionVoteFactory
 from kitsune.questions.cron import update_weekly_votes
 from kitsune.search.tests.test_es import ElasticTestCase
 
@@ -10,19 +10,19 @@ class TestVotes(TestCaseBase):
     """Test QuestionVote counting and cron job."""
 
     def test_vote_updates_count(self):
-        q = question(save=True)
+        q = QuestionFactory()
         eq_(0, q.num_votes_past_week)
 
-        questionvote(question=q, anonymous_id='abc123', save=True)
+        QuestionVoteFactory(question=q, anonymous_id='abc123')
 
         q = Question.objects.get(id=q.id)
         eq_(1, q.num_votes_past_week)
 
     def test_cron_updates_counts(self):
-        q = question(save=True)
+        q = QuestionFactory()
         eq_(0, q.num_votes_past_week)
 
-        questionvote(question=q, anonymous_id='abc123', save=True)
+        QuestionVoteFactory(question=q, anonymous_id='abc123')
 
         q.num_votes_past_week = 0
         q.save()
@@ -35,7 +35,7 @@ class TestVotes(TestCaseBase):
 
 class TestVotesWithElasticSearch(ElasticTestCase):
     def test_cron_updates_counts(self):
-        q = question(save=True)
+        q = QuestionFactory()
         self.refresh()
 
         eq_(q.num_votes_past_week, 0)
@@ -47,8 +47,7 @@ class TestVotesWithElasticSearch(ElasticTestCase):
 
         eq_(document['question_num_votes_past_week'], 0)
 
-        vote = questionvote(question=q, anonymous_id='abc123')
-        vote.save()
+        QuestionVoteFactory(question=q, anonymous_id='abc123')
         q.num_votes_past_week = 0
         q.save()
 

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -1715,8 +1715,8 @@ def screen_share(request, question_id):
     if not question.allows_new_answer(request.user):
         raise PermissionDenied
 
-    content = _("I invited {user} to a screen sharing session, "
-                "and I'll give an update here once we are done.")
+    content = _(u"I invited {user} to a screen sharing session, "
+                u"and I'll give an update here once we are done.")
     answer = Answer(question=question, creator=request.user,
                     content=content.format(user=display_name(question.creator)))
     answer.save()

--- a/kitsune/search/tests/__init__.py
+++ b/kitsune/search/tests/__init__.py
@@ -2,11 +2,12 @@ from django.conf import settings
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
+import factory
 from elasticutils.contrib.django import get_es
 
 from kitsune.search import es_utils
 from kitsune.search.models import generate_tasks, Synonym
-from kitsune.sumo.tests import SkipTest, TestCase, with_save
+from kitsune.sumo.tests import SkipTest, TestCase
 
 
 # Dummy request for passing to question_searcher() and brethren.
@@ -75,11 +76,9 @@ class ElasticTestCase(TestCase):
             es_utils.delete_index(index)
 
 
-@with_save
-def synonym(**kwargs):
-    defaults = {
-        "from_words": "foo, bar",
-        "to_words": "baz",
-    }
-    defaults.update(kwargs)
-    return Synonym(**defaults)
+class SynonymFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Synonym
+
+    from_words = "foo, bar"
+    to_words = "baz"

--- a/kitsune/search/tests/test_api.py
+++ b/kitsune/search/tests/test_api.py
@@ -8,14 +8,15 @@ from django.conf import settings
 
 from kitsune.search.tests.test_es import ElasticTestCase
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.questions.tests import question, answer
-from kitsune.products.tests import product
-from kitsune.wiki.tests import document, revision
+from kitsune.questions.tests import QuestionFactory, AnswerFactory
+from kitsune.products.tests import ProductFactory
+from kitsune.wiki.tests import DocumentFactory, RevisionFactory
 
 
 class SuggestViewTests(ElasticTestCase):
     client_class = APIClient
 
+    # TODO: This should probably be a subclass of QuestionFactory
     def _make_question(self, solved=True, **kwargs):
         defaults = {
             'title': 'Login to website comments disabled ' + str(time.time()),
@@ -37,27 +38,26 @@ class SuggestViewTests(ElasticTestCase):
 
                 Why this inability to login to this website commentary?
                 """,
-            'save': True,
         }
         defaults.update(kwargs)
-        q = question(**defaults)
+        q = QuestionFactory(**defaults)
         if solved:
-            a = answer(question=q, save=True)
+            a = AnswerFactory(question=q)
             q.solution = a
         # Trigger a reindex for the question.
         q.save()
         return q
 
+    # TODO: This should probably be a subclass of DocumentFactory
     def _make_document(self, **kwargs):
         defaults = {
             'title': 'How to make a pie from scratch with email ' + str(time.time()),
             'category': 10,
-            'save': True
         }
 
         defaults.update(kwargs)
-        d = document(**defaults)
-        revision(document=d, is_approved=True, save=True)
+        d = DocumentFactory(**defaults)
+        RevisionFactory(document=d, is_approved=True)
         d.save()
         return d
 
@@ -214,8 +214,8 @@ class SuggestViewTests(ElasticTestCase):
         eq_(len(req.data['documents']), 3)
 
     def test_product_filter_works(self):
-        p1 = product(save=True)
-        p2 = product(save=True)
+        p1 = ProductFactory()
+        p2 = ProductFactory()
         q1 = self._make_question(product=p1)
         self._make_question(product=p2)
         self.refresh()

--- a/kitsune/search/tests/test_cmds.py
+++ b/kitsune/search/tests/test_cmds.py
@@ -2,11 +2,11 @@ from django.core.management import call_command
 
 import mock
 
-from kitsune.products.tests import product
+from kitsune.products.tests import ProductFactory
 from kitsune.search import es_utils
 from kitsune.search.tests import ElasticTestCase
 from kitsune.search.utils import FakeLogger
-from kitsune.wiki.tests import document, revision
+from kitsune.wiki.tests import DocumentFactory, RevisionFactory
 
 
 class ESCommandTests(ElasticTestCase):
@@ -15,10 +15,9 @@ class ESCommandTests(ElasticTestCase):
         """Test that es_search command doesn't fail"""
         call_command('essearch', 'cupcakes')
 
-        doc = document(title=u'cupcakes rock', locale=u'en-US', category=10,
-                       save=True)
-        doc.products.add(product(title=u'firefox', slug=u'desktop', save=True))
-        revision(document=doc, is_approved=True, save=True)
+        p = ProductFactory(title=u'firefox', slug=u'desktop')
+        doc = DocumentFactory(title=u'cupcakes rock', locale=u'en-US', category=10, products=[p])
+        RevisionFactory(document=doc, is_approved=True)
 
         self.refresh()
 
@@ -26,10 +25,9 @@ class ESCommandTests(ElasticTestCase):
 
     @mock.patch.object(FakeLogger, '_out')
     def test_reindex(self, _out):
-        doc = document(title=u'cupcakes rock', locale=u'en-US', category=10,
-                       save=True)
-        doc.products.add(product(title=u'firefox', slug=u'desktop', save=True))
-        revision(document=doc, is_approved=True, save=True)
+        p = ProductFactory(title=u'firefox', slug=u'desktop')
+        doc = DocumentFactory(title=u'cupcakes rock', locale=u'en-US', category=10, products=[p])
+        RevisionFactory(document=doc, is_approved=True)
 
         self.refresh()
 
@@ -41,10 +39,9 @@ class ESCommandTests(ElasticTestCase):
 
     @mock.patch.object(FakeLogger, '_out')
     def test_status(self, _out):
-        doc = document(title=u'cupcakes rock', locale=u'en-US', category=10,
-                       save=True)
-        doc.products.add(product(title=u'firefox', slug=u'desktop', save=True))
-        revision(document=doc, is_approved=True, save=True)
+        p = ProductFactory(title=u'firefox', slug=u'desktop')
+        doc = DocumentFactory(title=u'cupcakes rock', locale=u'en-US', category=10, products=[p])
+        RevisionFactory(document=doc, is_approved=True)
 
         self.refresh()
 

--- a/kitsune/search/tests/test_search_advanced.py
+++ b/kitsune/search/tests/test_search_advanced.py
@@ -6,15 +6,17 @@ from django.contrib.contenttypes.models import ContentType
 from nose.tools import eq_
 
 from kitsune import search as constants
-from kitsune.access.tests import permission
-from kitsune.forums.tests import forum, post, restricted_forum, thread
-from kitsune.products.tests import product, topic
-from kitsune.questions.tests import question, answer, answervote, questionvote
+from kitsune.access.tests import PermissionFactory
+from kitsune.forums.tests import ForumFactory, PostFactory, RestrictedForumFactory, ThreadFactory
+from kitsune.products.tests import ProductFactory, TopicFactory
+from kitsune.questions.tests import (
+    QuestionFactory, AnswerFactory, AnswerVoteFactory, QuestionVoteFactory)
 from kitsune.search.tests.test_es import ElasticTestCase
 from kitsune.sumo.tests import LocalizingClient
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import group, user
-from kitsune.wiki.tests import document, revision, helpful_vote
+from kitsune.users.tests import GroupFactory, UserFactory
+from kitsune.wiki.tests import (
+    DocumentFactory, ApprovedRevisionFactory, RevisionFactory, HelpfulVoteFactory)
 
 
 class AdvancedSearchTests(ElasticTestCase):
@@ -59,12 +61,9 @@ class AdvancedSearchTests(ElasticTestCase):
         eq_(response['Content-Type'], 'application/json')
 
     def test_search_products(self):
-        p = product(title=u'Product One', slug='product', save=True)
-        doc1 = document(title=u'cookies', locale='en-US', category=10,
-                        save=True)
-        revision(document=doc1, is_approved=True, save=True)
-        doc1.products.add(p)
-        doc1.save()
+        p = ProductFactory(title=u'Product One', slug='product')
+        doc = DocumentFactory(title=u'cookies', locale='en-US', category=10, products=[p])
+        RevisionFactory(document=doc, is_approved=True)
 
         self.refresh()
 
@@ -77,14 +76,10 @@ class AdvancedSearchTests(ElasticTestCase):
         assert 'Product One' in response.content
 
     def test_search_multiple_products(self):
-        p = product(title=u'Product One', slug='product-one', save=True)
-        p2 = product(title=u'Product Two', slug='product-two', save=True)
-        doc1 = document(title=u'cookies', locale='en-US', category=10,
-                        save=True)
-        revision(document=doc1, is_approved=True, save=True)
-        doc1.products.add(p)
-        doc1.products.add(p2)
-        doc1.save()
+        p1 = ProductFactory(title=u'Product One', slug='product-one', display_order=1)
+        p2 = ProductFactory(title=u'Product Two', slug='product-two', display_order=2)
+        doc1 = DocumentFactory(title=u'cookies', locale='en-US', category=10, products=[p1, p2])
+        RevisionFactory(document=doc1, is_approved=True)
 
         self.refresh()
 
@@ -95,15 +90,15 @@ class AdvancedSearchTests(ElasticTestCase):
             'w': '1',
         })
 
-        assert "We couldn't find any results for" not in response.content
         eq_(200, response.status_code)
+        assert "We couldn't find any results for" not in response.content
         assert 'Product One, Product Two' in response.content
 
     def test_wiki_no_query(self):
         """Tests advanced search with no query"""
-        doc = document(locale=u'en-US', category=10, save=True)
+        doc = DocumentFactory(locale=u'en-US', category=10)
         doc.tags.add(u'desktop')
-        revision(document=doc, is_approved=True, save=True)
+        RevisionFactory(document=doc, is_approved=True)
 
         self.refresh()
 
@@ -119,7 +114,7 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_questions_sortby(self):
         """Tests advanced search for questions with a sortby"""
-        question(title=u'tags tags tags', save=True)
+        QuestionFactory(title=u'tags tags tags')
 
         self.refresh()
 
@@ -137,9 +132,9 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_sortby_documents_helpful(self):
         """Tests advanced search with a sortby_documents by helpful"""
-        r1 = revision(is_approved=True, save=True)
-        r2 = revision(is_approved=True, save=True)
-        helpful_vote(revision=r2, helpful=True, save=True)
+        r1 = RevisionFactory(is_approved=True)
+        r2 = RevisionFactory(is_approved=True)
+        HelpfulVoteFactory(revision=r2, helpful=True)
 
         # Note: We have to wipe and rebuild the index because new
         # helpful_votes don't update the index data.
@@ -157,8 +152,8 @@ class AdvancedSearchTests(ElasticTestCase):
         eq_(r2.document.title, content['results'][0]['title'])
 
         # Vote twice on r1, now it should come first.
-        helpful_vote(revision=r1, helpful=True, save=True)
-        helpful_vote(revision=r1, helpful=True, save=True)
+        HelpfulVoteFactory(revision=r1, helpful=True)
+        HelpfulVoteFactory(revision=r1, helpful=True)
 
         self.setup_indexes()
         self.reindex_and_refresh()
@@ -173,11 +168,11 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_questions_num_votes(self):
         """Tests advanced search for questions num_votes filter"""
-        q = question(title=u'tags tags tags', save=True)
+        q = QuestionFactory(title=u'tags tags tags')
 
         # Add two question votes
-        questionvote(question=q, save=True)
-        questionvote(question=q, save=True)
+        QuestionVoteFactory(question=q)
+        QuestionVoteFactory(question=q)
 
         self.refresh()
 
@@ -209,8 +204,8 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_num_votes_none(self):
         """Tests num_voted filtering where num_votes is ''"""
-        q = question(save=True)
-        questionvote(question=q, save=True)
+        q = QuestionFactory()
+        QuestionVoteFactory(question=q)
 
         self.refresh()
 
@@ -220,8 +215,8 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_forums_search(self):
         """This tests whether forum posts show up in searches"""
-        thread1 = thread(title=u'crash', save=True)
-        post(thread=thread1, save=True)
+        thread1 = ThreadFactory(title=u'crash')
+        PostFactory(thread=thread1)
 
         self.refresh()
 
@@ -240,13 +235,13 @@ class AdvancedSearchTests(ElasticTestCase):
     def test_forums_search_authorized_forums(self):
         """Only authorized people can search certain forums"""
         # Create two threads: one in a restricted forum and one not.
-        forum1 = forum(name=u'ou812forum', save=True)
-        thread1 = thread(forum=forum1, save=True)
-        post(thread=thread1, content=u'audio', save=True)
+        forum1 = ForumFactory(name=u'ou812forum')
+        thread1 = ThreadFactory(forum=forum1)
+        PostFactory(thread=thread1, content=u'audio')
 
-        forum2 = restricted_forum(name=u'restrictedkeepout', save=True)
-        thread2 = thread(forum=forum2, save=True)
-        post(thread=thread2, content=u'audio restricted', save=True)
+        forum2 = RestrictedForumFactory(name=u'restrictedkeepout')
+        thread2 = ThreadFactory(forum=forum2)
+        PostFactory(thread=thread2, content=u'audio restricted')
 
         self.refresh()
 
@@ -271,12 +266,15 @@ class AdvancedSearchTests(ElasticTestCase):
 
         # Do a search as an authorized user but don't specify the
         # forums to filter on. Should see both posts.
-        u = user(save=True)
-        g = group(save=True)
+        u = UserFactory()
+        g = GroupFactory()
         g.user_set.add(u)
         ct = ContentType.objects.get_for_model(forum2)
-        permission(codename='forums_forum.view_in_forum', content_type=ct,
-                   object_id=forum2.id, group=g, save=True)
+        PermissionFactory(
+            codename='forums_forum.view_in_forum',
+            content_type=ct,
+            object_id=forum2.id,
+            group=g)
 
         self.client.login(username=u.username, password='testpass')
         response = self.client.get(reverse('search.advanced'), {
@@ -300,13 +298,13 @@ class AdvancedSearchTests(ElasticTestCase):
     def test_forums_search_authorized_forums_specifying_forums(self):
         """Only authorized people can search certain forums they specified"""
         # Create two threads: one in a restricted forum and one not.
-        forum1 = forum(name=u'ou812forum', save=True)
-        thread1 = thread(forum=forum1, save=True)
-        post(thread=thread1, content=u'audio', save=True)
+        forum1 = ForumFactory(name=u'ou812forum')
+        thread1 = ThreadFactory(forum=forum1)
+        PostFactory(thread=thread1, content=u'audio')
 
-        forum2 = restricted_forum(name=u'restrictedkeepout', save=True)
-        thread2 = thread(forum=forum2, save=True)
-        post(thread=thread2, content=u'audio restricted', save=True)
+        forum2 = RestrictedForumFactory(name=u'restrictedkeepout')
+        thread2 = ThreadFactory(forum=forum2)
+        PostFactory(thread=thread2, content=u'audio restricted')
 
         self.refresh()
 
@@ -333,12 +331,15 @@ class AdvancedSearchTests(ElasticTestCase):
 
         # Do a search as an authorized user and specify both
         # forums. Should see both posts.
-        u = user(save=True)
-        g = group(save=True)
+        u = UserFactory()
+        g = GroupFactory()
         g.user_set.add(u)
         ct = ContentType.objects.get_for_model(forum2)
-        permission(codename='forums_forum.view_in_forum', content_type=ct,
-                   object_id=forum2.id, group=g, save=True)
+        PermissionFactory(
+            codename='forums_forum.view_in_forum',
+            content_type=ct,
+            object_id=forum2.id,
+            group=g)
 
         self.client.login(username=u.username, password='testpass')
         response = self.client.get(reverse('search.advanced'), {
@@ -363,10 +364,8 @@ class AdvancedSearchTests(ElasticTestCase):
     def test_forums_thread_created(self):
         """Tests created/created_date filtering for forums"""
         post_created_ds = datetime(2010, 1, 1, 12, 00)
-        thread1 = thread(title=u'crash', created=post_created_ds, save=True)
-        post(thread=thread1,
-             created=(post_created_ds + timedelta(hours=1)),
-             save=True)
+        thread1 = ThreadFactory(title=u'crash', created=post_created_ds)
+        PostFactory(thread=thread1, created=(post_created_ds + timedelta(hours=1)))
 
         self.refresh()
 
@@ -428,7 +427,7 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_multi_word_tag_search(self):
         """Tests searching for tags with spaces in them"""
-        ques = question(title=u'audio', save=True)
+        ques = QuestionFactory(title=u'audio')
         ques.tags.add(u'Windows 7')
 
         self.refresh()
@@ -446,15 +445,18 @@ class AdvancedSearchTests(ElasticTestCase):
     def test_category_invalid(self):
         """Tests passing an invalid category"""
         # wiki and questions
-        ques = question(title=u'q1 audio', save=True)
+        ques = QuestionFactory(title=u'q1 audio')
         ques.tags.add(u'desktop')
-        ans = answer(question=ques, save=True)
-        answervote(answer=ans, helpful=True, save=True)
+        ans = AnswerFactory(question=ques)
+        AnswerVoteFactory(answer=ans, helpful=True)
 
-        d1 = document(title=u'd1 audio', locale=u'en-US', category=10,
-                      is_archived=False, save=True)
-        d1.tags.add(u'desktop')
-        revision(document=d1, is_approved=True, save=True)
+        d1 = DocumentFactory(
+            title=u'd1 audio',
+            locale=u'en-US',
+            category=10,
+            is_archived=False,
+            tags=[u'desktop'])
+        ApprovedRevisionFactory(document=d1)
 
         self.refresh()
 
@@ -467,18 +469,18 @@ class AdvancedSearchTests(ElasticTestCase):
         created_ds = datetime(2010, 6, 19, 12, 00)
 
         # on 6/19/2010
-        q1 = question(title=u'q1 audio', created=created_ds, save=True)
+        q1 = QuestionFactory(title=u'q1 audio', created=created_ds)
         q1.tags.add(u'desktop')
-        ans = answer(question=q1, save=True)
-        answervote(answer=ans, helpful=True, save=True)
+        ans = AnswerFactory(question=q1)
+        AnswerVoteFactory(answer=ans, helpful=True)
 
         # on 6/21/2010
-        q2 = question(title=u'q2 audio',
-                      created=(created_ds + timedelta(days=2)),
-                      save=True)
-        q2.tags.add(u'desktop')
-        ans = answer(question=q2, save=True)
-        answervote(answer=ans, helpful=True, save=True)
+        q2 = QuestionFactory(
+            title=u'q2 audio',
+            created=(created_ds + timedelta(days=2)),
+            tags=[u'desktop'])
+        ans = AnswerFactory(question=q2)
+        AnswerVoteFactory(answer=ans, helpful=True)
 
         self.refresh()
 
@@ -503,8 +505,8 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_created_date_invalid(self):
         """Invalid created_date is ignored."""
-        thread1 = thread(save=True)
-        post(thread=thread1, save=True)
+        thread1 = ThreadFactory()
+        PostFactory(thread=thread1)
 
         self.refresh()
 
@@ -522,8 +524,8 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_updated_invalid(self):
         """Invalid updated_date is ignored."""
-        thread1 = thread(save=True)
-        post(thread=thread1, save=True)
+        thread1 = ThreadFactory()
+        PostFactory(thread=thread1)
 
         self.refresh()
 
@@ -534,8 +536,8 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_updated_nonexistent(self):
         """updated is set while updated_date is left out of the query."""
-        thread1 = thread(save=True)
-        post(thread=thread1, save=True)
+        thread1 = ThreadFactory()
+        PostFactory(thread=thread1)
 
         self.refresh()
 
@@ -555,12 +557,12 @@ class AdvancedSearchTests(ElasticTestCase):
         # questions, shove it all in the index, then query it and see
         # what happens.
         for name, number in author_vals:
-            u = user(username=name, save=True)
+            u = UserFactory(username=name)
             for i in range(number):
-                ques = question(title=u'audio', creator=u, save=True)
+                ques = QuestionFactory(title=u'audio', creator=u)
                 ques.tags.add(u'desktop')
-                ans = answer(question=ques, save=True)
-                answervote(answer=ans, helpful=True, save=True)
+                ans = AnswerFactory(question=ques)
+                AnswerVoteFactory(answer=ans, helpful=True)
 
         self.refresh()
 
@@ -573,14 +575,14 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_question_topics(self):
         """Search questions for topics."""
-        p = product(save=True)
-        t1 = topic(slug='doesnotexist', product=p, save=True)
-        t2 = topic(slug='cookies', product=p, save=True)
-        t3 = topic(slug='sync', product=p, save=True)
+        p = ProductFactory()
+        t1 = TopicFactory(slug='doesnotexist', product=p)
+        t2 = TopicFactory(slug='cookies', product=p)
+        t3 = TopicFactory(slug='sync', product=p)
 
-        question(topic=t2, save=True)
-        question(topic=t2, save=True)
-        question(topic=t3, save=True)
+        QuestionFactory(topic=t2)
+        QuestionFactory(topic=t2)
+        QuestionFactory(topic=t3)
 
         self.refresh()
 
@@ -598,18 +600,18 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_wiki_topics(self):
         """Search wiki for topics, includes multiple."""
-        t1 = topic(slug='doesnotexist', save=True)
-        t2 = topic(slug='extant', save=True)
-        t3 = topic(slug='tagged', save=True)
+        t1 = TopicFactory(slug='doesnotexist')
+        t2 = TopicFactory(slug='extant')
+        t3 = TopicFactory(slug='tagged')
 
-        doc = document(locale=u'en-US', category=10, save=True)
+        doc = DocumentFactory(locale=u'en-US', category=10)
         doc.topics.add(t2)
-        revision(document=doc, is_approved=True, save=True)
+        RevisionFactory(document=doc, is_approved=True)
 
-        doc = document(locale=u'en-US', category=10, save=True)
+        doc = DocumentFactory(locale=u'en-US', category=10)
         doc.topics.add(t2)
         doc.topics.add(t3)
-        revision(document=doc, is_approved=True, save=True)
+        RevisionFactory(document=doc, is_approved=True)
 
         self.refresh()
 
@@ -628,13 +630,12 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_wiki_topics_inherit(self):
         """Translations inherit topics from their parents."""
-        doc = document(locale=u'en-US', category=10, save=True)
-        doc.topics.add(topic(slug='extant', save=True))
-        revision(document=doc, is_approved=True, save=True)
+        doc = DocumentFactory(locale=u'en-US', category=10)
+        doc.topics.add(TopicFactory(slug='extant'))
+        RevisionFactory(document=doc, is_approved=True)
 
-        translated = document(locale=u'es', parent=doc, category=10,
-                              save=True)
-        revision(document=translated, is_approved=True, save=True)
+        translated = DocumentFactory(locale=u'es', parent=doc, category=10)
+        RevisionFactory(document=translated, is_approved=True)
 
         self.refresh()
 
@@ -644,13 +645,13 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_question_products(self):
         """Search questions for products."""
-        p1 = product(slug='b2g', save=True)
-        p2 = product(slug='mobile', save=True)
-        p3 = product(slug='desktop', save=True)
+        p1 = ProductFactory(slug='b2g')
+        p2 = ProductFactory(slug='mobile')
+        p3 = ProductFactory(slug='desktop')
 
-        question(product=p2, save=True)
-        question(product=p2, save=True)
-        question(product=p3, save=True)
+        QuestionFactory(product=p2)
+        QuestionFactory(product=p2)
+        QuestionFactory(product=p3)
 
         self.refresh()
 
@@ -670,16 +671,16 @@ class AdvancedSearchTests(ElasticTestCase):
         """Search wiki for products."""
 
         prod_vals = (
-            (product(slug='b2g', save=True), 0),
-            (product(slug='mobile', save=True), 1),
-            (product(slug='desktop', save=True), 2),
+            (ProductFactory(slug='b2g'), 0),
+            (ProductFactory(slug='mobile'), 1),
+            (ProductFactory(slug='desktop'), 2),
         )
 
         for prod, total in prod_vals:
             for i in range(total):
-                doc = document(locale=u'en-US', category=10, save=True)
+                doc = DocumentFactory(locale=u'en-US', category=10)
                 doc.products.add(prod)
-                revision(document=doc, is_approved=True, save=True)
+                RevisionFactory(document=doc, is_approved=True)
 
         self.refresh()
 
@@ -692,14 +693,13 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_wiki_products_inherit(self):
         """Translations inherit products from their parents."""
-        doc = document(locale=u'en-US', category=10, save=True)
-        p = product(title=u'Firefox', slug=u'desktop', save=True)
+        doc = DocumentFactory(locale=u'en-US', category=10)
+        p = ProductFactory(title=u'Firefox', slug=u'desktop')
         doc.products.add(p)
-        revision(document=doc, is_approved=True, save=True)
+        RevisionFactory(document=doc, is_approved=True)
 
-        translated = document(locale=u'fr', parent=doc, category=10,
-                              save=True)
-        revision(document=translated, is_approved=True, save=True)
+        translated = DocumentFactory(locale=u'fr', parent=doc, category=10)
+        RevisionFactory(document=translated, is_approved=True)
 
         self.refresh()
 
@@ -716,10 +716,10 @@ class AdvancedSearchTests(ElasticTestCase):
         )
 
         for name, number in author_vals:
-            u = user(username=name, save=True)
+            u = UserFactory(username=name)
             for i in range(number):
-                thread1 = thread(title=u'audio', save=True)
-                post(thread=thread1, author=u, save=True)
+                thread1 = ThreadFactory(title=u'audio')
+                PostFactory(thread=thread1, author=u)
 
         self.refresh()
 
@@ -732,9 +732,8 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_discussion_filter_sticky(self):
         """Filter for sticky threads."""
-        thread1 = thread(title=u'audio', is_locked=True, is_sticky=True,
-                         save=True)
-        post(thread=thread1, save=True)
+        thread1 = ThreadFactory(title=u'audio', is_locked=True, is_sticky=True)
+        PostFactory(thread=thread1)
 
         self.refresh()
 
@@ -745,9 +744,8 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_discussion_filter_locked(self):
         """Filter for locked threads."""
-        thread1 = thread(title=u'audio', is_locked=True,
-                         save=True)
-        post(thread=thread1, save=True)
+        thread1 = ThreadFactory(title=u'audio', is_locked=True)
+        PostFactory(thread=thread1)
 
         self.refresh()
 
@@ -758,9 +756,8 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_discussion_filter_sticky_locked(self):
         """Filter for locked and sticky threads."""
-        thread1 = thread(title=u'audio', is_locked=True, is_sticky=True,
-                         save=True)
-        post(thread=thread1, save=True)
+        thread1 = ThreadFactory(title=u'audio', is_locked=True, is_sticky=True)
+        PostFactory(thread=thread1)
 
         self.refresh()
 
@@ -773,13 +770,11 @@ class AdvancedSearchTests(ElasticTestCase):
         """Filter for updated date."""
         post_updated_ds = datetime(2010, 5, 3, 12, 00)
 
-        thread1 = thread(title=u't1 audio', save=True)
-        post(thread=thread1, created=post_updated_ds, save=True)
+        thread1 = ThreadFactory(title=u't1 audio')
+        PostFactory(thread=thread1, created=post_updated_ds)
 
-        thread2 = thread(title=u't2 audio', save=True)
-        post(thread=thread2,
-             created=(post_updated_ds + timedelta(days=2)),
-             save=True)
+        thread2 = ThreadFactory(title=u't2 audio')
+        PostFactory(thread=thread2, created=(post_updated_ds + timedelta(days=2)))
 
         self.refresh()
 
@@ -798,10 +793,8 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_archived(self):
         """Ensure archived articles show only when requested."""
-        doc = document(title=u'impalas', locale=u'en-US',
-                       is_archived=True, save=True)
-        revision(document=doc, summary=u'impalas',
-                 is_approved=True, save=True)
+        doc = DocumentFactory(title=u'impalas', locale=u'en-US', is_archived=True)
+        ApprovedRevisionFactory(document=doc, summary=u'impalas', is_approved=True)
 
         self.refresh()
 
@@ -821,13 +814,13 @@ class AdvancedSearchTests(ElasticTestCase):
 
     def test_discussion_filter_forum(self):
         """Filter by forum in discussion forums."""
-        forum1 = forum(name=u'Forum 1', save=True)
-        thread1 = thread(forum=forum1, title=u'audio 1', save=True)
-        post(thread=thread1, save=True)
+        forum1 = ForumFactory(name=u'Forum 1')
+        thread1 = ThreadFactory(forum=forum1, title=u'audio 1')
+        PostFactory(thread=thread1)
 
-        forum2 = forum(name=u'Forum 2', save=True)
-        thread2 = thread(forum=forum2, title=u'audio 2', save=True)
-        post(thread=thread2, save=True)
+        forum2 = ForumFactory(name=u'Forum 2')
+        thread2 = ThreadFactory(forum=forum2, title=u'audio 2')
+        PostFactory(thread=thread2)
 
         self.refresh()
 
@@ -842,13 +835,13 @@ class AdvancedSearchTests(ElasticTestCase):
         """Tests who can see restricted forums in search form."""
         # This is a long test, but it saves us from doing the setup
         # twice.
-        forum1 = forum(name=u'ou812forum', save=True)
-        thread1 = thread(forum=forum1, title=u'audio 2', save=True)
-        post(thread=thread1, save=True)
+        forum1 = ForumFactory(name=u'ou812forum')
+        thread1 = ThreadFactory(forum=forum1, title=u'audio 2')
+        PostFactory(thread=thread1)
 
-        forum2 = restricted_forum(name=u'restrictedkeepout', save=True)
-        thread2 = thread(forum=forum2, title=u'audio 2', save=True)
-        post(thread=thread2, save=True)
+        forum2 = RestrictedForumFactory(name=u'restrictedkeepout')
+        thread2 = ThreadFactory(forum=forum2, title=u'audio 2')
+        PostFactory(thread=thread2)
 
         self.refresh()
 
@@ -862,12 +855,15 @@ class AdvancedSearchTests(ElasticTestCase):
         # Restricted forum should not show up
         assert 'restrictedkeepout' not in response.content
 
-        u = user(save=True)
-        g = group(save=True)
+        u = UserFactory()
+        g = GroupFactory()
         g.user_set.add(u)
         ct = ContentType.objects.get_for_model(forum2)
-        permission(codename='forums_forum.view_in_forum', content_type=ct,
-                   object_id=forum2.id, group=g, save=True)
+        PermissionFactory(
+            codename='forums_forum.view_in_forum',
+            content_type=ct,
+            object_id=forum2.id,
+            group=g)
 
         # Get the Advanced Search Form as a logged in user
         self.client.login(username=u.username, password='testpass')

--- a/kitsune/sumo/tests/__init__.py
+++ b/kitsune/sumo/tests/__init__.py
@@ -121,23 +121,6 @@ class MobileTestCase(TestCase):
         self.client.cookies[settings.MOBILE_COOKIE] = 'on'
 
 
-def with_save(func):
-    """Decorate a model maker to add a `save` kwarg.
-
-    If save=True, the model maker will save the object before returning it.
-
-    """
-    @wraps(func)
-    def saving_func(*args, **kwargs):
-        save = kwargs.pop('save', False)
-        ret = func(*args, **kwargs)
-        if save:
-            ret.save()
-        return ret
-
-    return saving_func
-
-
 def eq_msg(a, b, msg=None):
     """Shorthand for 'assert a == b, "%s %r != %r" % (msg, a, b)'
     """
@@ -147,8 +130,9 @@ def eq_msg(a, b, msg=None):
 class FuzzyUnicode(factory.fuzzy.FuzzyText):
     """A FuzzyText factory that contains at least one non-ASCII character."""
 
-    def fuzz(self):
-        return u'đ{}'.format(super(FuzzyUnicode, self).fuzz())
+    def __init__(self, prefix=u'', **kwargs):
+        prefix = u'%sđ' % prefix
+        super(FuzzyUnicode, self).__init__(prefix=prefix, **kwargs)
 
 
 class set_waffle_flag(object):

--- a/kitsune/sumo/tests/test_email_utils.py
+++ b/kitsune/sumo/tests/test_email_utils.py
@@ -10,7 +10,7 @@ from kitsune.sumo.email_utils import (safe_translation,
                                       emails_with_users_and_watches)
 from kitsune.sumo.utils import uselocale
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 mock_translations = {
@@ -144,9 +144,8 @@ class PremailerTests(TestCase):
                                    '</body>'
                                    '</html>')
 
-            u = user(save=True)
-            msg = emails_with_users_and_watches('test', 'a.ltxt',
-                                                'a.html', {}, [(u, [None])])
+            u = UserFactory()
+            msg = emails_with_users_and_watches('test', 'a.ltxt', 'a.html', {}, [(u, [None])])
 
             for m in msg:
                 tag = ('<a href="https://%s/test" style="color:#000">'

--- a/kitsune/sumo/tests/test_googleanalytics.py
+++ b/kitsune/sumo/tests/test_googleanalytics.py
@@ -5,7 +5,7 @@ from nose.tools import eq_
 
 from kitsune.sumo import googleanalytics
 from kitsune.sumo.tests import TestCase
-from kitsune.wiki.tests import document, revision
+from kitsune.wiki.tests import ApprovedRevisionFactory
 
 
 class GoogleAnalyticsTests(TestCase):
@@ -45,10 +45,7 @@ class GoogleAnalyticsTests(TestCase):
         # Add some documents that match the response data.
         documents = []
         for i in range(1, 6):
-            documents.append(revision(
-                document=document(slug='doc-%s' % i, save=True),
-                is_approved=True,
-                save=True).document)
+            documents.append(ApprovedRevisionFactory(document__slug='doc-%s' % i).document)
 
         pageviews = googleanalytics.pageviews_by_document(
             date(2013, 01, 16), date(2013, 01, 16))

--- a/kitsune/sumo/tests/test_helpers.py
+++ b/kitsune/sumo/tests/test_helpers.py
@@ -7,7 +7,6 @@ from django.test.client import RequestFactory
 
 import jingo
 from babel.dates import format_date, format_time, format_datetime
-from mock import Mock
 from nose.tools import eq_, assert_raises
 from pyquery import PyQuery as pq
 from pytz import timezone
@@ -17,8 +16,6 @@ from kitsune.sumo.helpers import (
     timesince, label_with_help, urlparams, yesno, number, remove)
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
-
-from kitsune.users.tests import profile
 
 
 def render(s, context={}):
@@ -102,9 +99,6 @@ class TestDateTimeFormat(TestCase):
         url_ = reverse('forums.threads', args=['testslug'])
         self.context = {'request': RequestFactory().get(url_)}
         self.context['request'].LANGUAGE_CODE = self.locale
-        user_profile = profile(timezone=self.timezone, locale=self.locale)
-        self.context['request'].user = user_profile
-        self.context['request'].user.is_authenticated = Mock(return_value=True)
         self.context['request'].session = {'timezone': self.timezone}
 
     def _get_datetime_result(self, locale, timezone, format='short',
@@ -149,8 +143,7 @@ class TestDateTimeFormat(TestCase):
         """Expects date format."""
         value_test = datetime.fromordinal(733900)
         value_expected = format_date(value_test, locale=self.locale)
-        value_returned = datetimeformat(self.context, value_test,
-                                        format='date')
+        value_returned = datetimeformat(self.context, value_test, format='date')
         eq_(pq(value_returned)('time').text(), value_expected)
 
     def test_time(self):

--- a/kitsune/sumo/tests/test_locale_middleware.py
+++ b/kitsune/sumo/tests/test_locale_middleware.py
@@ -5,7 +5,7 @@ from nose.tools import eq_
 
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import get_best_language, get_non_supported
-from kitsune.users.tests import user, profile
+from kitsune.users.tests import UserFactory
 
 
 class TestLocaleMiddleware(TestCase):
@@ -42,7 +42,7 @@ class TestLocaleMiddleware(TestCase):
         self.assertRedirects(reponse, '/fr/search', status_code=302)
 
     def test_partial_redirect(self):
-        """Ensure that /en/ gets directed to /en-US/."""
+        """Ensure that /en/ gets directed t /en-US/."""
         response = self.client.get('/en/search', follow=True)
         self.assertRedirects(response, '/en-US/search', status_code=302)
 
@@ -99,8 +99,7 @@ class PreferredLanguageTests(TestCase):
         self.assertRedirects(response, '/en-US/')
 
     def test_loggedin_preferred_language(self):
-        u = user(save=True)
-        profile(user=u, locale='zh-CN')
+        u = UserFactory(profile__locale='zh-CN')
         self.client.login(username=u.username, password='testpass')
         response = self.client.get('/', follow=True)
         self.assertRedirects(response, '/zh-CN/')
@@ -110,8 +109,7 @@ class PreferredLanguageTests(TestCase):
         self.assertRedirects(response, '/xx/')
 
     def test_anonymous_change_to_login(self):
-        u = user(save=True)
-        profile(user=u, locale='zh-CN')
+        u = UserFactory(profile__locale='zh-CN')
 
         # anonymous is fr
         self.client.get('/?lang=fr', follow=True)

--- a/kitsune/sumo/tests/test_readonly.py
+++ b/kitsune/sumo/tests/test_readonly.py
@@ -11,7 +11,7 @@ from pyquery import PyQuery as pq
 
 from kitsune.questions.models import Question
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class ReadOnlyModeTest(TestCase):
@@ -19,7 +19,7 @@ class ReadOnlyModeTest(TestCase):
 
     def setUp(self):
         # This has to be done before the db goes into read only mode.
-        self.user = user(save=True, password='testpass')
+        self.user = UserFactory(password='testpass')
 
         models.signals.pre_save.connect(self.db_error)
         models.signals.pre_delete.connect(self.db_error)

--- a/kitsune/sumo/tests/test_utils.py
+++ b/kitsune/sumo/tests/test_utils.py
@@ -11,7 +11,7 @@ from kitsune.journal.models import Record
 from kitsune.sumo.utils import (
     chunked, get_next_url, is_ratelimited, smart_int, truncated_json_dumps, get_browser)
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import profile
+from kitsune.users.tests import UserFactory
 
 
 class SmartIntTestCase(TestCase):
@@ -131,7 +131,7 @@ class ChunkedTests(TestCase):
 class IsRatelimitedTest(TestCase):
 
     def test_ratelimited(self):
-        u = profile().user
+        u = UserFactory()
         request = Mock()
         request.user = u
         request.limited = False
@@ -143,7 +143,7 @@ class IsRatelimitedTest(TestCase):
         eq_(is_ratelimited(request, 'test-ratelimited', '1/min'), True)
 
     def test_ratelimit_bypass(self):
-        u = profile().user
+        u = UserFactory()
         bypass = Permission.objects.get(codename='bypass_ratelimit')
         u.user_permissions.add(bypass)
         request = Mock()
@@ -157,7 +157,7 @@ class IsRatelimitedTest(TestCase):
         eq_(is_ratelimited(request, 'test-ratelimited', '1/min'), False)
 
     def test_ratelimit_logging(self):
-        u = profile().user
+        u = UserFactory()
         request = Mock()
         request.user = u
         request.limited = False

--- a/kitsune/tags/tests/__init__.py
+++ b/kitsune/tags/tests/__init__.py
@@ -1,11 +1,9 @@
-from datetime import datetime
-
 from django.template.defaultfilters import slugify
 
 import factory
 from taggit.models import Tag
 
-from kitsune.sumo.tests import with_save, FuzzyUnicode
+from kitsune.sumo.tests import FuzzyUnicode
 
 
 class TagFactory(factory.DjangoModelFactory):
@@ -14,13 +12,3 @@ class TagFactory(factory.DjangoModelFactory):
 
     name = FuzzyUnicode()
     slug = factory.LazyAttribute(lambda o: slugify(o.name))
-
-
-@with_save
-def tag(**kwargs):
-    """Model Maker for Tags."""
-    defaults = {'name': str(datetime.now())}
-    defaults.update(kwargs)
-    if 'slug' not in kwargs:
-        defaults['slug'] = slugify(defaults['title'])
-    return Tag(**defaults)

--- a/kitsune/upload/tests/__init__.py
+++ b/kitsune/upload/tests/__init__.py
@@ -4,13 +4,13 @@ from django.core.files import File
 import factory
 from nose.tools import eq_, raises
 
-from kitsune.questions.tests import question, QuestionFactory
+from kitsune.questions.tests import QuestionFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.upload.models import ImageAttachment
 from kitsune.upload.storage import RenameFileStorage
 from kitsune.upload.utils import (
     create_imageattachment, check_file_size, FileTooLargeError)
-from kitsune.users.tests import user, UserFactory
+from kitsune.users.tests import UserFactory
 
 
 class ImageAttachmentFactory(factory.DjangoModelFactory):
@@ -58,8 +58,8 @@ class CreateImageAttachmentTestCase(TestCase):
 
     def setUp(self):
         super(CreateImageAttachmentTestCase, self).setUp()
-        self.user = user(save=True)
-        self.obj = question(save=True)
+        self.user = UserFactory()
+        self.obj = QuestionFactory()
 
     def tearDown(self):
         ImageAttachment.objects.all().delete()

--- a/kitsune/upload/tests/test_models.py
+++ b/kitsune/upload/tests/test_models.py
@@ -3,19 +3,19 @@ from django.core.files import File
 
 from nose.tools import eq_
 
-from kitsune.questions.tests import question
+from kitsune.questions.tests import QuestionFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.upload.models import ImageAttachment
 from kitsune.upload.tasks import generate_thumbnail
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class ImageAttachmentTestCase(TestCase):
 
     def setUp(self):
         super(ImageAttachmentTestCase, self).setUp()
-        self.user = user(save=True)
-        self.obj = question(save=True)
+        self.user = UserFactory()
+        self.obj = QuestionFactory()
         self.ct = ContentType.objects.get_for_model(self.obj)
 
     def tearDown(self):

--- a/kitsune/upload/tests/test_tasks.py
+++ b/kitsune/upload/tests/test_tasks.py
@@ -8,13 +8,13 @@ import mock
 from nose.tools import eq_
 
 import kitsune.upload.tasks
-from kitsune.questions.tests import question
+from kitsune.questions.tests import QuestionFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.upload.models import ImageAttachment
 from kitsune.upload.tasks import (
     _scale_dimensions, _create_image_thumbnail, compress_image,
     generate_thumbnail)
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class ScaleDimensionsTestCase(TestCase):
@@ -90,8 +90,8 @@ class GenerateThumbnail(TestCase):
 
     def setUp(self):
         super(GenerateThumbnail, self).setUp()
-        self.user = user(save=True)
-        self.obj = question(save=True)
+        self.user = UserFactory()
+        self.obj = QuestionFactory()
 
     def tearDown(self):
         ImageAttachment.objects.all().delete()
@@ -149,8 +149,8 @@ class CompressImageTestCase(TestCase):
 
     def setUp(self):
         super(CompressImageTestCase, self).setUp()
-        self.user = user(save=True)
-        self.obj = question(save=True)
+        self.user = UserFactory()
+        self.obj = QuestionFactory()
 
     def tearDown(self):
         ImageAttachment.objects.all().delete()

--- a/kitsune/upload/tests/test_views.py
+++ b/kitsune/upload/tests/test_views.py
@@ -8,11 +8,11 @@ from django.contrib.contenttypes.models import ContentType
 
 from nose.tools import eq_
 
-from kitsune.questions.tests import question
+from kitsune.questions.tests import QuestionFactory
 from kitsune.sumo.tests import post, LocalizingClient, TestCase
 from kitsune.upload.forms import MSG_IMAGE_LONG
 from kitsune.upload.models import ImageAttachment
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 class UploadImageTestCase(TestCase):
@@ -20,8 +20,8 @@ class UploadImageTestCase(TestCase):
 
     def setUp(self):
         super(UploadImageTestCase, self).setUp()
-        self.user = user(username='berker', save=True)
-        self.question = question(save=True)
+        self.user = UserFactory(username='berker')
+        self.question = QuestionFactory()
         self.client.login(username=self.user.username, password='testpass')
 
     def tearDown(self):
@@ -101,7 +101,7 @@ class UploadImageTestCase(TestCase):
 
     def test_delete_image_no_permission(self):
         """Can't delete an image without permission."""
-        u = user(username='tagger', save=True)
+        u = UserFactory(username='tagger')
         assert not u.has_perm('upload.delete_imageattachment')
         self.test_upload_image()
         im = ImageAttachment.objects.all()[0]

--- a/kitsune/users/tests/test_es.py
+++ b/kitsune/users/tests/test_es.py
@@ -3,13 +3,13 @@ from datetime import datetime, timedelta
 
 from nose.tools import eq_
 
-from kitsune.customercare.tests import reply
-from kitsune.questions.tests import answer
+from kitsune.customercare.tests import ReplyFactory
+from kitsune.questions.tests import AnswerFactory
 from kitsune.search.tests.test_es import ElasticTestCase
 from kitsune.users.cron import reindex_users_that_contributed_yesterday
 from kitsune.users.models import UserMappingType
-from kitsune.users.tests import profile, user
-from kitsune.wiki.tests import revision
+from kitsune.users.tests import ProfileFactory, UserFactory
+from kitsune.wiki.tests import RevisionFactory
 
 
 class UserSearchTests(ElasticTestCase):
@@ -18,7 +18,7 @@ class UserSearchTests(ElasticTestCase):
 
         Deleting should delete it.
         """
-        p = profile()
+        p = ProfileFactory()
         self.refresh()
         eq_(UserMappingType.search().count(), 1)
 
@@ -28,30 +28,26 @@ class UserSearchTests(ElasticTestCase):
 
     def test_data_in_index(self):
         """Verify the data we are indexing."""
-        u = user(username='r1cky', email='r@r.com', save=True)
-        p = profile(user=u, name=u'Rick Róss')
-        r1 = reply(user=u, twitter_username='r1cardo', save=True)
-        r2 = reply(user=u, twitter_username='r1cky', save=True)
+        u = UserFactory(username='r1cky', email='r@r.com', profile__name=u'Rick Róss')
+        r1 = ReplyFactory(user=u, twitter_username='r1cardo')
+        r2 = ReplyFactory(user=u, twitter_username='r1cky')
 
         self.refresh()
 
         eq_(UserMappingType.search().count(), 1)
         data = UserMappingType.search()[0]
-        eq_(data['username'], p.user.username)
-        eq_(data['display_name'], p.name)
+        eq_(data['username'], u.username)
+        eq_(data['display_name'], u.profile.name)
         assert r1.twitter_username in data['twitter_usernames']
         assert r2.twitter_username in data['twitter_usernames']
 
-        u = user(username='willkg', email='w@w.com', save=True)
-        p = profile(user=u, name=u'Will Cage')
+        u = UserFactory(username='willkg', email='w@w.com', profile__name='Will Cage')
         self.refresh()
         eq_(UserMappingType.search().count(), 2)
 
     def test_suggest_completions(self):
-        u1 = user(username='r1cky', save=True)
-        profile(user=u1, name=u'Rick Róss')
-        u2 = user(username='Willkg', save=True)
-        profile(user=u2, name=u'Will Cage')
+        u1 = UserFactory(username='r1cky', profile__name=u'Rick Róss')
+        u2 = UserFactory(username='Willkg', profile__name=u'Will Cage')
 
         self.refresh()
         eq_(UserMappingType.search().count(), 2)
@@ -67,8 +63,7 @@ class UserSearchTests(ElasticTestCase):
         eq_(u1.id, results[0]['payload']['user_id'])
 
         # Add another Ri....
-        u3 = user(username='richard', save=True)
-        profile(user=u3, name=u'Richard Smith')
+        UserFactory(username='richard', profile__name=u'Richard Smith')
 
         self.refresh()
         eq_(UserMappingType.search().count(), 3)
@@ -85,10 +80,8 @@ class UserSearchTests(ElasticTestCase):
         eq_(u'Rick Róss (r1cky)', results[0]['text'])
 
     def test_suggest_completions_numbers(self):
-        u1 = user(username='1337mike', save=True)
-        profile(user=u1, name=u'Elite Mike')
-        u2 = user(username='crazypants', save=True)
-        profile(user=u2, name=u'Crazy Pants')
+        u1 = UserFactory(username='1337mike', profile__name=u'Elite Mike')
+        UserFactory(username='crazypants', profile__name=u'Crazy Pants')
 
         self.refresh()
         eq_(UserMappingType.search().count(), 2)
@@ -99,24 +92,19 @@ class UserSearchTests(ElasticTestCase):
         eq_(u1.id, results[0]['payload']['user_id'])
 
     def test_query_username_with_numbers(self):
-        u1 = user(username='1337miKE', save=True)
-        p = profile(user=u1, name=u'Elite Mike')
-        u2 = user(username='mike', save=True)
-        profile(user=u2, name=u'NotElite Mike')
+        u = UserFactory(username='1337miKE', profile__name=u'Elite Mike')
+        UserFactory(username='mike', profile__name=u'NotElite Mike')
 
         self.refresh()
 
-        eq_(UserMappingType.search().query(
-            iusername__match='1337mike').count(), 1)
+        eq_(UserMappingType.search().query(iusername__match='1337mike').count(), 1)
         data = UserMappingType.search().query(iusername__match='1337mike')[0]
-        eq_(data['username'], p.user.username)
-        eq_(data['display_name'], p.name)
+        eq_(data['username'], u.username)
+        eq_(data['display_name'], u.profile.name)
 
     def test_query_display_name_with_whitespace(self):
-        u1 = user(username='1337miKE', save=True)
-        profile(user=u1, name=u'Elite Mike')
-        u2 = user(username='mike', save=True)
-        profile(user=u2, name=u'NotElite Mike')
+        UserFactory(username='1337miKE', profile__name=u'Elite Mike')
+        UserFactory(username='mike', profile__name=u'NotElite Mike')
 
         self.refresh()
 
@@ -125,28 +113,22 @@ class UserSearchTests(ElasticTestCase):
             idisplay_name__match_whitespace='elite').count(), 1)
 
     def test_query_twitter_usernames(self):
-        u1 = user(username='1337miKE', save=True)
-        p = profile(user=u1, name=u'Elite Mike')
-        u2 = user(username='mike', save=True)
-        profile(user=u2, name=u'NotElite Mike')
-        r1 = reply(user=u1, twitter_username='l33tmIkE', save=True)
-        reply(user=u2, twitter_username='mikey', save=True)
+        u1 = UserFactory(username='1337miKE', profile__name=u'Elite Mike')
+        u2 = UserFactory(username='mike', profile__name=u'NotElite Mike')
+        r1 = ReplyFactory(user=u1, twitter_username='l33tmIkE')
+        ReplyFactory(user=u2, twitter_username='mikey')
 
         self.refresh()
 
-        eq_(UserMappingType.search().query(
-            itwitter_usernames__match='l33tmike').count(), 1)
-        data = UserMappingType.search().query(
-            itwitter_usernames__match='l33tmike')[0]
-        eq_(data['username'], p.user.username)
-        eq_(data['display_name'], p.name)
+        eq_(UserMappingType.search().query(itwitter_usernames__match='l33tmike').count(), 1)
+        data = UserMappingType.search().query(itwitter_usernames__match='l33tmike')[0]
+        eq_(data['username'], u1.username)
+        eq_(data['display_name'], u1.profile.name)
         assert r1.twitter_username in data['twitter_usernames']
 
     def test_last_contribution_date(self):
         """Verify the last_contribution_date field works properly."""
-        u = user(username='satdav', save=True)
-        p = profile(user=u)
-
+        u = UserFactory(username='satdav')
         self.refresh()
 
         data = UserMappingType.search().query(username__match='satdav')[0]
@@ -154,8 +136,7 @@ class UserSearchTests(ElasticTestCase):
 
         # Add a AoA reply. It should be the last contribution.
         d = datetime(2014, 1, 1)
-        reply(user=u, created=d, save=True)
-
+        ReplyFactory(user=u, created=d)
         self.refresh()
 
         data = UserMappingType.search().query(username__match='satdav')[0]
@@ -163,9 +144,8 @@ class UserSearchTests(ElasticTestCase):
 
         # Add a Support Forum answer. It should be the last contribution.
         d = datetime(2014, 1, 2)
-        answer(creator=u, created=d, save=True)
-
-        p.save()  # we need to resave the profile to force a reindex
+        AnswerFactory(creator=u, created=d)
+        u.profile.save()  # we need to resave the profile to force a reindex
         self.refresh()
 
         data = UserMappingType.search().query(username__match='satdav')[0]
@@ -173,9 +153,8 @@ class UserSearchTests(ElasticTestCase):
 
         # Add a Revision edit. It should be the last contribution.
         d = datetime(2014, 1, 3)
-        revision(creator=u, created=d, save=True)
-
-        p.save()  # we need to resave the profile to force a reindex
+        RevisionFactory(created=d, creator=u)
+        u.profile.save()  # we need to resave the profile to force a reindex
         self.refresh()
 
         data = UserMappingType.search().query(username__match='satdav')[0]
@@ -183,9 +162,9 @@ class UserSearchTests(ElasticTestCase):
 
         # Add a Revision review. It should be the last contribution.
         d = datetime(2014, 1, 4)
-        revision(reviewer=u, reviewed=d, save=True)
+        RevisionFactory(reviewed=d, reviewer=u)
 
-        p.save()  # we need to resave the profile to force a reindex
+        u.profile.save()  # we need to resave the profile to force a reindex
         self.refresh()
 
         data = UserMappingType.search().query(username__match='satdav')[0]
@@ -195,9 +174,8 @@ class UserSearchTests(ElasticTestCase):
         yesterday = datetime.now() - timedelta(days=1)
 
         # Verify for answers.
-        u = user(username='answerer', save=True)
-        profile(user=u)
-        answer(creator=u, created=yesterday, save=True)
+        u = UserFactory(username='answerer')
+        AnswerFactory(creator=u, created=yesterday)
 
         reindex_users_that_contributed_yesterday()
         self.refresh()
@@ -206,9 +184,8 @@ class UserSearchTests(ElasticTestCase):
         eq_(data['last_contribution_date'].date(), yesterday.date())
 
         # Verify for edits.
-        u = user(username='editor', save=True)
-        profile(user=u)
-        revision(creator=u, created=yesterday, save=True)
+        u = UserFactory(username='editor')
+        RevisionFactory(creator=u, created=yesterday)
 
         reindex_users_that_contributed_yesterday()
         self.refresh()
@@ -217,9 +194,8 @@ class UserSearchTests(ElasticTestCase):
         eq_(data['last_contribution_date'].date(), yesterday.date())
 
         # Verify for reviews.
-        u = user(username='reviewer', save=True)
-        profile(user=u)
-        revision(reviewer=u, reviewed=yesterday, save=True)
+        u = UserFactory(username='reviewer')
+        RevisionFactory(reviewer=u, reviewed=yesterday)
 
         reindex_users_that_contributed_yesterday()
         self.refresh()

--- a/kitsune/users/tests/test_forms.py
+++ b/kitsune/users/tests/test_forms.py
@@ -8,7 +8,7 @@ from kitsune.users.forms import (
     AuthenticationForm, ProfileForm, RegisterForm, SetPasswordForm,
     ForgotUsernameForm, username_allowed)
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import TestCaseBase, user
+from kitsune.users.tests import TestCaseBase, UserFactory
 from kitsune.users.validators import TwitterValidator
 
 
@@ -17,13 +17,8 @@ class AuthenticationFormTests(TestCaseBase):
 
     def setUp(self):
         # create active and inactive users
-        self.active_user = user(save=True,
-                                username='activeuser',
-                                is_active=True)
-
-        self.inactive_user = user(save=True,
-                                  username='inactiveuser',
-                                  is_active=False)
+        self.active_user = UserFactory(username='activeuser', is_active=True)
+        self.inactive_user = UserFactory(username='inactiveuser', is_active=False)
 
     def test_only_active(self):
         # Verify with active user
@@ -51,7 +46,7 @@ class AuthenticationFormTests(TestCaseBase):
         assert form.is_valid()
 
     def test_at_in_username(self):
-        u = user(username='test@example.com', save=True)
+        u = UserFactory(username='test@example.com')
         form = AuthenticationForm(data={'username': u.username,
                                         'password': 'testpass'})
         assert form.is_valid()
@@ -177,7 +172,7 @@ class PasswordChangeFormFormTests(TestCaseBase):
     """PasswordChangeForm tests."""
 
     def test_common_password(self):
-        u = user(save=True)
+        u = UserFactory()
         form = SetPasswordForm(u, data={'new_password1': 'password',
                                         'new_password2': 'password',
                                         'old_password': 'testpass'})
@@ -194,7 +189,7 @@ class ForgotUsernameFormTests(TestCaseBase):
 
     def test_valid_email(self):
         """"If an account with email exists, form is valid."""
-        u = user(save=True, email='a@b.com', is_active=True)
+        u = UserFactory(email='a@b.com', is_active=True)
         form = ForgotUsernameForm({'email': u.email})
         assert form.is_valid()
 

--- a/kitsune/users/tests/test_helpers.py
+++ b/kitsune/users/tests/test_helpers.py
@@ -10,19 +10,18 @@ from pyquery import PyQuery as pq
 from kitsune.sumo.tests import TestCase
 from kitsune.users.helpers import (
     profile_url, profile_avatar, public_email, display_name, user_list)
-from kitsune.users.tests import profile, user
+from kitsune.users.tests import UserFactory
 
 
 class HelperTestCase(TestCase):
     def setUp(self):
         super(HelperTestCase, self).setUp()
-        self.u = user(username=u'testuser', save=True)
+        self.u = UserFactory()
 
     def test_profile_url(self):
         eq_(u'/user/%s' % self.u.username, profile_url(self.u))
 
     def test_profile_avatar_default(self):
-        profile(user=self.u)
         email_hash = hashlib.md5(self.u.email.lower()).hexdigest()
         gravatar_url = 'https://secure.gravatar.com/avatar/%s?s=48' % (
             email_hash)
@@ -35,7 +34,8 @@ class HelperTestCase(TestCase):
         assert profile_avatar(AnonymousUser()).startswith(gravatar_url)
 
     def test_profile_avatar(self):
-        profile(user=self.u, avatar='images/foo.png')
+        self.u.profile.avatar = 'images/foo.png'
+        self.u.profile.save()
         email_hash = hashlib.md5(self.u.email.lower()).hexdigest()
         gravatar_url = 'https://secure.gravatar.com/avatar/%s?s=48' % (
             email_hash)
@@ -44,7 +44,6 @@ class HelperTestCase(TestCase):
     def test_profile_avatar_unicode(self):
         self.u.email = u'rápido@example.com'
         self.u.save()
-        profile(user=self.u)
         gravatar_url = 'https://secure.gravatar.com/'
         assert profile_avatar(self.u).startswith(gravatar_url)
 
@@ -57,14 +56,17 @@ class HelperTestCase(TestCase):
             u'&#108;</span>', public_email('not.an.email'))
 
     def test_display_name(self):
-        eq_(u'testuser', display_name(self.u))
-        profile(user=self.u, name=u'Test User')
+        eq_(self.u.profile.name, display_name(self.u))
+        self.u.profile.name = u'Test User'
+        self.u.profile.save()
         eq_(u'Test User', display_name(self.u))
+
+    def test_display_name_anonymous(self):
         eq_(u'', display_name(AnonymousUser()))
 
     def test_user_list(self):
-        user(username='testuser2', save=True)
-        user(username='testuser3', save=True)
+        UserFactory(username='testuser2')
+        UserFactory(username='testuser3')
         users = User.objects.all()
         list = user_list(users)
         assert isinstance(list, Markup)

--- a/kitsune/users/tests/test_models.py
+++ b/kitsune/users/tests/test_models.py
@@ -9,7 +9,7 @@ from nose.tools import eq_
 from kitsune.sumo.tests import TestCase
 from kitsune.users.models import RegistrationProfile, Setting
 from kitsune.users.forms import SettingsForm
-from kitsune.users.tests import user
+from kitsune.users.tests import UserFactory
 
 
 log = logging.getLogger('k.users')
@@ -58,7 +58,7 @@ class RegistrationProfileTests(TestCase):
 class UserSettingsTests(TestCase):
 
     def setUp(self):
-        self.u = user(save=True)
+        self.u = UserFactory()
 
     def test_non_existant_setting(self):
         form = SettingsForm()

--- a/kitsune/users/tests/test_views.py
+++ b/kitsune/users/tests/test_views.py
@@ -12,7 +12,7 @@ from nose.tools import eq_
 from pyquery import PyQuery as pq
 from tidings.tests import watch
 
-from kitsune.questions.tests import question, answer
+from kitsune.questions.tests import QuestionFactory, AnswerFactory
 from kitsune.questions.models import Question, Answer
 from kitsune.sumo.tests import (TestCase, LocalizingClient,
                                 send_mail_raise_smtp)
@@ -21,7 +21,7 @@ from kitsune.users import ERROR_SEND_EMAIL
 from kitsune.users.models import (
     CONTRIBUTOR_GROUP, Profile, RegistrationProfile, EmailChange, Setting,
     email_utils, Deactivation)
-from kitsune.users.tests import profile, user, group, add_permission
+from kitsune.users.tests import UserFactory, GroupFactory, add_permission
 
 
 class RegisterTests(TestCase):
@@ -118,7 +118,7 @@ class RegisterTests(TestCase):
             'sumouser1234', 'testpass', 'sumouser@test.com')
         assert not user_.is_active
         then = datetime.now() - timedelta(days=1)
-        q = question(creator=user_, created=then, save=True)
+        q = QuestionFactory(creator=user_, created=then)
         assert q.created == then
         key = RegistrationProfile.objects.all()[0].activation_key
         url = reverse('users.activate', args=[user_.id, key])
@@ -168,7 +168,7 @@ class RegisterTests(TestCase):
         assert q.get_absolute_url() in response.content
 
     def test_duplicate_username(self):
-        u = user(save=True)
+        u = UserFactory()
         response = self.client.post(
             reverse('users.registercontributor', locale='en-US'),
             {'username': u.username,
@@ -178,7 +178,7 @@ class RegisterTests(TestCase):
         self.assertContains(response, 'already exists')
 
     def test_duplicate_email(self):
-        u = user(email='noob@example.com', save=True)
+        u = UserFactory(email='noob@example.com')
         User.objects.create(username='noob', email='noob@example.com').save()
         response = self.client.post(
             reverse('users.registercontributor', locale='en-US'),
@@ -223,7 +223,7 @@ class RegisterTests(TestCase):
         """Verify that interested contributors are added to group."""
         get_current.return_value.domain = 'su.mo.com'
         group_name = 'Registered as contributor'
-        group(name=group_name, save=True)
+        GroupFactory(name=group_name)
         data = {
             'username': 'newbie',
             'email': 'newbie@example.com',
@@ -250,9 +250,8 @@ class ChangeEmailTestCase(TestCase):
     client_class = LocalizingClient
 
     def setUp(self):
-        self.u = user(save=True)
-        profile(user=self.u)
-        self.client.login(username=self.u.username, password='testpass')
+        self.user = UserFactory()
+        self.client.login(username=self.user.username, password='testpass')
         super(ChangeEmailTestCase, self).setUp()
 
     def test_redirect(self):
@@ -284,22 +283,22 @@ class ChangeEmailTestCase(TestCase):
         response = self.client.get(reverse('users.confirm_email',
                                            args=[ec.activation_key]))
         eq_(200, response.status_code)
-        u = User.objects.get(username=self.u.username)
+        u = User.objects.get(username=self.user.username)
         eq_('paulc@trololololololo.com', u.email)
 
     def test_user_change_email_same(self):
         """Changing to same email shows validation error."""
-        self.u.email = 'valid@email.com'
-        self.u.save()
+        self.user.email = 'valid@email.com'
+        self.user.save()
         response = self.client.post(reverse('users.change_email'),
-                                    {'email': self.u.email})
+                                    {'email': self.user.email})
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_('This is your current email.', doc('ul.errorlist').text())
 
     def test_user_change_email_duplicate(self):
         """Changing to same email shows validation error."""
-        u = user(email='newvalid@email.com', save=True)
+        u = UserFactory(email='newvalid@email.com')
         response = self.client.post(reverse('users.change_email'),
                                     {'email': u.email})
         eq_(200, response.status_code)
@@ -312,7 +311,7 @@ class ChangeEmailTestCase(TestCase):
         """If we detect a duplicate email when confirming an email change,
         don't change it and notify the user."""
         get_current.return_value.domain = 'su.mo.com'
-        old_email = self.u.email
+        old_email = self.user.email
         new_email = 'newvalid@email.com'
         response = self.client.post(reverse('users.change_email'),
                                     {'email': new_email})
@@ -321,73 +320,73 @@ class ChangeEmailTestCase(TestCase):
         ec = EmailChange.objects.all()[0]
 
         # Before new email is confirmed, give the same email to a user
-        u = user(email=new_email, save=True)
+        u = UserFactory(email=new_email)
 
         # Visit confirmation link and verify email wasn't changed.
         response = self.client.get(reverse('users.confirm_email',
                                            args=[ec.activation_key]))
         eq_(200, response.status_code)
         doc = pq(response.content)
-        eq_('Unable to change email for user %s' % self.u.username,
+        eq_('Unable to change email for user %s' % self.user.username,
             doc('article h1').text())
-        u = User.objects.get(username=self.u.username)
+        u = User.objects.get(username=self.user.username)
         eq_(old_email, u.email)
 
 
 class MakeContributorTests(TestCase):
     def setUp(self):
-        self.u = user(save=True)
-        self.client.login(username=self.u.username, password='testpass')
-        group(name=CONTRIBUTOR_GROUP, save=True)
+        self.user = UserFactory()
+        self.client.login(username=self.user.username, password='testpass')
+        GroupFactory(name=CONTRIBUTOR_GROUP)
         super(MakeContributorTests, self).setUp()
 
     def test_make_contributor(self):
         """Test adding a user to the contributor group"""
-        eq_(0, self.u.groups.filter(name=CONTRIBUTOR_GROUP).count())
+        eq_(0, self.user.groups.filter(name=CONTRIBUTOR_GROUP).count())
 
         response = self.client.post(reverse('users.make_contributor',
                                             force_locale=True))
         eq_(302, response.status_code)
 
-        eq_(1, self.u.groups.filter(name=CONTRIBUTOR_GROUP).count())
+        eq_(1, self.user.groups.filter(name=CONTRIBUTOR_GROUP).count())
 
 
 class AvatarTests(TestCase):
     def setUp(self):
-        self.u = user(save=True)
-        self.p = profile(user=self.u)
-        self.client.login(username=self.u.username, password='testpass')
+        self.user = UserFactory()
+        self.profile = self.user.profile
+        self.client.login(username=self.user.username, password='testpass')
         super(AvatarTests, self).setUp()
 
     def tearDown(self):
-        p = Profile.objects.get(user=self.u)
+        p = Profile.objects.get(user=self.user)
         if os.path.exists(p.avatar.path):
             os.unlink(p.avatar.path)
         super(AvatarTests, self).tearDown()
 
     def test_upload_avatar(self):
-        assert not self.p.avatar, 'User has no avatar.'
+        assert not self.profile.avatar, 'User has no avatar.'
         with open('kitsune/upload/tests/media/test.jpg') as f:
             url = reverse('users.edit_avatar', locale='en-US')
             data = {'avatar': f}
             r = self.client.post(url, data)
         eq_(302, r.status_code)
-        p = Profile.objects.get(user=self.u)
+        p = Profile.objects.get(user=self.user)
         assert p.avatar, 'User has an avatar.'
         assert p.avatar.path.endswith('.png')
 
     def test_replace_missing_avatar(self):
         """If an avatar is missing, allow replacing it."""
-        assert not self.p.avatar, 'User has no avatar.'
-        self.p.avatar = 'path/does/not/exist.jpg'
-        self.p.save()
-        assert self.p.avatar, 'User has a bad avatar.'
+        assert not self.profile.avatar, 'User has no avatar.'
+        self.profile.avatar = 'path/does/not/exist.jpg'
+        self.profile.save()
+        assert self.profile.avatar, 'User has a bad avatar.'
         with open('kitsune/upload/tests/media/test.jpg') as f:
             url = reverse('users.edit_avatar', locale='en-US')
             data = {'avatar': f}
             r = self.client.post(url, data)
         eq_(302, r.status_code)
-        p = Profile.objects.get(user=self.u)
+        p = Profile.objects.get(user=self.user)
         assert p.avatar, 'User has an avatar.'
         assert not p.avatar.path.endswith('exist.jpg')
         assert p.avatar.path.endswith('.png')
@@ -397,14 +396,14 @@ class SessionTests(TestCase):
     client_class = LocalizingClient
 
     def setUp(self):
-        self.u = user(save=True)
+        self.user = UserFactory()
         self.client.logout()
         super(SessionTests, self).setUp()
 
     def test_login_sets_extra_cookie(self):
         """On login, set the SESSION_EXISTS_COOKIE."""
         url = reverse('users.login')
-        res = self.client.post(url, {'username': self.u.username,
+        res = self.client.post(url, {'username': self.user.username,
                                      'password': 'testpass'})
         assert settings.SESSION_EXISTS_COOKIE in res.cookies
         c = res.cookies[settings.SESSION_EXISTS_COOKIE]
@@ -422,7 +421,7 @@ class SessionTests(TestCase):
     def test_expire_at_browser_close(self):
         """If SESSION_EXPIRE_AT_BROWSER_CLOSE, do expire then."""
         url = reverse('users.login')
-        res = self.client.post(url, {'username': self.u.username,
+        res = self.client.post(url, {'username': self.user.username,
                                      'password': 'testpass'})
         c = res.cookies[settings.SESSION_EXISTS_COOKIE]
         eq_('', c['max-age'])
@@ -432,7 +431,7 @@ class SessionTests(TestCase):
     def test_expire_in_a_long_time(self):
         """If not SESSION_EXPIRE_AT_BROWSER_CLOSE, set an expiry date."""
         url = reverse('users.login')
-        res = self.client.post(url, {'username': self.u.username,
+        res = self.client.post(url, {'username': self.user.username,
                                      'password': 'testpass'})
         c = res.cookies[settings.SESSION_EXISTS_COOKIE]
         eq_(123, c['max-age'])
@@ -440,86 +439,83 @@ class SessionTests(TestCase):
 
 class UserSettingsTests(TestCase):
     def setUp(self):
-        self.u = user(save=True)
-        self.p = profile(user=self.u)
-        self.client.login(username=self.u.username, password='testpass')
+        self.user = UserFactory()
+        self.profile = self.user.profile
+        self.client.login(username=self.user.username, password='testpass')
         super(UserSettingsTests, self).setUp()
 
     def test_create_setting(self):
         url = reverse('users.edit_settings', locale='en-US')
-        eq_(Setting.objects.filter(user=self.u).count(), 0)  # No settings
+        eq_(Setting.objects.filter(user=self.user).count(), 0)  # No settings
         res = self.client.get(url, follow=True)
         eq_(200, res.status_code)
         res = self.client.post(url, {'forums_watch_new_thread': True},
                                follow=True)
         eq_(200, res.status_code)
-        assert Setting.get_for_user(self.u, 'forums_watch_new_thread')
+        assert Setting.get_for_user(self.user, 'forums_watch_new_thread')
 
 
 class UserProfileTests(TestCase):
     def setUp(self):
-        self.u = user(save=True)
-        self.profile = profile(user=self.u)
-        self.url = reverse('users.profile', args=[self.u.username],
-                           locale='en-US')
+        self.user = UserFactory()
+        self.profile = self.user.profile
+        self.userrl = reverse('users.profile', args=[self.user.username], locale='en-US')
         super(UserProfileTests, self).setUp()
 
-    def test_profile(self):
-        res = self.client.get(self.url)
-        self.assertContains(res, self.u.username)
+    def test_ProfileFactory(self):
+        res = self.client.get(self.userrl)
+        self.assertContains(res, self.user.username)
 
     def test_profile_redirect(self):
         """Ensure that old profile URL's get redirected."""
-        res = self.client.get(reverse('users.profile', args=[self.u.pk],
+        res = self.client.get(reverse('users.profile', args=[self.user.pk],
                                       locale='en-US'))
         eq_(302, res.status_code)
 
     def test_profile_inactive(self):
         """Inactive users don't have a public profile."""
-        self.u.is_active = False
-        self.u.save()
-        res = self.client.get(self.url)
+        self.user.is_active = False
+        self.user.save()
+        res = self.client.get(self.userrl)
         eq_(404, res.status_code)
 
     def test_profile_post(self):
-        res = self.client.post(self.url)
+        res = self.client.post(self.userrl)
         eq_(405, res.status_code)
 
     def test_profile_deactivate(self):
         """Test user deactivation"""
-        p = profile()
+        p = UserFactory().profile
 
-        self.client.login(username=self.u.username, password='testpass')
-        res = self.client.post(reverse('users.deactivate', locale='en-US'),
-                               {'user_id': p.user.id})
+        self.client.login(username=self.user.username, password='testpass')
+        res = self.client.post(reverse('users.deactivate', locale='en-US'), {'user_id': p.user.id})
 
         eq_(403, res.status_code)
 
-        add_permission(self.u, Profile, 'deactivate_users')
-        res = self.client.post(reverse('users.deactivate', locale='en-US'),
-                               {'user_id': p.user.id})
+        add_permission(self.user, Profile, 'deactivate_users')
+        res = self.client.post(reverse('users.deactivate', locale='en-US'), {'user_id': p.user.id})
 
         eq_(302, res.status_code)
 
         log = Deactivation.objects.get(user_id=p.user_id)
-        eq_(log.moderator_id, self.u.id)
+        eq_(log.moderator_id, self.user.id)
 
         p = Profile.objects.get(user_id=p.user_id)
         assert not p.user.is_active
 
     def test_deactivate_and_flag_spam(self):
-        self.client.login(username=self.u.username, password='testpass')
-        add_permission(self.u, Profile, 'deactivate_users')
+        self.client.login(username=self.user.username, password='testpass')
+        add_permission(self.user, Profile, 'deactivate_users')
 
         # Verify content is flagged as spam when requested.
-        p = profile()
-        answer(creator=p.user, save=True)
-        question(creator=p.user, save=True)
+        u = UserFactory()
+        AnswerFactory(creator=u)
+        QuestionFactory(creator=u)
         url = reverse('users.deactivate-spam', locale='en-US')
-        res = self.client.post(url, {'user_id': p.user.id})
+        res = self.client.post(url, {'user_id': u.id})
 
         eq_(302, res.status_code)
-        eq_(1, Question.objects.filter(creator=p.user, is_spam=True).count())
-        eq_(0, Question.objects.filter(creator=p.user, is_spam=False).count())
-        eq_(1, Answer.objects.filter(creator=p.user, is_spam=True).count())
-        eq_(0, Answer.objects.filter(creator=p.user, is_spam=False).count())
+        eq_(1, Question.objects.filter(creator=u, is_spam=True).count())
+        eq_(0, Question.objects.filter(creator=u, is_spam=False).count())
+        eq_(1, Answer.objects.filter(creator=u, is_spam=True).count())
+        eq_(0, Answer.objects.filter(creator=u, is_spam=False).count())

--- a/kitsune/users/tests/test_views.py
+++ b/kitsune/users/tests/test_views.py
@@ -327,7 +327,7 @@ class ChangeEmailTestCase(TestCase):
                                            args=[ec.activation_key]))
         eq_(200, response.status_code)
         doc = pq(response.content)
-        eq_('Unable to change email for user %s' % self.user.username,
+        eq_(u'Unable to change email for user %s' % self.user.username,
             doc('article h1').text())
         u = User.objects.get(username=self.user.username)
         eq_(old_email, u.email)

--- a/kitsune/wiki/sampledata.py
+++ b/kitsune/wiki/sampledata.py
@@ -3,8 +3,8 @@ import os
 from datetime import datetime
 
 from kitsune.products.models import Product, Topic
-from kitsune.products.tests import topic
-from kitsune.wiki.tests import document, revision
+from kitsune.products.tests import TopicFactory
+from kitsune.wiki.tests import DocumentFactory, RevisionFactory, ApprovedRevisionFactory
 
 
 def read_file(filename):
@@ -44,48 +44,45 @@ def generate_sampledata(options):
 
     for p in [firefox, mobile]:
         # Create the top 10 topics used
-        topic(
+        TopicFactory(
             product=p,
             title='Learn the Basics: get started',
-            slug='get-started',
-            save=True)
-        topic(
+            slug='get-started')
+        TopicFactory(
             product=p,
             title='Download, install and migration',
-            slug='download-and-install',
-            save=True)
-        topic(
+            slug='download-and-install')
+        TopicFactory(
             product=p,
             title='Privacy and security settings',
-            slug='privacy-and-security',
-            save=True)
-        topic(
+            slug='privacy-and-security')
+        TopicFactory(
             product=p,
             title='Customize controls, options and add-ons',
-            slug='customize',
-            save=True)
-        topic(
+            slug='customize')
+        TopicFactory(
             product=p,
             title='Fix slowness, crashing, error messages and other problems',
-            slug='fix-problems',
-            save=True)
-        topic(product=p, title='Tips and tricks', slug='tips', save=True)
-        topic(product=p, title='Bookmarks', slug='bookmarks', save=True)
-        topic(product=p, title='Cookies', slug='cookies', save=True)
-        topic(product=p, title='Tabs', slug='tabs', save=True)
-        topic(product=p, title='Websites', slug='websites', save=True)
-        topic(product=p, title='Other', slug='other', save=True)
+            slug='fix-problems')
+        TopicFactory(product=p, title='Tips and tricks', slug='tips')
+        TopicFactory(product=p, title='Bookmarks', slug='bookmarks')
+        TopicFactory(product=p, title='Cookies', slug='cookies')
+        TopicFactory(product=p, title='Tabs', slug='tabs')
+        TopicFactory(product=p, title='Websites', slug='websites')
+        TopicFactory(product=p, title='Other', slug='other')
 
         # 'hot' topic is created by a migration. Check for it's existence
         # before creating a new one.
         if not Topic.objects.filter(product=p, slug='hot').exists():
-            topic(product=p, title='Hot topics', slug='hot', save=True)
+            TopicFactory(product=p, title='Hot topics', slug='hot')
 
     # Create a hot article
-    flash = document(title='Flash 11.3 crashes', slug='flash-113-crashes',
-                     save=True)
-    revision(content=FLASH_CONTENT, document=flash, is_approved=True,
-             reviewed=datetime.now(), save=True)
+    flash = DocumentFactory(title='Flash 11.3 crashes', slug='flash-113-crashes')
+    RevisionFactory(
+        content=FLASH_CONTENT,
+        document=flash,
+        is_approved=True,
+        reviewed=datetime.now())
     flash.products.add(firefox)
     flash.topics.add(Topic.objects.get(product=firefox, slug='fix-problems'))
     flash.topics.add(Topic.objects.get(product=firefox, slug='hot'))
@@ -93,11 +90,14 @@ def generate_sampledata(options):
     # Generate 9 sample documents with 2 topics each
     topics = list(Topic.objects.all())
     for i in xrange(9):
-        d = document(title='Sample Article %s' % str(i + 1),
-                     slug='sample-article-%s' % str(i + 1), save=True)
-        revision(document=d, is_approved=True, reviewed=datetime.now(),
-                 save=True)
+        d = DocumentFactory(title='Sample Article %s' % str(i + 1),
+                            slug='sample-article-%s' % str(i + 1))
+        RevisionFactory(document=d, is_approved=True, reviewed=datetime.now())
         d.products.add(firefox)
         d.products.add(mobile)
         d.topics.add(topics[i])
         d.topics.add(topics[i + 11])
+
+        ApprovedRevisionFactory(
+            document__products=[firefox, mobile],
+            document__topics=[topics[i], topics[i + 1]])

--- a/kitsune/wiki/templates/wiki/translate.html
+++ b/kitsune/wiki/templates/wiki/translate.html
@@ -121,6 +121,7 @@
               <input type="hidden" name="form" value="rev" />
               <input type="hidden" name="slug" value="{{ document.slug }}" />
               <input type="hidden" name="locale" value="{{ document.locale }}" />
+            </form>
           {% endif %}
           {% if recent_approved_revs %}
             <h3>{{ _('Recently approved updates') }}:</h3>
@@ -136,6 +137,15 @@
           {% endif %}
 
           <h3>{{ _('Differences') }}:</h3>
+
+          document: {{ document }}{{ document.slug }}{{ document.slug }},
+          currev: {{ document.current_revision }},
+          {% if document.current_revision %}
+            {{ document.current_revision.id }},
+            currev.based_on: {{ document.current_revision.based_on.id }}
+          {% endif %}
+          parent.latest_localizable_revision: {{ parent.latest_localizable_revision.id }}
+
           {% if document.current_revision and document.current_revision.based_on and parent.latest_localizable_revision %}
             {# Diff between the English version the current translation is based on and the most recent ready-to-localize English version. #}
             {{ revision_diff(document.current_revision.based_on, parent.latest_localizable_revision, show_picker=True) }}

--- a/kitsune/wiki/templates/wiki/translate.html
+++ b/kitsune/wiki/templates/wiki/translate.html
@@ -138,14 +138,6 @@
 
           <h3>{{ _('Differences') }}:</h3>
 
-          document: {{ document }}{{ document.slug }}{{ document.slug }},
-          currev: {{ document.current_revision }},
-          {% if document.current_revision %}
-            {{ document.current_revision.id }},
-            currev.based_on: {{ document.current_revision.based_on.id }}
-          {% endif %}
-          parent.latest_localizable_revision: {{ parent.latest_localizable_revision.id }}
-
           {% if document.current_revision and document.current_revision.based_on and parent.latest_localizable_revision %}
             {# Diff between the English version the current translation is based on and the most recent ready-to-localize English version. #}
             {{ revision_diff(document.current_revision.based_on, parent.latest_localizable_revision, show_picker=True) }}

--- a/kitsune/wiki/tests/__init__.py
+++ b/kitsune/wiki/tests/__init__.py
@@ -1,17 +1,20 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 
+from django.conf import settings
 from django.template.defaultfilters import slugify
 
 import factory
+from nose.tools import eq_
 
 from kitsune.products.models import Product
-from kitsune.products.tests import product, topic
-from kitsune.sumo.tests import LocalizingClient, TestCase, with_save
-from kitsune.users.tests import user, UserFactory
-from kitsune.wiki.models import Document, Revision, HelpfulVote, Locale
+from kitsune.products.tests import ProductFactory, TopicFactory
+from kitsune.sumo.tests import LocalizingClient, TestCase, FuzzyUnicode
+from kitsune.users.tests import UserFactory
+from kitsune.wiki.models import Document, Revision, Locale, HelpfulVote
 from kitsune.wiki.config import (
-    CATEGORIES, SIGNIFICANCES, TEMPLATES_CATEGORY, TEMPLATE_TITLE_PREFIX)
+    CATEGORIES, SIGNIFICANCES, TEMPLATES_CATEGORY, TEMPLATE_TITLE_PREFIX, REDIRECT_CONTENT,
+    REDIRECT_TITLE)
 
 
 class TestCaseBase(TestCase):
@@ -24,7 +27,7 @@ class DocumentFactory(factory.DjangoModelFactory):
         model = Document
 
     category = CATEGORIES[0][0]
-    title = factory.Sequence(lambda n: u'đoc-{}'.format(n))
+    title = FuzzyUnicode()
     slug = factory.LazyAttribute(lambda o: slugify(o.title))
 
     @factory.post_generation
@@ -37,10 +40,30 @@ class DocumentFactory(factory.DjangoModelFactory):
             for p in extracted:
                 doc.products.add(p)
 
+    @factory.post_generation
+    def topics(doc, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing
+            return
+
+        if extracted is not None:
+            for t in extracted:
+                doc.topics.add(t)
+
+    @factory.post_generation
+    def tags(doc, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing
+            return
+
+        if extracted is not None:
+            for t in extracted:
+                doc.tags.add(t)
+
 
 class TemplateDocumentFactory(DocumentFactory):
     category = TEMPLATES_CATEGORY
-    title = factory.Sequence(lambda n: u'{}:τmpl-{}'.format(TEMPLATE_TITLE_PREFIX, n))
+    title = FuzzyUnicode(prefix=TEMPLATE_TITLE_PREFIX + ':')
 
 
 class RevisionFactory(factory.DjangoModelFactory):
@@ -48,100 +71,76 @@ class RevisionFactory(factory.DjangoModelFactory):
         model = Revision
 
     document = factory.SubFactory(DocumentFactory)
-    summary = 'đSome summary.'
-    content = 'đSome summary.'
+    summary = FuzzyUnicode()
+    content = FuzzyUnicode()
     significance = SIGNIFICANCES[0][0]
-    comment = 'đSome comment',
+    comment = FuzzyUnicode()
     creator = factory.SubFactory(UserFactory)
     document = factory.SubFactory(DocumentFactory)
+    is_approved = False
+
+    @factory.post_generation
+    def set_current_revision(obj, create, extracted, **kwargs):
+        if obj.is_approved:
+            obj.document.current_revision = obj
+            obj.document.save()
 
 
 class ApprovedRevisionFactory(RevisionFactory):
     is_approved = True
+    reviewed = factory.LazyAttribute(lambda o: datetime.now())
 
 
-# Model makers. These make it clearer and more concise to create objects in
-# test cases. They allow the significant attribute values to stand out rather
-# than being hidden amongst the values needed merely to get the model to
-# validate.
+class TranslatedRevisionFactory(ApprovedRevisionFactory):
+    """Makes a revision that is a translation of an English revision."""
 
-@with_save
-def document(**kwargs):
-    """Return an empty document with enough stuff filled out that it can be
-    saved."""
-    defaults = {'category': CATEGORIES[0][0],
-                'title': u'đ' + str(datetime.now())}
-    defaults.update(kwargs)
-    if 'slug' not in kwargs:
-        defaults['slug'] = slugify(defaults['title'])
-    return Document(**defaults)
+    document = factory.SubFactory(
+        DocumentFactory,
+        locale=factory.fuzzy.FuzzyChoice(l for l in settings.SUMO_LANGUAGES if l != 'en-US'),
+        parent=factory.SubFactory(DocumentFactory, locale=settings.WIKI_DEFAULT_LANGUAGE))
+    based_on = factory.SubFactory(
+        ApprovedRevisionFactory,
+        is_ready_for_localization=True,
+        document=factory.SelfAttribute('..document.parent'))
 
 
-@with_save
-def revision(**kwargs):
-    """Return an empty revision with enough stuff filled out that it can be
-    saved.
-
-    Revision's is_approved=False unless you specify otherwise.
-
-    Requires a users fixture if no creator is provided.
-
-    """
-    d = kwargs.pop('document', None) or document(save=True)
-
-    defaults = {'summary': u'đSome summary', 'content': u'đSome content',
-                'significance': SIGNIFICANCES[0][0],
-                'comment': u'đSome comment',
-                'creator': kwargs.get('creator', user(save=True)),
-                'document': d}
-    defaults.update(kwargs)
-
-    return Revision(**defaults)
+def test_translated_revision_factory():
+    rev = TranslatedRevisionFactory()
+    assert rev.document.locale != 'en-US'
+    eq_(rev.based_on.document, rev.document.parent)
+    eq_(rev.document.parent.locale, 'en-US')
 
 
-@with_save
-def helpful_vote(**kwargs):
-    r = kwargs.pop('revision', None) or revision(save=True)
-    defaults = {'created': datetime.now(), 'helpful': False, 'revision': r}
-    defaults.update(kwargs)
-    return HelpfulVote(**defaults)
+class RedirectRevisionFactory(RevisionFactory):
+    class Meta:
+        exclude = ('target',)
+
+    target = factory.SubFactory(DocumentFactory)
+    document__title = factory.LazyAttribute(
+        lambda o: REDIRECT_TITLE % {'old': factory.SelfAttribute('..target.title'), 'number': 1})
+    content = factory.LazyAttribute(lambda o: REDIRECT_CONTENT % o.target.title)
+    is_approved = True
 
 
-@with_save
-def locale(**kwargs):
-    defaults = {'locale': 'en-US'}
-    defaults.update(kwargs)
-    return Locale(**defaults)
+class LocaleFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Locale
+
+    locale = 'en-US'
 
 
-def translated_revision(locale='de', save=False, **kwargs):
-    """Return a revision that is the translation of a default-language one."""
-    parent_rev = revision(is_approved=True,
-                          is_ready_for_localization=True,
-                          save=True)
-    translation = document(parent=parent_rev.document, locale=locale,
-                           save=True)
-    new_kwargs = {'document': translation, 'based_on': parent_rev}
-    new_kwargs.update(kwargs)
-    return revision(save=save, **new_kwargs)
+class HelpfulVoteFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = HelpfulVote
+
+    revision = factory.SubFactory(RevisionFactory)
 
 
-# I don't like this thing. revision() is more flexible. All this adds is
-# is_approved=True, but it doesn't even mention approval in its name.
-# TODO: Remove.
-def doc_rev(content=''):
-    """Save a document and an approved revision with the given content."""
-    r = revision(content=content, is_approved=True)
-    r.save()
-    return r.document, r
-
-# End model makers.
-
-
+# Todo: This should probably be a non-Django factory class
 def new_document_data(topic_ids=None, product_ids=None):
-    product_ids = product_ids or [product(save=True).id]
+    product_ids = product_ids or [ProductFactory().id]
     p = Product.objects.get(id=product_ids[0])
-    topic_ids = topic_ids or [topic(product=p, save=True).id]
+    topic_ids = topic_ids or [TopicFactory(product=p).id]
     return {
         'title': 'A Test Article',
         'slug': 'a-test-article',

--- a/kitsune/wiki/tests/test_admin.py
+++ b/kitsune/wiki/tests/test_admin.py
@@ -4,7 +4,7 @@ from nose.tools import eq_
 from kitsune.sumo.tests import TestCase
 from kitsune.wiki.admin import DocumentAdmin
 from kitsune.wiki.models import Document
-from kitsune.wiki.tests import document, translated_revision
+from kitsune.wiki.tests import DocumentFactory, TranslatedRevisionFactory
 
 
 class ArchiveTests(TestCase):
@@ -12,12 +12,13 @@ class ArchiveTests(TestCase):
 
     def test_inheritance(self):
         """Make sure parent/child equality of is_archived is maintained."""
+        eq_(Document.objects.filter(is_archived=True).count(), 0)
         # Set up a child and a parent and an orphan (all false) and something
         # true.
-        translated_revision(save=True)
-        translated_revision(save=True)
-        document(save=True)
-        document(is_archived=True, save=True)
+        TranslatedRevisionFactory()
+        TranslatedRevisionFactory()
+        DocumentFactory()
+        DocumentFactory(is_archived=True)
 
         # Batch-clear the archival bits:
         DocumentAdmin._set_archival(Document.objects.all(), True)

--- a/kitsune/wiki/tests/test_badges.py
+++ b/kitsune/wiki/tests/test_badges.py
@@ -2,43 +2,37 @@ from datetime import date
 
 from django.conf import settings
 
-from kitsune.kbadge.tests import badge
+from kitsune.kbadge.tests import BadgeFactory
 from kitsune.sumo.tests import TestCase
-from kitsune.users.tests import profile
-from kitsune.wiki.badges import WIKI_BADGES
-from kitsune.wiki.models import Revision
-from kitsune.wiki.tests import revision, document
+from kitsune.users.tests import UserFactory
+from kitsune.wiki.badges import register_signals, WIKI_BADGES
+from kitsune.wiki.tests import ApprovedRevisionFactory, RevisionFactory, DocumentFactory
 
 
 class TestWikiBadges(TestCase):
+
+    def setUp(self):
+        register_signals()
 
     def test_kb_badge(self):
         """Verify the KB Badge is awarded properly."""
         # Create the user and badge.
         year = date.today().year
-        u = profile().user
-        b = badge(
+        u = UserFactory()
+        b = BadgeFactory(
             slug=WIKI_BADGES['kb-badge']['slug'].format(year=year),
             title=WIKI_BADGES['kb-badge']['title'].format(year=year),
-            description=WIKI_BADGES['kb-badge']['description'].format(
-                year=year),
-            save=True)
+            description=WIKI_BADGES['kb-badge']['description'].format(year=year))
 
         # Create 9 approved en-US revisions.
-        d = document(locale=settings.WIKI_DEFAULT_LANGUAGE, save=True)
-        revisions = []
-        for i in range(8):
-            revisions.append(revision(creator=u, document=d, is_approved=True))
-        Revision.objects.bulk_create(revisions)
-
-        # Create the 9th revision separately so signals get triggered.
-        revision(creator=u, document=d, is_approved=True, save=True)
+        d = DocumentFactory(locale=settings.WIKI_DEFAULT_LANGUAGE)
+        ApprovedRevisionFactory.create_batch(9, creator=u, document=d)
 
         # User should NOT have the badge yet
         assert not b.is_awarded_to(u)
 
         # Create 1 more approved en-US revision.
-        revision(creator=u, document=d, is_approved=True, save=True)
+        RevisionFactory(creator=u, document=d, is_approved=True)
 
         # User should have the badge now
         assert b.is_awarded_to(u)
@@ -47,29 +41,21 @@ class TestWikiBadges(TestCase):
         """Verify the L10n Badge is awarded properly."""
         # Create the user and badge.
         year = date.today().year
-        u = profile().user
-        b = badge(
+        u = UserFactory()
+        b = BadgeFactory(
             slug=WIKI_BADGES['l10n-badge']['slug'].format(year=year),
             title=WIKI_BADGES['l10n-badge']['title'].format(year=year),
-            description=WIKI_BADGES['l10n-badge']['description'].format(
-                year=year),
-            save=True)
+            description=WIKI_BADGES['l10n-badge']['description'].format(year=year))
 
         # Create 9 approved es revisions.
-        d = document(locale='es', save=True)
-        revisions = []
-        for i in range(8):
-            revisions.append(revision(creator=u, document=d, is_approved=True))
-        Revision.objects.bulk_create(revisions)
-
-        # Create the 9th revision separately so signals get triggered.
-        revision(creator=u, document=d, is_approved=True, save=True)
+        d = DocumentFactory(locale='es')
+        ApprovedRevisionFactory.create_batch(9, creator=u, document=d)
 
         # User should NOT have the badge yet
         assert not b.is_awarded_to(u)
 
         # Create 1 more approved es revision.
-        revision(creator=u, document=d, is_approved=True, save=True)
+        RevisionFactory(creator=u, document=d, is_approved=True)
 
         # User should have the badge now
         assert b.is_awarded_to(u)

--- a/kitsune/wiki/tests/test_es.py
+++ b/kitsune/wiki/tests/test_es.py
@@ -2,19 +2,19 @@ from datetime import datetime, timedelta
 
 from nose.tools import eq_
 
-from kitsune.products.tests import product, topic
+from kitsune.products.tests import ProductFactory, TopicFactory
 from kitsune.search.tests.test_es import ElasticTestCase
-from kitsune.wiki.tests import document, revision, helpful_vote
+from kitsune.wiki.tests import (
+    DocumentFactory, RevisionFactory, HelpfulVoteFactory, RedirectRevisionFactory)
 from kitsune.wiki.models import DocumentMappingType, RevisionMetricsMappingType
-from kitsune.wiki.config import REDIRECT_CONTENT
 
 
 class DocumentUpdateTests(ElasticTestCase):
     def test_add_and_delete(self):
         """Adding a doc should add it to the search index; deleting should
         delete it."""
-        doc = document(save=True)
-        revision(document=doc, is_approved=True, save=True)
+        doc = DocumentFactory()
+        RevisionFactory(document=doc, is_approved=True)
         self.refresh()
         eq_(DocumentMappingType.search().count(), 1)
 
@@ -23,38 +23,37 @@ class DocumentUpdateTests(ElasticTestCase):
         eq_(DocumentMappingType.search().count(), 0)
 
     def test_translations_get_parent_tags(self):
-        doc1 = document(title=u'Audio too loud')
-        doc1.save()
-        revision(document=doc1, is_approved=True, save=True)
-        doc1.topics.add(topic(slug='cookies', save=True))
-        doc1.topics.add(topic(slug='general', save=True))
-        doc1.products.add(product(slug='desktop', save=True))
+        t1 = TopicFactory(display_order=1)
+        t2 = TopicFactory(display_order=2)
+        p = ProductFactory()
+        doc1 = DocumentFactory(
+            title=u'Audio too loud',
+            products=[p],
+            topics=[t1, t2])
+        RevisionFactory(document=doc1, is_approved=True)
 
-        doc2 = document(title=u'Audio too loud bork bork',
-                        parent=doc1)
-        doc2.save()
-        revision(document=doc2, is_approved=True, save=True)
-        doc2.tags.add(u'badtag')
+        doc2 = DocumentFactory(title=u'Audio too loud bork bork', parent=doc1, tags=[u'badtag'])
+        RevisionFactory(document=doc2, is_approved=True)
 
         # Verify the parent has the right tags.
         doc_dict = DocumentMappingType.extract_document(doc1.id)
-        eq_(doc_dict['topic'], [u'cookies', u'general'])
-        eq_(doc_dict['product'], [u'desktop'])
+        eq_(sorted(doc_dict['topic']), sorted([t1.slug, t2.slug]))
+        eq_(doc_dict['product'], [p.slug])
 
         # Verify the translation has the parent's tags.
         doc_dict = DocumentMappingType.extract_document(doc2.id)
-        eq_(doc_dict['topic'], [u'cookies', u'general'])
-        eq_(doc_dict['product'], [u'desktop'])
+        eq_(sorted(doc_dict['topic']), sorted([t1.slug, t2.slug]))
+        eq_(doc_dict['product'], [p.slug])
 
     def test_wiki_topics(self):
         """Make sure that adding topics to a Document causes it to
         refresh the index.
 
         """
-        t = topic(slug=u'hiphop', save=True)
+        t = TopicFactory(slug=u'hiphop')
         eq_(DocumentMappingType.search().filter(topic=t.slug).count(), 0)
-        doc = document(save=True)
-        revision(document=doc, is_approved=True, save=True)
+        doc = DocumentFactory()
+        RevisionFactory(document=doc, is_approved=True)
         self.refresh()
         eq_(DocumentMappingType.search().filter(topic=t.slug).count(), 0)
         doc.topics.add(t)
@@ -74,10 +73,10 @@ class DocumentUpdateTests(ElasticTestCase):
         refresh the index.
 
         """
-        p = product(slug=u'desktop', save=True)
+        p = ProductFactory(slug=u'desktop')
         eq_(DocumentMappingType.search().filter(product=p.slug).count(), 0)
-        doc = document(save=True)
-        revision(document=doc, is_approved=True, save=True)
+        doc = DocumentFactory()
+        RevisionFactory(document=doc, is_approved=True)
         self.refresh()
         eq_(DocumentMappingType.search().filter(product=p.slug).count(), 0)
         doc.products.add(p)
@@ -96,12 +95,12 @@ class DocumentUpdateTests(ElasticTestCase):
         """Don't index documents without approved revisions"""
         # Create a document with no revisions and make sure the
         # document is not in the index.
-        doc = document(save=True)
+        doc = DocumentFactory()
         self.refresh()
         eq_(DocumentMappingType.search().count(), 0)
         # Create a revision that's not approved and make sure the
         # document is still not in the index.
-        revision(document=doc, is_approved=False, save=True)
+        RevisionFactory(document=doc, is_approved=False)
         self.refresh()
         eq_(DocumentMappingType.search().count(), 0)
 
@@ -109,50 +108,44 @@ class DocumentUpdateTests(ElasticTestCase):
         """Make sure we don't index redirects"""
         # First create a revision that doesn't have a redirect and
         # make sure it's in the index.
-        doc = document(title=u'wool hats')
-        doc.save()
-        revision(document=doc, is_approved=True, save=True)
+        doc = DocumentFactory(title=u'wool hats')
+        RevisionFactory(document=doc, is_approved=True)
         self.refresh()
-        eq_(DocumentMappingType.search().query(
-            document_title__match='wool').count(), 1)
+        eq_(DocumentMappingType.search().query(document_title__match='wool').count(), 1)
 
         # Now create a revision that is a redirect and make sure the
         # document is removed from the index.
-        revision(document=doc, content=REDIRECT_CONTENT, is_approved=True,
-                 save=True)
+        RedirectRevisionFactory(document=doc)
         self.refresh()
-        eq_(DocumentMappingType.search().query(
-            document_title__match='wool').count(), 0)
+        eq_(DocumentMappingType.search().query(document_title__match='wool').count(), 0)
 
     def test_wiki_keywords(self):
         """Make sure updating keywords updates the index."""
         # Create a document with a revision with no keywords. It
         # shouldn't show up with a document_keywords term query for
         # 'wool' since it has no keywords.
-        doc = document(title=u'wool hats')
-        doc.save()
-        revision(document=doc, is_approved=True, save=True)
+        doc = DocumentFactory(title=u'wool hats')
+        RevisionFactory(document=doc, is_approved=True)
         self.refresh()
         eq_(DocumentMappingType.search().query(
             document_keywords='wool').count(), 0)
 
-        revision(document=doc, is_approved=True, keywords='wool', save=True)
+        RevisionFactory(document=doc, is_approved=True, keywords='wool')
         self.refresh()
 
-        eq_(DocumentMappingType.search().query(
-            document_keywords='wool').count(), 1)
+        eq_(DocumentMappingType.search().query(document_keywords='wool').count(), 1)
 
     def test_recent_helpful_votes(self):
         """Recent helpful votes are indexed properly."""
         # Create a document and verify it doesn't show up in a
         # query for recent_helpful_votes__gt=0.
-        r = revision(is_approved=True, save=True)
+        r = RevisionFactory(is_approved=True)
         self.refresh()
         eq_(DocumentMappingType.search().filter(
             document_recent_helpful_votes__gt=0).count(), 0)
 
         # Add an unhelpful vote, it still shouldn't show up.
-        helpful_vote(revision=r, helpful=False, save=True)
+        HelpfulVoteFactory(revision=r, helpful=False)
         r.document.save()  # Votes don't trigger a reindex.
         self.refresh()
         eq_(DocumentMappingType.search().filter(
@@ -160,7 +153,7 @@ class DocumentUpdateTests(ElasticTestCase):
 
         # Add an helpful vote created 31 days ago, it still shouldn't show up.
         created = datetime.now() - timedelta(days=31)
-        helpful_vote(revision=r, helpful=True, created=created, save=True)
+        HelpfulVoteFactory(revision=r, helpful=True, created=created)
         r.document.save()  # Votes don't trigger a reindex.
         self.refresh()
         eq_(DocumentMappingType.search().filter(
@@ -168,7 +161,7 @@ class DocumentUpdateTests(ElasticTestCase):
 
         # Add an helpful vote created 29 days ago, it should show up now.
         created = datetime.now() - timedelta(days=29)
-        helpful_vote(revision=r, helpful=True, created=created, save=True)
+        HelpfulVoteFactory(revision=r, helpful=True, created=created)
         r.document.save()  # Votes don't trigger a reindex.
         self.refresh()
         eq_(DocumentMappingType.search().filter(
@@ -181,7 +174,7 @@ class RevisionMetricsTests(ElasticTestCase):
 
         Deleting should delete it.
         """
-        r = revision(save=True)
+        r = RevisionFactory()
         self.refresh()
         eq_(RevisionMetricsMappingType.search().count(), 1)
 
@@ -191,11 +184,10 @@ class RevisionMetricsTests(ElasticTestCase):
 
     def test_data_in_index(self):
         """Verify the data we are indexing."""
-        p = product(save=True)
-        base_doc = document(locale='en-US', save=True)
-        base_doc.products.add(p)
-        d = document(locale='es', parent=base_doc, save=True)
-        r = revision(document=d, is_approved=True, save=True)
+        p = ProductFactory()
+        base_doc = DocumentFactory(locale='en-US', products=[p])
+        d = DocumentFactory(locale='es', parent=base_doc)
+        r = RevisionFactory(document=d, is_approved=True)
 
         self.refresh()
 

--- a/kitsune/wiki/tests/test_locale_views.py
+++ b/kitsune/wiki/tests/test_locale_views.py
@@ -4,9 +4,9 @@ from pyquery import PyQuery as pq
 
 from kitsune.sumo.tests import TestCase, LocalizingClient
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import user, add_permission
+from kitsune.users.tests import UserFactory, add_permission
 from kitsune.wiki.models import Locale
-from kitsune.wiki.tests import locale
+from kitsune.wiki.tests import LocaleFactory
 
 
 class LocaleListTests(TestCase):
@@ -14,9 +14,9 @@ class LocaleListTests(TestCase):
 
     def test_locale_list(self):
         """Verify the locale list renders all locales."""
-        locale(locale='en-US', save=True)
-        locale(locale='es', save=True)
-        locale(locale='de', save=True)
+        LocaleFactory(locale='en-US')
+        LocaleFactory(locale='es')
+        LocaleFactory(locale='de')
 
         r = self.client.get(reverse('wiki.locales'))
         eq_(r.status_code, 200)
@@ -29,12 +29,12 @@ class LocaleDetailsTests(TestCase):
 
     def test_locale_list(self):
         """Verify the locale list renders all locales."""
-        l = locale(locale='es', save=True)
-        leader = user(save=True)
+        l = LocaleFactory(locale='es')
+        leader = UserFactory()
         l.leaders.add(leader)
-        reviewer = user(save=True)
+        reviewer = UserFactory()
         l.reviewers.add(reviewer)
-        editor = user(save=True)
+        editor = UserFactory()
         l.editors.add(editor)
 
         r = self.client.get(reverse('wiki.locale_details', args=[l.locale]))
@@ -42,13 +42,13 @@ class LocaleDetailsTests(TestCase):
         doc = pq(r.content)
         leaders = doc('ul.leaders > li')
         eq_(1, len(leaders))
-        assert leader.username in leaders.text()
+        assert leader.profile.name in leaders.text()
         reviewers = doc('ul.reviewers > li')
         eq_(1, len(reviewers))
-        assert reviewer.username in reviewers.text()
+        assert reviewer.profile.name in reviewers.text()
         editors = doc('ul.editors > li')
         eq_(1, len(editors))
-        assert editor.username in editors.text()
+        assert editor.profile.name in editors.text()
 
 
 class AddRemoveLeaderTests(TestCase):
@@ -56,10 +56,10 @@ class AddRemoveLeaderTests(TestCase):
 
     def setUp(self):
         super(AddRemoveLeaderTests, self).setUp()
-        self.locale = locale(locale='es', save=True)
-        self.user = user(save=True)
+        self.locale = LocaleFactory(locale='es')
+        self.user = UserFactory()
         add_permission(self.user, Locale, 'change_locale')
-        self.leader = user(save=True)
+        self.leader = UserFactory()
         self.client.login(username=self.user.username, password='testpass')
 
     def test_add_leader(self):
@@ -86,10 +86,10 @@ class AddRemoveReviewerTests(TestCase):
 
     def setUp(self):
         super(AddRemoveReviewerTests, self).setUp()
-        self.locale = locale(locale='es', save=True)
-        self.user = user(save=True)
+        self.locale = LocaleFactory(locale='es')
+        self.user = UserFactory()
         self.locale.leaders.add(self.user)
-        self.reviewer = user(save=True)
+        self.reviewer = UserFactory()
         self.client.login(username=self.user.username, password='testpass')
 
     def test_add_reviewer(self):
@@ -116,10 +116,10 @@ class AddRemoveEditorTests(TestCase):
 
     def setUp(self):
         super(AddRemoveEditorTests, self).setUp()
-        self.locale = locale(locale='es', save=True)
-        self.user = user(save=True)
+        self.locale = LocaleFactory(locale='es')
+        self.user = UserFactory()
         self.locale.leaders.add(self.user)
-        self.editor = user(save=True)
+        self.editor = UserFactory()
         self.client.login(username=self.user.username, password='testpass')
 
     def test_add_editor(self):

--- a/kitsune/wiki/tests/test_models.py
+++ b/kitsune/wiki/tests/test_models.py
@@ -8,7 +8,7 @@ from taggit.models import TaggedItem
 
 from django.core.exceptions import ValidationError
 
-from kitsune.products.tests import product, topic
+from kitsune.products.tests import ProductFactory, TopicFactory
 from kitsune.sumo import ProgrammingError
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
@@ -18,20 +18,13 @@ from kitsune.wiki.config import (
 from kitsune.wiki.models import Document
 from kitsune.wiki.parser import wiki_to_html
 from kitsune.wiki.tests import (
-    document, revision, doc_rev, translated_revision, DocumentFactory, TemplateDocumentFactory)
+    RevisionFactory, ApprovedRevisionFactory, TranslatedRevisionFactory, DocumentFactory,
+    TemplateDocumentFactory, RedirectRevisionFactory)
 
 
 def _objects_eq(manager, list_):
     """Assert that the objects contained by `manager` are those in `list_`."""
     eq_(set(manager.all()), set(list_))
-
-
-def redirect_rev(title, redirect_to):
-    return revision(
-        document=document(title=title, save=True),
-        content='REDIRECT [[%s]]' % redirect_to,
-        is_approved=True,
-        save=True)
 
 
 class DocumentTests(TestCase):
@@ -60,9 +53,7 @@ class DocumentTests(TestCase):
         # TODO: Move to wherever the tests for TaggableMixin are.
         # This works because Django's delete() sees the `tags` many-to-many
         # field (actually a manager) and follows the reference.
-        d = document()
-        d.save()
-        d.tags.add('grape')
+        d = DocumentFactory(tags=['grape'])
         eq_(1, TaggedItem.objects.count())
 
         d.delete()
@@ -75,12 +66,10 @@ class DocumentTests(TestCase):
 
         # Notice if somebody ever changes the default on the category field,
         # which would invalidate our test:
-        assert some_category != document().category
+        assert some_category != DocumentFactory().category
 
-        parent = document(category=some_category)
-        parent.save()
-        child = document(parent=parent, locale='de')
-        child.save()
+        parent = DocumentFactory(category=some_category)
+        child = DocumentFactory(parent=parent, locale='de')
 
         # Make sure child sees stuff set on parent:
         eq_(some_category, child.category)
@@ -100,10 +89,9 @@ class DocumentTests(TestCase):
     def _test_remembering_setter_unsaved(self, field):
         """A remembering setter shouldn't kick in until the doc is saved."""
         old_field = 'old_' + field
-        d = document()
+        d = DocumentFactory.build()
         setattr(d, field, 'Foo')
-        assert not hasattr(d, old_field), "Doc shouldn't have %s until it's" \
-                                          "saved." % old_field
+        assert not hasattr(d, old_field), "Doc shouldn't have %s until it's saved." % old_field
 
     def test_slug_setter_unsaved(self):
         self._test_remembering_setter_unsaved('slug')
@@ -113,8 +101,7 @@ class DocumentTests(TestCase):
 
     def _test_remembering_setter(self, field):
         old_field = 'old_' + field
-        d = document()
-        d.save()
+        d = DocumentFactory()
         old = getattr(d, field)
 
         # Changing the field makes old_field spring into life:
@@ -150,28 +137,24 @@ class DocumentTests(TestCase):
     def test_only_localizable_allowed_children(self):
         """You can't have children for a non-localizable document."""
         # Make English rev:
-        en_doc = document(is_localizable=False)
-        en_doc.save()
+        en_doc = DocumentFactory(is_localizable=False)
 
         # Make Deutsch translation:
-        de_doc = document(parent=en_doc, locale='de')
+        de_doc = DocumentFactory.build(parent=en_doc, locale='de')
         self.assertRaises(ValidationError, de_doc.save)
 
     def test_cannot_make_non_localizable_if_children(self):
         """You can't make a document non-localizable if it has children."""
         # Make English rev:
-        en_doc = document(is_localizable=True)
-        en_doc.save()
+        en_doc = DocumentFactory(is_localizable=True)
 
         # Make Deutsch translation:
-        de_doc = document(parent=en_doc, locale='de')
-        de_doc.save()
+        DocumentFactory(parent=en_doc, locale='de')
         en_doc.is_localizable = False
         self.assertRaises(ValidationError, en_doc.save)
 
     def test_non_english_implies_nonlocalizable(self):
-        d = document(is_localizable=True, locale='de')
-        d.save()
+        d = DocumentFactory(is_localizable=True, locale='de')
         assert not d.is_localizable
 
     def test_validate_category_on_save(self):
@@ -180,16 +163,15 @@ class DocumentTests(TestCase):
         Invalid categories cause errors when viewing documents.
 
         """
-        d = document(category=9999)
+        d = DocumentFactory.build(category=9999)
         self.assertRaises(ValidationError, d.save)
 
     def test_new_doc_does_not_update_categories(self):
         """Make sure that creating a new document doesn't change the
         category of all the other documents."""
-        d1 = document(category=20)
-        d1.save()
+        d1 = DocumentFactory(category=20)
         assert d1.pk
-        d2 = document(category=30)
+        d2 = DocumentFactory.build(category=30)
         assert not d2.pk
         d2._clean_category()
         d1prime = Document.objects.get(pk=d1.pk)
@@ -197,8 +179,7 @@ class DocumentTests(TestCase):
 
     def test_majorly_outdated(self):
         """Test the is_majorly_outdated method."""
-        trans = translated_revision(is_approved=True)
-        trans.save()
+        trans = TranslatedRevisionFactory(is_approved=True)
         trans_doc = trans.document
 
         # Make sure a doc returns False if it has no parent:
@@ -207,9 +188,7 @@ class DocumentTests(TestCase):
         assert not trans_doc.is_majorly_outdated()
 
         # Add a parent revision of MAJOR significance:
-        r = revision(document=trans_doc.parent,
-                     significance=MAJOR_SIGNIFICANCE)
-        r.save()
+        r = RevisionFactory(document=trans_doc.parent, significance=MAJOR_SIGNIFICANCE)
         assert not trans_doc.is_majorly_outdated()
 
         # Approve it:
@@ -229,13 +208,10 @@ class DocumentTests(TestCase):
 
         """
         # Create a parent doc with only an unapproved revision...
-        parent_rev = revision()
-        parent_rev.save()
+        parent_rev = RevisionFactory()
         # ...and a translation with a revision based on nothing.
-        trans = document(parent=parent_rev.document, locale='de')
-        trans.save()
-        trans_rev = revision(document=trans, is_approved=True)
-        trans_rev.save()
+        trans = DocumentFactory(parent=parent_rev.document, locale='de')
+        trans_rev = RevisionFactory(document=trans, is_approved=True)
 
         assert trans_rev.based_on is None, \
             ('based_on defaulted to something non-None, which this test '
@@ -246,11 +222,10 @@ class DocumentTests(TestCase):
              'the English document has never had an approved revision of '
              'major significance.')
 
-        major_parent_rev = revision(document=parent_rev.document,
-                                    significance=MAJOR_SIGNIFICANCE,
-                                    is_approved=True,
-                                    is_ready_for_localization=True)
-        major_parent_rev.save()
+        ApprovedRevisionFactory(
+            document=parent_rev.document,
+            significance=MAJOR_SIGNIFICANCE,
+            is_ready_for_localization=True)
 
         assert trans.is_majorly_outdated(), \
             ('A translation was not considered majorly outdated when its '
@@ -258,60 +233,53 @@ class DocumentTests(TestCase):
 
     def test_redirect_document_non_redirect(self):
         """Assert redirect_document on non-redirects returns None."""
-        eq_(None, document().redirect_document())
+        eq_(None, DocumentFactory().redirect_document())
 
     def test_redirect_document_external_redirect(self):
         """Assert redirects to external pages return None."""
-        eq_(None, revision(content='REDIRECT [http://example.com]',
-                           is_approved=True,
-                           save=True).document.redirect_document())
+        rev = ApprovedRevisionFactory(content='REDIRECT [http://example.com')
+        eq_(rev.document.redirect_document(), None)
 
     def test_redirect_document_nonexistent(self):
         """Assert redirects to non-existent pages return None."""
-        eq_(None, revision(content='REDIRECT [[kersmoo]]',
-                           is_approved=True,
-                           save=True).document.redirect_document())
+        rev = ApprovedRevisionFactory(content='REDIRECT [[kersmoo]]')
+        eq_(None, rev.document.redirect_document())
 
     def test_redirect_nondefault_locales(self):
         title1 = 'title1'
         title2 = 'title2'
 
-        redirect_to = revision(
-            document=document(title=title1, locale='es', save=True),
-            is_approved=True,
-            save=True)
+        redirect_to = ApprovedRevisionFactory(
+            document__title=title1,
+            document__locale='es',
+            document=DocumentFactory(title=title1, locale='es'))
 
-        redirector = revision(
-            document=document(title=title2, locale='es', save=True),
-            content=u'REDIRECT [[%s]]' % redirect_to.document.title,
-            is_approved=True,
-            save=True)
+        redirector = RedirectRevisionFactory(
+            target=redirect_to.document,
+            document__title=title2,
+            document__locale='es',
+            is_approved=True)
 
         eq_(redirect_to.document.get_absolute_url(),
             redirector.document.redirect_url())
 
     def test_get_topics(self):
         """Test the get_topics() method."""
-        en_us = document(save=True)
-        en_us.topics.add(topic(save=True))
-        en_us.topics.add(topic(save=True))
-
+        en_us = DocumentFactory(topics=TopicFactory.create_batch(2))
         eq_(2, len(en_us.get_topics()))
 
         # Localized document inherits parent's topics.
-        document(parent=en_us, save=True)
+        DocumentFactory(parent=en_us)
         eq_(2, len(en_us.get_topics()))
 
     def test_get_products(self):
         """Test the get_products() method."""
-        en_us = document(save=True)
-        en_us.products.add(product(save=True))
-        en_us.products.add(product(save=True))
+        en_us = DocumentFactory(products=ProductFactory.create_batch(2))
 
         eq_(2, len(en_us.get_products()))
 
         # Localized document inherits parent's topics.
-        document(parent=en_us, save=True)
+        DocumentFactory(parent=en_us)
         eq_(2, len(en_us.get_products()))
 
     def test_template_title_and_category_to_template(self):
@@ -402,17 +370,12 @@ class FromUrlTests(TestCase):
     def test_redirect_to_translated_document(self):
         from_url = Document.from_url
 
-        d_en = document(locale='en-US',
-                        title=u'How to delete Google Chrome?',
-                        save=True)
-        d_tr = document(locale='tr',
-                        title=u'Google Chrome\'u nasıl silerim?',
-                        parent=d_en, save=True)
+        d_en = DocumentFactory(locale='en-US', title=u'How to delete Google Chrome?')
+        d_tr = DocumentFactory(locale='tr', title=u'Google Chrome\'u nasıl silerim?', parent=d_en)
         # The /tr/kb/how-to-delete-google-chrome URL for Turkish locale
         # should be redirected to /tr/kb/google-chromeu-nasl-silerim
         # if there is a Turkish translation of the document.
-        tr_translate_url = reverse('wiki.document', locale='tr',
-                                   args=[d_en.slug])
+        tr_translate_url = reverse('wiki.document', locale='tr', args=[d_en.slug])
         self.assertEqual(d_en.translated_to('tr'), from_url(tr_translate_url))
         self.assertEqual(d_tr, from_url(tr_translate_url))
         self.assertEqual(d_en, from_url(d_en.get_absolute_url()))
@@ -420,26 +383,19 @@ class FromUrlTests(TestCase):
     def test_id_only(self):
         from_url = Document.from_url
 
-        d = document(locale='en-US',
-                     title=u'How to delete Google Chrome?',
-                     save=True)
+        d = DocumentFactory(locale='en-US', title=u'How to delete Google Chrome?')
         doc = from_url(d.get_absolute_url(), id_only=True)
         self.assertEqual(d.title, doc.title)
         self.assertEqual(d.locale, doc.locale)
 
     def test_document_translate_fallback(self):
-        d_en = document(locale='en-US',
-                        title=u'How to delete Google Chrome?',
-                        save=True)
-        invalid_translate = reverse('wiki.document', locale='tr',
-                                    args=[d_en.slug])
+        d_en = DocumentFactory(locale='en-US', title=u'How to delete Google Chrome?')
+        invalid_translate = reverse('wiki.document', locale='tr', args=[d_en.slug])
         self.assertEqual(d_en, Document.from_url(invalid_translate))
 
     def test_check_host(self):
         from_url = Document.from_url
-        d_en = document(locale='en-US',
-                        title=u'How to delete Google Chrome?',
-                        save=True)
+        d_en = DocumentFactory(locale='en-US', title=u'How to delete Google Chrome?')
         sumo_host = 'http://support.mozilla.org'
         invalid_url = urlparse.urljoin(sumo_host, d_en.get_absolute_url())
         self.assertIsNone(from_url(invalid_url))
@@ -447,79 +403,55 @@ class FromUrlTests(TestCase):
 
 
 class LocalizableOrLatestRevisionTests(TestCase):
-    """Tests for Document.localizable_or_latest_revision()"""
+    """Tests for Document.localizable_or_latest_revision"""
 
     def test_none(self):
         """If there are no revisions, return None."""
-        d = document(save=True)
+        d = DocumentFactory()
         eq_(None, d.localizable_or_latest_revision())
 
     def test_only_rejected(self):
         """If there are only rejected revisions, return None."""
-        rejected = revision(is_approved=False,
-                            reviewed=datetime.now(),
-                            save=True)
+        rejected = RevisionFactory(is_approved=False, reviewed=datetime.now())
         eq_(None, rejected.document.localizable_or_latest_revision())
 
     def test_multiple_ready(self):
         """When multiple ready revisions exist, return the most recent."""
-        r1 = revision(is_approved=True,
-                      is_ready_for_localization=True,
-                      save=True)
-        r2 = revision(document=r1.document,
-                      is_approved=True,
-                      is_ready_for_localization=True,
-                      save=True)
+        r1 = ApprovedRevisionFactory(is_approved=True, is_ready_for_localization=True)
+        r2 = ApprovedRevisionFactory(document=r1.document, is_ready_for_localization=True)
         eq_(r2, r2.document.localizable_or_latest_revision())
 
     def test_ready_over_recent(self):
         """Favor a ready revision over a more recent unready one."""
-        ready = revision(is_approved=True,
-                         is_ready_for_localization=True,
-                         save=True)
-        revision(document=ready.document,
-                 is_approved=True,
-                 is_ready_for_localization=False,
-                 save=True)
+        ready = ApprovedRevisionFactory(is_approved=True, is_ready_for_localization=True)
+        ApprovedRevisionFactory(document=ready.document, is_ready_for_localization=False)
         eq_(ready, ready.document.localizable_or_latest_revision())
 
     def test_approved_over_unreviewed(self):
         """Favor an approved revision over a more recent unreviewed one."""
-        approved = revision(is_approved=True,
-                            is_ready_for_localization=False,
-                            save=True)
-        revision(document=approved.document,
-                 is_ready_for_localization=False,
-                 is_approved=False,
-                 reviewed=None,
-                 save=True)
+        approved = ApprovedRevisionFactory(is_ready_for_localization=False)
+        RevisionFactory(
+            document=approved.document,
+            is_ready_for_localization=False,
+            is_approved=False,
+            reviewed=None)
         eq_(approved, approved.document.localizable_or_latest_revision())
 
     def test_latest_unreviewed_if_none_ready(self):
         """Return the latest unreviewed revision when no ready one exists."""
-        unreviewed = revision(is_approved=False,
-                              reviewed=None,
-                              save=True)
+        unreviewed = RevisionFactory(is_approved=False, reviewed=None)
         eq_(unreviewed, unreviewed.document.localizable_or_latest_revision())
 
     def test_latest_rejected_if_none_unreviewed(self):
         """Return the latest rejected revision when no ready or unreviewed ones
         exist, if include_rejected=True."""
-        rejected = revision(is_approved=False,
-                            reviewed=datetime.now(),
-                            save=True)
-        eq_(rejected, rejected.document.localizable_or_latest_revision(
-            include_rejected=True))
+        rejected = RevisionFactory(is_approved=False, reviewed=datetime.now())
+        eq_(rejected, rejected.document.localizable_or_latest_revision(include_rejected=True))
 
     def test_non_localizable(self):
         """When document isn't localizable, ignore is_ready_for_l10n."""
-        r1 = revision(is_approved=True,
-                      is_ready_for_localization=True,
-                      save=True)
-        r2 = revision(document=r1.document,
-                      is_approved=True,
-                      is_ready_for_localization=False,
-                      save=True)
+        r1 = ApprovedRevisionFactory(is_ready_for_localization=True)
+        r2 = ApprovedRevisionFactory(document=r1.document, is_ready_for_localization=False)
         r1.document.is_localizable = False
         r1.document.save()
         eq_(r2, r2.document.localizable_or_latest_revision())
@@ -529,7 +461,8 @@ class RedirectCreationTests(TestCase):
     """Tests for automatic creation of redirects when slug or title changes"""
 
     def setUp(self):
-        self.d, self.r = doc_rev()
+        self.r = ApprovedRevisionFactory()
+        self.d = self.r.document
         self.old_title = self.d.title
         self.old_slug = self.d.slug
 
@@ -567,7 +500,7 @@ class RedirectCreationTests(TestCase):
     def test_no_redirect_on_unsaved_change(self):
         """No redirect should be made when an unsaved doc's title or slug is
         changed."""
-        d = document(title='Gerbil')
+        d = DocumentFactory(title='Gerbil')
         d.title = 'Weasel'
         d.save()
         # There should be no redirect from Gerbil -> Weasel:
@@ -582,7 +515,7 @@ class RedirectCreationTests(TestCase):
                 'number': 1
             }
         }
-        document(locale=self.d.locale, **kwargs).save()
+        DocumentFactory(locale=self.d.locale, **kwargs)
 
         # Trigger creation of a redirect of a new title or slug:
         setattr(self.d, attr, 'new')
@@ -615,65 +548,59 @@ class RevisionTests(TestCase):
 
     def test_approved_revision_updates_html(self):
         """Creating an approved revision updates document.html"""
-        d, _ = doc_rev('Replace document html')
+        d = ApprovedRevisionFactory(content='Replace document html').document
 
-        assert 'Replace document html' in d.html, \
-               '"Replace document html" not in %s' % d.html
+        assert 'Replace document html' in d.html, '"Replace document html" not in %s' % d.html
 
         # Creating another approved revision replaces it again
-        r = revision(document=d, content='Replace html again',
-                     is_approved=True)
-        r.save()
+        ApprovedRevisionFactory(document=d, content='Replace html again')
 
         assert 'Replace html again' in d.html, \
                '"Replace html again" not in %s' % d.html
 
     def test_unapproved_revision_not_updates_html(self):
         """Creating an unapproved revision does not update document.html"""
-        d, _ = doc_rev('Here to stay')
-
+        d = ApprovedRevisionFactory(content='Here to stay').document
         assert 'Here to stay' in d.html, '"Here to stay" not in %s' % d.html
 
         # Creating another approved revision keeps initial content
-        r = revision(document=d, content='Fail to replace html')
-        r.save()
-
+        RevisionFactory(document=d, content='Fail to replace html')
         assert 'Here to stay' in d.html, '"Here to stay" not in %s' % d.html
 
     def test_revision_unicode(self):
         """Revision containing unicode characters is saved successfully."""
         str = u' \r\nFirefox informa\xe7\xf5es \u30d8\u30eb'
-        _, r = doc_rev(str)
+        r = ApprovedRevisionFactory(content=str)
         eq_(str, r.content)
 
     def test_save_bad_based_on(self):
         """Saving a Revision with a bad based_on value raises an error."""
-        r = revision()
-        r.based_on = revision()  # Revision of some other unrelated Document
-        self.assertRaises(ProgrammingError, r.save)
+        r1 = RevisionFactory()
+        # Revision of some other unrelated Document
+        r2 = RevisionFactory.build(based_on=r1)
+        self.assertRaises(ProgrammingError, r2.save)
 
     def test_correct_based_on_to_none(self):
         """Assure Revision.clean() changes a bad based_on value to None when
         there is no current_revision of the English document."""
-        r = revision()
-        r.based_on = revision()  # Revision of some other unrelated Document
-        self.assertRaises(ValidationError, r.clean)
-        eq_(None, r.based_on)
+        r1 = RevisionFactory()
+        # Revision of some other unrelated Document
+        r2 = RevisionFactory.build(based_on=r1)
+        self.assertRaises(ValidationError, r2.clean)
+        eq_(None, r2.based_on)
 
     def test_correct_based_on_to_current_revision(self):
         """Assure Revision.clean() changes a bad based_on value to the English
         doc's current_revision when there is one."""
         # Make English rev:
-        en_rev = revision(is_approved=True)
-        en_rev.save()
+        en_rev = ApprovedRevisionFactory()
 
         # Make Deutsch translation:
-        de_doc = document(parent=en_rev.document, locale='de')
-        de_doc.save()
-        de_rev = revision(document=de_doc)
+        de_doc = DocumentFactory(parent=en_rev.document, locale='de')
+        de_rev = RevisionFactory(document=de_doc)
 
         # Set based_on to some random, unrelated Document's rev:
-        de_rev.based_on = revision()
+        de_rev.based_on = RevisionFactory()
 
         # Try to recover:
         self.assertRaises(ValidationError, de_rev.clean)
@@ -682,38 +609,35 @@ class RevisionTests(TestCase):
 
     def test_correct_ready_for_localization_if_unapproved(self):
         """Revision.clean() must clear is_ready_for_l10n if not is_approved."""
-        r = revision(is_approved=False, is_ready_for_localization=True)
+        r = RevisionFactory.build(is_approved=False, is_ready_for_localization=True)
         r.clean()
         assert not r.is_ready_for_localization
 
     def test_correct_ready_for_localization_if_insignificant(self):
         """Revision.clean() must clear is_ready_for_l10n if the rev is of
         typo-level significance."""
-        r = revision(is_approved=True,
-                     is_ready_for_localization=True,
-                     significance=TYPO_SIGNIFICANCE)
+        r = ApprovedRevisionFactory.build(
+            is_ready_for_localization=True,
+            significance=TYPO_SIGNIFICANCE)
         r.clean()
         assert not r.is_ready_for_localization
 
     def test_ready_for_l10n_updates_doc(self):
         """Approving and marking ready a rev should update the doc's ref."""
         # Ready a rev in a new doc:
-        ready_1 = revision(is_approved=True,
-                           is_ready_for_localization=True,
-                           save=True)
+        ready_1 = ApprovedRevisionFactory(is_ready_for_localization=True)
         eq_(ready_1, ready_1.document.latest_localizable_revision)
 
         # Add an unready revision that we can ready later:
-        unready = revision(document=ready_1.document,
-                           is_approved=False,
-                           is_ready_for_localization=False,
-                           save=True)
+        unready = RevisionFactory(
+            document=ready_1.document,
+            is_approved=False,
+            is_ready_for_localization=False)
 
         # Ready a rev in a doc that already has a ready revision:
-        ready_2 = revision(document=ready_1.document,
-                           is_approved=True,
-                           is_ready_for_localization=True,
-                           save=True)
+        ready_2 = ApprovedRevisionFactory(
+            document=ready_1.document,
+            is_ready_for_localization=True)
         eq_(ready_2, ready_2.document.latest_localizable_revision)
 
         # Ready the older rev. It should not become the latest_localizable.
@@ -731,14 +655,9 @@ class RevisionTests(TestCase):
         test_delete_current_revision template test.
 
         """
-        r1 = revision(is_approved=True,
-                      is_ready_for_localization=True,
-                      save=True)
+        r1 = ApprovedRevisionFactory(is_ready_for_localization=True)
         d = r1.document
-        r2 = revision(document=d,
-                      is_approved=True,
-                      is_ready_for_localization=True,
-                      save=True)
+        r2 = ApprovedRevisionFactory(document=d, is_ready_for_localization=True)
 
         # Deleting r2 should make the latest fall back to r1:
         r2.delete()
@@ -750,12 +669,9 @@ class RevisionTests(TestCase):
 
     def test_delete_rendering(self):
         """Make sure the cached HTML updates when deleting the current rev."""
-        unapproved = revision(is_approved=False, save=True)
+        unapproved = RevisionFactory(is_approved=False)
         d = unapproved.document
-        approved = revision(document=d,
-                            is_approved=True,
-                            content='booyah',
-                            save=True)
+        approved = ApprovedRevisionFactory(document=d, content='booyah')
         assert 'booyah' in d.content_parsed
 
         # Delete the current rev. Since there are no other approved revs, the
@@ -768,9 +684,9 @@ class RevisionTests(TestCase):
         eq_('', d.content_parsed)
 
     def test_previous(self):
-        r1 = revision(is_approved=True, save=True)
+        r1 = RevisionFactory(is_approved=True)
         d = r1.document
-        r2 = revision(document=d, is_approved=True, save=True)
+        r2 = RevisionFactory(document=d, is_approved=True)
 
         eq_(r1.previous, None)
         eq_(r2.previous.id, r1.id)

--- a/kitsune/wiki/tests/test_notifications.py
+++ b/kitsune/wiki/tests/test_notifications.py
@@ -5,14 +5,15 @@ from nose.tools import eq_
 
 from kitsune.sumo.tests import post
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.users.tests import add_permission, user
-from kitsune.products.tests import product
+from kitsune.users.tests import add_permission, UserFactory
+from kitsune.products.tests import ProductFactory
 from kitsune.wiki.config import (
     SIGNIFICANCES, MAJOR_SIGNIFICANCE, MEDIUM_SIGNIFICANCE, TYPO_SIGNIFICANCE)
 from kitsune.wiki.events import (
     ReadyRevisionEvent, ApproveRevisionInLocaleEvent)
 from kitsune.wiki.models import Revision
-from kitsune.wiki.tests import document, revision, TestCaseBase
+from kitsune.wiki.tests import (
+    DocumentFactory, RevisionFactory, ApprovedRevisionFactory, TestCaseBase)
 
 
 def _assert_ready_mail(mail):
@@ -29,7 +30,7 @@ def _assert_creator_mail(mail):
 
 def _set_up_ready_watcher():
     """Make a user who watches for revision readiness."""
-    ready_watcher = user(email='ready@example.com', save=True)
+    ready_watcher = UserFactory(email='ready@example.com')
     ReadyRevisionEvent.notify(ready_watcher)
     return ready_watcher
 
@@ -39,24 +40,23 @@ class ReviewTests(TestCaseBase):
 
     def setUp(self):
         """Have a user watch for revision approval. Log in."""
-        self.approved_watcher = user(email='approved@example.com', save=True)
+        self.approved_watcher = UserFactory(email='approved@example.com')
         ApproveRevisionInLocaleEvent.notify(self.approved_watcher,
                                             locale='en-US')
-        approver = user(save=True)
+        approver = UserFactory()
         add_permission(approver, Revision, 'review_revision')
         add_permission(approver, Revision, 'mark_ready_for_l10n')
         self.client.login(username=approver.username, password='testpass')
 
-    def _review_revision(self, is_approved=True, is_ready=False,
-                         significance=SIGNIFICANCES[0][0], r=None,
-                         comment=None, doc=None):
+    def _review_revision(self, is_approved=True, is_ready=False, significance=SIGNIFICANCES[0][0],
+                         r=None, comment=None, **kwargs):
         """Make a revision, and approve or reject it through the view."""
         if not r:
-            r = revision(is_approved=False,
-                         is_ready_for_localization=False,
-                         significance=significance,
-                         document=doc,
-                         save=True)
+            r = RevisionFactory(
+                is_approved=False,
+                is_ready_for_localization=False,
+                significance=significance,
+                **kwargs)
 
         # Figure out POST data:
         data = {'comment': 'đSome comment'}
@@ -91,19 +91,19 @@ class ReviewTests(TestCaseBase):
         """Verify product-specific ready for review notifications."""
         # Add an all products in 'es' watcher and a Firefox OS in 'es'
         # watcher.
-        ApproveRevisionInLocaleEvent.notify(user(save=True), locale='es')
+        ApproveRevisionInLocaleEvent.notify(UserFactory(), locale='es')
         ApproveRevisionInLocaleEvent.notify(
-            user(save=True), product='firefox-os', locale='es')
+            UserFactory(), product='firefox-os', locale='es')
 
         # Create an 'es' document for Firefox
-        parent = document(save=True)
-        doc = document(parent=parent, locale='es', save=True)
-        parent.products.add(product(slug='firefox', save=True))
+        parent = DocumentFactory()
+        doc = DocumentFactory(parent=parent, locale='es')
+        parent.products.add(ProductFactory(slug='firefox'))
 
         # Review a revision. There should be 3 new emails:
         # 1 to the creator, 1 to the reviewer and 1 to the 'es' watcher.
         self._review_revision(
-            doc=doc, is_ready=True, significance=MEDIUM_SIGNIFICANCE)
+            document=doc, is_ready=True, significance=MEDIUM_SIGNIFICANCE)
         eq_(3, len(mail.outbox))
         _assert_approved_mail(mail.outbox[0])
         _assert_creator_mail(mail.outbox[1])
@@ -111,9 +111,9 @@ class ReviewTests(TestCaseBase):
         # Add firefox-os to the document's products and review a new revision.
         # There should be 4 new emails now (the same 3 from before plus one
         # for the firefox-os watcher).
-        parent.products.add(product(slug='firefox-os', save=True))
+        parent.products.add(ProductFactory(slug='firefox-os'))
         self._review_revision(
-            doc=doc, is_ready=True, significance=MEDIUM_SIGNIFICANCE)
+            document=doc, is_ready=True, significance=MEDIUM_SIGNIFICANCE)
         eq_(7, len(mail.outbox))
         _assert_approved_mail(mail.outbox[3])
         _assert_approved_mail(mail.outbox[4])
@@ -121,19 +121,19 @@ class ReviewTests(TestCaseBase):
 
         # Add a Firefox watcher. This time there should be 5 new emails.
         ApproveRevisionInLocaleEvent.notify(
-            user(save=True), product='firefox', locale='es')
+            UserFactory(), product='firefox', locale='es')
         self._review_revision(
-            doc=doc, is_ready=True, significance=MEDIUM_SIGNIFICANCE)
+            document=doc, is_ready=True, significance=MEDIUM_SIGNIFICANCE)
         eq_(12, len(mail.outbox))
 
     def test_typo_significance_ignore(self):
         # Create the first approved revision for the document. This one will
         # always have MAJOR_SIGNIFICANCE.
-        r = revision(is_approved=True, save=True)
+        r = RevisionFactory(is_approved=True)
 
         # Then, set up a watcher and create a TYPO_SIGNIFICANCE revision.
         _set_up_ready_watcher()
-        self._review_revision(is_ready=True, doc=r.document,
+        self._review_revision(is_ready=True, document=r.document,
                               significance=TYPO_SIGNIFICANCE)
         # This is the same as test_ready, except we miss 1 mail, that is the
         # localization mail.
@@ -150,18 +150,15 @@ class ReviewTests(TestCaseBase):
         assert 'Your revision has been approved' in mail.outbox[1].subject
 
     def test_based_on_approved(self):
-        u1 = user()
-        u1.save()
-        r1 = revision(is_approved=False,
-                      creator=u1,
-                      is_ready_for_localization=False,
-                      save=True)
-        u2 = user()
-        u2.save()
-        r2 = revision(document=r1.document, based_on=r1, is_approved=False,
-                      creator=u2,
-                      is_ready_for_localization=False,
-                      save=True)
+        u1 = UserFactory()
+        r1 = RevisionFactory(is_approved=False, creator=u1, is_ready_for_localization=False)
+        u2 = UserFactory()
+        r2 = RevisionFactory(
+            document=r1.document,
+            based_on=r1,
+            is_approved=False,
+            creator=u2,
+            is_ready_for_localization=False)
         eq_(0, len(mail.outbox))
         self._review_revision(r=r2)
         # 1 mail for each watcher, 1 for creator, and one for reviewer.
@@ -214,23 +211,22 @@ class ReadyForL10nTests(TestCaseBase):
 
     def setUp(self):
         """Have a user watch for revision approval. Log in."""
-        self.ready_watcher = user(email='approved@example.com', save=True)
+        self.ready_watcher = UserFactory(email='approved@example.com')
         ReadyRevisionEvent.notify(self.ready_watcher)
 
-        readyer = user(save=True)
+        readyer = UserFactory()
         add_permission(readyer, Revision, 'mark_ready_for_l10n')
         self.client.login(username=readyer.username, password='testpass')
 
     def _mark_as_ready_revision(self, doc=None):
         """Make a revision, and approve or reject it through the view."""
         if doc is None:
-            doc = document(save=True)
+            doc = DocumentFactory()
 
-        r = revision(is_approved=True,
-                     is_ready_for_localization=False,
-                     significance=MEDIUM_SIGNIFICANCE,
-                     document=doc,
-                     save=True)
+        r = ApprovedRevisionFactory(
+            is_ready_for_localization=False,
+            significance=MEDIUM_SIGNIFICANCE,
+            document=doc)
 
         # Figure out POST data:
         data = {'comment': 'something'}
@@ -253,11 +249,11 @@ class ReadyForL10nTests(TestCaseBase):
     def test_product_specific_ready(self):
         """Verify product-specific ready for l10n notifications."""
         # Add a Firefox OS watcher.
-        ReadyRevisionEvent.notify(user(save=True), product='firefox-os')
+        ReadyRevisionEvent.notify(UserFactory(), product='firefox-os')
 
         # Create a document for Firefox
-        doc = document(save=True)
-        doc.products.add(product(slug='firefox', save=True))
+        doc = DocumentFactory()
+        doc.products.add(ProductFactory(slug='firefox'))
 
         # Mark a revision a ready for L10n. There should be only one email
         # to the watcher created in setUp.
@@ -267,7 +263,7 @@ class ReadyForL10nTests(TestCaseBase):
 
         # Add firefox-os to the document's products. Mark as ready for l10n,
         # and there should be two new emails.
-        doc.products.add(product(slug='firefox-os', save=True))
+        doc.products.add(ProductFactory(slug='firefox-os'))
         self._mark_as_ready_revision(doc=doc)
         eq_(3, len(mail.outbox))
         _assert_ready_mail(mail.outbox[1])
@@ -275,6 +271,6 @@ class ReadyForL10nTests(TestCaseBase):
 
         # Add a Firefox watcher, mark as ready for l10n, and there should
         # be three new emails.
-        ReadyRevisionEvent.notify(user(save=True), product='firefox')
+        ReadyRevisionEvent.notify(UserFactory(), product='firefox')
         self._mark_as_ready_revision(doc=doc)
         eq_(6, len(mail.outbox))

--- a/kitsune/wiki/tests/test_parser.py
+++ b/kitsune/wiki/tests/test_parser.py
@@ -451,7 +451,6 @@ class TestWikiVideo(TestCase):
     def test_video_fallback_french(self):
         """English video is found in French."""
         p = WikiParser()
-        # self.test_video_english()
         v = VideoFactory()
         doc = pq(p.parse('[[V:%s]]' % v.title, locale='fr'))
         eq_('video', doc('div.video').attr('class'))

--- a/kitsune/wiki/tests/test_showfor.py
+++ b/kitsune/wiki/tests/test_showfor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from nose.tools import eq_
 
-from kitsune.products.tests import product, version
+from kitsune.products.tests import ProductFactory, VersionFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.wiki.showfor import showfor_data
 
@@ -11,9 +11,9 @@ class ShowforDataTests(TestCase):
 
     def test_all_versions(self):
         """Test that products with visible=False are in the showfor data."""
-        prod = product(save=True)
-        version(visible=True, product=prod, save=True)
-        version(visible=False, product=prod, save=True)
+        prod = ProductFactory()
+        VersionFactory(visible=True, product=prod)
+        VersionFactory(visible=False, product=prod)
 
         data = showfor_data([prod])
 

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -2697,7 +2697,7 @@ class RecentRevisionsTest(TestCaseBase):
         eq_(len(doc('#revisions-fragment ul li:not(.header)')), 1)
 
 
-# TODO: This should be a model maker subclass
+# TODO: This should be a factory subclass
 def _create_document(title='Test Document', parent=None, locale=settings.WIKI_DEFAULT_LANGUAGE,
                      doc_kwargs={}, rev_kwargs={}):
     d = DocumentFactory(

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -169,8 +169,11 @@ elasticsearch==1.2.0
 # sha256: 08GfJqajRinBjHdfWd_F3VlXZMcitXotpW6_tpuU5Ec
 enum34==1.0.4
 
-# sha256: zYMG5kw6EV3soTZoXpRduI_-FxOCAS7JOO0kGiDdfro
-factory-boy==2.5.2
+# sha256: deTJeG7SjRnsf7UA88ciGm64d0jLxvXi7qykw9aPMMs
+factory-boy==2.6.0
+
+# sha256: kPUHiRrRBz4Iz2kI61HV4d68PFpdVUQn6MP79zzfEu4
+fake-factory==0.5.3
 
 # sha256: A3VLx7JWOXwbZG5QSOIpFZD1CAFxrbiwD04tc4THbu4
 GitPython==0.1.7


### PR DESCRIPTION
Wooh boy. This is a big-un. +2125/-2598 lines. Touched 146 files. I edited almost every single test. GitHub won't show me the full diff.

A lot of this was trivial. A lot of this I did with mass find/replace. Some of those find/replaces might be a little uglier than they need to be.

Some of this is not trivial. Some of the factories have subtly different semantics than the model makers. Most of the tests are logically the same, with a different spelling. A couple tests I changed the logic of, but I think they are still testing the same thing.

This only affects the test infrastructure (in theory). If Travis passes, we know that didn't break. Besides that, check out the tests, make sure I didn't make any of them invalid. Check out the new factories, see if they are terrible or awesome.

I probably owe a drink to whoever reviews this. Luckily we'll all be together next week.

r?

PS: I have a version of this git history on my laptop that is module-by-module. It is messier, but if you'd prefer to review that, I can put it up.