### PR TITLE
[bug 1171413] Fix highlighting for <code>.

### DIFF
--- a/kitsune/sumo/static/sumo/js/codemirror.sumo-mode.js
+++ b/kitsune/sumo/static/sumo/js/codemirror.sumo-mode.js
@@ -68,18 +68,18 @@
         regex: /(<del>)(.*?)(<\/del>)/
       },
       {
-        token: ['variable.language', 'comment'],
-        regex: /(<nowiki>)(.*?)/,
+        token: 'variable.language',
+        regex: /<nowiki>/,
         next: 'nowiki'
       },
       {
-        token: ['variable.language', 'comment'],
-        regex: /(<code>)(.*?)/,
+        token: 'variable.language',
+        regex: /<code>/,
         next: 'code'
       },
       {
-        token: ['variable.language', 'comment'],
-        regex: /(<pre>)(.*?)/,
+        token: 'variable.language',
+        regex: /<pre>/,
         next: 'pre'
       },
       {
@@ -127,31 +127,35 @@
     ],
     nowiki: [
       {
-        token: ['variable.language'],
-        regex: /(<\/nowiki>)/,
+        token: 'variable.language',
+        regex: /<\/nowiki>/,
         next: 'start'
+      },
+      {
+        token: 'comment',
+        regex: /./
       }
     ],
     code: [
       {
-        token: ['variable.language'],
-        regex: /(<\/code>)/,
+        token: 'variable.language',
+        regex: /<\/code>/,
         next: 'start'
       },
       {
-        token: ['variable.language'],
-        regex: /(<\/?nowiki>)/
+        token: 'comment',
+        regex: /./
       }
     ],
     pre: [
       {
-        token: ['variable.language'],
-        regex: /(<\/pre>)/,
+        token: 'variable.language',
+        regex: /<\/pre>/,
         next: 'start'
       },
       {
-        token: ['variable.language'],
-        regex: /(<\/?nowiki>)/
+        token: 'comment',
+        regex: /./
       }
     ],
     space: [


### PR DESCRIPTION
The parsers for CodeMirror's syntax highlighting of `<code>`, `<pre>`, and `<nowiki>`  now consume input until their closing tags are found, and no longer have the odd behavior around `</nowiki>` tags.

I'm not sure whether I should add tests for this; if I did, I'd be testing if the `<div class="CodeMirror-code">` tag within the CodeMirror editor has `display: none` applied to it. I'm also unsure of where I'd add that test: Would it be with the in-browser tests in smoketests? Somewhere else? I'm happy to add them if I can get guidance on where to add them. :D
r?