### PR TITLE
[bug 1232637] Add check for production db

### DIFF
--- a/kitsune/sumo/management/commands/extract_db.py
+++ b/kitsune/sumo/management/commands/extract_db.py
@@ -66,6 +66,12 @@ class Command(BaseCommand):
         except AttributeError:
             raise CommandError('DB_LOCALIZE setting is not defined!')
 
+        areyousure = raw_input(
+            'Are you sure you have a recent production db? y/n: '
+        )
+        if areyousure.lower() != 'y':
+            raise CommandError('Not sure if it is a recent production db.')
+
         strings = []
         for app, models in apps.items():
             for model, params in models.items():


### PR DESCRIPTION
I can't figure out a way to distinguish an anonymized production db
dump from a db dump generated by sample data without doing hand-wavey
"are there at least x users?" or other things which are fragile. So
instead, I added a reminder prompt.

r?