### PR TITLE
[Bug 1254690] Fix escaping of share link on mobile articles

### DIFF
--- a/kitsune/wiki/jinja2/wiki/mobile/document.html
+++ b/kitsune/wiki/jinja2/wiki/mobile/document.html
@@ -43,10 +43,10 @@
 
     {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
     {% if share_link %}
-      <p>
+      <p class="share-link">
         <br/>
         {% set link='<a href="' + share_link + '">' + share_link + '</a>' %}
-        {{ _('Share this article: {link}')|f(link=link)|safe }}
+        {{ _('Share this article: {link}')|f(link=link|safe) }}
       </p>
     {% endif %}
 

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -438,6 +438,16 @@ class MobileArticleTemplate(MobileTestCase):
         eq_(200, response.status_code)
         assert template_used(response, 'wiki/mobile/document.html')
 
+    def test_document_share_link_escape(self):
+        """Ensure that the share link isn't escaped."""
+        r = ApprovedRevisionFactory(
+            content='Test',
+            document__share_link='https://www.example.org',
+        )
+        response = self.client.get(r.document.get_absolute_url())
+        doc = pq(response.content)
+        eq_(doc('#wiki-doc .share-link a').attr('href'), 'https://www.example.org')
+
 
 class RevisionTests(TestCaseBase):
     """Tests for the Revision template"""


### PR DESCRIPTION
This blatantly steals the same solution used in #2804.

@Osmose r?