### PR TITLE
[Bug 1225506] (WIP) Show product & topic in AAQ urls

### DIFF
--- a/kitsune/questions/static/questions/js/components/AAQApp.jsx
+++ b/kitsune/questions/static/questions/js/components/AAQApp.jsx
@@ -49,7 +49,7 @@ export default class AAQApp extends React.Component {
       questionState: QuestionEditStore.getState(),
       userAuth: UserAuthStore.getAll(),
       troubleshooting: TroubleshootingDataStore.getAll(),
-      step: UrlStore.get('step'),
+      step: UrlStore.get('queryParams').step,
     };
   }
 

--- a/kitsune/questions/static/questions/js/components/AAQApp.jsx
+++ b/kitsune/questions/static/questions/js/components/AAQApp.jsx
@@ -54,6 +54,8 @@ export default class AAQApp extends React.Component {
   }
 
   setStep(step) {
+    var questionState = this.getStateFromStores().question;
+    UrlActions.updateUrlPath([questionState.product, questionState.topic]);
     UrlActions.updateQueryString({step});
   }
 

--- a/kitsune/questions/static/questions/js/components/AAQApp.jsx
+++ b/kitsune/questions/static/questions/js/components/AAQApp.jsx
@@ -50,7 +50,7 @@ export default class AAQApp extends React.Component {
       questionState: QuestionEditStore.getState(),
       userAuth: UserAuthStore.getAll(),
       troubleshooting: TroubleshootingDataStore.getAll(),
-      step: UrlStore.get('queryParams').step,
+      step: UrlStore.get('step'),
     };
   }
 

--- a/kitsune/questions/static/questions/js/components/AAQApp.jsx
+++ b/kitsune/questions/static/questions/js/components/AAQApp.jsx
@@ -10,6 +10,7 @@ import UserAuth from './UserAuth.jsx';
 import SubmitQuestion from './SubmitQuestion.jsx';
 import TroubleshootingDataStore from '../stores/TroubleshootingDataStore.es6.js';
 import UrlStore from '../../../sumo/js/stores/UrlStore.es6.js';
+import {pathStructure} from '../../../sumo/js/constants/UrlConstants.es6.js';
 import UrlActions from '../../../sumo/js/actions/UrlActions.es6.js';
 import aaqGa from '../utils/aaqGa.es6.js';
 
@@ -26,7 +27,7 @@ export default class AAQApp extends React.Component {
     TroubleshootingDataStore.addChangeListener(this.onChange);
     UrlStore.addChangeListener(this.onChange);
 
-    UrlActions.updateQueryStringDefaults({step: 'product'});
+    UrlActions.updatePathDefaults(pathStructure);
     aaqGa.trackEvent('AAQ SPA loaded');
   }
 
@@ -53,10 +54,9 @@ export default class AAQApp extends React.Component {
     };
   }
 
