### PR TITLE
[Bug 1265027] More space for user-meta in the questions list

### DIFF
--- a/kitsune/sumo/static/sumo/less/questions.less
+++ b/kitsune/sumo/static/sumo/less/questions.less
@@ -785,7 +785,7 @@ h2 {
         position: absolute;
         right: 20px;
         text-align: right;
-        width: 250px;
+        width: 270px;
       }
 
     }


### PR DESCRIPTION
Caused by long translation (lines got wrapped). We have more space there thanks to tag-list 280px padding.