### PR TITLE
[Bug 1189489] Disable redirect URL checks when DEBUG=True.

### DIFF
--- a/kitsune/sumo/tests/test_utils.py
+++ b/kitsune/sumo/tests/test_utils.py
@@ -80,6 +80,12 @@ class GetNextUrlTests(TestCase):
         r = self.r.get('/', {'next': 'https://example.com'})
         eq_(None, get_next_url(r))
 
+    def test_bad_host_https_debug(self):
+        """If settings.DEBUG == True, bad hosts pass."""
+        r = self.r.get('/', {'next': 'https://example.com'})
+        with self.settings(DEBUG=True):
+            eq_('https://example.com', get_next_url(r))
+
     def test_bad_host_protocol_relative(self):
         """Protocol-relative URLs do not let bad hosts through."""
         r = self.r.get('/', {'next': '//example.com'})

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -4,6 +4,7 @@ import sys
 from contextlib import contextmanager
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models.signals import pre_delete
@@ -131,7 +132,7 @@ def get_next_url(request):
     else:
         url = request.META.get('HTTP_REFERER')
 
-    if not is_safe_url(url, Site.objects.get_current().domain):
+    if not settings.DEBUG and not is_safe_url(url, Site.objects.get_current().domain):
         return None
 
     return url

--- a/kitsune/users/tests/test_templates.py
+++ b/kitsune/users/tests/test_templates.py
@@ -36,13 +36,7 @@ class LoginTests(TestCaseBase):
 
     def setUp(self):
         super(LoginTests, self).setUp()
-        self.orig_debug = settings.DEBUG
-        settings.DEBUG = True
         self.u = UserFactory()
-
-    def tearDown(self):
-        super(LoginTests, self).tearDown()
-        settings.DEBUG = self.orig_debug
 
     def test_login_bad_password(self):
         '''Test login with a good username and bad password.'''


### PR DESCRIPTION
Disables `is_safe_url` check for redirect URLs when DEBUG is True, because most local development setups probably don't have their Sites table set up properly, and we don't want to hard-code certain domains in case devs (like @mythmon) use different ones.

r?