### PR TITLE
[bug 1441583] TrafficCop displays FxA CTA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ venv/
 .env
 .npm
 .config
+.node-gyp

--- a/kitsune/bundles.py
+++ b/kitsune/bundles.py
@@ -638,4 +638,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'build/kpi.dashboard-min.js'
     },
+    'experiment_fxa_cta_topbar': {
+        'source_filenames': (
+            'sumo/js/libs/mozilla-dnt-helper.js',
+            'sumo/js/libs/mozilla-cookie-helper.js',
+            'sumo/js/libs/mozilla-traffic-cop.js',
+            'sumo/js/experiment-fxa-cta-topbar.js',
+        ),
+        'output_filename': 'build/experiment-fxa-cta-topbar-min.js'
+    },
 }

--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -18,6 +18,22 @@
   {% endif %}
   {# End Optimizely #}
 
+  {# TrafficCop experiment_fxa_cta_topbar #}
+  {% set run_experiments = False %}
+  {% if waffle.flag('experiment_fxa_cta_topbar') %}
+    {% if request.path in ['/en-US/kb/install-firefox-android-device-using-google-play',
+                           '/en-US/kb/will-firefox-work-my-mobile-device',
+                           '/en-US/kb/get-started-firefox-overview-main-features',
+                           '/en-US/kb/update-firefox-latest-version',
+                           '/en-US/kb/install-firefox-your-ipad-iphone-or-ipod'] %}
+      {% set run_experiments = True %}
+    {% endif %}
+  {% endif %}
+  {% if run_experiments %}
+    {% javascript 'experiment_fxa_cta_topbar' %}
+  {% endif %}
+  {# end TrafficCop #}
+
   <link rel="search" type="application/opensearchdescription+xml" title="{{ _('Mozilla Support') }}" href="{{ url('search.plugin') }}"/>
   {% if feeds %}
     {% for feed in feeds %}
@@ -118,6 +134,19 @@
     </a>
   </div>
 {% endif %}
+
+{# TrafficCop experiment_fxa_cta_topbar #}
+{% if run_experiments %}
+  <div id="promotions" class="hidden">
+    <span data-variation="a" class="hidden">Sync Firefox with your phone.</span>
+    <span data-variation="b" class="hidden">Sync your Firefox bookmarks, tabs and more to your phone.</span>
+    <span data-variation="c" class="hidden">Browsing is better with a Firefox Account.</span>
+    <span data-variation="d" class="hidden">Connect Firefox on your computer and phone.</span>
+    <a href="https://www.mozilla.org/firefox/features/sync/?utm_source=support.mozilla.org&utm_medium=referral&utm_campaign=sumo_promotions">Learn more</a>
+    <a href="https://accounts.firefox.com/?utm_source=support.mozilla.org&utm_medium=referral&utm_campaign=sumo_promotions">Get started</a>
+  </div>
+{% endif %}
+{# end TrafficCop #}
 
 <div id="announcements">
   {% call announcement_bar('geoip-suggestion', 'warning') %}{% endcall %}

--- a/kitsune/sumo/static/sumo/js/experiment-fxa-cta-topbar.js
+++ b/kitsune/sumo/static/sumo/js/experiment-fxa-cta-topbar.js
@@ -1,0 +1,58 @@
+(function(Mozilla) {
+  'use strict';
+
+  // callback for UITour conditional
+  var rogerThat = function(sync) {
+
+    // only run if not syncing
+    var notSyncing = !sync.detail.data.setup;
+
+    if (notSyncing) {
+
+      var showPromotion = function(variation) {
+        document.addEventListener('DOMContentLoaded', function() {
+          var promotions = document.getElementById('promotions');
+          var showSpan = promotions.querySelector('span[data-variation="'+variation+'"]');
+          var links = promotions.getElementsByTagName('a');
+
+          for (var i=0; i<links.length; i++) {
+            links[i].href = links[i].href + '&utm_term=' + variation;
+          }
+
+          showSpan.className = showSpan.className.replace('hidden', '');
+          promotions.className = promotions.className.replace('hidden', '');
+        });
+      };
+
+      var laverneHooks = new Mozilla.TrafficCop({
+        id: 'experiment-fxa-cta-topbar',
+        customCallback: showPromotion,
+        variations: {
+          'a': 25,
+          'b': 25,
+          'c': 25,
+          'd': 25
+        }
+      });
+
+      laverneHooks.init();
+    }
+  };
+
+  // only run on Firefox
+  var isFirefox = /\sFirefox/.test(navigator.userAgent);
+
+  if (isFirefox) {
+    var event = new CustomEvent('mozUITour', {
+      bubbles: true,
+      detail: {
+        action: 'getConfiguration',
+        data: {configuration: 'sync'}
+      }
+    });
+
+    document.addEventListener('mozUITourResponse', rogerThat, {once: true});
+    document.dispatchEvent(event);
+  }
+
+})(window.Mozilla);

--- a/kitsune/sumo/static/sumo/js/libs/mozilla-cookie-helper.js
+++ b/kitsune/sumo/static/sumo/js/libs/mozilla-cookie-helper.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*\
+|*|
+|*|  :: cookies.js ::
+|*|
+|*|  A complete cookies reader/writer framework with full unicode support.
+|*|
+|*|  Revision #1 - September 4, 2014
+|*|
+|*|  https://developer.mozilla.org/en-US/docs/Web/API/document.cookie
+|*|  https://developer.mozilla.org/User:fusionchess
+|*|
+|*|  This framework is released under the GNU Public License, version 3 or later.
+|*|  http://www.gnu.org/licenses/gpl-3.0-standalone.html
+|*|
+|*|  Syntaxes:
+|*|
+|*|  * Mozilla.Cookies.setItem(name, value[, end[, path[, domain[, secure]]]])
+|*|  * Mozilla.Cookies.getItem(name)
+|*|  * Mozilla.Cookies.removeItem(name[, path[, domain]])
+|*|  * Mozilla.Cookies.hasItem(name)
+|*|  * Mozilla.Cookies.keys()
+|*|
+\*/
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
+
+Mozilla.Cookies = {
+    getItem: function (sKey) {
+        if (!sKey) { return null; }
+        return decodeURIComponent(document.cookie.replace(new RegExp('(?:(?:^|.*;)\\s*' + encodeURIComponent(sKey).replace(/[\-\.\+\*]/g, '\\$&') + '\\s*\\=\\s*([^;]*).*$)|^.*$'), '$1')) || null;
+    },
+    setItem: function (sKey, sValue, vEnd, sPath, sDomain, bSecure) {
+        if (!sKey || /^(?:expires|max\-age|path|domain|secure)$/i.test(sKey)) { return false; }
+        var sExpires = '';
+        if (vEnd) {
+            switch (vEnd.constructor) {
+            case Number:
+                sExpires = vEnd === Infinity ? '; expires=Fri, 31 Dec 9999 23:59:59 GMT' : '; max-age=' + vEnd;
+                break;
+            case String:
+                sExpires = '; expires=' + vEnd;
+                break;
+            case Date:
+                sExpires = '; expires=' + vEnd.toUTCString();
+                break;
+            }
+        }
+        document.cookie = encodeURIComponent(sKey) + '=' + encodeURIComponent(sValue) + sExpires + (sDomain ? '; domain=' + sDomain : '') + (sPath ? '; path=' + sPath : '') + (bSecure ? '; secure' : '');
+        return true;
+    },
+    removeItem: function (sKey, sPath, sDomain) {
+        if (!this.hasItem(sKey)) { return false; }
+        document.cookie = encodeURIComponent(sKey) + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT' + (sDomain ? '; domain=' + sDomain : '') + (sPath ? '; path=' + sPath : '');
+        return true;
+    },
+    hasItem: function (sKey) {
+        if (!sKey) { return false; }
+        return (new RegExp('(?:^|;\\s*)' + encodeURIComponent(sKey).replace(/[\-\.\+\*]/g, '\\$&') + '\\s*\\=')).test(document.cookie);
+    },
+    keys: function () {
+        var aKeys = document.cookie.replace(/((?:^|\s*;)[^\=]+)(?=;|$)|^\s*|\s*(?:\=[^;]*)?(?:\1|$)/g, '').split(/\s*(?:\=[^;]*)?;\s*/);
+        for (var nLen = aKeys.length, nIdx = 0; nIdx < nLen; nIdx++) { aKeys[nIdx] = decodeURIComponent(aKeys[nIdx]); }
+        return aKeys;
+    },
+    enabled: function() {
+        /**
+         * Cookies feature detect lifted from Modernizr
+         * https://github.com/Modernizr/Modernizr/blob/master/feature-detects/cookies.js
+         *
+         * navigator.cookieEnabled cannot detect custom or nuanced cookie blocking
+         * configurations. For example, when blocking cookies via the Advanced
+         * Privacy Settings in IE9, it always returns true. And there have been
+         * issues in the past with site-specific exceptions.
+         * Don't rely on it.
+
+         * try..catch because in some situations `document.cookie` is exposed but throws a
+         * SecurityError if you try to access it; e.g. documents created from data URIs
+         * or in sandboxed iframes (depending on flags/context)
+         */
+        try {
+            // Create cookie
+            document.cookie = 'cookietest=1';
+            var ret = document.cookie.indexOf('cookietest=') !== -1;
+            // Delete cookie
+            document.cookie = 'cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT';
+            return ret;
+        }
+        catch (e) {
+            return false;
+        }
+    }
+};

--- a/kitsune/sumo/static/sumo/js/libs/mozilla-dnt-helper.js
+++ b/kitsune/sumo/static/sumo/js/libs/mozilla-dnt-helper.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
+
+/**
+ * Returns true or false based on whether doNotTack is enabled. It also takes into account the
+ * anomalies, such as !bugzilla 887703, which effect versions of Fx 31 and lower. It also handles
+ * IE versions on Windows 7, 8 and 8.1, where the DNT implementation does not honor the spec.
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1217896 for more details
+ * @params {string} [dnt] - An optional mock doNotTrack string to ease unit testing.
+ * @params {string} [ua] - An optional mock userAgent string to ease unit testing.
+ * @returns {boolean} true if enabled else false
+ */
+Mozilla.dntEnabled = function(dnt, ua) {
+    'use strict';
+
+    // for old version of IE we need to use the msDoNotTrack property of navigator
+    // on newer versions, and newer platforms, this is doNotTrack but, on the window object
+    // Safari also exposes the property on the window object.
+    var dntStatus = dnt || navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
+    var userAgent = ua || navigator.userAgent;
+
+    // List of Windows versions known to not implement DNT according to the standard.
+    var anomalousWinVersions = ['Windows NT 6.1', 'Windows NT 6.2', 'Windows NT 6.3'];
+
+    var fxMatch = userAgent.match(/Firefox\/(\d+)/);
+    var ieRegEx = /MSIE|Trident/i;
+    var isIE = ieRegEx.test(userAgent);
+    // Matches from Windows up to the first occurance of ; un-greedily
+    // http://www.regexr.com/3c2el
+    var platform = userAgent.match(/Windows.+?(?=;)/g);
+
+    // With old versions of IE, DNT did not exist so we simply return false;
+    if (isIE && typeof Array.prototype.indexOf !== 'function') {
+        return false;
+    } else if (fxMatch && parseInt(fxMatch[1], 10) < 32) {
+        // Can't say for sure if it is 1 or 0, due to Fx bug 887703
+        dntStatus = 'Unspecified';
+    } else if (isIE && platform && anomalousWinVersions.indexOf(platform.toString()) !== -1) {
+        // default is on, which does not honor the specification
+        dntStatus = 'Unspecified';
+    } else {
+        // sets dntStatus to Disabled or Enabled based on the value returned by the browser.
+        // If dntStatus is undefined, it will be set to Unspecified
+        dntStatus = { '0': 'Disabled', '1': 'Enabled' }[dntStatus] || 'Unspecified';
+    }
+
+    return dntStatus === 'Enabled' ? true : false;
+};

--- a/kitsune/sumo/static/sumo/js/libs/mozilla-traffic-cop.js
+++ b/kitsune/sumo/static/sumo/js/libs/mozilla-traffic-cop.js
@@ -1,0 +1,326 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
+
+/**
+ * Traffic Cop traffic redirector for A/B/x testing
+ *
+ * Example usage:
+ *
+ * var cop = new Mozilla.TrafficCop({
+ *     id: 'exp_firefox_new_all_link',
+ *     cookieExpires: 48,
+ *     variations: {
+ *         'v=1': 25,
+ *         'v=2': 25,
+ *         'v=3': 25
+ *     }
+ * });
+ *
+ * cop.init();
+ *
+ *
+ * @param Object config: Object literal containing the following:
+ *      [String] id (required): Unique-ish string for cookie identification.
+ *          Only needs to be unique to other currently running tests.
+ *      [Number] cookieExpires (optional): Number of hours browser should
+ *          remember the variation chosen for the user. Defaults to 24 (hours).
+ *          A value of 0 will result in a session-length cookie.
+ *      [Boolean] storeReferrerCookie (optional): Flag to specify whether or not
+ *          original HTTP referrer should be placed in a cookie for later use.
+ *          Defaults to true.
+ *      [Function] customCallback (optional): Arbitrary function to run when
+ *          a variation (or lack thereof) is chosen. This function will be
+ *          passed the variation value (if chosen), or the value of
+ *          noVariationCookieValue if no variation was chosen. *Specifying this
+ *          function means no redirect will occur.*
+ *      Object variations (required): Object holding key/value pairs of
+ *          variations and their respective traffic percentages. Example:
+ *
+ *          variations: {
+ *              'v=1': 20,
+ *              'v=2': 20,
+ *              'v=3': 20
+ *          }
+ */
+Mozilla.TrafficCop = function(config) {
+    'use strict';
+
+    // make sure config is an object
+    this.config = (typeof config === 'object') ? config : {};
+
+    // store id
+    this.id = this.config.id;
+
+    // store variations
+    this.variations = this.config.variations;
+
+    // store total percentage of users targeted
+    this.totalPercentage = 0;
+
+    // store custom callback function (if supplied)
+    this.customCallback = (typeof this.config.customCallback === 'function') ? this.config.customCallback : null;
+
+    // store experiment cookie expiry (defaults to 24 hours)
+    this.cookieExpires = (this.config.cookieExpires !== undefined) ? this.config.cookieExpires : Mozilla.TrafficCop.defaultCookieExpires;
+
+    this.cookieExpiresDate = Mozilla.TrafficCop.generateCookieExpiresDate(this.cookieExpires);
+
+    // store pref to store referrer cookie on redirect (default to true)
+    this.storeReferrerCookie = (this.config.storeReferrerCookie === false) ? false : true;
+
+    this.chosenVariation = null;
+
+    // calculate and store total percentage of variations
+    for (var v in this.variations) {
+        if (this.variations.hasOwnProperty(v) && typeof this.variations[v] === 'number') {
+            this.totalPercentage += this.variations[v];
+        }
+    }
+
+    return this;
+};
+
+Mozilla.TrafficCop.defaultCookieExpires = 24;
+Mozilla.TrafficCop.noVariationCookieValue = 'novariation';
+Mozilla.TrafficCop.referrerCookieName = 'mozilla-traffic-cop-original-referrer';
+
+/*
+ * Initialize the traffic cop. Validates variations, ensures user is not
+ * currently viewing a variation, and (possibly) redirects to a variation
+ */
+Mozilla.TrafficCop.prototype.init = function() {
+    // respect the DNT
+    if (typeof Mozilla.dntEnabled === 'function' && Mozilla.dntEnabled()) {
+        return;
+    }
+
+    // If cookie helper is not defined or cookies are not enabled, do nothing.
+    if (typeof Mozilla.Cookies === 'undefined' || !Mozilla.Cookies.enabled()) {
+        return;
+    }
+
+    // make sure config is valid (id & variations present)
+    if (this.verifyConfig()) {
+        // determine which (if any) variation to choose for this user/experiment
+        this.chosenVariation = Mozilla.TrafficCop.chooseVariation(this.id, this.variations, this.totalPercentage);
+
+        // developer specified callback takes precedence
+        if (this.customCallback) {
+            this.initiateCustomCallbackRoutine();
+        // if no customCallback is supplied, initiate redirect routine
+        } else {
+            this.initiateRedirectRoutine();
+        }
+    }
+};
+
+/*
+ * Executes the logic around firing the custom callback specified by the
+ * developer.
+ */
+Mozilla.TrafficCop.prototype.initiateCustomCallbackRoutine = function() {
+    // set a cookie to remember the chosen variation
+    Mozilla.Cookies.setItem(this.id, this.chosenVariation || Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate);
+
+    // invoke the developer supplied callback, passing in the chosen variation
+    this.customCallback(this.chosenVariation);
+};
+
+/*
+ * Executes logic around determining variation to which the visitor will be
+ * redirected. May result in no redirect.
+ */
+Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function() {
+    var redirectUrl;
+
+    // make sure current page doesn't match a variation
+    // (avoid infinite redirects)
+    if (!Mozilla.TrafficCop.isRedirectVariation(this.variations)) {
+        // roll the dice to see if user should be send to a variation
+        redirectUrl = Mozilla.TrafficCop.generateRedirectUrl(this.chosenVariation);
+
+        // if we get a variation, send the user and store a cookie
+        if (redirectUrl) {
+            // Store the original referrer for use after redirect takes place so analytics can
+            // keep track of where visitors are coming from.
+
+            // Traffic Cop does nothing with this referrer - it's up to the implementing site to
+            // send it on to an analytics platform (or whatever).
+            if (this.storeReferrerCookie) {
+                Mozilla.TrafficCop.setReferrerCookie(this.cookieExpiresDate);
+            // a previous experiment may have set the cookie, so explicitly remove it here
+            } else {
+                Mozilla.TrafficCop.clearReferrerCookie();
+            }
+
+            // set a cookie containing the chosen variation
+            Mozilla.Cookies.setItem(this.id, this.chosenVariation, this.cookieExpiresDate);
+
+            Mozilla.TrafficCop.performRedirect(redirectUrl);
+        } else {
+            // if no variation, set a cookie so user isn't re-entered into
+            // the dice roll on next page load
+            Mozilla.Cookies.setItem(this.id, Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate);
+
+            // same as above - referrer cookie could be set from previous experiment, so best to clear
+            Mozilla.TrafficCop.clearReferrerCookie();
+        }
+    }
+};
+
+/*
+ * Ensures variations were provided and in total capture between 1 and 99%
+ * of users.
+ */
+Mozilla.TrafficCop.prototype.verifyConfig = function() {
+    if (!this.id || typeof this.id !== 'string') {
+        return false;
+    }
+
+    // make sure totalPercent is between 0 and 100
+    if (this.totalPercentage === 0 || this.totalPercentage > 100) {
+        return false;
+    }
+
+    // make sure cookieExpires is null or a number
+    if (typeof this.cookieExpires !== 'number') {
+        return false;
+    }
+
+    return true;
+};
+
+/*
+ * Generates an expiration date for the visitor's cookie.
+ * 'date' param used only for unit testing.
+ */
+Mozilla.TrafficCop.generateCookieExpiresDate = function(cookieExpires, date) {
+    // default to null, meaning a session-length cookie
+    var d = null;
+
+    if (cookieExpires > 0) {
+        d = date || new Date();
+        d.setHours(d.getHours() + cookieExpires);
+    }
+
+    return d;
+};
+
+/*
+ * Checks to see if user is currently viewing a variation.
+ */
+Mozilla.TrafficCop.isRedirectVariation = function(variations, queryString) {
+    var isVariation = false;
+    queryString = queryString || window.location.search;
+
+    // check queryString for presence of variation
+    for (var v in variations) {
+        if (queryString.indexOf('?' + v) > -1 || queryString.indexOf('&' + v) > -1) {
+            isVariation = true;
+            break;
+        }
+    }
+
+    return isVariation;
+};
+
+/*
+ * Returns the variation chosen for the current user/experiment.
+ */
+Mozilla.TrafficCop.chooseVariation = function(id, variations, totalPercentage) {
+    var rando;
+    var runningTotal;
+    var choice = Mozilla.TrafficCop.noVariationCookieValue;
+
+    // check to see if user has a cookie from a previously visited variation
+    // also make sure variation in cookie is still valid (you never know)
+    if (Mozilla.Cookies.hasItem(id) && (variations[Mozilla.Cookies.getItem(id)] || Mozilla.Cookies.getItem(id) === Mozilla.TrafficCop.noVariationCookieValue)) {
+        choice = Mozilla.Cookies.getItem(id);
+    // no cookie exists, or cookie has invalid variation, so choose a shiny new
+    // variation
+    } else {
+        // conjure a random number between 1 and 100 (inclusive)
+        rando = Math.floor(Math.random() * 100) + 1;
+
+        // make sure random number falls in the distribution range
+        if (rando <= totalPercentage) {
+            runningTotal = 0;
+
+            // loop through all variations
+            for (var v in variations) {
+                // check if random number falls within current variation range
+                if (rando <= (variations[v] + runningTotal)) {
+                    // if so, we have found our variation
+                    choice = v;
+                    break;
+                }
+
+                // tally variation percentages for the next loop iteration
+                runningTotal += variations[v];
+            }
+        }
+    }
+
+    return choice;
+};
+
+/*
+ * Generates a random percentage (between 1 and 100, inclusive) and determines
+ * which (if any) variation should be matched.
+ */
+Mozilla.TrafficCop.generateRedirectUrl = function(chosenVariation, url) {
+    var hash;
+    var redirect;
+    var urlParts;
+
+    // url parameter only supplied for unit tests
+    url = url || window.location.href;
+
+    // strip hash from URL (if present)
+    if (url.indexOf('#') > -1) {
+        urlParts = url.split('#');
+        url = urlParts[0];
+        hash = urlParts[1];
+    }
+
+    // if a variation was chosen, construct a new URL
+    if (chosenVariation !== Mozilla.TrafficCop.noVariationCookieValue) {
+        redirect = url + (url.indexOf('?') > -1 ? '&' : '?') + chosenVariation;
+
+        // re-insert hash (if originally present)
+        if (hash) {
+            redirect += '#' + hash;
+        }
+    }
+
+    return redirect;
+};
+
+Mozilla.TrafficCop.performRedirect = function(redirectURL) {
+    window.location.href = redirectURL;
+};
+
+Mozilla.TrafficCop.setReferrerCookie = function(expirationDate, referrer) {
+    // in order of precedence, referrer should be:
+    // 1. custom value passed in via unit test
+    // 2. value of document.referrer
+    // 3. 'direct' string literal
+    referrer = referrer || Mozilla.TrafficCop.getDocumentReferrer() || 'direct';
+
+    Mozilla.Cookies.setItem(Mozilla.TrafficCop.referrerCookieName, referrer, expirationDate);
+};
+
+Mozilla.TrafficCop.clearReferrerCookie = function() {
+    Mozilla.Cookies.removeItem(Mozilla.TrafficCop.referrerCookieName);
+};
+
+// wrapper around document.referrer for better unit testing
+Mozilla.TrafficCop.getDocumentReferrer = function() {
+    return document.referrer;
+};

--- a/kitsune/sumo/static/sumo/less/main.less
+++ b/kitsune/sumo/static/sumo/less/main.less
@@ -2036,3 +2036,29 @@ input[type=button],
     }
   }
 }
+/* bug1441583 experiment-fxa-cta-topbar */
+#promotions {
+  background: #003eaa;
+  background: linear-gradient(148deg,#c7216a 7%,#fda41e 100%);
+  height: 28px;
+  color: #fff;
+  text-align: center;
+  font-size: 1.25em;
+  padding: 3px 0;
+  a {
+    color: #fff;
+    margin-left: 10px;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+  a:before {
+    content: "»\a0";
+    font-family: 'Open Sans Light',X-LocaleSpecific-Light,'Open Sans',X-LocaleSpecific,sans-serif;
+    font-weight: 400;
+  }
+}
+.hidden {
+  display: none;
+}
+/* end bug1441583 */


### PR DESCRIPTION
This experiment creates a promotional block to show to Firefox users who visit very particular SUMO URLs and do not have sync setup.

To test in local:

* set waffle flag `experiment_fxa_cta_topbar` to `Yes` for everyone
* add a wiki article at `/en-US/kb/install-firefox-android-device-using-google-play`
* [add 2 prefs to Firefox about:config](http://bedrock.readthedocs.io/en/latest/uitour.html#local-development) to allow localhost UITours 
* If you use Sync, set up a custom browser profile to simulate a browser that does not have Sync setup
* browse to http://localhost:8000/en-US/kb/install-firefox-android-device-using-google-play with different browsers, different sync setups to verify the promotional block appears **in Firefox** and only **when sync is not set up**
* browse to other URLs to verify it does not appear

The topbar here is what to look for: https://screenshots.firefox.com/eW03oYS0vqX0a6NP/localhost