### PR TITLE
[Bug 1241629] Use correct domain for jsi18n urls.

### DIFF
--- a/kitsune/sumo/helpers.py
+++ b/kitsune/sumo/helpers.py
@@ -4,6 +4,7 @@ import re
 import urlparse
 
 from django.conf import settings
+from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse as django_reverse
 from django.http import QueryDict
 from django.utils.encoding import smart_str
@@ -443,3 +444,6 @@ def add_utm(url_, campaign, source='notification', medium='email'):
 @register.function
 def to_unicode(str):
     return unicode(str)
+
+
+register.function(static)

--- a/kitsune/sumo/templates/base.html
+++ b/kitsune/sumo/templates/base.html
@@ -225,11 +225,13 @@
 
 {{ csrf() }}
 
-{# TODO: The BUILD_ID_JS changes whenever our js code changes.
+{# TODO: The JS url changes whenever our js code changes.
    But this should get cached busted whenever a locale is updated.
    It's complicatred to fix. But for now it isn't more broken than
    before. #}
-<script src="{{ STATIC_URL }}jsi18n/{{ request.LANGUAGE_CODE|lower }}/javascript.js?{{ BUILD_ID_JS }}"></script>
+{% if request.LANGUAGE_CODE %}
+  <script src="{{ static('jsi18n/{lang}/djangojs.js'|f(lang=request.LANGUAGE_CODE|lower)) }}"></script>
+{% endif %}
 
 {# Optimizely script for A/B testing - Bug 850816 #}
 {% if waffle.flag('optimizely') %}

--- a/kitsune/sumo/templates/mobile/base.html
+++ b/kitsune/sumo/templates/mobile/base.html
@@ -151,11 +151,13 @@
 
 {% block after_main %}{% endblock %}
 
-{# TODO: The BUILD_ID_JS changes whenever our js code changes.
+{# TODO: The JS url changes whenever our js code changes.
    But this should get cached busted whenever a locale is updated.
    It's complicatred to fix. But for now it isn't more broken than
    before. #}
-<script src="{{ STATIC_URL }}jsi18n/{{ request.LANGUAGE_CODE|lower }}/javascript.js?{{ BUILD_ID_JS }}"></script>
+{% if request.LANGUAGE_CODE %}
+ <script src="{{ static('jsi18n/{lang}/djangojs.js'|f(lang=request.LANGUAGE_CODE|lower)) }}"></script>
+{% endif %}
 
 {% javascript 'mobile-common' %}
 {% for script in scripts %}

--- a/kitsune/sumo/templates/mobile/minimal.html
+++ b/kitsune/sumo/templates/mobile/minimal.html
@@ -59,11 +59,13 @@
 
 {% block after_main %}{% endblock %}
 
-{# TODO: The BUILD_ID_JS changes whenever our js code changes.
+{# TODO: The JS url changes whenever our js code changes.
    But this should get cached busted whenever a locale is updated.
    It's complicatred to fix. But for now it isn't more broken than
    before. #}
-<script src="{{ STATIC_URL }}jsi18n/{{ request.LANGUAGE_CODE|lower }}/javascript.js?{{ BUILD_ID_JS }}"></script>
+{% if request.LANGUAGE_CODE %}
+ <script src="{{ static('jsi18n/{lang}/djangojs.js'|f(lang=request.LANGUAGE_CODE|lower)) }}"></script>
+{% endif %}
 
 {% for script in scripts %}
   {% javascript script %}

--- a/kitsune/urls.py
+++ b/kitsune/urls.py
@@ -47,7 +47,7 @@ urlpatterns = patterns(
 
     # Javascript translations.
     url(r'^jsi18n/.*$', cache_page(60 * 60 * 24 * 365)(javascript_catalog),
-        {'domain': 'javascript', 'packages': ['kitsune']}, name='jsi18n'),
+        {'domain': 'djangojs', 'packages': ['kitsune']}, name='jsi18n'),
     # App translations. These don't need cached because they are downloaded
     # in a build step, not on the client.
     url(r'^jsi18n-yaocho/.*$', javascript_catalog,

--- a/scripts/travis/setup.sh
+++ b/scripts/travis/setup.sh
@@ -76,4 +76,5 @@ echo "Running migrations"
 
 echo "Doing static dance."
 ./manage.py nunjucks_precompile
+./manage.py compilejsi18n
 ./manage.py collectstatic --noinput > /dev/null


### PR DESCRIPTION
Two problems are being solved:

1. We were using the `javascript` domain instead of `djangojs` in a bunch of places for Javascript translations, due to missing these uses when we switched to Puente.
2. We were relying on Pipeline's `BUILD_ID_JS`, which no longer works, to cache-bust the JS translations. I've used the staticfiles URL function in an attempt to make this cache-busting work again, but testing it out locally is proving to be very difficult. We'll need to verify on a server that a cache-busting hash or whatever is added to the URL after it hits a server.

   If it ends up not working, this will still improve our current situations of translations being completely broken, and instead will simply freeze our translations at the the point we deploy.