### PR TITLE
[Bug 1385087] Add firefox download button for non fx user

### DIFF
--- a/kitsune/bundles.py
+++ b/kitsune/bundles.py
@@ -300,6 +300,12 @@ PIPELINE_JS = {
         ),
         'output_filename': 'build/common-min.js'
     },
+    'common.fx.download': {
+        'source_filenames': (
+            'sumo/js/show-fx-download.js',
+        ),
+        'output_filename': 'build/show-fx-download.js'
+    },
     'community': {
         'source_filenames': (
             'jquery/jquery.min.js',
@@ -631,5 +637,5 @@ PIPELINE_JS = {
             'kpi/js/kpi.browserify.js',
         ),
         'output_filename': 'build/kpi.dashboard-min.js'
-    }
+    },
 }

--- a/kitsune/products/tests/test_templates.py
+++ b/kitsune/products/tests/test_templates.py
@@ -53,6 +53,15 @@ class ProductViewsTestCase(ElasticTestCase):
         eq_(11, len(doc('#help-topics li')))
         eq_(p.slug, doc('#support-search input[name=product]').attr['value'])
 
+    def test_firefox_product_landing(self):
+        """Verify that there are no firefox button at header in the firefox landing page"""
+        p = ProductFactory(slug="firefox")
+        url = reverse('products.product', args=[p.slug])
+        r = self.client.get(url, follow=True)
+        eq_(200, r.status_code)
+        doc = pq(r.content)
+        eq_(False, doc(".firefox-download-button").length)
+
     def test_document_listing(self):
         """Verify /products/<product slug>/<topic slug> renders articles."""
         # Create a topic and product.

--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -44,12 +44,16 @@ def product_landing(request, template, slug):
         else:
             latest_version = 0
 
+    # Don't show firefox download button at header at firefox product page
+    hide_fx_download = product.slug == 'firefox'
+
     return render(request, template, {
         'product': product,
         'products': Product.objects.filter(visible=True),
         'topics': topics_for(product=product, parent=None),
         'search_params': {'product': slug},
-        'latest_version': latest_version
+        'latest_version': latest_version,
+        'hide_fx_download': hide_fx_download
     })
 
 
@@ -74,10 +78,6 @@ def document_listing(request, template, product_slug, topic_slug,
 
     documents, fallback_documents = documents_for(**doc_kw)
 
-    user_agent = request.META.get('HTTP_USER_AGENT', '')
-    browser = get_browser(user_agent)
-    show_fx_download = (product.slug == 'thunderbird' and browser != 'Firefox')
-
     return render(request, template, {
         'product': product,
         'topic': topic,
@@ -86,5 +86,5 @@ def document_listing(request, template, product_slug, topic_slug,
         'subtopics': topics_for(product=product, parent=topic),
         'documents': documents,
         'fallback_documents': fallback_documents,
-        'search_params': {'product': product_slug},
-        'show_fx_download': show_fx_download})
+        'search_params': {'product': product_slug}
+    })

--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -138,9 +138,9 @@
             {% if not hide_locale_switcher %}
               <li><a href="{{ locale_picker_url }}" class="locale-picker">{{ settings.LANGUAGES_DICT[request.LANGUAGE_CODE.lower()] }}</a></li>
             {% endif %}
-            {% if show_fx_download and not user.is_authenticated() %}
-              <a href="https://www.mozilla.org/firefox/new/?scene=2&utm_source=support.mozilla.org&utm_medium=referral&utm_campaign=non-fx-button#download-fx"
-                class="firefox-download-button" data-ga-click="_trackEvent | Download Button | Firefox button on Thunderbird article">
+            {% if not (hide_fx_download or user.is_authenticated()) %}
+              <a href="https://www.mozilla.org/firefox/new/?utm_source=support.mozilla.org&utm_medium=referral&utm_campaign=non-fx-button"
+                class="firefox-download-button hidden" data-ga-click="_trackEvent | Download Button | Firefox for Desktop">
                 <strong class="download-title">{{ _('Download Firefox') }}</strong>
               </a>
             {% endif %}
@@ -243,6 +243,11 @@
 {% for script in scripts %}
   {% javascript script %}
 {% endfor %}
+
+{# Show firefox download button to unauthenticated users only #}
+{% if not user.is_authenticated() %}
+  {% javascript 'common.fx.download' %}
+{% endif %}
 
 {# Temporary Pontoon testing - bug 812176 #}
 {% if settings.STAGE %}

--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -245,7 +245,7 @@
 {% endfor %}
 
 {# Show firefox download button to unauthenticated users only #}
-{% if not user.is_authenticated() %}
+{% if not (hide_fx_download or user.is_authenticated()) %}
   {% javascript 'common.fx.download' %}
 {% endif %}
 

--- a/kitsune/sumo/static/sumo/js/show-fx-download.js
+++ b/kitsune/sumo/static/sumo/js/show-fx-download.js
@@ -1,0 +1,13 @@
+(function() {
+  var isFirefox = function () {
+    var userAgent = navigator.userAgent.toLowerCase();
+    return userAgent.includes('firefox');
+  };
+
+  if (!isFirefox()) {
+    /* remove the hide class from the download button as the browser is not firefox */
+    var fxDownloadButton = document.getElementsByClassName('firefox-download-button')[0];
+    fxDownloadButton.classList.remove('hidden');
+  }
+
+})();

--- a/kitsune/sumo/static/sumo/less/main.less
+++ b/kitsune/sumo/static/sumo/less/main.less
@@ -1252,6 +1252,11 @@ input[type=button],
       text-transform: capitalize;
     }
   }
+
+  .hidden {
+    display: none;
+  }
+
 }
 
 .html-rtl {


### PR DESCRIPTION
So it will show Firefox Download Button to non fx users in all pages except Firefox Landing page because it already have a download firefox button.
@pmac @bensternthal r?