### PR TITLE
[Bug 619284] Create a "draft" status for unfinished translations

### DIFF
--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -1,5 +1,5 @@
 /* globals k:false, jQuery:false, ShowFor:false, Marky:false, VERSIONS:false,
-           BrowserDetect:false, gettext:false, KBox:false, CodeMirror:false */
+           BrowserDetect:false, gettext:false, KBox:false, CodeMirror:false, interpolate:false */
 /*
  * wiki.js
  * Scripts for the wiki app.
@@ -73,6 +73,7 @@
 
     if ($body.is('.translate')) {  // Translate page
       initToggleDiff();
+      initTranslationDraft();
     }
 
     initEditingTools();
@@ -636,6 +637,33 @@
                     $contentOrDiff.toggleClass('content diff');
                   }));
     }
+  }
+
+  function initTranslationDraft() {
+    var $draftButton = $('.btn-draft'),
+      url = $('.btn-draft').data('draft-url'),
+      $draftMessage = $('#draft-message');
+
+    $draftButton.click( function() {
+      var message = gettext('<strong>Draft is saving...</strong>'),
+        image = '<img src="/static/sumo/img/customercare/spinner.gif">',
+        bothData = $('#both_form').serializeArray(),
+        docData = $('#doc_form').serializeArray(),
+        revData = $('#rev_form').serializeArray(),
+        totalData = $.extend(bothData, docData, revData);
+
+      $draftMessage.html(image + message).removeClass('success error').addClass('info').show()
+      $.post(url, totalData)
+        .done(function() {
+          var time = new Date(),
+            message = interpolate(gettext('<strong>Draft has been saved on:</strong> %s'), [time]);
+          $draftMessage.html(message).toggleClass('info success').show();
+        })
+        .fail(function() {
+          var message = gettext('<strong>Draft is saving...</strong>');
+          $draftMessage.html(message).toggleClass('info error').show();
+        });
+    });
   }
 
   function initRevisionList() {

--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -660,7 +660,7 @@
           $draftMessage.html(message).toggleClass('info success').show();
         })
         .fail(function() {
-          var message = gettext('<strong>Draft is saving...</strong>');
+          var message = gettext('<strong>Error saving draft</strong>');
           $draftMessage.html(message).toggleClass('info error').show();
         });
     });

--- a/kitsune/sumo/static/sumo/less/wiki.less
+++ b/kitsune/sumo/static/sumo/less/wiki.less
@@ -127,6 +127,38 @@ article {
   margin-bottom: 20px;
 }
 
+/* Document Translation page */
+#localize-document {
+  .buttons-and-preview {
+    /* Taken from Bootstrap V3 */
+    .alert {
+      background: #FFE url("../img/warning-stripes.png") repeat-x scroll left top;
+      border: 1px solid transparent;
+      border-radius: 4px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+
+    .error {
+      background-color: #f2dede;
+      border-color: #ebccd1;
+      color: #a94442;
+    }
+
+    .info {
+      background-color: #fcf8e3;
+      border-color: #faf2cc;
+      color: #8a6d3b;
+    }
+
+    .success {
+      background-color: #dff0d8;
+      border-color: #d6e9c6;
+      color: #3c763d;
+    }
+  }
+}
+
 /* Document history page */
 #revision-list {
   form {

--- a/kitsune/wiki/forms.py
+++ b/kitsune/wiki/forms.py
@@ -9,7 +9,7 @@ from kitsune.products.models import Product, Topic
 from kitsune.sumo.form_fields import MultiUsernameField, StrippedCharField
 from kitsune.wiki.config import SIGNIFICANCES, CATEGORIES
 from kitsune.wiki.models import (
-    Document, Revision, MAX_REVISION_COMMENT_LENGTH)
+    Document, Revision, DraftRevision, MAX_REVISION_COMMENT_LENGTH)
 from kitsune.wiki.tasks import add_short_links
 from kitsune.wiki.widgets import (
     RadioFieldRendererWithHelpText, ProductTopicsAndSubtopicsWidget,
@@ -274,6 +274,22 @@ class RevisionForm(forms.ModelForm):
 
         new_rev.save()
         return new_rev
+
+
+class DraftRevisionForm(forms.ModelForm):
+    class Meta(object):
+        model = DraftRevision
+        fields = ('keywords', 'summary', 'content', 'slug', 'title', 'based_on')
+
+    def save(self, request):
+        """save the draft revision and return the draft revision"""
+        creator = request.user
+        doc_data = self.cleaned_data
+        parent_doc = doc_data['based_on'].document
+        locale = request.LANGUAGE_CODE
+        draft, created = DraftRevision.objects.update_or_create(
+            creator=creator, document=parent_doc, locale=locale, defaults=doc_data)
+        return draft
 
 
 class ReviewForm(forms.Form):

--- a/kitsune/wiki/migrations/0007_draftrevision.py
+++ b/kitsune/wiki/migrations/0007_draftrevision.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+import kitsune.sumo.models
+import kitsune.search.models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('wiki', '0006_auto_20151110_1307'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DraftRevision',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', models.DateTimeField(default=datetime.datetime.now)),
+                ('keywords', models.CharField(max_length=255, blank=True)),
+                ('content', models.TextField(blank=True)),
+                ('locale', kitsune.sumo.models.LocaleField(default=b'en-US', max_length=7, db_index=True, choices=[(b'af', 'Afrikaans'), (b'ar', '\u0639\u0631\u0628\u064a'), (b'az', 'Az\u0259rbaycanca'), (b'bg', '\u0411\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438'), (b'bm', 'Bamanankan'), (b'bn-BD', '\u09ac\u09be\u0982\u09b2\u09be (\u09ac\u09be\u0982\u09b2\u09be\u09a6\u09c7\u09b6)'), (b'bn-IN', '\u09ac\u09be\u0982\u09b2\u09be (\u09ad\u09be\u09b0\u09a4)'), (b'bs', 'Bosanski'), (b'ca', 'catal\xe0'), (b'cs', '\u010ce\u0161tina'), (b'da', 'Dansk'), (b'de', 'Deutsch'), (b'ee', '\xc8\u028begbe'), (b'el', '\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac'), (b'en-US', 'English'), (b'es', 'Espa\xf1ol'), (b'et', 'eesti keel'), (b'eu', 'Euskara'), (b'fa', '\u0641\u0627\u0631\u0633\u06cc'), (b'fi', 'suomi'), (b'fr', 'Fran\xe7ais'), (b'fy-NL', 'Frysk'), (b'ga-IE', 'Gaeilge (\xc9ire)'), (b'gl', 'Galego'), (b'gu-IN', '\u0a97\u0ac1\u0a9c\u0ab0\u0abe\u0aa4\u0ac0'), (b'ha', '\u0647\u064e\u0631\u0652\u0634\u064e\u0646 \u0647\u064e\u0648\u0652\u0633\u064e'), (b'he', '\u05e2\u05d1\u05e8\u05d9\u05ea'), (b'hi-IN', '\u0939\u093f\u0928\u094d\u0926\u0940 (\u092d\u093e\u0930\u0924)'), (b'hr', 'Hrvatski'), (b'hu', 'Magyar'), (b'dsb', 'Dolnoserb\u0161\u0107ina'), (b'hsb', 'Hornjoserbsce'), (b'id', 'Bahasa Indonesia'), (b'ig', 'As\u1ee5s\u1ee5 Igbo'), (b'it', 'Italiano'), (b'ja', '\u65e5\u672c\u8a9e'), (b'km', '\u1781\u17d2\u1798\u17c2\u179a'), (b'kn', '\u0c95\u0ca8\u0ccd\u0ca8\u0ca1'), (b'ko', '\ud55c\uad6d\uc5b4'), (b'ln', 'Ling\xe1la'), (b'lt', 'lietuvi\u0173 kalba'), (b'mg', 'Malagasy'), (b'mk', '\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0441\u043a\u0438'), (b'ml', '\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02'), (b'ne-NP', '\u0928\u0947\u092a\u093e\u0932\u0940'), (b'nl', 'Nederlands'), (b'no', 'Norsk'), (b'pl', 'Polski'), (b'pt-BR', 'Portugu\xeas (do Brasil)'), (b'pt-PT', 'Portugu\xeas (Europeu)'), (b'ro', 'rom\xe2n\u0103'), (b'ru', '\u0420\u0443\u0441\u0441\u043a\u0438\u0439'), (b'si', '\u0dc3\u0dd2\u0d82\u0dc4\u0dbd'), (b'sk', 'sloven\u010dina'), (b'sl', 'sloven\u0161\u010dina'), (b'sq', 'Shqip'), (b'sr', '\u0421\u0440\u043f\u0441\u043a\u0438'), (b'sw', 'Kiswahili'), (b'sv', 'Svenska'), (b'ta', '\u0ba4\u0bae\u0bbf\u0bb4\u0bcd'), (b'ta-LK', '\u0ba4\u0bae\u0bbf\u0bb4\u0bcd (\u0b87\u0bb2\u0b99\u0bcd\u0b95\u0bc8)'), (b'te', '\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41'), (b'th', '\u0e44\u0e17\u0e22'), (b'tn', 'Setswana'), (b'tr', 'T\xfcrk\xe7e'), (b'uk', '\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430'), (b'ur', '\u0627\u064f\u0631\u062f\u0648'), (b'vi', 'Ti\u1ebfng Vi\u1ec7t'), (b'wo', 'Wolof'), (b'xh', 'isiXhosa'), (b'yo', '\xe8d\xe8 Yor\xf9b\xe1'), (b'zh-CN', '\u4e2d\u6587 (\u7b80\u4f53)'), (b'zh-TW', '\u6b63\u9ad4\u4e2d\u6587 (\u7e41\u9ad4)'), (b'zu', 'isiZulu')])),
+                ('slug', models.CharField(max_length=255, blank=True)),
+                ('summary', models.TextField(blank=True)),
+                ('title', models.CharField(max_length=255, blank=True)),
+                ('based_on', models.ForeignKey(to='wiki.Revision')),
+                ('creator', models.ForeignKey(related_name='created_draftrevisions', to=settings.AUTH_USER_MODEL)),
+                ('document', models.ForeignKey(related_name='draftrevisions', to='wiki.Document')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(kitsune.search.models.SearchMixin, models.Model),
+        ),
+    ]