-  setStep(step) {
-    var questionState = this.getStateFromStores().question;
-    UrlActions.updateUrlPath([questionState.product, questionState.topic]);
-    UrlActions.updateQueryString({step});
+  setStep() {
+    let questionState = this.getStateFromStores().question;
+    UrlActions.updatePath({product: questionState.product, topic: questionState.topic});
   }
 
   render() {
@@ -65,9 +65,9 @@ export default class AAQApp extends React.Component {
         {(() => {
           switch (this.state.step) {
             case 'product':
-              return <ProductSelector {...this.state} setStep={this.setStep.bind(this, 'topic')}/>;
+              return <ProductSelector {...this.state} setStep={this.setStep.bind(this)}/>;
             case 'topic':
-              return <TopicSelector {...this.state} setStep={this.setStep.bind(this, 'title')}/>;
+              return <TopicSelector {...this.state} setStep={this.setStep.bind(this)}/>;
             case 'title':
               return [
                 <TitleContentEditor {...this.state}/>,

--- a/kitsune/questions/static/questions/js/components/AAQStep.jsx
+++ b/kitsune/questions/static/questions/js/components/AAQStep.jsx
@@ -1,5 +1,7 @@
 /* globals React:false */
+import AAQActions from '../actions/AAQActions.es6.js';
 import scrollTo from '../../../sumo/js/utils/scrollTo.es6.js';
+import UrlStore from '../../../sumo/js/stores/UrlStore.es6.js';
 
 export default class AAQStep extends React.Component {
   render() {
@@ -14,6 +16,16 @@ export default class AAQStep extends React.Component {
           : null}
       </div>
     );
+  }
+
+  setPropsFromUrl() {
+    let urlData = UrlStore.get('pathProps');
+    if (urlData.product) {
+      AAQActions.setProduct(urlData.product);
+    }
+    if (urlData.topic) {
+      AAQActions.setTopic(urlData.topic);
+    }
   }
 
   shouldExpand() {

--- a/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
+++ b/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
@@ -19,14 +19,13 @@ export default class TitleContentEditor extends AAQStep {
   }
 
   setPropsFromUrl() {
-      UrlActions.getPropsFromPath("/questions/new/(.*)/(.*)", ['product', 'topic']);
-      let urlData = UrlStore.get('pathProps');
-      if (urlData.product) {
-        AAQActions.setProduct(urlData.product);
-      }
-      if (urlData.topic) {
-        AAQActions.setTopic(urlData.topic);
-      }
+    let urlData = UrlStore.get('pathProps');
+    if (urlData.product) {
+      AAQActions.setProduct(urlData.product);
+    }
+    if (urlData.topic) {
+      AAQActions.setTopic(urlData.topic);
+    }
   }
 
   componentWillMount() {

--- a/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
+++ b/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
@@ -2,6 +2,7 @@
 import AAQStep from './AAQStep.jsx';
 import AAQActions from '../actions/AAQActions.es6.js';
 import aaqGa from '../utils/aaqGa.es6.js';
+import UrlStore from '../../../sumo/js/stores/UrlStore.es6.js';
 
 export default class TitleContentEditor extends AAQStep {
   handleChange(ev) {
@@ -18,6 +19,11 @@ export default class TitleContentEditor extends AAQStep {
 
   componentDidMount() {
     AAQActions.checkTroubleshootingAvailable();
+    if (this.shouldExpand() === false) {
+      let urlData = UrlStore.get('pathData');
+      AAQActions.setProduct(urlData.product);
+      AAQActions.setTopic(urlData.topic);
+    }
   }
 
   shouldExpand() {

--- a/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
+++ b/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
@@ -30,8 +30,7 @@ export default class TitleContentEditor extends AAQStep {
   }
 
   componentWillMount() {
-    if (!this.props.question.topic &&
-            !this.props.question.product) {
+    if (!this.props.question.topic && !this.props.question.product) {
       this.setPropsFromUrl();
     }
   }

--- a/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
+++ b/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
@@ -2,6 +2,7 @@
 import AAQStep from './AAQStep.jsx';
 import AAQActions from '../actions/AAQActions.es6.js';
 import aaqGa from '../utils/aaqGa.es6.js';
+import UrlActions from '../../../sumo/js/actions/UrlActions.es6.js';
 import UrlStore from '../../../sumo/js/stores/UrlStore.es6.js';
 
 export default class TitleContentEditor extends AAQStep {
@@ -17,13 +18,26 @@ export default class TitleContentEditor extends AAQStep {
     }
   }
 
+  setPropsFromUrl() {
+      UrlActions.getPropsFromPath("/questions/new/(.*)/(.*)", ['product', 'topic']);
+      let urlData = UrlStore.get('pathProps');
+      if (urlData.product) {
+        AAQActions.setProduct(urlData.product);
+      }
+      if (urlData.topic) {
+        AAQActions.setTopic(urlData.topic);
+      }
+  }
+
+  componentWillMount() {
+    if (!this.props.question.topic &&
+            !this.props.question.product) {
+      this.setPropsFromUrl();
+    }
+  }
+
   componentDidMount() {
     AAQActions.checkTroubleshootingAvailable();
-    if (this.shouldExpand() === false) {
-      let urlData = UrlStore.get('pathData');
-      AAQActions.setProduct(urlData.product);
-      AAQActions.setTopic(urlData.topic);
-    }
   }
 
   shouldExpand() {

--- a/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
+++ b/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
@@ -3,7 +3,6 @@ import AAQStep from './AAQStep.jsx';
 import AAQActions from '../actions/AAQActions.es6.js';
 import aaqGa from '../utils/aaqGa.es6.js';
 import UrlActions from '../../../sumo/js/actions/UrlActions.es6.js';
-import UrlStore from '../../../sumo/js/stores/UrlStore.es6.js';
 
 export default class TitleContentEditor extends AAQStep {
   handleChange(ev) {
@@ -15,16 +14,6 @@ export default class TitleContentEditor extends AAQStep {
       AAQActions.setContent(value);
     } else {
       throw new Error(`Unknown field name ${name} in TitleContentEditor.`);
-    }
-  }
-
-  setPropsFromUrl() {
-    let urlData = UrlStore.get('pathProps');
-    if (urlData.product) {
-      AAQActions.setProduct(urlData.product);
-    }
-    if (urlData.topic) {
-      AAQActions.setTopic(urlData.topic);
     }
   }
 

--- a/kitsune/questions/static/questions/js/components/TopicSelector.jsx
+++ b/kitsune/questions/static/questions/js/components/TopicSelector.jsx
@@ -4,18 +4,10 @@ import AAQStep from './AAQStep.jsx';
 import AAQActions from '../actions/AAQActions.es6.js';
 import aaqGa from '../utils/aaqGa.es6.js';
 import UrlActions from '../../../sumo/js/actions/UrlActions.es6.js';
-import UrlStore from '../../../sumo/js/stores/UrlStore.es6.js';
 
 const topics = JSON.parse(document.querySelector('.data[name=topics]').innerHTML);
 
 export default class TopicSelector extends AAQStep {
-
-  setPropsFromUrl() {
-    let urlData = UrlStore.get('pathProps');
-    if (urlData.product) {
-      AAQActions.setProduct(urlData.product);
-    }
-  }
 
   componentWillMount() {
     if (!this.props.question.product) {

--- a/kitsune/questions/static/questions/js/components/TopicSelector.jsx
+++ b/kitsune/questions/static/questions/js/components/TopicSelector.jsx
@@ -3,10 +3,27 @@ import cx from 'classnames';
 import AAQStep from './AAQStep.jsx';
 import AAQActions from '../actions/AAQActions.es6.js';
 import aaqGa from '../utils/aaqGa.es6.js';
+import UrlActions from '../../../sumo/js/actions/UrlActions.es6.js';
+import UrlStore from '../../../sumo/js/stores/UrlStore.es6.js';
 
 const topics = JSON.parse(document.querySelector('.data[name=topics]').innerHTML);
 
 export default class TopicSelector extends AAQStep {
+
+  setPropsFromUrl() {
+    UrlActions.getPropsFromPath("/questions/new/(.*)", ['product']);
+    let urlData = UrlStore.get('pathProps');
+    if (urlData.product) {
+      AAQActions.setProduct(urlData.product);
+    }
+  }
+
+  componentWillMount() {
+    if (!this.props.question.product) {
+      this.setPropsFromUrl();
+    }
+  }
+
   shouldExpand() {
     return !!this.props.question.product;
   }

--- a/kitsune/questions/static/questions/js/components/TopicSelector.jsx
+++ b/kitsune/questions/static/questions/js/components/TopicSelector.jsx
@@ -11,7 +11,6 @@ const topics = JSON.parse(document.querySelector('.data[name=topics]').innerHTML
 export default class TopicSelector extends AAQStep {
 
   setPropsFromUrl() {
-    UrlActions.getPropsFromPath("/questions/new/(.*)", ['product']);
     let urlData = UrlStore.get('pathProps');
     if (urlData.product) {
       AAQActions.setProduct(urlData.product);

--- a/kitsune/sumo/static/sumo/js/actions/UrlActions.es6.js
+++ b/kitsune/sumo/static/sumo/js/actions/UrlActions.es6.js
@@ -3,6 +3,19 @@ import {actionTypes} from '../constants/UrlConstants.es6.js';
 
 /**
  * Update the url path string, notify any listeners, and call history.pushState.
+ * @param  string pathRegex Regular expression string to test against the current path.
+ * @param  [array] propNames The property names to associate with each match in the path.
+ */
+export function getPropsFromPath(pathRegex, propNames) {
+  Dispatcher.dispatch({
+    type: actionTypes.GET_PROPS_FROM_PATH,
+    pathRegex,
+    propNames,
+  });
+}
+
+/**
+ * Update the url path string, notify any listeners, and call history.pushState.
  * @param  [array] paths Variables to merge into the current url path.
  */
 export function updateUrlPath(paths) {
@@ -37,6 +50,7 @@ export function updateQueryStringDefaults(params) {
 }
 
 export default {
+  getPropsFromPath,
   updateQueryString,
   updateQueryStringDefaults,
   updateUrlPath,

--- a/kitsune/sumo/static/sumo/js/actions/UrlActions.es6.js
+++ b/kitsune/sumo/static/sumo/js/actions/UrlActions.es6.js
@@ -2,6 +2,17 @@ import Dispatcher from '../Dispatcher.es6.js';
 import {actionTypes} from '../constants/UrlConstants.es6.js';
 
 /**
+ * Update the url path string, notify any listeners, and call history.pushState.
+ * @param  [array] paths Variables to merge into the current url path.
+ */
+export function updateUrlPath(paths) {
+  Dispatcher.dispatch({
+    type: actionTypes.UPDATE_URL_PATH,
+    paths,
+  });
+}
+
+/**
  * Update the query string, notify any listeners, and call history.pushState.
  * @param  {object} params Variables to merge into the current query string state.
  */
@@ -28,4 +39,5 @@ export function updateQueryStringDefaults(params) {
 export default {
   updateQueryString,
   updateQueryStringDefaults,
+  updateUrlPath,
 };

--- a/kitsune/sumo/static/sumo/js/actions/UrlActions.es6.js
+++ b/kitsune/sumo/static/sumo/js/actions/UrlActions.es6.js
@@ -2,56 +2,30 @@ import Dispatcher from '../Dispatcher.es6.js';
 import {actionTypes} from '../constants/UrlConstants.es6.js';
 
 /**
- * Update the url path string, notify any listeners, and call history.pushState.
- * @param  string pathRegex Regular expression string to test against the current path.
- * @param  [array] propNames The property names to associate with each match in the path.
+ * Update the url path, notify any listeners, and call history.pushState.
+ * @param  {object} params Variables to merge into the current path state.
  */
-export function getPropsFromPath(pathRegex, propNames) {
+export function updatePath(params) {
   Dispatcher.dispatch({
-    type: actionTypes.GET_PROPS_FROM_PATH,
-    pathRegex,
-    propNames,
-  });
-}
-
-/**
- * Update the url path string, notify any listeners, and call history.pushState.
- * @param  [array] paths Variables to merge into the current url path.
- */
-export function updateUrlPath(paths) {
-  Dispatcher.dispatch({
-    type: actionTypes.UPDATE_URL_PATH,
-    paths,
-  });
-}
-
-/**
- * Update the query string, notify any listeners, and call history.pushState.
- * @param  {object} params Variables to merge into the current query string state.
- */
-export function updateQueryString(params) {
-  Dispatcher.dispatch({
-    type: actionTypes.UPDATE_QUERY_STRING,
+    type: actionTypes.UPDATE_PATH,
     params,
   });
 }
 
 /**
- * Set the query string defaults and notify listeners. If the query
- * string does not have the given values, they will be set, otherwise
+ * Set the path defaults and notify listeners. If the path string
+ * does not have the given values, they will be set, otherwise
  * the existing value will be kept. This will call history.replaceState.
- * @param  {object} params Default values for querystrings.
+ * @param  {object} params Default values for path.
  */
-export function updateQueryStringDefaults(params) {
+export function updatePathDefaults(params) {
   Dispatcher.dispatch({
-    type: actionTypes.UPDATE_QUERY_STRING_DEFAULTS,
+    type: actionTypes.UPDATE_PATH_DEFAULTS,
     params,
   });
 }
 
 export default {
-  getPropsFromPath,
-  updateQueryString,
-  updateQueryStringDefaults,
-  updateUrlPath,
+  updatePath,
+  updatePathDefaults,
 };

--- a/kitsune/sumo/static/sumo/js/constants/UrlConstants.es6.js
+++ b/kitsune/sumo/static/sumo/js/constants/UrlConstants.es6.js
@@ -1,6 +1,7 @@
 import constantMap from '../../../sumo/js/utils/constantMap.es6.js';
 
 export const actionTypes = constantMap([
+  'GET_PROPS_FROM_PATH',
   'UPDATE_QUERY_STRING',
   'UPDATE_QUERY_STRING_DEFAULTS',
   'UPDATE_URL_PATH',

--- a/kitsune/sumo/static/sumo/js/constants/UrlConstants.es6.js
+++ b/kitsune/sumo/static/sumo/js/constants/UrlConstants.es6.js
@@ -1,12 +1,13 @@
 import constantMap from '../../../sumo/js/utils/constantMap.es6.js';
 
 export const actionTypes = constantMap([
-  'GET_PROPS_FROM_PATH',
-  'UPDATE_QUERY_STRING',
-  'UPDATE_QUERY_STRING_DEFAULTS',
-  'UPDATE_URL_PATH',
+  'UPDATE_PATH',
+  'UPDATE_PATH_DEFAULTS',
 ]);
 
+export const pathStructure = ['locale', 'model', 'action', 'product', 'topic'];
+
 export default {
-  actionTypes
+  actionTypes,
+  pathStructure
 };

--- a/kitsune/sumo/static/sumo/js/constants/UrlConstants.es6.js
+++ b/kitsune/sumo/static/sumo/js/constants/UrlConstants.es6.js
@@ -3,6 +3,7 @@ import constantMap from '../../../sumo/js/utils/constantMap.es6.js';
 export const actionTypes = constantMap([
   'UPDATE_QUERY_STRING',
   'UPDATE_QUERY_STRING_DEFAULTS',
+  'UPDATE_URL_PATH',
 ]);
 
 export default {

--- a/kitsune/sumo/static/sumo/js/main.js
+++ b/kitsune/sumo/static/sumo/js/main.js
@@ -5,29 +5,6 @@ window.k = window.k || {};
 (function () {
   k.LAZY_DELAY = 500;  // delay to lazy loading scripts, in ms
   k.STATIC_URL = $('body').data('static-url');
-  k.getPathAsDict = function(propertyNames) {
-    var pathDict = {},
-      pathArray = window.location.pathname.split('/').filter(Boolean);
-
-    _.forEach(propertyNames, function(value, index) {
-      pathDict[value] = pathArray[index];
-    });
-
-    return pathDict;
-  };
-
-  k.pathStringFromDict = function(pathDict) {
-    var pathString = '';
-
-    _.forEach(pathDict, function(value, key) {
-      if (value) {
-        pathString += '/' + value;
-      }
-    });
-
-    return pathString;
-  };
-
   k.getQueryParamsAsDict = function (url) {
     // Parse the url's query parameters into a dict. Mostly stolen from:
     // http://stackoverflow.com/questions/901115/get-query-string-values-in-javascript/2880929#2880929

--- a/kitsune/sumo/static/sumo/js/main.js
+++ b/kitsune/sumo/static/sumo/js/main.js
@@ -9,7 +9,7 @@ window.k = window.k || {};
     var pathDict = {},
       pathArray = window.location.pathname.split('/').filter(Boolean);
 
-    propertyNames.map(function(value, index) {
+    _.forEach(propertyNames, function(value, index) {
       pathDict[value] = pathArray[index];
     });
 

--- a/kitsune/sumo/static/sumo/js/main.js
+++ b/kitsune/sumo/static/sumo/js/main.js
@@ -6,17 +6,18 @@ window.k = window.k || {};
   k.LAZY_DELAY = 500;  // delay to lazy loading scripts, in ms
   k.STATIC_URL = $('body').data('static-url');
   k.getPathAsDict = function(propertyNames) {
-    let pathDict = {},
+    var pathDict = {},
       pathArray = window.location.pathname.split('/').filter(Boolean);
 
-    propertyNames.map((x, i) =>
-      pathDict[x] = pathArray[i]);
+    propertyNames.map(function(value, index) {
+      pathDict[value] = pathArray[index];
+    });
 
     return pathDict;
   };
 
   k.pathStringFromDict = function(pathDict) {
-    let pathString = '';
+    var pathString = '';
 
     _.forEach(pathDict, function(value, key) {
       if (value) {

--- a/kitsune/sumo/static/sumo/js/main.js
+++ b/kitsune/sumo/static/sumo/js/main.js
@@ -5,6 +5,28 @@ window.k = window.k || {};
 (function () {
   k.LAZY_DELAY = 500;  // delay to lazy loading scripts, in ms
   k.STATIC_URL = $('body').data('static-url');
+  k.getPathAsDict = function(propertyNames) {
+    let pathDict = {},
+      pathArray = window.location.pathname.split('/').filter(Boolean);
+
+    propertyNames.map((x, i) =>
+      pathDict[x] = pathArray[i]);
+
+    return pathDict;
+  };
+
+  k.pathStringFromDict = function(pathDict) {
+    let pathString = '';
+
+    _.forEach(pathDict, function(value, key) {
+      if (value) {
+        pathString += '/' + value;
+      }
+    });
+
+    return pathString;
+  };
+
   k.getQueryParamsAsDict = function (url) {
     // Parse the url's query parameters into a dict. Mostly stolen from:
     // http://stackoverflow.com/questions/901115/get-query-string-values-in-javascript/2880929#2880929

--- a/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
+++ b/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
@@ -20,7 +20,7 @@ var urlData = {
 
 class _UrlStore extends BaseStore {
   get(key) {
-    return getQueryParamsAsDict()[key] || urlData[key];
+    return urlData[key];
   }
 }
 
@@ -50,6 +50,7 @@ UrlStore.dispatchToken = Dispatcher.register((action) => {
 
     case actionTypes.UPDATE_QUERY_STRING:
       params = _.extend({}, getQueryParamsAsDict(), action.params);
+      urlData.queryParams = params;
       qs = queryParamStringFromDict(params);
       window.history.pushState(params, null, urlData.fullPath + qs);
       UrlStore.emitChange();
@@ -57,6 +58,7 @@ UrlStore.dispatchToken = Dispatcher.register((action) => {
 
     case actionTypes.UPDATE_QUERY_STRING_DEFAULTS:
       params = _.extend({}, action.params, getQueryParamsAsDict());
+      urlData.queryParams = params;
       qs = queryParamStringFromDict(params);
       window.history.replaceState(params, null, qs);
       UrlStore.emitChange();

--- a/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
+++ b/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
@@ -31,9 +31,7 @@ UrlStore.dispatchToken = Dispatcher.register((action) => {
   let params, pathProps, qs, urlPath;
   switch (action.type) {
     case actionTypes.GET_PROPS_FROM_PATH:
-      pathProps = createDictFromPath(action.pathRegex, action.propNames);
-      urlData.pathProps = pathProps;
-
+      urlData.pathProps = createDictFromPath(action.pathRegex, action.propNames);
       UrlStore.emitChange();
       break;
 

--- a/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
+++ b/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
@@ -13,7 +13,6 @@ import {actionTypes, pathStructure} from '../constants/UrlConstants.es6.js';
 import {getPathAsDict, pathStringFromDict, getQueryParamsAsDict, queryParamStringFromDict} from '../utils/urls.es6.js';
 
 var urlData = {
-  fullPath: '',
   pathProps: getPathAsDict(pathStructure),
   queryParams: getQueryParamsAsDict(),
   step: 'product'
@@ -24,14 +23,11 @@ function updateStep() {
 
   if (pathProps.product && pathProps.topic) {
     return 'title';
-  }
-  else if (pathProps.product && !pathProps.topic) {
+  } else if (pathProps.product && !pathProps.topic) {
     return 'topic';
-  }
-  else if (!pathProps.product && !pathProps.topic) {
+  } else if (!pathProps.product && !pathProps.topic) {
     return 'product';
   }
-
 }
 
 class _UrlStore extends BaseStore {

--- a/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
+++ b/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
@@ -16,7 +16,7 @@ var urlData = {
   pathProps: getPathAsDict(pathStructure),
   queryParams: getQueryParamsAsDict(),
   step: 'product'
-}
+};
 
 function updateStep() {
   let pathProps = getPathAsDict(pathStructure);

--- a/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
+++ b/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
@@ -9,13 +9,29 @@
 
 import BaseStore from './BaseStore.es6.js';
 import Dispatcher from '../Dispatcher.es6.js';
-import {actionTypes} from '../constants/UrlConstants.es6.js';
-import {buildUrlPath, createDictFromPath, getQueryParamsAsDict, queryParamStringFromDict} from '../utils/urls.es6.js';
+import {actionTypes, pathStructure} from '../constants/UrlConstants.es6.js';
+import {getPathAsDict, pathStringFromDict, getQueryParamsAsDict, queryParamStringFromDict} from '../utils/urls.es6.js';
 
 var urlData = {
   fullPath: '',
-  pathProps: {},
-  queryParams: getQueryParamsAsDict()
+  pathProps: getPathAsDict(pathStructure),
+  queryParams: getQueryParamsAsDict(),
+  step: 'product'
+}
+
+function updateStep() {
+  let pathProps = getPathAsDict(pathStructure);
+
+  if (pathProps.product && pathProps.topic) {
+    return 'title';
+  }
+  else if (pathProps.product && !pathProps.topic) {
+    return 'topic';
+  }
+  else if (!pathProps.product && !pathProps.topic) {
+    return 'product';
+  }
+
 }
 
 class _UrlStore extends BaseStore {
@@ -28,37 +44,21 @@ class _UrlStore extends BaseStore {
 const UrlStore = new _UrlStore();
 
 UrlStore.dispatchToken = Dispatcher.register((action) => {
-  let params, pathProps, qs, urlPath;
+  let params, pathString, qs;
   switch (action.type) {
-    case actionTypes.GET_PROPS_FROM_PATH:
-      urlData.pathProps = createDictFromPath(action.pathRegex, action.propNames);
+    case actionTypes.UPDATE_PATH:
+      params = _.extend({}, urlData.pathProps, action.params);
+      pathString = pathStringFromDict(params);
+      window.history.pushState(params, null, pathString + window.location.search);
+      urlData.step = updateStep();
       UrlStore.emitChange();
       break;
 
-    case actionTypes.UPDATE_URL_PATH:
-      urlPath = buildUrlPath(action.paths);
-      urlData.fullPath = urlPath;
-      urlData.pathData = {
-        product: action.paths.product,
-        topic: action.paths.topic
-      };
-
-      UrlStore.emitChange();
-      break;
-
-    case actionTypes.UPDATE_QUERY_STRING:
-      params = _.extend({}, getQueryParamsAsDict(), action.params);
-      urlData.queryParams = params;
-      qs = queryParamStringFromDict(params);
-      window.history.pushState(params, null, urlData.fullPath + qs);
-      UrlStore.emitChange();
-      break;
-
-    case actionTypes.UPDATE_QUERY_STRING_DEFAULTS:
-      params = _.extend({}, action.params, getQueryParamsAsDict());
-      urlData.queryParams = params;
-      qs = queryParamStringFromDict(params);
-      window.history.replaceState(params, null, qs);
+    case actionTypes.UPDATE_PATH_DEFAULTS:
+      params = getPathAsDict(action.params);
+      pathString = pathStringFromDict(params);
+      window.history.replaceState(params, null, pathString + window.location.search);
+      urlData.step = updateStep();
       UrlStore.emitChange();
       break;
 
@@ -70,6 +70,7 @@ UrlStore.dispatchToken = Dispatcher.register((action) => {
 /* When the user clicks back/forward, the store will return different
  * values, so notify all listeners. */
 window.addEventListener('popstate', function() {
+  urlData.step = updateStep();
   UrlStore.emitChange();
 });
 

--- a/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
+++ b/kitsune/sumo/static/sumo/js/stores/UrlStore.es6.js
@@ -10,21 +10,17 @@
 import BaseStore from './BaseStore.es6.js';
 import Dispatcher from '../Dispatcher.es6.js';
 import {actionTypes} from '../constants/UrlConstants.es6.js';
-import {buildUrlPath, getQueryParamsAsDict, queryParamStringFromDict} from '../utils/urls.es6.js';
+import {buildUrlPath, createDictFromPath, getQueryParamsAsDict, queryParamStringFromDict} from '../utils/urls.es6.js';
 
 var urlData = {
   fullPath: '',
-  pathData: {},
-  queryParams: {}
+  pathProps: {},
+  queryParams: getQueryParamsAsDict()
 }
 
 class _UrlStore extends BaseStore {
   get(key) {
     return getQueryParamsAsDict()[key] || urlData[key];
-  }
-
-  set(key, value) {
-    this[key] = value;
   }
 }
 
@@ -32,8 +28,15 @@ class _UrlStore extends BaseStore {
 const UrlStore = new _UrlStore();
 
 UrlStore.dispatchToken = Dispatcher.register((action) => {
-  let params, qs, urlPath;
+  let params, pathProps, qs, urlPath;
   switch (action.type) {
+    case actionTypes.GET_PROPS_FROM_PATH:
+      pathProps = createDictFromPath(action.pathRegex, action.propNames);
+      urlData.pathProps = pathProps;
+
+      UrlStore.emitChange();
+      break;
+
     case actionTypes.UPDATE_URL_PATH:
       urlPath = buildUrlPath(action.paths);
       urlData.fullPath = urlPath;

--- a/kitsune/sumo/static/sumo/js/utils/urls.es6.js
+++ b/kitsune/sumo/static/sumo/js/utils/urls.es6.js
@@ -22,21 +22,21 @@ export function getPathAsDict(propertyNames) {
   var pathDict = {},
     pathArray = window.location.pathname.split('/').filter(Boolean);
 
-  _.forEach(propertyNames, function(value, index) {
+  propertyNames.forEach(function(value, index) {
     pathDict[value] = pathArray[index];
   });
 
   return pathDict;
-};
+}
 
 export function pathStringFromDict(pathDict) {
   var pathString = '';
 
-  _.forEach(pathDict, function(value, key) {
-    if (value) {
-      pathString += '/' + value;
+  for (let key in pathDict) {
+    if (pathDict[key]) {
+      pathString += '/' + pathDict[key];
     }
-  });
+  }
 
   return pathString;
-};
+}

--- a/kitsune/sumo/static/sumo/js/utils/urls.es6.js
+++ b/kitsune/sumo/static/sumo/js/utils/urls.es6.js
@@ -7,8 +7,6 @@ import '../main.js';
 const names = [
   'getQueryParamsAsDict',
   'queryParamStringFromDict',
-  'getPathAsDict',
-  'pathStringFromDict',
 ];
 
 for (let name of names) {
@@ -19,6 +17,26 @@ for (let name of names) {
 
 export const getQueryParamsAsDict = window.k.getQueryParamsAsDict;
 export const queryParamStringFromDict = window.k.queryParamStringFromDict;
-export const getPathAsDict = window.k.getPathAsDict;
-export const pathStringFromDict = window.k.pathStringFromDict;
 
+export function getPathAsDict(propertyNames) {
+  var pathDict = {},
+    pathArray = window.location.pathname.split('/').filter(Boolean);
+
+  _.forEach(propertyNames, function(value, index) {
+    pathDict[value] = pathArray[index];
+  });
+
+  return pathDict;
+};
+
+export function pathStringFromDict(pathDict) {
+  var pathString = '';
+
+  _.forEach(pathDict, function(value, key) {
+    if (value) {
+      pathString += '/' + value;
+    }
+  });
+
+  return pathString;
+};

--- a/kitsune/sumo/static/sumo/js/utils/urls.es6.js
+++ b/kitsune/sumo/static/sumo/js/utils/urls.es6.js
@@ -7,6 +7,8 @@ import '../main.js';
 const names = [
   'getQueryParamsAsDict',
   'queryParamStringFromDict',
+  'getPathAsDict',
+  'pathStringFromDict',
 ];
 
 for (let name of names) {
@@ -17,3 +19,6 @@ for (let name of names) {
 
 export const getQueryParamsAsDict = window.k.getQueryParamsAsDict;
 export const queryParamStringFromDict = window.k.queryParamStringFromDict;
+export const getPathAsDict = window.k.getPathAsDict;
+export const pathStringFromDict = window.k.pathStringFromDict;
+


### PR DESCRIPTION
Stopping here for some review before this PR gets too unruly...

This adds the product & topic values to the path of the URL. If the question store doesn't have this data readily available (i.e. if you use the back button or refresh the page), we can now check for this information in the URL.

There's some cleanup/refactoring I can still do here, but more immediately I'm curious if we think `step` as a query parameter is still necessary? Does the new URL structure with a more specific path give us all the information we need to imply the step? (i.e. `/questions/new/product` implies `step=topic`, `questions/new/product/topic implies `step=title`) My first impression is that it should be pretty safe to remove but perhaps someone else knows better off the top of their head ¯\_(ツ)_/¯