### PR TITLE
 [fix bug 1254198] Pass request to render_to_string. 

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -1407,7 +1407,9 @@ def watch_question(request, question_id):
         else:
             tmpl = 'questions/includes/email_subscribe.html'
 
-        html = render_to_string(tmpl, {'question': question, 'watch_form': form})
+        html = render_to_string(tmpl,
+                                context={'question': question, 'watch_form': form},
+                                request=request)
         return HttpResponse(json.dumps({'html': html}))
 
     if msg:


### PR DESCRIPTION
`render_to_string` needs `request` to access the `user` obj.