### PR TITLE
[Bug 1225511] Hide signin menu link during AAQ

### DIFF
--- a/kitsune/questions/templates/questions/new_question_react.html
+++ b/kitsune/questions/templates/questions/new_question_react.html
@@ -7,7 +7,7 @@
 {% block breadcrumbs %}{% endblock %}
 
 {% set hide_aaq_link = True %}
-{% set hide_signout_link = True %}
+{% set hide_signin = True %}
 
 {% block content %}
   {{ csrf() }}{# CSRF token for AJAX actions. #}

--- a/kitsune/questions/templates/questions/new_question_react.html
+++ b/kitsune/questions/templates/questions/new_question_react.html
@@ -7,7 +7,7 @@
 {% block breadcrumbs %}{% endblock %}
 
 {% set hide_aaq_link = True %}
-{% set within_aaq = True %}
+{% set hide_aux_nav = True %}
 
 {% block content %}
   {{ csrf() }}{# CSRF token for AJAX actions. #}

--- a/kitsune/questions/templates/questions/new_question_react.html
+++ b/kitsune/questions/templates/questions/new_question_react.html
@@ -7,7 +7,7 @@
 {% block breadcrumbs %}{% endblock %}
 
 {% set hide_aaq_link = True %}
-{% set hide_signin = True %}
+{% set within_aaq = True %}
 
 {% block content %}
   {{ csrf() }}{# CSRF token for AJAX actions. #}

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -135,7 +135,7 @@
       <div class="cf">
         <nav id="aux-nav" role="navigation">
           <ul>
-            {{ aux_nav(user, hide_aaq_link, hide_signout_link) }}
+            {{ aux_nav(user, hide_aaq_link, hide_signin) }}
             {% if not hide_locale_switcher %}
               <li><a href="{{ locale_picker_url }}" class="locale-picker">{{ settings.LANGUAGES_DICT[request.LANGUAGE_CODE.lower()] }}</a></li>
             {% endif %}

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -135,7 +135,9 @@
       <div class="cf">
         <nav id="aux-nav" role="navigation">
           <ul>
-            {{ aux_nav(user, hide_aaq_link, within_aaq) }}
+            {% if not hide_aux_nav %}
+              {{ aux_nav(user, hide_aaq_link) }}
+            {% endif %}
             {% if not hide_locale_switcher %}
               <li><a href="{{ locale_picker_url }}" class="locale-picker">{{ settings.LANGUAGES_DICT[request.LANGUAGE_CODE.lower()] }}</a></li>
             {% endif %}

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -135,7 +135,7 @@
       <div class="cf">
         <nav id="aux-nav" role="navigation">
           <ul>
-            {{ aux_nav(user, hide_aaq_link, hide_signin) }}
+            {{ aux_nav(user, hide_aaq_link, within_aaq) }}
             {% if not hide_locale_switcher %}
               <li><a href="{{ locale_picker_url }}" class="locale-picker">{{ settings.LANGUAGES_DICT[request.LANGUAGE_CODE.lower()] }}</a></li>
             {% endif %}

--- a/kitsune/sumo/templates/includes/common_macros.html
+++ b/kitsune/sumo/templates/includes/common_macros.html
@@ -11,7 +11,7 @@
   </form>
 {% endmacro %}
 
-{% macro aux_nav(user, hide_aaq_link=False, within_aaq=False) %}
+{% macro aux_nav(user, hide_aaq_link=False) %}
   {% if not settings.READ_ONLY %}
     {% if not hide_aaq_link %}
       {% if request.LANGUAGE_CODE in AAQ_LANGUAGES %}
@@ -21,43 +21,41 @@
       {% endif %}
       <li><a href="{{ ask_url }}" class="ask">{{ _('Ask a question') }}</a></li>
     {% endif %}
-    {% if not within_aaq %}
-      {% if user.is_authenticated() %}
-        <li class="dropdown">
-          <a href="#">{{ _('Contributor Tools') }}</a>
-          <ul class="double">
-            {{ _for_contributor_links(user, settings.WIKI_DEFAULT_LANGUAGE) }}
+    {% if user.is_authenticated() %}
+      <li class="dropdown">
+        <a href="#">{{ _('Contributor Tools') }}</a>
+        <ul class="double">
+          {{ _for_contributor_links(user, settings.WIKI_DEFAULT_LANGUAGE) }}
+        </ul>
+      </li>
+        <li class="dropdown"><a href="{{ profile_url(user) }}" class="user">{{ user }}</a>
+          <ul>
+            <li><a href="{{ profile_url(user) }}">{{ _('View Profile') }}</a></li>
+            <li><a href="{{ url('search')|urlparams(asked_by=user.username, a=1, w=2) }}">{{ _('My Questions') }}</a></li>
+            <li><a href="{{ profile_url(user, edit=True) }}">{{ _('Edit Profile') }}</a></li>
+            <li><a href="{{ url('users.edit_settings') }}">{{ _('Settings') }}</a></li>
+            <li>
+              <form id="sign-out" action="{{ url('users.logout') }}" method="post">
+                {{ csrf() }}
+              </form>
+              <a class="sign-out" data-type="submit" data-form="sign-out" href="#sign-out">{{ _('Sign Out') }}</a>
+            </li>
           </ul>
         </li>
-          <li class="dropdown"><a href="{{ profile_url(user) }}" class="user">{{ user }}</a>
-            <ul>
-              <li><a href="{{ profile_url(user) }}">{{ _('View Profile') }}</a></li>
-              <li><a href="{{ url('search')|urlparams(asked_by=user.username, a=1, w=2) }}">{{ _('My Questions') }}</a></li>
-              <li><a href="{{ profile_url(user, edit=True) }}">{{ _('Edit Profile') }}</a></li>
-              <li><a href="{{ url('users.edit_settings') }}">{{ _('Settings') }}</a></li>
-              <li>
-                <form id="sign-out" action="{{ url('users.logout') }}" method="post">
-                  {{ csrf() }}
-                </form>
-                <a class="sign-out" data-type="submit" data-form="sign-out" href="#sign-out">{{ _('Sign Out') }}</a>
-              </li>
-            </ul>
-          </li>
-        <li>
-          <a href="{{ url('messages.inbox') }}">
-            {{ _('Inbox') }}
-            {% if unread_message_count > 0 %}
-              <span class="unread-message-count">{{ unread_message_count }}</span>
-            {% endif %}
-          </a>
-        </li>
-      {% else %}
-        <li>
-          <a href="{{ url('users.auth') }}" class="sign-in register">
-            {{ _('Sign In') }}
-          </a>
-        </li>
-      {% endif %}
+      <li>
+        <a href="{{ url('messages.inbox') }}">
+          {{ _('Inbox') }}
+          {% if unread_message_count > 0 %}
+            <span class="unread-message-count">{{ unread_message_count }}</span>
+          {% endif %}
+        </a>
+      </li>
+    {% else %}
+      <li>
+        <a href="{{ url('users.auth') }}" class="sign-in register">
+          {{ _('Sign In') }}
+        </a>
+      </li>
     {% endif %}
   {% endif %}
 {% endmacro %}

--- a/kitsune/sumo/templates/includes/common_macros.html
+++ b/kitsune/sumo/templates/includes/common_macros.html
@@ -11,7 +11,7 @@
   </form>
 {% endmacro %}
 
-{% macro aux_nav(user, hide_aaq_link=False, hide_signout_link=False) %}
+{% macro aux_nav(user, hide_aaq_link=False, hide_signin=False) %}
   {% if not settings.READ_ONLY %}
     {% if not hide_aaq_link %}
       {% if request.LANGUAGE_CODE in AAQ_LANGUAGES %}
@@ -21,43 +21,43 @@
       {% endif %}
       <li><a href="{{ ask_url }}" class="ask">{{ _('Ask a question') }}</a></li>
     {% endif %}
-    {% if user.is_authenticated() %}
-      <li class="dropdown">
-        <a href="#">{{ _('Contributor Tools') }}</a>
-        <ul class="double">
-          {{ _for_contributor_links(user, settings.WIKI_DEFAULT_LANGUAGE) }}
-        </ul>
-      </li>
-      <li class="dropdown"><a href="{{ profile_url(user) }}" class="user">{{ user }}</a>
-        <ul>
-          <li><a href="{{ profile_url(user) }}">{{ _('View Profile') }}</a></li>
-          <li><a href="{{ url('search')|urlparams(asked_by=user.username, a=1, w=2) }}">{{ _('My Questions') }}</a></li>
-          <li><a href="{{ profile_url(user, edit=True) }}">{{ _('Edit Profile') }}</a></li>
-          <li><a href="{{ url('users.edit_settings') }}">{{ _('Settings') }}</a></li>
-          {% if not hide_signout_link %}
-            <li>
-              <form id="sign-out" action="{{ url('users.logout') }}" method="post">
-                {{ csrf() }}
-              </form>
-              <a class="sign-out" data-type="submit" data-form="sign-out" href="#sign-out">{{ _('Sign Out') }}</a>
-            </li>
-          {% endif %}
-        </ul>
-      </li>
-      <li>
-        <a href="{{ url('messages.inbox') }}">
-          {{ _('Inbox') }}
-          {% if unread_message_count > 0 %}
-            <span class="unread-message-count">{{ unread_message_count }}</span>
-          {% endif %}
-        </a>
-      </li>
-    {% else %}
-      <li>
-        <a href="{{ url('users.auth') }}" class="sign-in register">
-          {{ _('Sign In') }}
-        </a>
-      </li>
+    {% if not hide_signin %}
+      {% if user.is_authenticated() %}
+        <li class="dropdown">
+          <a href="#">{{ _('Contributor Tools') }}</a>
+          <ul class="double">
+            {{ _for_contributor_links(user, settings.WIKI_DEFAULT_LANGUAGE) }}
+          </ul>
+        </li>
+          <li class="dropdown"><a href="{{ profile_url(user) }}" class="user">{{ user }}</a>
+            <ul>
+              <li><a href="{{ profile_url(user) }}">{{ _('View Profile') }}</a></li>
+              <li><a href="{{ url('search')|urlparams(asked_by=user.username, a=1, w=2) }}">{{ _('My Questions') }}</a></li>
+              <li><a href="{{ profile_url(user, edit=True) }}">{{ _('Edit Profile') }}</a></li>
+              <li><a href="{{ url('users.edit_settings') }}">{{ _('Settings') }}</a></li>
+              <li>
+                <form id="sign-out" action="{{ url('users.logout') }}" method="post">
+                  {{ csrf() }}
+                </form>
+                <a class="sign-out" data-type="submit" data-form="sign-out" href="#sign-out">{{ _('Sign Out') }}</a>
+              </li>
+            </ul>
+          </li>
+        <li>
+          <a href="{{ url('messages.inbox') }}">
+            {{ _('Inbox') }}
+            {% if unread_message_count > 0 %}
+              <span class="unread-message-count">{{ unread_message_count }}</span>
+            {% endif %}
+          </a>
+        </li>
+      {% else %}
+        <li>
+          <a href="{{ url('users.auth') }}" class="sign-in register">
+            {{ _('Sign In') }}
+          </a>
+        </li>
+      {% endif %}
     {% endif %}
   {% endif %}
 {% endmacro %}

--- a/kitsune/sumo/templates/includes/common_macros.html
+++ b/kitsune/sumo/templates/includes/common_macros.html
@@ -11,7 +11,7 @@
   </form>
 {% endmacro %}
 
-{% macro aux_nav(user, hide_aaq_link=False, hide_signin=False) %}
+{% macro aux_nav(user, hide_aaq_link=False, within_aaq=False) %}
   {% if not settings.READ_ONLY %}
     {% if not hide_aaq_link %}
       {% if request.LANGUAGE_CODE in AAQ_LANGUAGES %}
@@ -21,7 +21,7 @@
       {% endif %}
       <li><a href="{{ ask_url }}" class="ask">{{ _('Ask a question') }}</a></li>
     {% endif %}
-    {% if not hide_signin %}
+    {% if not within_aaq %}
       {% if user.is_authenticated() %}
         <li class="dropdown">
           <a href="#">{{ _('Contributor Tools') }}</a>


### PR DESCRIPTION
This removes the sign in link/drop-down during the AAQ flow. We previously just hid the sign out button because it was having problems, but this will hide the entire thing in order to solve https://bugzilla.mozilla.org/show_bug.cgi?id=1225511