### PR TITLE
Collect jsi18n files via staticfiles to get hashed filenames.

### DIFF
--- a/jsi18n/.gitignore
+++ b/jsi18n/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -362,6 +362,7 @@ STATIC_ROOT = path('static')
 STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     path('bower_components'),
+    path('jsi18n'),  # Collect jsi18n so that it is cache-busted
 )
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
@@ -641,6 +642,9 @@ STANDALONE_DOMAINS = [
 
 STATICI18N_DOMAIN = 'djangojs'
 STATICI18N_PACKAGES = ['kitsune.sumo']
+# Save jsi18n files outside of static so that collectstatic will pick
+# them up and save it with hashed filenames in the static directory.
+STATICI18N_ROOT = path('jsi18n')
 
 #
 # Django Pipline

--- a/kitsune/sumo/helpers.py
+++ b/kitsune/sumo/helpers.py
@@ -1,10 +1,11 @@
 import datetime
 import json as jsonlib
+import logging
 import re
 import urlparse
 
 from django.conf import settings
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.contrib.staticfiles.templatetags.staticfiles import static as django_static
 from django.core.urlresolvers import reverse as django_reverse
 from django.http import QueryDict
 from django.utils.encoding import smart_str
@@ -25,6 +26,9 @@ from kitsune.sumo import parser
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.users.models import Profile
 from kitsune.wiki.showfor import showfor_data as _showfor_data
+
+
+log = logging.getLogger('k.helpers')
 
 
 class DateTimeFormatError(Exception):
@@ -446,4 +450,11 @@ def to_unicode(str):
     return unicode(str)
 
 
-register.function(static)
+@register.function
+def static(path):
+    """Generate a URL for the specified static file."""
+    try:
+        return django_static(path)
+    except ValueError as err:
+        log.error('Static helper error: %s' % err)
+        return ''

--- a/kitsune/sumo/tests/test_helpers.py
+++ b/kitsune/sumo/tests/test_helpers.py
@@ -13,7 +13,8 @@ from pytz import timezone
 
 from kitsune.sumo.helpers import (
     datetimeformat, DateTimeFormatError, collapse_linebreaks, url, json,
-    timesince, label_with_help, urlparams, yesno, number, remove)
+    timesince, label_with_help, static, urlparams, yesno, number,
+    remove)
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
 
@@ -89,6 +90,10 @@ class TestHelpers(TestCase):
         tags = remove(tags, tag)
         # Nothing was removed and we didn't crash.
         eq_(2, len(tags))
+
+    def test_static_failure(self):
+        """Should not raise an error if the static file is missing."""
+        assert static('does/not/exist.js') == ''
 
 
 class TestDateTimeFormat(TestCase):

--- a/scripts/update/deploy.py
+++ b/scripts/update/deploy.py
@@ -145,8 +145,8 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
 
 @task
 def update(ctx):
-    update_assets()
     update_locales()
+    update_assets()
     db_migrations()
 
 


### PR DESCRIPTION
`STATICI18N_ROOT` causes the `compilejsi18n` command to write the jsi18n files to `/jsi18n` in the repo root. Then, adding that to `STATICFILES_DIRS` causes them to be collected during `collectstatic`, which saves them with the hashes we expect in their filenames.

I had to update the deploy script to collect the jsi18n files before running `collectstatic`, as well.