### PR TITLE
[Bug 1235806] Review Revision page shows <label> tag

### DIFF
--- a/kitsune/wiki/templates/wiki/review_revision.html
+++ b/kitsune/wiki/templates/wiki/review_revision.html
@@ -25,7 +25,7 @@
               <li>
                 {{ _('Revision {id} by {user}')|f(id=revision.id, user=revision.creator) }}.
                 <br>
-                {{ _('<label>Revision Comment:</label> {comment}')|f(comment=revision.comment) }}
+                {{ _('<label>Revision Comment:</label> {comment}')|fe(comment=revision.comment) }}
                 <br>
                 <a href="{{ url('wiki.review_revision', document.slug, revision.id) }}">{{ _('Review Revision {id}')|f(id=revision.id) }}</a>
               </li>

--- a/kitsune/wiki/templates/wiki/review_translation.html
+++ b/kitsune/wiki/templates/wiki/review_translation.html
@@ -25,7 +25,7 @@
               <li>
                 {{ _('Revision {id} by {user}')|f(id=revision.id, user=revision.creator) }}.
                 <br>
-                {{ _('<label>Revision Comment:</label> {comment}')|f(comment=revision.comment) }}
+                {{ _('<label>Revision Comment:</label> {comment}')|fe(comment=revision.comment) }}
                 <br>
                 <a href="{{ url('wiki.review_revision', document.slug, revision.id) }}">{{ _('Review Revision {id}')|f(id=revision.id) }}</a>
               </li>

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -1695,6 +1695,10 @@ class ReviewRevisionTests(TestCaseBase):
         message = 'Unreviewed Revisions:'
         assert message in subject
 
+        # Check *Revision Comment* text is in <label> to to be bolded
+        text = doc('ul.revision-comment li label')[0].text_content()
+        eq_('Revision Comment:', text)
+
         # Check whether past revisions Comments are there
         # As the comments are reversed means that the latest ones comment will be at 1st
         # the 2nd latest ones comment will be at second and like that.


### PR DESCRIPTION
Changing jija2 filter "f" to "fe" should work. As it will escape the <label> tag.
Also modified the previous test so this issue will not be raise in future.
@mythmon @rehandalal r?