### PR TITLE
 	[fix bug 1272860] Disable UI tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,10 @@ env:
   - PIP_DOWNLOAD_CACHE="pip_cache"
   matrix:
   - TEST_SUITE=lint
-  - TEST_SUITE=ui
   - TEST_SUITE=ui MARK_EXPRESSION=smoke
   - TEST_SUITE=django
 matrix:
   fast_finish: true
-  allow_failures:
-   - env: TEST_SUITE=ui
 cache:
   directories:
   - /home/travis/virtualenv


### PR DESCRIPTION
UI tests are known to fail. Stop running them until we fix bug 1251698.