### PR TITLE
[Bug 1238252] Properly encode search URL in mobile instant search.

### DIFF
--- a/kitsune/sumo/static/sumo/tpl/mobile-search-results.html
+++ b/kitsune/sumo/static/sumo/tpl/mobile-search-results.html
@@ -2,7 +2,7 @@
   <ol class="search-results">
     {% for doc in results %}
       <li class="{{ doc.type }}">
-        <a href="{{ doc.url|urlparams(s=q, as='s') }}">
+        <a href="{{ doc.url|urlparams(s=q, as='s')|encodeURI }}">
           <span class="title">{{ doc.title }}</span>
           {{ doc.search_summary|safe }}
         </a>


### PR DESCRIPTION
This is very similar to [bug 1223970](https://bugzilla.mozilla.org/show_bug.cgi?id=1223970).

Nunjucks tries to escape a lot of things, but it only does HTML encoding, not URI encoding.

small r?