### PR TITLE
[fix bug 1381436] Replace ES facets with DB queries.

### DIFF
--- a/kitsune/community/utils.py
+++ b/kitsune/community/utils.py
@@ -1,11 +1,14 @@
 from datetime import datetime, date, timedelta
+from django.core.cache import cache
 from django.conf import settings
+from django.db.models import Count
 
 from kitsune.customercare.models import ReplyMetricsMappingType
 from kitsune.products.models import Product
 from kitsune.questions.models import AnswerMetricsMappingType
 from kitsune.search.es_utils import F
-from kitsune.users.models import UserMappingType
+from kitsune.users.models import User
+from kitsune.users.templatetags.jinja_helpers import profile_avatar
 from kitsune.wiki.models import RevisionMetricsMappingType
 
 
@@ -13,38 +16,57 @@ from kitsune.wiki.models import RevisionMetricsMappingType
 # section.  There isn't a way to tell ES to just return everything.
 BIG_NUMBER = 3000
 
+# This should be higher than the max number of questions, revisions or tweets
+HUGE_NUMBER = 1500000
+
 
 def top_contributors_questions(start=None, end=None, locale=None, product=None,
-                               count=10, page=1):
+                               count=10, page=1, use_cache=True):
     """Get the top Support Forum contributors."""
     # Get the user ids and contribution count of the top contributors.
-    query = (
-        AnswerMetricsMappingType
-        .search()
-        .facet('creator_id', filtered=True, size=BIG_NUMBER))
+
+    cache_key = 'top_contributors_questions_{}_{}_{}_{}_{}_{}'.format(start, end, locale,
+                                                                      product, count, page)
+    cached = cache.get(cache_key, None)
+    if use_cache and cached:
+        return cached
+
+    query = AnswerMetricsMappingType.search()
 
     # Adding answer to your own question, isn't a contribution.
     query = query.filter(by_asker=False)
-
     query = _apply_filters(query, start, end, locale, product)
 
-    return _get_creator_counts(query, count, page)
+    answers = [q.id for q in query.all()[:HUGE_NUMBER]]
+    users = (User.objects
+             .filter(answers__in=answers)
+             .annotate(query_count=Count('answers'))
+             .order_by('-query_count'))
+
+    counts = _get_creator_counts(users, count, page)
+    if use_cache:
+        cache.set(cache_key, counts, 60*15)  # 15 minutes
+    return counts
 
 
-def top_contributors_kb(start=None, end=None, product=None, count=10, page=1):
+def top_contributors_kb(start=None, end=None, product=None, count=10, page=1, use_cache=True):
     """Get the top KB editors (locale='en-US')."""
     return top_contributors_l10n(
-        start, end, settings.WIKI_DEFAULT_LANGUAGE, product, count)
+        start, end, settings.WIKI_DEFAULT_LANGUAGE, product, count, use_cache)
 
 
 def top_contributors_l10n(start=None, end=None, locale=None, product=None,
-                          count=10, page=1):
+                          count=10, page=1, use_cache=True):
     """Get the top l10n contributors for the KB."""
+
+    cache_key = 'top_contributors_l10n_{}_{}_{}_{}_{}_{}'.format(start, end, locale,
+                                                                 product, count, page)
+    cached = cache.get(cache_key, None)
+    if use_cache and cached:
+        return cached
+
     # Get the user ids and contribution count of the top contributors.
-    query = (
-        RevisionMetricsMappingType
-        .search()
-        .facet('creator_id', filtered=True, size=BIG_NUMBER))
+    query = RevisionMetricsMappingType.search()
 
     if locale is None:
         # If there is no locale specified, exclude en-US only. The rest are
