### PR TITLE
[Bug 611641] Redirect to history page for translated articles

### DIFF
--- a/kitsune/wiki/templates/wiki/select_locale.html
+++ b/kitsune/wiki/templates/wiki/select_locale.html
@@ -19,7 +19,7 @@
       <h3>{{ _('This document has already been translated to the following locales:') }}</h3>
       <ul class="locales">
         {% for locale in translated_locales %}
-          <li><a href="{{ url('wiki.document', locale=locale[0], document_slug=document.slug) }}">{{ locale[1] }} ({{ locale[0] }})</a></li>
+          <li><a href="{{ url('wiki.document_revisions', locale=locale[0], document_slug=document.slug) }}">{{ locale[1] }} ({{ locale[0] }})</a></li>
         {% endfor %}
       </ul>
     </article>


### PR DESCRIPTION
It was proposed in [Bug 611641 comment 22](https://bugzilla.mozilla.org/show_bug.cgi?id=611641#c22) that the link should be article history page instead of article page. So landing it will finally close up the bug.
r?