### PR TITLE
Fix #2998: Add host enforcement middleware

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -475,6 +475,7 @@ MIDDLEWARE_CLASSES = (
     'multidb.middleware.PinningRouterMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'commonware.request.middleware.SetRemoteAddrFromForwardedFor',
+    'enforce_host.EnforceHostMiddleware',
 
     # LocaleURLMiddleware requires access to request.user. These two must be
     # loaded before the LocaleURLMiddleware
@@ -1037,6 +1038,12 @@ SILENCED_SYSTEM_CHECKS = [
 ]
 
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='', cast=Csv())
+# in production set this to 'support.mozilla.org' and all other domains will redirect.
+# can be a comma separated list of allowed domains.
+# the first in the list will be the target of redirects.
+# needs to be None if not set so that the middleware will
+# be turned off. can't set default to None because of the Csv() cast.
+ENFORCE_HOST = config('ENFORCE_HOST', default='', cast=Csv()) or None
 
 # Allows you to specify waffle settings in the querystring.
 WAFFLE_OVERRIDE = config('WAFFLE_OVERRIDE', default=DEBUG, cast=bool)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -450,3 +450,5 @@ mozilla-django-oidc==0.5.0 \
 josepy==1.0.1 \
     --hash=sha256:354a3513038a38bbcd27c97b7c68a8f3dfaff0a135b20a92c6db4cc4ea72915e \
     --hash=sha256:9f48b88ca37f0244238b1cc77723989f7c54f7b90b2eee6294390bacfe870acc
+django-enforce-host==1.0.1 \
+    --hash=sha256:40c4b4830e7fc27710c1606e8f3a91e82f8f1d5ae6c26aaec76f453b1407fc3d


### PR DESCRIPTION
This will ensure that other domains we point at the site (e.g. support.mozilla.com) will redirect to the canonical domain.