### PR TITLE
Update API url for CSAT campaign

### DIFF
--- a/kitsune/kpi/cron.py
+++ b/kitsune/kpi/cron.py
@@ -684,18 +684,17 @@ def csat_survey_emails():
     for u in users:
         p = u.profile
         if p.csat_email_sent is None or p.csat_email_sent < start:
-            user = settings.SURVEYGIZMO_USER
-            password = settings.SURVEYGIZMO_PASSWORD
-
             survey_id = SURVEYS['general']['community_health']
             campaign_id = SURVEYS['general']['community_health_campaign_id']
 
             try:
                 requests.put(
-                    'https://restapi.surveygizmo.com/v2/survey/{survey}/surveycampaign/'
-                    '{campaign}/contact?semailaddress={email}&user:pass={user}:{password}'.format(
-                        survey=survey_id, campaign=campaign_id,
-                        email=u.email, user=user, password=password),
+                    'https://restapi.surveygizmo.com/v4/survey/{survey}/surveycampaign/'
+                    '{campaign}/contact?semailaddress={email}&api_token={token}'
+                    '&api_token_secret={secret}&allowdupe=true'.format(
+                        survey=survey_id, campaign=campaign_id, email=u.email,
+                        token=settings.SURVEYGIZMO_API_TOKEN,
+                        secret=settings.SURVEYGIZMO_API_TOKEN_SECRET),
                     timeout=30)
             except requests.exceptions.Timeout:
                 print 'Timed out adding: %s' % u.email


### PR DESCRIPTION
N.B.: We will need to add the API key and secret to the settings on the admin node before pushing this.

r?