### PR TITLE
[Fix #2964  #2966] Run test in travis as non root and fix cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,29 +10,20 @@ before_install:
 install:
   - pip install -U docker-compose
   - cp .env-travis .env
+  - export UID
+  - docker build -t mozmeao/kitsune:latest --cache-from mozmeao/kitsune .
   - docker-compose up -d mariadb
   - docker-compose up -d elasticsearch
   - docker-compose up -d redis
+  - docker-compose up -d
 
-  # Docker always copies data as root. Chowning files to root before the build
-  # command will prevent docker cache invalidation due to different file
-  # metadata. Once Travis updates to the latest docker version we should
-  # probably use --chown flag for COPY. See https://github.com/moby/moby/pull/34263
-  - sudo chown -c 0:0 -R requirements package.json bower.json
-  - sudo chmod -c a+rw -R requirements package.json bower.json
-
-  # For some strange reason `docker-compose build` -even with the above chown
-  # trick- still invalidates the cache at the COPY command. Directly building
-  # with `docker build` works.
-  - docker build -t kitsune:latest --cache-from mozmeao/kitsune .
-
-  - docker-compose run --user root web ./manage.py nunjucks_precompile
-  - docker-compose run --user root web ./manage.py compilejsi18n
-  - docker-compose run --user root web ./manage.py collectstatic --noinput
+  - docker-compose exec web ./manage.py nunjucks_precompile
+  - docker-compose exec web ./manage.py compilejsi18n
+  - docker-compose exec web ./manage.py collectstatic --noinput
 script:
-  - docker-compose run --user root web flake8 kitsune
-  - docker-compose run --user root web ./node_modules/.bin/mocha --compilers js:babel/register --recursive kitsune/*/static/*/js/tests/* $@
-  - docker-compose run --user root -e REUSE_STATIC=1 web ./manage.py test --noinput --nologcapture -a '!search_tests' --with-nicedots
+  - docker-compose exec web flake8 kitsune
+  - docker-compose exec web sh -c "BABEL_DISABLE_CACHE=1 ./node_modules/.bin/mocha --compilers js:babel/register --recursive kitsune/*/static/*/js/tests/* $@"
+  - docker-compose exec web sh -c "REUSE_STATIC=1 ./manage.py test --noinput --nologcapture -a '!search_tests' --with-nicedots"
 notifications:
   email: false
   irc:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install apt-transport-https && \
             nodejs=0.10.48-1nodesource1~jessie1 && \
     rm -rf /var/lib/apt/lists/*
 
-COPY ./requirements /app/requirements
+COPY ./requirements /app/requirements/
 
 RUN pip install --no-cache-dir -r requirements/default.txt --require-hashes
 RUN pip install --no-cache-dir -r requirements/dev.txt --require-hashes
@@ -28,8 +28,15 @@ RUN pip install --no-cache-dir -r requirements/test.txt --require-hashes
 COPY ./package.json /app/package.json
 COPY ./bower.json /app/bower.json
 
-RUN npm install
+# debowerify try to download bower dependency while running collectstatic.
+# So all the user need to have access to /.cache
+RUN mkdir /.cache && chmod -R 777 /.cache
 
-RUN ./node_modules/.bin/bower install --allow-root
 RUN chown -R kitsune /app
+# npm and bower tries to write in /home directory. So this permission is needed
+RUN chown -R kitsune /home
+
 USER kitsune
+# Its not safe to run npm with root
+RUN npm install
+RUN ./node_modules/.bin/bower install

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,17 +26,6 @@ conduit {
     stage("Build") {
       if (!dockerImageExists(docker_image)) {
             sh "echo 'ENV GIT_SHA ${GIT_COMMIT}' >> Dockerfile"
-
-            // Docker always copies data as root. Chowning files to root before
-            // the build command will prevent docker cache invalidation due to
-            // different file metadata. When we upgrade to a newer docker
-            // version we should probably use --chown flag for COPY. See
-            // https://github.com/moby/moby/pull/34263
-            dockerRun('debian', [
-                    "docker_args": "-v `pwd`:/app",
-                    "cmd": "cd /app && chown -c root.root -R requirements bower.json package.json && chmod -c a+rw -R requirements bower.json package.json",
-                    "bash_wrap": true
-                ])
             dockerImagePull( "${config.project.docker_name}:latest")
             dockerImageBuild(docker_image, [
                     "pull": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         context: .
         cache_from:
             - mozmeao/kitsune:latest
-    image: kitsune:latest
+    image: mozmeao/kitsune:latest
     command: ./manage.py runserver 0.0.0.0:8000
     user: ${UID:-kitsune}
     volumes:


### PR DESCRIPTION
This will add functionality to run test using non root user.
It will also fix the cache invalidation issue. Docker thinks its directory if trailing slash `/` is present in destination path, so it copy the file content. Otherwise it copy the file with metadata. Which cause the cache invalidation without any reason.

I have fixed the things and remove the fixup done in jenkins.

Moreover, Its better to use `mozmeao/kitsune:latest` image in docker compose. otherwise if anyone open a repo with `kitsune`, docker compose will try to fetch from there.

The build cache affect cant be seen in the build of this PR because image with this commits is not pushed yet. Its something like [Chicken and Egg Problem](https://en.wikipedia.org/wiki/Chicken_or_the_egg). So this PR needs te be merged first then Jenkins will make a build and push to docker hub and from next build, we can see the affect.

@glogiotatidis @pmac r?