### PR TITLE
Set UTF-8 as default encoding for peep

### DIFF
--- a/scripts/peep.py
+++ b/scripts/peep.py
@@ -22,6 +22,9 @@ hashes in requirements.txt, and you're all set.
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 from __future__ import print_function
+import sys
+reload(sys)
+sys.setdefaultencoding("utf-8")
 try:
     xrange = xrange
 except NameError:


### PR DESCRIPTION
This was necessary for me to make the build work. Maybe will help someone too, and hopefully not break anything.