### PR TITLE
Add Jenkinsfile pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ james.ini
 build.py
 .vagrant/
 venv/
+.cache
+.tox

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,173 @@
+import groovy.json.JsonOutput
+
+/** Map of Tox environments and associated capabilities */
+def environments = [
+  desktop: [
+    browserName: 'Firefox',
+    version: '47.0',
+    platform: 'Windows 7'
+  ],
+  mobile: [
+    browserName: 'Browser',
+    platformName: 'Android',
+    platformVersion: '5.1',
+    deviceName: 'Android Emulator',
+    appiumVersion: '1.5.3'
+  ]
+]
+
+/** Transform a map into a list of maps
+ *
+ * @param aMap map to transform
+ * @return a list of maps
+*/
+@NonCPS
+def entrySet(aMap) {
+  aMap.collect {
+    k, v -> [key: k, value: v]
+  }
+}
+
+/** Write capabilities to JSON file
+ *
+ * @param desiredCapabilities capabilities to include in the file
+*/
+def writeCapabilities(desiredCapabilities) {
+    def defaultCapabilities = [
+        build: env.BUILD_TAG,
+        public: 'public restricted'
+    ]
+    def capabilities = defaultCapabilities.clone()
+    capabilities.putAll(desiredCapabilities)
+    def json = JsonOutput.toJson([capabilities: capabilities])
+    writeFile file: 'capabilities.json', text: json
+}
+
+/** Run Tox
+ *
+ * @param environment test environment to run
+*/
+def runTox(environment) {
+  try {
+    wrap([$class: 'AnsiColorBuildWrapper']) {
+      withCredentials([[
+        $class: 'StringBinding',
+        credentialsId: 'SAUCELABS_API_KEY',
+        variable: 'SAUCELABS_API_KEY']]) {
+        withEnv(["PYTEST_ADDOPTS=${PYTEST_ADDOPTS} " +
+          "--base-url=${PYTEST_BASE_URL} " +
+          "--driver=SauceLabs " +
+          "--variables=capabilities.json " +
+          "--color=yes"]) {
+          sh "tox -e ${environment}"
+        }
+      }
+    }
+  } catch(err) {
+    currentBuild.result = 'FAILURE'
+    throw err
+  } finally {
+    dir('results') {
+      stash environment
+    }
+  }
+}
+
+/** Send a notice to #fxtest-alerts on irc.mozilla.org with the build result
+ *
+ * @param result outcome of build
+*/
+def ircNotification(result) {
+  def nick = "fxtest${BUILD_NUMBER}"
+  def channel = '#fx-test-alerts'
+  result = result.toUpperCase()
+  def message = "Project ${JOB_NAME} build #${BUILD_NUMBER}: ${result}: ${BUILD_URL}"
+  node {
+    sh """
+        (
+        echo NICK ${nick}
+        echo USER ${nick} 8 * : ${nick}
+        sleep 5
+        echo "JOIN ${channel}"
+        echo "NOTICE ${channel} :${message}"
+        echo QUIT
+        ) | openssl s_client -connect irc.mozilla.org:6697
+    """
+  }
+}
+
+stage('Checkout') {
+  node {
+    timestamps {
+      deleteDir()
+      checkout scm
+      stash 'workspace'
+    }
+  }
+}
+
+def builders = [:]
+for (entry in entrySet(environments)) {
+  def environment = entry.key
+  def capabilities = entry.value
+  builders[(environment)] = {
+    node {
+      timeout(time: 1, unit: 'HOURS') {
+        timestamps {
+          deleteDir()
+          unstash 'workspace'
+          writeCapabilities(capabilities)
+          withCredentials([[
+            $class: 'FileBinding',
+            credentialsId: 'SUMO_VARIABLES',
+            variable: 'VARIABLES']]) {
+            withEnv(["PYTEST_ADDOPTS=--variables=${VARIABLES}"]) {
+              runTox(environment)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+try {
+  stage('Test') {
+    parallel builders
+  }
+} catch(err) {
+  currentBuild.result = 'FAILURE'
+  ircNotification(currentBuild.result)
+  mail(
+    body: "${BUILD_URL}",
+    from: "firefox-test-engineering@mozilla.com",
+    replyTo: "firefox-test-engineering@mozilla.com",
+    subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}",
+    to: "fte-ci@mozilla.com")
+  throw err
+} finally {
+  stage('Results') {
+    def keys = environments.keySet() as String[]
+    def htmlFiles = []
+    node {
+      deleteDir()
+      sh 'mkdir results'
+      dir('results') {
+        for (int i = 0; i < keys.size(); i++) {
+          // Unstash results from each environment
+          unstash keys[i]
+          htmlFiles.add("${keys[i]}.html")
+        }
+      }
+      publishHTML(target: [
+        allowMissing: false,
+        alwaysLinkToLastBuild: true,
+        keepAll: true,
+        reportDir: 'results',
+        reportFiles: htmlFiles.join(','),
+        reportName: 'HTML Report'])
+      junit 'results/*.xml'
+      archiveArtifacts 'results/*'
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ def writeCapabilities(desiredCapabilities) {
  * @param environment test environment to run
 */
 def runTox(environment) {
+  def processes = env.PYTEST_PROCESSES ?: 'auto'
   try {
     wrap([$class: 'AnsiColorBuildWrapper']) {
       withCredentials([[
@@ -55,6 +56,7 @@ def runTox(environment) {
         credentialsId: 'SAUCELABS_API_KEY',
         variable: 'SAUCELABS_API_KEY']]) {
         withEnv(["PYTEST_ADDOPTS=${PYTEST_ADDOPTS} " +
+          "-n=${processes} " +
           "--base-url=${PYTEST_BASE_URL} " +
           "--driver=SauceLabs " +
           "--variables=capabilities.json " +

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -179,7 +179,8 @@ Installing dependencies
 Follow the steps in :ref:`the installation docs <hacking-howto-chapter>`,
 including the test dependencies to make sure you have everything you need to
 run the tests. If you're running the tests against a deployed environment then
-there's no need to install anything other than the test dependencies.
+there's no need to install anything other than
+`Tox <http://tox.readthedocs.io/en/latest/install.html>`_.
 
 Create test users
 -----------------
@@ -198,7 +199,7 @@ your test accounts.
 The credentials associated with the test users are stored in a JSON file, which
 we then pass to the tests via the command line. If you used the above mentioned
 script, then these users are stored in ``/scripts/travis/variables.json``. The
-variable file needs to be referenced on the command line when running the
+variables file needs to be referenced on the command line when running the
 tests.
 
 The following is an example JSON file with the values missing. You can use this
@@ -230,28 +231,43 @@ the tests:
 
 To run all of the desktop tests against the default environment::
 
-  $ py.test --driver Firefox --variables my_variables.json tests/functional/desktop
+  $ PYTEST_ADDOPTS=--variables=my_variables.json
+  $ tox -e desktop
 
 To run against a different environment, pass in a value for ``--base-url``,
 like so::
 
-  $ py.test --base-url https://support.allizom.org --driver Firefox --variables my_variables.json tests/functional/desktop
+  $ PYTEST_ADDOPTS=--base-url=https://support.allizom.org
+  $ PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --variables=my_variables.json"
+  $ tox -e desktop
 
 To run the mobile tests you will need to target a mobile device or emulator
-using a tool like `Appium <http://appium.io/>`_::
+using a tool like `Appium <http://appium.io/>`_. You can create a suitable
+variables file with the necessary capabilities like so:
 
-  $ py.test --driver Remote --port 4723 \
-  --capability platformName iOS \
-  --capability platformVersion 9.2 \
-  --capability deviceName "iPhone 6" \
-  --capability browserName Safari \
-  --variables my_variables.json \
-  tests/functional/mobile
+.. code:: json
+
+     {
+       "capabilities": {
+         "platformName": "iOS",
+         "platformVersion": "9.2",
+         "deviceName": "iPhone 6",
+         "browserName": "Safari",
+       }
+     }
+
+Then you can run this like so::
+
+  $ PYTEST_ADDOPTS=--driver=Remote
+  $ PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --port=4723"
+  $ PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --variables=capabilities.json"
+  $ PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --variables=my_variables.json"
+  $ tox -e mobile
 
 Alternatively, if you run the mobile tests in Firefox the user agent will be
 changed to masquerade as a mobile browser.
 
 The pytest plugin that we use for running tests has a number of advanced
 command line options available. To see the options available, run
-``py.test --help``. The full documentation for the plugin can be found
+``pytest --help``. The full documentation for the plugin can be found
 `here <https://pytest-selenium.readthedocs.io/>`_.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,28 +6,29 @@ execnet==1.4.1
 # sha256: plAZY8cl_CVU2r_s6K6aj7XhScCsCkL9KwLFwcV_wRQ
 py==1.4.31
 
-# sha256: PmNXBvzgenNPeISgujLEblcgIl2GGz7RjKdsYGLehs0
-# sha256: DUjSehJ2RPvnyBWBV-CLNfglUEXUR232lLkes6gUfmU
-pytest==2.9.1
+# sha256: rqh8pCQLeYaMyr0UulahLs6xwegHa1hf4vpWAqWHTbc
+# sha256: 8hNQCjVoAKSD6KFG_5ca4UqN8_LArkFFGBqtlplqvuc
+pytest==3.0.3
 
-# sha256: zzI98ijiZdZ1XsOaJvKXGsxZoxsN4M_QJtNBJJ2-72k
-# sha256: 3-epy0EWdBTKe56Fr71mlOjMg_2_V9DlRcIVwyzUDNY
-pytest-html==1.8.0
+# sha256: 9vwczv6U-xe6KJ7jhb667M_UTPTwXu-RFlcsrmma9tY
+# sha256: gI3dXpNGYGMA7rOKfJ7pF8o98cUQddAkSenPWVaujvs
+pytest-html==1.10.1
 
-# sha256: 6C8KJlsOI4rEKsJ115MT0KfgvvGkUGM66z1lScwU9Rc
-# sha256: vSEhAi_zJVzoL67A7zYCRi7GvOnKYntTRimGz8mzkek
-pytest-selenium==1.2.1
+# sha256: 8UmqPYLgqjEvjq_tZyXMuw3RYgNyCiw5xrbfiyPPOHQ
+# sha256: bC8eYs30CPFnmNNeI1obgZv-h_5invc0yx1soQYOlQg
+pytest-selenium==1.5.0
 
 # sha256: KdywhO1dDDV-klyabLRU2-euYZL96i-dGSn1IbTlMuM
 # sha256: vS4VLmTI9nDnlpx2IZp4Qs-O3nlXAxJ5ge1xrzjP4Io
 pytest-variables==1.4
 
-# sha256: Sl4RmRIvop4wF9jRifWczF2C6EFHS6Kh7sDolgYVNiM
-pytest-xdist==1.14
+# sha256: Yjg5X4vQUPkoijsQ80Mw7ezoD0QkzytCBNbn1iLw8As
+pytest-xdist==1.15.0
 
-# sha256: xXeBXdAPE5QgP8ROuXlySwmPiCZKnviY7kW45enPWH8
-requests==2.9.1
+# sha256: VFxIVc2dfBJnFEQyYzcBN2b07qYGjD8DB_stwmltWA4
+# sha256: Ws-YA1goP6uguJfHOVnOz4uEEgW7SyrT71RfRurhoTM
+requests==2.11.1
 
-# sha256: -oMzzzATSX5g2HumjK5l6tjn-iCL6Iq5xWFVYQP1QO8
-# sha256: RsusTvML_3oApe8eVDiveMXalzWxNRsS4zkgEBBeX-k
-selenium==2.53.2
+# sha256: qeTxOYMC53GtpKCiaGUIFbQ7NUuvLeTn5QI_tflnXlA
+# sha256: BwWAM0mWTHoqFE8XlqXSmQX-KgmTGyu5Re4MtN6rddc
+selenium==3.0.1

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -14,7 +14,7 @@ echo
 
 # Installing dependencies for UI tests
 if [[ $TEST_SUITE == "ui" ]]; then
-  ./peep.sh install -r requirements/test.txt
+  pip install tox
 fi
 
 # Optimization: None of the rest is needed for lint tests.

--- a/scripts/travis/uitests.sh
+++ b/scripts/travis/uitests.sh
@@ -12,17 +12,11 @@ echo 'Starting a server'
 ./manage.py runserver &
 sleep 3
 
-CMD="py.test"
-CMD="${CMD} -r a"
-CMD="${CMD} --verbose"
-CMD="${CMD} --base-url http://localhost:8000"
-CMD="${CMD} --html results.html"
-CMD="${CMD} --driver Firefox"
-CMD="${CMD} --variables scripts/travis/variables.json"
-if [ -n "${MARK_EXPRESSION}" ]; then CMD="${CMD} -m \"${MARK_EXPRESSION}\""; fi
-CMD="${CMD} tests/functional"
+PYTEST_ADDOPTS="--base-url=http://localhost:8000"
+PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --variables=scripts/travis/variables.json"
+if [ -n "${MARK_EXPRESSION}" ]; then PYTEST_ADDOPTS="${PYTEST_ADDOPTS} -m=\"${MARK_EXPRESSION}\""; fi
 
 echo 'Running UI tests'
-eval ${CMD}
+tox
 
 echo 'Booyahkasha!'

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,3 @@ max-line-length = 99
 
 [nosetests]
 exclude-dir=tests/functional
-
-[pytest]
-base_url=https://support.allizom.org
-sensitive_url=mozilla\.org

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands = pytest \
     {posargs:tests/functional/{envname}}
 
 [pytest]
-addopts=-n=auto --verbose -r=a --driver=Firefox
-xfail_strict=true
-base_url=https://support.allizom.org
-sensitive_url=mozilla\.org
+addopts = -n=auto --verbose -r=a --driver=Firefox
+xfail_strict = true
+base_url = https://support.allizom.org
+sensitive_url = mozilla\.org

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+skipsdist = true
+envlist = desktop, mobile
+
+[testenv]
+passenv = PYTEST_ADDOPTS SAUCELABS_API_KEY SAUCELABS_USERNAME
+deps = -rrequirements/test.txt
+commands = pytest \
+    --junit-xml=results/{envname}.xml \
+    --html=results/{envname}.html \
+    {posargs:tests/functional/{envname}}
+
+[pytest]
+addopts=-n=auto --verbose -r=a --driver=Firefox
+xfail_strict=true
+base_url=https://support.allizom.org
+sensitive_url=mozilla\.org


### PR DESCRIPTION
This moves a lot of the Jenkins job configuration into the repository as a Groovy script, which gives us better tracking of changes, and allows changes to the target platforms and build without needing to grant permissions in Jenkins and use their dashboard. An overview of Jenkins pipelines can be found [here](https://jenkins.io/doc/book/pipeline/overview/).

Please note that we'll need to update the Jenkins job configuration (hopefully for one of the last times) after merging this. I'm happy to take care of this, so feel free to review and leave the merge to me.

Adhoc: http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/sumo.pipeline.adhoc/10/

@stephendonner @rpappalax r?
/cc @rbillings @glogiotatidis 