### PR TITLE
Upgrade Django to 1.8.11

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -48,8 +48,8 @@ cryptography==0.7.2
 # sha256: _eJnrrA6jUnjNB5_caIoxnSNzkO1wA9lWBeA2Ztwstk
 dennis==0.7
 
-# sha256: _AEthQcgGmKOh3ICu3gAeZFSKF9pqg1Cp8UGqW-70uM
-Django==1.8.9
+# sha256: 7BSL5zVI2gkN12wujFfJjosehPLLh1ALm-VCAYekNfs
+Django==1.8.11
 
 # sha256: kjEbxXu6YpeZv9FrlKYlEQe79VE5TCBFg6cI0g-2gbY
 django-activity-stream==0.6.0


### PR DESCRIPTION
The changes between 1.8.9 and 1.8.11 are minor, so this shouldn't be any problem. If CI passes, I expect we are done here.

r?