### PR TITLE
[Bug 1240582]  Remove wiki page redirect for dsb/hsb (Sorbian)

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -215,8 +215,6 @@ SIMPLE_WIKI_LANGUAGES = [
     'et',
     'ga-IE',
     'gl',
-    'dsb',
-    'hsb',
     'kn',
     'ml',
     'tn',


### PR DESCRIPTION
This addresses https://bugzilla.mozilla.org/show_bug.cgi?id=1240582