### PR TITLE
Monkey patch elasticutils.django.S.get_es to support HTTPS.

### DIFF
--- a/kitsune/sumo/monkeypatch.py
+++ b/kitsune/sumo/monkeypatch.py
@@ -4,7 +4,7 @@ from django.forms import fields
 from django.forms import widgets
 
 from elasticutils import get_es as base_get_es
-from elasticutils.contrib import django
+from elasticutils.contrib import django as elasticutils_django
 
 
 _has_been_patched = False
@@ -120,7 +120,17 @@ def patch():
 
         defaults.update(overrides)
         return base_get_es(**defaults)
-    django.get_es = get_es
+    elasticutils_django.get_es = get_es
+
+    def S_get_es(self, default_builder=get_es):
+        """Returns the elasticsearch Elasticsearch object to use.
+
+        This uses the django get_es builder by default which takes
+        into account settings in ``settings.py``.
+
+        """
+        return super(elasticutils_django.S, self).get_es(default_builder=default_builder)
+    elasticutils_django.S.get_es = S_get_es
 
     _has_been_patched = True
 


### PR DESCRIPTION
In the same spirit as #3022, figured out the `cron update_top_contributors` failed b/c of this