### PR TITLE
[Bug 1154833] Add searchresult timestamps

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -1836,6 +1836,7 @@ def _search_suggestions(request, text, locale, product_slugs):
                     'title': q.title,
                     'type': 'question',
                     'object': q,
+                    'last_updated': q.updated,
                     'is_solved': q.is_solved,
                     'num_answers': q.num_answers,
                     'num_votes': q.num_votes,

--- a/kitsune/search/templates/search/includes/result.html
+++ b/kitsune/search/templates/search/includes/result.html
@@ -21,8 +21,7 @@
                   result.num_votes)|f(n=result.num_votes) }}
         </li>
         <li>
-          {{ ngettext('1 new this week', '{n} new this week',
-                  result.num_votes_past_week)|f(n=result.num_votes_past_week) }}
+          Last updated {{ result.last_updated|timesince }}
         </li>
       </ul>{# .thread-meta #}
     {% endif %}

--- a/kitsune/search/templates/search/includes/result.html
+++ b/kitsune/search/templates/search/includes/result.html
@@ -4,10 +4,13 @@
     <h3><a class="title" href="{{ url }}" {% if as == 'aaq' %}target="_blank"{% endif %}>{{ result.title }}</a></h3>
     <a tabindex="-1" href="{{ url }}" {% if as == 'aaq' %}target="_blank"{% endif %}>{{ result.search_summary }}</a>
     {% if result.type == 'question' %}
-      <ul class="thread-meta cf">
+      <p class="question-status cf">
         {% if result.is_solved %}
-          <li>{{ _('Solved') }}</li>
+          <span class="solved">{{ _('Solved') }}</span> &mdash;
         {% endif %}
+        Last updated {{ result.last_updated|timesince }}
+      </p>
+      <ul class="thread-meta cf">
         <li>
           {% if result.num_answers > 0 %}
             {{ ngettext('1 reply', '{n} replies',
@@ -21,7 +24,8 @@
                   result.num_votes)|f(n=result.num_votes) }}
         </li>
         <li>
-          Last updated {{ result.last_updated|timesince }}
+          {{ ngettext('1 new this week', '{n} new this week',
+                  result.num_votes_past_week)|f(n=result.num_votes_past_week) }}
         </li>
       </ul>{# .thread-meta #}
     {% endif %}

--- a/kitsune/search/views.py
+++ b/kitsune/search/views.py
@@ -17,6 +17,7 @@ import jinja2
 from elasticutils.utils import format_explanation
 from elasticutils.contrib.django import ES_EXCEPTIONS
 from mobility.decorators import mobile_template
+from rest_framework.renderers import JSONRenderer
 from tower import ugettext as _, ugettext_lazy as _lazy
 
 from kitsune import search as constants
@@ -135,6 +136,9 @@ def simple_search(request, template=None):
     * document type (`w=2`, for example, for Support Forum questions only)
 
     """
+
+    to_json = JSONRenderer().render
+
     # 1. Prep request.
     # Redirect to old Advanced Search URLs (?a={1,2}) to the new URL.
     if request.GET.get('a') in ['1', '2']:
@@ -227,7 +231,7 @@ def simple_search(request, template=None):
         if not results:
             data['message'] = _('No pages matched the search criteria')
 
-        json_data = json.dumps(data)
+        json_data = to_json(data)
         if request.JSON_CALLBACK:
             json_data = request.JSON_CALLBACK + '(' + json_data + ');'
         return HttpResponse(json_data, content_type=request.CONTENT_TYPE)
@@ -250,8 +254,9 @@ def simple_search(request, template=None):
 def advanced_search(request, template=None):
     """Elasticsearch-specific Advanced search view"""
 
-    # 1. Prep request.
+    to_json = JSONRenderer().render
 
+    # 1. Prep request.
     r = request.GET.copy()
     # TODO: Figure out how to get rid of 'a' and do it.
     # It basically is used to switch between showing the form or results.
@@ -569,7 +574,7 @@ def advanced_search(request, template=None):
         )
         if not results:
             data['message'] = _('No pages matched the search criteria')
-        json_data = json.dumps(data)
+        json_data = to_json(data)
         if request.JSON_CALLBACK:
             json_data = request.JSON_CALLBACK + '(' + json_data + ');'
         return HttpResponse(json_data, content_type=request.CONTENT_TYPE)

--- a/kitsune/search/views.py
+++ b/kitsune/search/views.py
@@ -94,6 +94,7 @@ def build_results_list(pages, is_json):
             result = {
                 'title': doc['question_title'],
                 'type': 'question',
+                'last_updated': datetime.fromtimestamp(doc['updated']),
                 'is_solved': doc['question_is_solved'],
                 'num_answers': doc['question_num_answers'],
                 'num_votes': doc['question_num_votes'],

--- a/kitsune/sumo/static/sumo/less/includes/search-result.less
+++ b/kitsune/sumo/static/sumo/less/includes/search-result.less
@@ -46,9 +46,23 @@
     }
   }
 
+  .question-status {
+    font-size: 13px;
+    margin: 12px 0 0 0;
+
+    .solved {
+      background: transparent @iconsSprite no-repeat scroll -49px -862px;
+      color: rgb(129, 188, 46);
+      display: inline-block;
+      font-family: "Open Sans Light",Arial,Helvetica,sans-serif;
+      line-height: 18px;
+      text-indent: 22px;
+    }
+  }
+
   .thread-meta {
     list-style: none;
-    margin: 12px 0 0 0;
+    margin: 3px 0 0 0;
     padding: 0;
 
     li {

--- a/kitsune/sumo/static/sumo/less/includes/search-result.less
+++ b/kitsune/sumo/static/sumo/less/includes/search-result.less
@@ -54,6 +54,7 @@
     li {
       border-left: 1px solid @borderLightGrey;
       float: left;
+      font-size: 13px;
       margin-left: 10px;
       padding-left: 10px;
 

--- a/kitsune/sumo/static/sumo/less/includes/search-result.less
+++ b/kitsune/sumo/static/sumo/less/includes/search-result.less
@@ -54,7 +54,7 @@
       background: transparent @iconsSprite no-repeat scroll -49px -862px;
       color: rgb(129, 188, 46);
       display: inline-block;
-      font-family: "Open Sans Light",Arial,Helvetica,sans-serif;
+      font-family: 'Open Sans Light', Arial, Helvetica, sans-serif;
       line-height: 18px;
       text-indent: 22px;
     }


### PR DESCRIPTION
This adds a last_updated timestamp to question search results as per [bug 1154833](https://bugzilla.mozilla.org/show_bug.cgi?id=1154833)

Had to make some styling decisions to avoid awkward line-wraps with the additional data.

<img width="700" alt="timestamps-styling" src="https://cloud.githubusercontent.com/assets/856935/11707272/2f63b804-9ed0-11e5-8cc3-d06b77d2c358.png">


