### PR TITLE
[bug 1268346] Redirect to lang only if lang is supported

### DIFF
--- a/kitsune/sumo/middleware.py
+++ b/kitsune/sumo/middleware.py
@@ -34,9 +34,10 @@ class LocaleURLMiddleware(object):
         set_url_prefixer(prefixer)
         full_path = prefixer.fix(prefixer.shortened_path)
 
-        if 'lang' in request.GET:
+        if request.GET.get('lang', '') in settings.SUMO_LANGUAGES:
             # Blank out the locale so that we can set a new one. Remove lang
             # from the query params so we don't have an infinite loop.
+
             prefixer.locale = ''
             new_path = prefixer.fix(prefixer.shortened_path)
             query = dict((smart_str(k), v) for


### PR DESCRIPTION
Fixes 1268346 by performing the lang setting only if `lang` is in `SUMO_LANGUAGES`.

You can test this code on support.allizom.org