### PR TITLE
[Bug 1219716] Expand a string shown above articles with l10n in progress

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -60,9 +60,11 @@
     {% elif fallback_reason == 'translation_not_approved' %}
       <div id="doc-pending-fallback" class="warning-box">
         {# L10n: This is shown for existing, never-approved translations #}
-        {% trans %}
+        {% trans help_link=url('wiki.document', 'localize-firefox-help') %}
           Our volunteers are working on translating this article.
           Until it's ready, maybe the English version can be of some help.
+          If you want to help us translate articles like this one,
+          <a href="{{ help_link }}">please click here</a>.
         {% endtrans %}
       </div>
       {% if document.locale == settings.WIKI_DEFAULT_LANGUAGE %}


### PR DESCRIPTION
The change is basically a copy&past what's above for completely untranslated articles.

@vesper-mozilla does the text look good, or do you want to chime it a little bit?