### PR TITLE
Make warnings on translate page more consistent in tests

### DIFF
--- a/kitsune/wiki/jinja2/wiki/translate.html
+++ b/kitsune/wiki/jinja2/wiki/translate.html
@@ -56,7 +56,7 @@
           </li>
         {% endif %}
         {% if more_updated_rev %}
-          <li class="warning">
+          <li class="warning draft-warning">
             <p><strong>{{ _('This version is outdated, but there is a new version <a href="{link}">{revision}</a> available.')|fe(link=url('wiki.revision', document.slug, more_updated_rev.id, locale=locale), revision=more_updated_rev.id) }}</strong></p>
           </li>
         {% endif %}

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -1144,7 +1144,7 @@ class NewRevisionTests(TestCaseBase):
         trans_resp = self.client.get(trans_url, draft_request)
         trans_content = pq(trans_resp.content)
         # Check there is a warning message
-        eq_(2, len(trans_content('.user-messages li')))
+        eq_(1, len(trans_content('.user-messages li.draft-warning')))
 
 
 class HistoryTests(TestCaseBase):

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -1144,7 +1144,7 @@ class NewRevisionTests(TestCaseBase):
         trans_resp = self.client.get(trans_url, draft_request)
         trans_content = pq(trans_resp.content)
         # Check there is a warning message
-        eq_(1, len(trans_content('.user-messages li')))
+        eq_(2, len(trans_content('.user-messages li')))
 
 
 class HistoryTests(TestCaseBase):

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -1517,8 +1517,7 @@ def _get_next_url_fallback_localization(request):
 
 def _show_revision_warning(document, revision):
     if revision:
-        return document.revisions.filter(created__gt=revision.created,
-                                         reviewed=None).exists()
+        return document.revisions.filter(id__gt=revision.id, reviewed=None).exists()
     return False
 
 


### PR DESCRIPTION
This makes the tests pass consistently for me, and I think the logic is unchanged (though the result is a bit surprising).

@safwanrahman r?

@homu delegate=safwanrahman