### PR TITLE
Hack around no longer getting x-forwarded-proto headers

### DIFF
--- a/wsgi/app.py
+++ b/wsgi/app.py
@@ -9,17 +9,31 @@ https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 import os
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'kitsune.settings')  # NOQA
 
+from django.core.handlers.wsgi import WSGIRequest
 from django.core.wsgi import get_wsgi_application
 
-import newrelic.agent
 from decouple import config
-from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
 
+
+IS_HTTPS = config('HTTPS', default='off', cast=bool)
 # For django-celery
 os.environ['CELERY_LOADER'] = 'django'
 
+
+class WSGIHTTPSRequest(WSGIRequest):
+    def _get_scheme(self):
+        if IS_HTTPS:
+            return 'https'
+
+        return super(WSGIHTTPSRequest, self)._get_scheme()
+
+
 application = get_wsgi_application()
-application = Sentry(application)
+application.request_class = WSGIHTTPSRequest
+
+if config('SENTRY_DSN', None):
+    from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
+    application = Sentry(application)
 
 if config('ENABLE_WHITENOISE', default=False, cast=bool):
     from whitenoise.django import DjangoWhiteNoise
@@ -29,5 +43,6 @@ if config('ENABLE_WHITENOISE', default=False, cast=bool):
 newrelic_ini = config('NEW_RELIC_CONFIG_FILE', default='newrelic.ini')
 newrelic_license_key = config('NEW_RELIC_LICENSE_KEY', default=None)
 if newrelic_ini and newrelic_license_key:
+    import newrelic.agent
     newrelic.agent.initialize(newrelic_ini)
     application = newrelic.agent.wsgi_application()(application)


### PR DESCRIPTION
In some prod clusters we can assume that it's always HTTPS, so we get that from the environment.

Also rearrange some code and imports.