### PR TITLE
[Bug 1246937] Fix AAQ event tracking

### DIFF
--- a/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
+++ b/kitsune/questions/static/questions/js/components/TitleContentEditor.jsx
@@ -107,7 +107,7 @@ class SuggestionItem extends React.Component {
       <li className={classString}>
         <a
           href={suggestion.url}
-          data-ga-click="Ask A Question Flow - SPA | suggested article selected"
+          data-ga-click="_trackEvent | Ask A Question Flow - SPA | suggested article selected"
         >
           {suggestion.title}
         </a>

--- a/kitsune/users/static/users/js/actions/UserAuthActions.es6.js
+++ b/kitsune/users/static/users/js/actions/UserAuthActions.es6.js
@@ -3,6 +3,7 @@ import apiFetch, {apiFetchRaw} from '../../../sumo/js/utils/apiFetch.es6.js';
 import Dispatcher from '../../../sumo/js/Dispatcher.es6.js';
 import {actionTypes} from '../constants/UserAuthConstants.es6.js';
 import UserAuthStore from '../stores/UserAuthStore.es6.js';
+import userGa from '../utils/userGa.es6.js';
 
 export function checkAuthState() {
   return apiFetchRaw('/api/1/users/test_auth', {
@@ -90,6 +91,7 @@ export function login(username, password, {inactive=false}={}) {
     Dispatcher.dispatch({
       type: actionTypes.AUTH_LOG_IN_FAILURE,
     });
+    userGa.trackEvent('login failed');
   });
 }
 
@@ -115,6 +117,7 @@ export function register(username, email, password) {
       type: actionTypes.AUTH_REGISTER_FAILURE,
       error: errData,
     });
+    userGa.trackEvent('registration failed');
   });
 }
 

--- a/kitsune/users/static/users/js/actions/UserAuthActions.es6.js
+++ b/kitsune/users/static/users/js/actions/UserAuthActions.es6.js
@@ -31,6 +31,7 @@ export function checkAuthState() {
     } else {
       throw new Error(`Unexpected response from test_auth: ${status}: ${JSON.stringify(data)}`);
     }
+  }).then(function() {
     return UserAuthStore.getState();
   });
 }


### PR DESCRIPTION
This fixes the event tracking for the new AAQ flow as outlined [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1246937). 

The submission failure tracking isn't implemented exactly as described:
* Authentication errors are being tracked with a simple 'registration failed' or 'login failed' message, under the `SPA User Auth` scope rather than the AAQ scope.
* Submission failures as a result of missing or incorrect data are being tracked, but not specific to the actual problem (i.e. 'no product selected'). The UI doesn't render the submit button if there is missing information, which makes submission failures of this nature much less likely. (That said, the UI could be improved to render helpful error messages rather than just hiding the submit button. But that is a separate issue.)