### PR TITLE
[bug 1388942] Add snowball analyzer in document mapping 

### DIFF
--- a/kitsune/search/config.py
+++ b/kitsune/search/config.py
@@ -1,3 +1,3 @@
 ES_SYNONYM_LOCALES = [
-
+    'en-US',
 ]

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -710,11 +710,13 @@ class DocumentMappingType(SearchMappingType):
                 'topic': {'type': 'string', 'index': 'not_analyzed'},
 
                 # Document specific fields (locale aware)
-                'document_title': {'type': 'string'},
-                'document_keywords': {'type': 'string'},
+                'document_title': {'type': 'string', 'analyzer': 'snowball'},
+                'document_keywords': {'type': 'string', 'analyzer': 'snowball'},
                 'document_content': {'type': 'string', 'store': 'yes',
+                                     'analyzer': 'snowball',
                                      'term_vector': 'with_positions_offsets'},
                 'document_summary': {'type': 'string', 'store': 'yes',
+                                     'analyzer': 'snowball',
                                      'term_vector': 'with_positions_offsets'},
 
                 # Document specific fields (locale naive)


### PR DESCRIPTION
In ESv2 document mapping must include the 'snowball' analyzer to work with searches that use it. This change brings Wiki Document mappings in part with Question mappings which already define the analyzer. 

This also brings back support support synonims