### PR TITLE
Fix #2899: Use s3 for user media

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:2
+      - image: circleci/python:2-stretch
     steps:
       - checkout
       - setup_remote_docker:

--- a/docker/dockerfiles/base
+++ b/docker/dockerfiles/base
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install apt-transport-https && \
             libmariadbclient-dev mariadb-client && \
     rm -rf /var/lib/apt/lists/*
 
-COPY ./requirements/ /app/requirements/
+COPY ./requirements/*.txt /app/requirements/
 
 RUN bash -c '\
     virtualenv /venv && \

--- a/kitsune/gallery/tests/test_models.py
+++ b/kitsune/gallery/tests/test_models.py
@@ -1,4 +1,7 @@
+from django.core.files.base import ContentFile
+
 from nose.tools import eq_
+from mock import patch
 
 from kitsune.gallery.models import Image
 from kitsune.gallery.tests import ImageFactory
@@ -6,16 +9,18 @@ from kitsune.sumo.tests import TestCase
 from kitsune.upload.tasks import generate_thumbnail
 
 
+@patch('kitsune.upload.tasks._create_image_thumbnail')
 class ImageTestCase(TestCase):
     def tearDown(self):
         Image.objects.all().delete()
         super(ImageTestCase, self).tearDown()
 
-    def test_thumbnail_url_if_set(self):
+    def test_thumbnail_url_if_set(self, create_thumbnail_mock):
         """thumbnail_url_if_set() returns self.thumbnail if set, or else
         returns self.file"""
         img = ImageFactory()
         eq_(img.file.url, img.thumbnail_url_if_set())
 
+        create_thumbnail_mock.return_value = ContentFile('the dude')
         generate_thumbnail(img, 'file', 'thumbnail')
         eq_(img.thumbnail.url, img.thumbnail_url_if_set())

--- a/kitsune/gallery/views.py
+++ b/kitsune/gallery/views.py
@@ -244,7 +244,7 @@ def _get_media_info(media_id, media_type):
     if media_type == 'image':
         media = get_object_or_404(Image, pk=media_id)
         try:
-            media_format = imghdr.what(media.file.path)
+            media_format = imghdr.what(media.file.file)
         except UnicodeEncodeError:
             pass
     elif media_type == 'video':

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -536,6 +536,7 @@ INSTALLED_APPS = (
     'authority',
     'timezones',
     'waffle',
+    'storages',
     'kitsune.access',
     'kitsune.sumo',
     'kitsune.search',
@@ -743,6 +744,15 @@ MAX_FILENAME_LENGTH = 200
 MAX_FILEPATH_LENGTH = 250
 # Default storage engine - ours does not preserve filenames
 DEFAULT_FILE_STORAGE = 'kitsune.upload.storage.RenameFileStorage'
+
+# AWS S3 Storage Settings
+AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID', default='')
+AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', default='')
+AWS_STORAGE_BUCKET_NAME = config('AWS_STORAGE_BUCKET_NAME', default='')
+AWS_S3_CUSTOM_DOMAIN = config('AWS_S3_CUSTOM_DOMAIN', default='prod-cdn.sumo.mozilla.net')
+AWS_S3_OBJECT_PARAMETERS = {
+    'CacheControl': 'max-age=2592000',
+}
 
 # Auth and permissions related constants
 LOGIN_URL = '/users/login'

--- a/kitsune/upload/storage.py
+++ b/kitsune/upload/storage.py
@@ -3,7 +3,13 @@ import itertools
 import os
 import time
 
-from django.core.files.storage import FileSystemStorage as DjangoStorage
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+DjangoStorage = S3Boto3Storage if settings.AWS_ACCESS_KEY_ID else FileSystemStorage
 
 
 class RenameFileStorage(DjangoStorage):

--- a/kitsune/upload/tasks.py
+++ b/kitsune/upload/tasks.py
@@ -131,6 +131,9 @@ def compress_image(for_obj, for_field):
 
 
 def _optipng(file_name):
+    if not settings.OPTIPNG_PATH:
+        return
+
     with default_storage.open(file_name, 'rb') as file_obj:
         with NamedTemporaryFile(suffix='.png') as tmpfile:
             tmpfile.write(file_obj.read())

--- a/kitsune/upload/tests/test_tasks.py
+++ b/kitsune/upload/tests/test_tasks.py
@@ -162,7 +162,7 @@ class CompressImageTestCase(TestCase):
             image.file.save(up_file.name, up_file, save=True)
         return image
 
-    @mock.patch.object(settings._wrapped, 'OPTIPNG_PATH', '')
+    @mock.patch.object(settings._wrapped, 'OPTIPNG_PATH', '/dude')
     @mock.patch.object(kitsune.upload.tasks.subprocess, 'call')
     def test_compressed_image_default(self, call):
         """uploaded image is compressed."""
@@ -170,7 +170,7 @@ class CompressImageTestCase(TestCase):
         compress_image(image, 'file')
         assert call.called
 
-    @mock.patch.object(settings._wrapped, 'OPTIPNG_PATH', '')
+    @mock.patch.object(settings._wrapped, 'OPTIPNG_PATH', '/dude')
     @mock.patch.object(kitsune.upload.tasks.subprocess, 'call')
     def test_compress_no_file(self, call):
         """compress_image does not fail when no file is provided."""
@@ -178,7 +178,7 @@ class CompressImageTestCase(TestCase):
         compress_image(image, 'file')
         assert not call.called
 
-    @mock.patch.object(settings._wrapped, 'OPTIPNG_PATH', None)
+    @mock.patch.object(settings._wrapped, 'OPTIPNG_PATH', '')
     @mock.patch.object(kitsune.upload.tasks.subprocess, 'call')
     def test_compress_no_compression_software(self, call):
         """compress_image does not fail when no compression software."""
@@ -186,7 +186,7 @@ class CompressImageTestCase(TestCase):
         compress_image(image, 'file')
         assert not call.called
 
-    @mock.patch.object(settings._wrapped, 'OPTIPNG_PATH', '')
+    @mock.patch.object(settings._wrapped, 'OPTIPNG_PATH', '/dude')
     @mock.patch.object(kitsune.upload.tasks.subprocess, 'call')
     def test_compressed_image_animated(self, call):
         """uploaded animated gif image is not compressed."""

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -321,8 +321,9 @@ pyparsing==1.5.5 \
     --hash=sha256:b450a0a0af7423ff93a79e1f4dc364f56283c8e7a893d957e78c22a3155f95c0
 pyquery==1.2.9 \
     --hash=sha256:46c51eb878b787e814ee8f9737b0a62111034aeb4d1c06450ac5a8ea5a70e602
-python-dateutil==1.5 \
-    --hash=sha256:6f197348b46fb8cdf9f3fcfc2a7d5a97da95db3e2e8667cf657216274fe1b009
+python-dateutil==2.6.1 \
+    --hash=sha256:891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca \
+    --hash=sha256:95511bae634d69bc7329ba55e646499a842bc4ec342ad54a8cdb65645a0aad3c
 python-gflags==2.0 \
     --hash=sha256:0dff6360423f3ec08cbe3bfaf37b339461a54a21d13be0dd5d9c9999ce531078 \
     --hash=sha256:7f09e616239302abb231f93abc997e9c4e0e0e41aea07ecdfc6a5182c50cd07e
@@ -423,3 +424,22 @@ olefile==0.44 \
 whitenoise==3.3.0 \
     --hash=sha256:1d62a003a0ab747de96da45c831cbb512dcb7f69c1ef0bd20b1cd4ae45d8a0c4 \
     --hash=sha256:d098327276de6fd189398a7bcb95789d1bb2d41b3e011eeae4562f6b1a107dd4
+django-storages==1.6.5 \
+    --hash=sha256:bc8e4c1f483608c5dd1212072fd41042f3ef2d2a2896ec4fb12dbc62c82996a0 \
+    --hash=sha256:ab6be1538cf29511400bce83d0e5ca74d2e935cad82086063bcf5e7edacc1661
+boto3==1.4.7 \
+    --hash=sha256:38057b066990172ce6ebbf2a5e046a545503793581fcf14cab0e3821c6112eb0 \
+    --hash=sha256:f79f77dca2280f7780f39d72a5088f4cf2b626c0921e7185ed6ac17abfdd7e6c
+botocore==1.7.41 \
+    --hash=sha256:1f6d0019b6a1d7bdd5d4406fdfe7b6776f7469f5f558e2cad6cbec37f1b86ed4 \
+    --hash=sha256:353b0ce134dae1bffd0c4bbe8779e277e3dd5b73aadaf767b97ed3f43f6e26d2
+jmespath==0.9.3 \
+    --hash=sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63 \
+    --hash=sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64
+s3transfer==0.1.11 \
+    --hash=sha256:c7b16f4cca5acd2bd57ac9623bfba3fece047247392893506d0d2e6f25620eb3 \
+    --hash=sha256:76f1f58f4a47e2c8afa135e2c76958806a3abbc42b721d87fd9d11409c75d979
+docutils==0.14 \
+    --hash=sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6 \
+    --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
+    --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274


### PR DESCRIPTION
This is the same as the PR for legacy, but for master so that we can use docker for testing. Once this is merged I'll back-port to legacy branch for use in scl3.