### PR TITLE
Rename "xx" test locale to "xx_testing" to match locales repo

### DIFF
--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -381,10 +381,10 @@ Run::
 
 It'll extract all the strings, create a ``.pot`` file, then create a
 Pirate translation of all strings. The Pirate strings are available in
-the xx locale. After running the ``test_locales.sh`` script, you can
-access the xx locale with:
+the xx_testing locale. After running the ``test_locales.sh`` script, you can
+access the xx_testing locale with:
 
-    http://localhost:8000/xx/
+    http://localhost:8000/xx_testing/
 
 Strings in the Pirate translation have the following properties:
 
@@ -398,7 +398,7 @@ Strings in the Pirate translation have the following properties:
 
 .. Note::
 
-   The xx locale is only available on your local machine. It is not
+   The xx_testing locale is only available on your local machine. It is not
    available on -dev, -stage, or -prod.
 
 

--- a/kitsune/lib/languages.json
+++ b/kitsune/lib/languages.json
@@ -594,7 +594,7 @@
         "english": "Bambara",
         "native": "Bamanankan"
     },
-    "xx": {
+    "xx_testing": {
         "iso639_1": "xx",
         "english": "Pirate",
         "native": "Pirate ARrr!"

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -166,7 +166,7 @@ SUMO_LANGUAGES = (
     'vi',
     'wo',
     'xh',
-    'xx',  # This is a test locale
+    'xx_testing',
     'yo',
     'zh-CN',
     'zh-TW',
@@ -226,10 +226,10 @@ SIMPLE_WIKI_LANGUAGES = [
 # Languages that should show up in language switcher.
 LANGUAGE_CHOICES = tuple(
     [(lang, LOCALES[lang].native) for lang in SUMO_LANGUAGES
-     if lang != 'xx'])
+     if lang != 'xx_testing'])
 LANGUAGE_CHOICES_ENGLISH = tuple(
     [(lang, LOCALES[lang].english) for lang in SUMO_LANGUAGES
-     if lang != 'xx'])
+     if lang != 'xx_testing'])
 LANGUAGES_DICT = dict([(i.lower(), LOCALES[i].native) for i in SUMO_LANGUAGES])
 LANGUAGES = LANGUAGES_DICT.items()
 

--- a/kitsune/sumo/api.py
+++ b/kitsune/sumo/api.py
@@ -13,7 +13,7 @@ def locales_api_view(request):
     locales = {}
     for lang in settings.SUMO_LANGUAGES:
         # FIXME: Need a better way to skip fake locales.
-        if lang == 'xx':
+        if lang == 'xx_testing':
             continue
 
         locale = {

--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -4,7 +4,7 @@
 {% else %}
   {% set SURVEY_GIZMOS = [] %}
 {% endif %}
-{% if request.LANGUAGE_CODE == 'xx' %}
+{% if request.LANGUAGE_CODE == 'xx_testing' %}
   {% set meta = [('robots', 'noindex')] %}
 {% endif %}
 <!DOCTYPE html>

--- a/scripts/test_locales.sh
+++ b/scripts/test_locales.sh
@@ -1,31 +1,37 @@
 #!/bin/bash
 
-# This creates a faux Pirate locale under xx and transforms all the
-# strings such that every resulting string has four properties:
+# This creates a faux Pirate locale under xx and transforms
+# all the strings such that every resulting string has four
+# properties:
 #
 # 1. it's longer than the English equivalent (tests layout issues)
-# 2. it's different than the English equivalent (tests missing gettext calls)
-# 3, every string ends up with a non-ascii character (tests unicode)
-# 4. looks close enough to the English equivalent that you can quickly
-#    figure out what's wrong
+# 2. it's different than the English equivalent (tests missing
+# gettext calls) 3, every string ends up with a non-ascii character
+# (tests unicode) 4. looks close enough to the English equivalent
+# that you can quickly figure out what's wrong
 #
 # Run this from the project root directory like this:
 #
 # $ scripts/test_locales.sh
 
-echo "create required directories..."
+echo "Create required directories..."
 mkdir -p locale/templates/LC_MESSAGES
 
-echo "extract and merge...."
-./manage.py extract
-./manage.py merge
+echo "Extract and merge...."
+./manage.py extract > /dev/null
+./manage.py merge > /dev/null &2>/dev/null
 
-echo "creating dir...."
-mkdir -p locale/xx/LC_MESSAGES
+echo "Creating xx_testing locale dir...."
+mkdir -p locale/xx_testing/LC_MESSAGES
 
-echo "copying messages.pot file...."
-cp locale/templates/LC_MESSAGES/messages.pot locale/xx/LC_MESSAGES/messages.po
+for template in locale/templates/LC_MESSAGES/*.pot; do
+    name=$(basename $template .pot)
+    pofile="locale/xx_testing/LC_MESSAGE/${name}.po"
+    echo "Copying $name.pot to $name.po..."
+    cp $template $pofile
+    echo "Translating $name.po..."
+    ./manage.py translate --pipeline=html,pirate $pofile > /dev/null
+done
 
-echo "translate messages.po file...."
-./manage.py translate --pipeline=html,pirate locale/xx/LC_MESSAGES/messages.po
-locale/compile-mo.sh locale/xx/
+echo "Compile .mo files"
+locale/compile-mo.sh locale/xx_testing/ > /dev/null


### PR DESCRIPTION
White trying to figure out [bug 1254199](https://bugzilla.mozilla.org/show_bug.cgi?id=1254199), I noticed that our testing locale got renamed in SVN. This makes all our systems correctly refer to the locale as `xx_testing` instead of `xx`.

I suspect this is actually causing problems in prod, since the `xx` locale is suddenly accessible on the site. It seems to be very error prone. I hope this will fix that too.