--- a/kitsune/wiki/templates/wiki/includes/document_macros.html
+++ b/kitsune/wiki/templates/wiki/includes/document_macros.html
@@ -182,9 +182,12 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro submit_revision(form, buttons_only=False, show_no_update_checkbox=False, include_diff=False) -%}
+{% macro submit_revision(form, buttons_only=False, show_no_update_checkbox=False, include_diff=False, translate=False) -%}
   <div class="submit">
     <button class="btn btn-important btn-submit" type="submit">{{ _('Submit for Review') }}</button>
+    {% if translate %}
+      <button class="btn btn-important btn-draft" data-draft-url="{{ url('wiki.draft_revision') }}" type="button">{{ _('Save as Draft') }}</button>
+    {% endif %}
     <button class="btn btn-preview" data-preview-url="{{ url('wiki.preview') }}" type="button">{{ _('Preview Content') }}</button>
     {% if include_diff %}
       <button class="btn btn-diff" type="button">{{ _('Preview Changes') }}</button>

--- a/kitsune/wiki/templates/wiki/translate.html
+++ b/kitsune/wiki/templates/wiki/translate.html
@@ -46,6 +46,20 @@
           </li>
         {% endif %}
 
+        {% if draft_revision %}
+          <li class="info">
+            <p><strong>{{ _('You have a draft revision for this article saved on {date_time}')|f(date_time=draft_revision.created) }}</strong></p>
+            <form action="" method="get">
+              <input class="btn" name="restore" value={{ _('Restore') }} type="submit">
+              <input class="btn" name="discard" value={{ _('Discard') }} type="submit">
+            </form>
+          </li>
+        {% endif %}
+        {% if more_updated_rev %}
+          <li class="warning">
+            <p><strong>{{ _('This version is outdated, but there is a new version <a href="{link}">{revision}</a> available.')|fe(link=url('wiki.revision', document.slug, more_updated_rev.id, locale=locale), revision=more_updated_rev.id) }}</strong></p>
+          </li>
+        {% endif %}
         {{ edit_messages(document, show_revision_warning) }}
         {{ document_lock_warning() }}
       </ul>
