### PR TITLE
Make showfor more resilient to missing data.

### DIFF
--- a/kitsune/sumo/static/sumo/js/showfor.js
+++ b/kitsune/sumo/static/sumo/js/showfor.js
@@ -35,7 +35,15 @@
   /* Get the product/platform data from the DOM, and munge it into the
    * desired format. */
   ShowFor.prototype.loadData = function() {
-    this.data = JSON.parse(this.$container.find('.showfor-data').html());
+    try {
+      this.data = JSON.parse(this.$container.find('.showfor-data').html());
+    } catch (e) {
+      this.data = {
+        products: [],
+        platforms: [],
+        versions: [],
+      };
+    }
     this.productSlugs = this.data.products.map(function(prod) {
       return prod.slug;
     });


### PR DESCRIPTION
Someone pointed out that the minimal KB view wasn't loading images. It turns out this is because showfor was trying to load non-existent data and crashing, taking down everything else with it (including lazy loading images).

This doesn't fix the issue of showfor data not being on the minimal page, but it does make showfor not crash and burn the page to the ground, which helps this particular issue.

@rehandalal r?