### PR TITLE
[bug 1232637] Fix extract_db re: empty strings

### DIFF
--- a/kitsune/sumo/management/commands/extract_db.py
+++ b/kitsune/sumo/management/commands/extract_db.py
@@ -74,6 +74,10 @@ class Command(BaseCommand):
                 qs = model_class.objects.all().values_list(*attrs).distinct()
                 for item in qs:
                     for i in range(len(attrs)):
+                        if not item[i]:
+                            # Skip empty strings because empty string msgids
+                            # are super bad.
+                            continue
                         msg = {
                             'id': strip_whitespace(item[i]),
                             'context': 'DB: %s.%s.%s' % (app, model, attrs[i]),


### PR DESCRIPTION
Empty string msgids are super bad. This reduces the likelihood we have
those.

r?