### PR TITLE
[Bug 1245330] Change mobile banner breakpoints to ignore iPads

### DIFF
--- a/kitsune/sumo/static/sumo/less/main.less
+++ b/kitsune/sumo/static/sumo/less/main.less
@@ -1596,7 +1596,7 @@ input[type=button],
   }
 }
 
-@media only screen and (max-device-width: 800px) {
+@media only screen and (max-device-width: 450px) {
   .mobile-banner {
     position: relative;
     width: 100%;
@@ -1636,7 +1636,7 @@ input[type=button],
   }
 }
 
-@media only screen and (min-device-width: 801px) {
+@media only screen and (min-device-width: 451px) {
   .mobile-banner {
     display: none;
   }


### PR DESCRIPTION
[This site](http://screensiz.es/tablet) tells me that all iPhones (and other phones on that site too) report as less than 450 device pixels wide, and all iPads (and other tablets) report has greater than 450 device pixels wide.

r?