### PR TITLE
 [Bug 1205093] Show Ready for L10n in the KB dashboard based on the latest normal or major revision

### DIFF
--- a/kitsune/dashboards/readouts.py
+++ b/kitsune/dashboards/readouts.py
@@ -230,10 +230,16 @@ def kb_overview_rows(mode=None, max=None, locale=None, product=None, category=No
             'trans_url': reverse('wiki.show_translations', args=[d.slug],
                                  locale=settings.WIKI_DEFAULT_LANGUAGE),
             'title': d.title,
-            'num_visits': d.num_visits,
-            'ready_for_l10n': d.revisions.filter(is_approved=True,
-                                                 is_ready_for_localization=True).exists()
+            'num_visits': d.num_visits
         }
+
+        for r in list(reversed(d.revisions.filter(is_approved=True))):
+            if r.significance > TYPO_SIGNIFICANCE:
+                data['ready_for_l10n'] = r.is_ready_for_localization
+                break
+
+        if 'ready_for_l10n' not in data:
+            data['ready_for_l10n'] = False
 
         if d.current_revision:
             data['expiry_date'] = d.current_revision.expires

--- a/kitsune/dashboards/tests/test_readouts.py
+++ b/kitsune/dashboards/tests/test_readouts.py
@@ -59,7 +59,25 @@ class KBOverviewTests(TestCase):
         eq_(1, len(data))
         eq_(False, data[0]['ready_for_l10n'])
 
-        ApprovedRevisionFactory(document=d, is_ready_for_localization=True)
+        # No significance means the same as typo
+        ApprovedRevisionFactory(document=d,
+                                is_ready_for_localization=True)
+
+        data = kb_overview_rows()
+        eq_(False, data[0]['ready_for_l10n'])
+
+        # Typo significance should not be taken into account
+        ApprovedRevisionFactory(document=d,
+                                is_ready_for_localization=True,
+                                significance=TYPO_SIGNIFICANCE)
+
+        data = kb_overview_rows()
+        eq_(False, data[0]['ready_for_l10n'])
+
+        # Only significance greater than typo should be taken into account
+        ApprovedRevisionFactory(document=d,
+                                is_ready_for_localization=True,
+                                significance=MEDIUM_SIGNIFICANCE)
 
         data = kb_overview_rows()
         eq_(True, data[0]['ready_for_l10n'])


### PR DESCRIPTION
Waiting for Joni info about the minor revisions correct behavior.