### PR TITLE
Set env variables in .env only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ To setup a local Kitsune development environment:
     docker-compose -f docker-compose.yml -f docker/composefiles/build.yml build base
     docker-compose -f docker-compose.yml -f docker/composefiles/build.yml build dev
 
+ #. Copy .env-dist to .env
+
+    cp .env-dist .env
+
  #. Create your database
 
     docker-compose -f docker-compose.yml -f docker/composefiles/dev.yml run web ./manage.py migrate

--- a/docker/composefiles/dev.yml
+++ b/docker/composefiles/dev.yml
@@ -2,7 +2,6 @@ version: '3.4'
 services:
   web:
     command: ./manage.py runserver 0.0.0.0:8000
-    env_file: .env-dist
     volumes:
       - ./:/app:cached
 


### PR DESCRIPTION
Removes loading of env variables with docker-compose which complicates things:

 - docker-compose loads .env-dist file and sets as real env variables
 - python-decouple loads .env file which overrides with the real env variables
   set from docker-compose

Practically means that dev have to modify .env-dist to make changes. This change
instructs users to copy .env-dist to .env and we only load variables using
python-decouple.