### PR TITLE
[Bug 1012384] Make localization readouts more robust with is_archived.

### DIFF
--- a/kitsune/dashboards/readouts.py
+++ b/kitsune/dashboards/readouts.py
@@ -335,6 +335,7 @@ def l10n_overview_rows(locale, product=None):
         '        (' + ','.join(ignore_categories) + ')'
         '    AND transdoc.is_template=%s '
         '    AND NOT transdoc.is_archived '
+        '    AND NOT engdoc.is_archived '
         '    AND engdoc.latest_localizable_revision_id IS NOT NULL '
         '    AND engdoc.is_localizable '
         '    AND engdoc.html NOT LIKE "<p>REDIRECT <a%%" '

--- a/kitsune/dashboards/tests/test_readouts.py
+++ b/kitsune/dashboards/tests/test_readouts.py
@@ -282,7 +282,7 @@ class L10NOverviewTests(TestCase):
 
         # Document.save() will enforce that parents and translations share is_archived.
         # The point of this is to test what happens when that isn't true though,
-        # so by pass Document.save().
+        # so bypass Document.save().
         translation2.is_archived = False
         ModelBase.save(translation2)
         eq_(translation2.is_archived, False)


### PR DESCRIPTION
This is weird, and the test is super goofy, but it does fix one of the problems in Bug 1012384.

r?