@@ -58,7 +72,7 @@
       </div>
       {% if not document %}
         {# If this is the first translation to this locale, we use 1 big form. #}
-        <form action="" method="post" data-json-url="{{ url('wiki.json') }}">
+        <form id="both_form" action="" method="post" data-json-url="{{ url('wiki.json') }}">
           {{ csrf() }}
           <input type="hidden" name="form" value="both" />
           <input type="hidden" name="slug" value="{{ parent.slug }}" />
@@ -70,7 +84,7 @@
           {{ errorlist(document_form) }}
           {% if document %}
             {# If there are existing translations in this locale, we use 2 separate forms. #}
-            <form action="" method="post" data-json-url="{{ url('wiki.json') }}" data-document-id="{{ document.id }}">
+            <form id="doc_form" action="" method="post" data-json-url="{{ url('wiki.json') }}" data-document-id="{{ document.id }}">
               {{ csrf() }}
               <input type="hidden" name="form" value="doc" />
               <input type="hidden" name="slug" value="{{ document.slug }}" />
@@ -116,7 +130,7 @@
           {{ errorlist(revision_form) }}
           {% if document %}
             {# If there are existing translations in this locale, we use 2 separate forms. #}
-            <form action="" method="post">
+            <form id="rev_form" action="" method="post">
               {{ csrf() }}
               <input type="hidden" name="form" value="rev" />
               <input type="hidden" name="slug" value="{{ document.slug }}" />
@@ -186,7 +200,7 @@
             {# If the document has been created and has a current revision,
                we allow the localizer to keep the translation out of date
                with this new revision. #}
-            {{ submit_revision(revision_form, show_no_update_checkbox=(document and document.current_revision), include_diff=True) }}
+            {{ submit_revision(revision_form, show_no_update_checkbox=(document and document.current_revision), include_diff=True, translate=True) }}
             <div id="preview" class="cf"></div>
             <div id="preview-diff">
                 <div class="from">{{ revision_form.content.value() }}</div>
@@ -195,6 +209,8 @@
               </div>
             <div class="submit" id="preview-bottom">
               {{ submit_revision(revision_form, buttons_only=True, include_diff=True) }}
+            </div>
+            <div id="draft-message" class="alert" hidden>
             </div>
           </div>
           {% if document %}

--- a/kitsune/wiki/tests/__init__.py
+++ b/kitsune/wiki/tests/__init__.py
@@ -11,7 +11,7 @@ from kitsune.products.models import Product
 from kitsune.products.tests import ProductFactory, TopicFactory
 from kitsune.sumo.tests import LocalizingClient, TestCase, FuzzyUnicode
 from kitsune.users.tests import UserFactory
-from kitsune.wiki.models import Document, Revision, Locale, HelpfulVote
+from kitsune.wiki.models import Document, DraftRevision, Revision, Locale, HelpfulVote
 from kitsune.wiki.config import (
     CATEGORIES, SIGNIFICANCES, TEMPLATES_CATEGORY, TEMPLATE_TITLE_PREFIX, REDIRECT_CONTENT,
     REDIRECT_TITLE)
@@ -120,6 +120,25 @@ class RedirectRevisionFactory(RevisionFactory):
         lambda o: REDIRECT_TITLE % {'old': factory.SelfAttribute('..target.title'), 'number': 1})
     content = factory.LazyAttribute(lambda o: REDIRECT_CONTENT % o.target.title)
     is_approved = True
+
+
+class DraftRevisionFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = DraftRevision
+
+    document = factory.SubFactory(DocumentFactory,
+                                  is_localizable=True, locale=settings.WIKI_DEFAULT_LANGUAGE)
+    based_on = factory.SubFactory(
+        ApprovedRevisionFactory,
+        is_ready_for_localization=True,
+        document=factory.SelfAttribute('..document'))
+    content = FuzzyUnicode()
+    creator = factory.SubFactory(UserFactory)
+    keywords = 'test, test1'
+    locale = factory.fuzzy.FuzzyChoice(l for l in settings.SUMO_LANGUAGES if l != 'en-US')
+    summary = FuzzyUnicode()
+    title = FuzzyUnicode()
+    slug = factory.LazyAttribute(lambda o: slugify(o.title))
 
 
 class LocaleFactory(factory.DjangoModelFactory):

--- a/kitsune/wiki/urls.py
+++ b/kitsune/wiki/urls.py
@@ -115,6 +115,7 @@ urlpatterns = patterns(
     url(r'^/new$', 'new_document', name='wiki.new_document'),
     url(r'^/all$', 'list_documents', name='wiki.all_documents'),
     url(r'^/preview-wiki-content$', 'preview_revision', name='wiki.preview'),
+    url(r'^/save_draft$', 'draft_revision', name='wiki.draft_revision'),
     url(r'^/category/(?P<category>\d+)$', 'list_documents',
         name='wiki.category'),
     (r'^/(?P<document_slug>[^/]+)', include(document_patterns)),


### PR DESCRIPTION
A long waiting patch. :smiley: :sunglasses: Saving a revision as draft is badly needed from localization end. The saving and restoring system can be better by using javascript, but I dont have much Idea about javascript. so leaving it for others to work in future. The javascript in this patch may not be as good because of that, so please consider reviewing. Though most of the work is done in the backend.
@mythmon r?