### PR TITLE
Include non-supported locales in robots.txt

### DIFF
--- a/kitsune/sumo/jinja2/sumo/robots.html
+++ b/kitsune/sumo/jinja2/sumo/robots.html
@@ -6,3 +6,8 @@ Disallow: /{{ l }}/forums
 Disallow: /{{ l }}/users
 Disallow: /{{ l }}/user
 {% endfor %}
+{% for l in settings.NON_SUPPORTED_LOCALES.keys() %}
+Disallow: /{{ l }}/forums
+Disallow: /{{ l }}/users
+Disallow: /{{ l }}/user
+{% endfor %}


### PR DESCRIPTION
Webops noticed that robots are hitting urls for locales that get redirected. This should stop that.

r?