### PR TITLE
Delete contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,0 @@
-Kitsune EOL
-============
-
-
-Hi kind contributor! Please be advised that Kitsune has reached its
-EOL (End Of Life) and **is no longer maintained or supported**.
-
-You can find other great projects to contribute to over
-at [Mozilla Webdev](http://mozilla.github.io/webdev/) project listing page.


### PR DESCRIPTION
It was only created to announce that Kitsune was EOL'd, and that is no longer the case. We should add a useful one in future.