@@ -52,24 +74,43 @@ def top_contributors_l10n(start=None, end=None, locale=None, product=None,
         query = query.filter(~F(locale=settings.WIKI_DEFAULT_LANGUAGE))
 
     query = _apply_filters(query, start, end, locale, product)
+    revisions = [q.id for q in query.all()[:HUGE_NUMBER]]
+    users = (User.objects
+             .filter(created_revisions__in=revisions)
+             .annotate(query_count=Count('created_revisions'))
+             .order_by('-query_count'))
 
-    return _get_creator_counts(query, count, page)
+    counts = _get_creator_counts(users, count, page)
+    if use_cache:
+        cache.set(cache_key, counts, 60*15)  # 15 minutes
+    return counts
 
 
-def top_contributors_aoa(start=None, end=None, locale=None, count=10, page=1):
+def top_contributors_aoa(start=None, end=None, locale=None, count=10, page=1, use_cache=True):
     """Get the top Army of Awesome contributors."""
+
+    cache_key = 'top_contributors_l10n_{}_{}_{}_{}_{}'.format(start, end, locale, count, page)
+    cached = cache.get(cache_key, None)
+    if use_cache and cached:
+        return cached
+
     # Get the user ids and contribution count of the top contributors.
-    query = (
-        ReplyMetricsMappingType
-        .search()
-        .facet('creator_id', filtered=True, size=BIG_NUMBER))
+    query = ReplyMetricsMappingType.search()
 
     # twitter only does language
     locale = locale.split('-')[0] if locale else None
 
     query = _apply_filters(query, start, end, locale)
+    tweets = [q.id for q in query.all()[:HUGE_NUMBER]]
+    users = (User.objects
+             .filter(tweet_replies__in=tweets)
+             .annotate(query_count=Count('tweet_replies'))
+             .order_by('-query_count'))
 
-    return _get_creator_counts(query, count, page)
+    counts = _get_creator_counts(users, count, page)
+    if use_cache:
+        cache.set(cache_key, counts, 60*15)  # 15 minutes
+    return counts
 
 
 def _apply_filters(query, start, end, locale=None, product=None):
@@ -95,40 +136,27 @@ def _apply_filters(query, start, end, locale=None, product=None):
 
 
 def _get_creator_counts(query, count, page):
-    """Get the list of top contributors with the contribution count."""
-    creator_counts = query.facet_counts()['creator_id']['terms']
+    total = query.count()
+    results = []
+    now = datetime.now()
+    for user in query[((page - 1) * count):(page * count)]:
+        last_contribution_date = user.profile.last_contribution_date
+        days_since_last_activity = None
+        if last_contribution_date:
+            days_since_last_activity = now - last_contribution_date
 
-    total = len(creator_counts)
+        data = {
+            'count': user.query_count,
+            'term': user.id,
+            'user': {
+                'username': user.username,
+                'display_name': user.profile.display_name,
+                'avatar': profile_avatar(user, size=120),
+                'twitter_usernames': user.profile.twitter_usernames,
+                'last_contribution_date': last_contribution_date,
+                'days_since_last_activity': days_since_last_activity,
+            }
+        }
+        results.append(data)
 
-    # Pagination
-    creator_counts = creator_counts[((page - 1) * count):(page * count)]
-
-    # Grab all the users from the user index in ES.
-    user_ids = [x['term'] for x in creator_counts]
-    results = (
-        UserMappingType
-        .search()
-        .filter(id__in=user_ids)
-        .values_dict('id', 'username', 'display_name', 'avatar',
-                     'twitter_usernames', 'last_contribution_date'))[:count]
-    results = UserMappingType.reshape(results)
-
-    # Calculate days since last activity and
-    # create a {<user_id>: <user>,...} dict for convenience.
-    user_lookup = {}
-    for r in results:
-        lcd = r.get('last_contribution_date', None)
-        if lcd:
-            delta = datetime.now() - lcd
-            r['days_since_last_activity'] = delta.days
-        else:
-            r['days_since_last_activity'] = None
-
-        user_lookup[r['id']] = r
-
-    # Add the user to each dict in the creator_counts array.
-    for item in creator_counts:
-        item['user'] = user_lookup.get(item['term'], None)
-
-    return ([item for item in creator_counts if item['user'] is not None],
-            total)
+    return (results, total)

--- a/kitsune/community/utils.py
+++ b/kitsune/community/utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date, timedelta
-from django.core.cache import cache
 from django.conf import settings
+from django.core.cache import cache
 from django.db.models import Count
 
 from kitsune.customercare.models import ReplyMetricsMappingType
@@ -12,11 +12,8 @@ from kitsune.users.templatetags.jinja_helpers import profile_avatar
 from kitsune.wiki.models import RevisionMetricsMappingType
 
 
-# This should be the higher than the max number of contributors for a
-# section.  There isn't a way to tell ES to just return everything.
-BIG_NUMBER = 3000
-
-# This should be higher than the max number of questions, revisions or tweets
+# This should be higher than the max number of questions, revisions or tweets.
+# There isn't a way to tell ES to just return everything.
 HUGE_NUMBER = 1500000
 
 
@@ -25,11 +22,12 @@ def top_contributors_questions(start=None, end=None, locale=None, product=None,
     """Get the top Support Forum contributors."""
     # Get the user ids and contribution count of the top contributors.
 
-    cache_key = 'top_contributors_questions_{}_{}_{}_{}_{}_{}'.format(start, end, locale,
-                                                                      product, count, page)
-    cached = cache.get(cache_key, None)
-    if use_cache and cached:
-        return cached
+    if use_cache:
+        cache_key = u'top_contributors_questions_{}_{}_{}_{}_{}_{}'.format(start, end, locale,
+                                                                           product, count, page)
+        cached = cache.get(cache_key, None)
+        if cached:
+            return cached
 
     query = AnswerMetricsMappingType.search()
 
@@ -59,11 +57,12 @@ def top_contributors_l10n(start=None, end=None, locale=None, product=None,
                           count=10, page=1, use_cache=True):
     """Get the top l10n contributors for the KB."""
 
-    cache_key = 'top_contributors_l10n_{}_{}_{}_{}_{}_{}'.format(start, end, locale,
-                                                                 product, count, page)
-    cached = cache.get(cache_key, None)
-    if use_cache and cached:
-        return cached
+    if use_cache:
+        cache_key = u'top_contributors_l10n_{}_{}_{}_{}_{}_{}'.format(start, end, locale,
+                                                                      product, count, page)
+        cached = cache.get(cache_key, None)
+        if cached:
+            return cached
 
     # Get the user ids and contribution count of the top contributors.
     query = RevisionMetricsMappingType.search()
@@ -89,10 +88,12 @@ def top_contributors_l10n(start=None, end=None, locale=None, product=None,
 def top_contributors_aoa(start=None, end=None, locale=None, count=10, page=1, use_cache=True):
     """Get the top Army of Awesome contributors."""
 
-    cache_key = 'top_contributors_l10n_{}_{}_{}_{}_{}'.format(start, end, locale, count, page)
-    cached = cache.get(cache_key, None)
-    if use_cache and cached:
-        return cached
+    if use_cache:
+        cache_key = u'top_contributors_l10n_{}_{}_{}_{}_{}'.format(start, end, locale, count, page)
+        cached = cache.get(cache_key, None)
+
+        if cached:
+            return cached
 
     # Get the user ids and contribution count of the top contributors.
     query = ReplyMetricsMappingType.search()
@@ -149,6 +150,7 @@ def _get_creator_counts(query, count, page):
             'count': user.query_count,
             'term': user.id,
             'user': {
+                'id': user.id,
                 'username': user.username,
                 'display_name': user.profile.display_name,
                 'avatar': profile_avatar(user, size=120),


### PR DESCRIPTION
ElasticSearch v2 has deprecated facets in favor of aggregations. To upgrade to
aggregations we need to update elastic search python libraries. This is a
combination of ES and Database queries to serve as a workaround until we move
codebase to v2.

Since the DB is quite slower compared to ES, the results get cached for 15
minutes.

This has been tested on staging on ESv2 and works fine.