### PR TITLE
Skip cron jobs based on READ_ONLY and STAGE settings.

### DIFF
--- a/kitsune/dashboards/cron.py
+++ b/kitsune/dashboards/cron.py
@@ -17,9 +17,6 @@ from kitsune.wiki.utils import num_active_contributors
 
 @cronjobs.register
 def reload_wiki_traffic_stats():
-    if settings.STAGE:
-        return
-
     for period, _ in PERIODS:
         WikiDocumentVisits.reload_period_from_analytics(
             period, verbose=settings.DEBUG)

--- a/kitsune/kpi/cron.py
+++ b/kitsune/kpi/cron.py
@@ -90,10 +90,6 @@ def update_l10n_metric():
     * There are only new revisions with TYPO_SIGNIFICANCE not translated
     * There is only one revision of MEDIUM_SIGNIFICANCE not translated
     """
-    if settings.STAGE:
-        # Let's be nice to GA and skip on stage.
-        return
-
     # Get the top 60 visited articles. We will only use the top 50
     # but a handful aren't localizable so we get some extras.
     top_60_docs = _get_top_docs(60)
@@ -133,10 +129,6 @@ def update_l10n_metric():
 @cronjobs.register
 def update_contributor_metrics(day=None):
     """Calculate and save contributor metrics."""
-    if settings.STAGE:
-        # Let's be nice to the admin node and skip on stage.
-        return
-
     update_support_forum_contributors_metric(day)
     update_kb_contributors_metric(day)
     update_aoa_contributors_metric(day)
@@ -418,10 +410,6 @@ def process_exit_surveys():
 
     # Get the email addresses from two days ago and add them to the survey
     # campaign (skip this on stage).
-    if settings.STAGE:
-        # Only run this on prod, it doesn't need to be running multiple times
-        # from different places.
-        return
 
     startdate = date.today() - timedelta(days=2)
     enddate = date.today() - timedelta(days=1)
@@ -484,11 +472,6 @@ def _process_exit_survey_results():
 @cronjobs.register
 def survey_recent_askers():
     """Add question askers to a surveygizmo campaign to get surveyed."""
-    if settings.STAGE:
-        # Only run this on prod, it doesn't need to be running multiple times
-        # from different places.
-        return
-
     # We get the email addresses of all users that asked a question 2 days
     # ago. Then, all we have to do is send the email address to surveygizmo
     # and it does the rest.
@@ -499,8 +482,9 @@ def survey_recent_askers():
         Question.objects
         .filter(created__gte=two_days_ago, created__lt=yesterday)
         .values_list('creator__email', flat=True))
+
     for email in emails:
-            add_email_to_campaign('askers', email)
+        add_email_to_campaign('askers', email)
 
     statsd.gauge('survey.askers', len(emails))
 

--- a/kitsune/questions/cron.py
+++ b/kitsune/questions/cron.py
@@ -113,9 +113,6 @@ def auto_archive_old_questions():
 @cronjobs.register
 def reload_question_traffic_stats():
     """Reload question views from the analytics."""
-    if settings.STAGE:
-        return
-
     QuestionVisits.reload_from_analytics(verbose=settings.DEBUG)
 
 
@@ -127,8 +124,6 @@ def escalate_questions():
     still have no replies after 24 hours, but not that are older
     than 25 hours (this runs every hour).
     """
-    if settings.STAGE:
-        return
     # Get all the questions that need attention and haven't been escalated.
     qs = Question.objects.needs_attention().exclude(
         tags__slug__in=[config.ESCALATE_TAG_NAME])

--- a/kitsune/users/cron.py
+++ b/kitsune/users/cron.py
@@ -3,8 +3,6 @@ from datetime import datetime, timedelta
 
 from rest_framework.authtoken.models import Token
 
-from django.conf import settings
-
 from kitsune.questions.models import Answer
 from kitsune.search.models import generate_tasks
 from kitsune.search.tasks import index_task
@@ -25,9 +23,6 @@ def reindex_users_that_contributed_yesterday():
 
     The idea is to update the last_contribution_date field.
     """
-    if settings.STAGE:
-        return
-
     today = datetime.now()
     yesterday = today - timedelta(days=1)
 

--- a/kitsune/wiki/cron.py
+++ b/kitsune/wiki/cron.py
@@ -57,10 +57,6 @@ def reindex_kb():
 def send_weekly_ready_for_review_digest():
     """Sends out the weekly "Ready for review" digest email."""
 
-    # If this is stage, do nothing.
-    if settings.STAGE:
-        return
-
     @email_utils.safe_translation
     def _send_mail(locale, user, context):
         subject = _('[Reviews Pending: %s] SUMO needs your help!') % locale

--- a/scripts/cron.py
+++ b/scripts/cron.py
@@ -23,12 +23,15 @@ class scheduled_job(object):
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
+        self.skip = self.kwargs.pop('skip', False)
 
     def __call__(self, fn):
-        job_name = fn.__name__
-        self.name = job_name
+        self.name = fn.__name__
+        if self.skip:
+            self.log('Skipped, not registered.')
+            return None
         self.callback = fn
-        schedule.add_job(self.run, id=job_name, *self.args, **self.kwargs)
+        schedule.add_job(self.run, id=self.name, *self.args, **self.kwargs)
         self.log('Registered.')
         return self.run
 
@@ -50,76 +53,89 @@ class scheduled_job(object):
 
 
 # Every 10 minutes.
-@scheduled_job('cron', month='*', day='*', hour='*', minute='*/10', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='*', minute='*/10',
+               max_instances=1, coalesce=True)
 @babis.decorator(ping_after=settings.DMS_ENQUEUE_LAG_MONITOR_TASK)
 def job_enqueue_lag_monitor_task():
     call_command('cron enqueue_lag_monitor_task')
 
 
 # Every hour.
-@scheduled_job('cron', month='*', day='*', hour='*', minute='30', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='*', minute='30',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_SEND_WELCOME_EMAILS)
 def job_send_welcome_emails():
     call_command('cron send_welcome_emails')
 
 
-@scheduled_job('cron', month='*', day='*', hour='*', minute='59', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='*', minute='59',
+               max_instances=1, coalesce=True, skip=(settings.READ_ONLY or settings.STAGE))
 @babis.decorator(ping_after=settings.DMS_ESCALATE_QUESTIONS)
 def job_escalate_questions():
     call_command('cron escalate_questions')
 
 
 # Every 6 hours.
-@scheduled_job('cron', month='*', day='*', hour='*/6', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='*/6', minute='00',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_UPDATE_PRODUCT_DETAILS)
 def job_update_product_details():
     call_command('update_product_details')
 
 
-@scheduled_job('cron', month='*', day='*', hour='*/6', minute='20', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='*/6', minute='20',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_GENERATE_MISSING_SHARE_LINKS)
 def job_generate_missing_share_links():
     call_command('cron generate_missing_share_links')
 
 
 # Once per day.
-@scheduled_job('cron', month='*', day='*', hour='00', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='00', minute='00',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_REBUILD_KB)
 def job_rebuild_kb():
     call_command('cron rebuild_kb')
 
 
-@scheduled_job('cron', month='*', day='*', hour='00', minute='42', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='00', minute='42',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_UPDATE_TOP_CONTRIBUTORS)
 def job_update_top_contributors():
     call_command('cron update_top_contributors')
 
 
-@scheduled_job('cron', month='*', day='*', hour='01', minute='00', max_instances=1, coalesce=True)
+#@skip_read_only()
+@scheduled_job('cron', month='*', day='*', hour='01', minute='00',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_UPDATE_L10N_COVERAGE_METRICS)
 def job_update_l10n_coverage_metrics():
     call_command('cron update_l10n_coverage_metrics')
 
 
-@scheduled_job('cron', month='*', day='*', hour='01', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='01', minute='00',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_CALCULATE_CSAT_METRICS)
 def job_calculate_csat_metrics():
     call_command('cron calculate_csat_metrics')
 
 
-@scheduled_job('cron', month='*', day='*', hour='01', minute='11', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='01', minute='11',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_REPORT_EMPLOYEE_ANSWERS)
 def job_report_employee_answers():
     call_command('cron report_employee_answers')
 
 
-@scheduled_job('cron', month='*', day='*', hour='01', minute='30', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='01', minute='30',
+               max_instances=1, coalesce=True, skip=settings.STAGE)
 @babis.decorator(ping_after=settings.DMS_REINDEX_USERS_THAT_CONTRIBUTED_YESTERDAY)
 def job_reindex_users_that_contributed_yesterday():
     call_command('cron reindex_users_that_contributed_yesterday')
 
 
-@scheduled_job('cron', month='*', day='*', hour='01', minute='40', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='01', minute='40',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_UPDATE_WEEKLY_VOTES)
 def job_update_weekly_votes():
     call_command('cron update_weekly_votes')
@@ -131,19 +147,22 @@ def job_update_weekly_votes():
 #     call_command('cron update_search_ctr_metric')
 
 
-@scheduled_job('cron', month='*', day='*', hour='02', minute='47', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='02', minute='47',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_REMOVE_EXPIRED_REGISTRATION_PROFILES)
 def job_remove_expired_registration_profiles():
     call_command('cron remove_expired_registration_profiles')
 
 
-@scheduled_job('cron', month='*', day='*', hour='03', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='03', minute='00',
+               max_instances=1, coalesce=True, skip=(settings.READ_ONLY or settings.STAGE))
 @babis.decorator(ping_after=settings.DMS_UPDATE_CONTRIBUTOR_METRICS)
 def job_update_contributor_metrics():
     call_command('cron update_contributor_metrics')
 
 
-@scheduled_job('cron', month='*', day='*', hour='04', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='04', minute='00',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_AUTO_ARCHIVE_OLD_QUESTIONS)
 def job_auto_archive_old_questions():
     call_command('cron auto_archive_old_questions')
@@ -155,19 +174,22 @@ def job_reindex_kb():
     call_command('cron reindex_kb')
 
 
-@scheduled_job('cron', month='*', day='*', hour='06', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='06', minute='00',
+               max_instances=1, coalesce=True, skip=(settings.READ_ONLY or settings.STAGE))
 @babis.decorator(ping_after=settings.DMS_PROCESS_EXIT_SURVEYS)
 def job_process_exit_surveys():
     call_command('cron process_exit_surveys')
 
 
-@scheduled_job('cron', month='*', day='*', hour='07', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='07', minute='00',
+               max_instances=1, coalesce=True, skip=(settings.READ_ONLY or settings.STAGE))
 @babis.decorator(ping_after=settings.DMS_SURVEY_RECENT_ASKERS)
 def job_survey_recent_askers():
     call_command('cron survey_recent_askers')
 
 
-@scheduled_job('cron', month='*', day='*', hour='08', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='08', minute='00',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_CLEAR_EXPIRED_AUTH_TOKENS)
 def job_clear_expired_auth_tokens():
     call_command('cron clear_expired_auth_tokens')
@@ -179,61 +201,66 @@ def job_clear_expired_auth_tokens():
 #     call_command('cron update_visitors_metric')
 
 
-@scheduled_job('cron', month='*', day='*', hour='10', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='10', minute='00',
+               max_instances=1, coalesce=True, skip=(settings.READ_ONLY or settings.STAGE))
 @babis.decorator(ping_after=settings.DMS_UPDATE_L10N_METRIC)
 def job_update_l10n_metric():
     call_command('cron update_l10n_metric')
 
 
-@scheduled_job('cron', month='*', day='*', hour='16', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='16', minute='00',
+               max_instances=1, coalesce=True, skip=(settings.READ_ONLY or settings.STAGE))
 @babis.decorator(ping_after=settings.DMS_RELOAD_WIKI_TRAFFIC_STATS)
 def job_reload_wiki_traffic_stats():
     call_command('cron reload_wiki_traffic_stats')
 
 
-@scheduled_job('cron', month='*', day='*', hour='21', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='21', minute='00',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_CACHE_MOST_UNHELPFUL_KB_ARTICLES)
 def job_cache_most_unhelpful_kb_articles():
     call_command('cron cache_most_unhelpful_kb_articles')
 
 
-@scheduled_job('cron', month='*', day='*', hour='23', minute='00', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='23', minute='00',
+               max_instances=1, coalesce=True, skip=(settings.READ_ONLY or settings.STAGE))
 @babis.decorator(ping_after=settings.DMS_RELOAD_QUESTION_TRAFFIC_STATS)
 def job_reload_question_traffic_stats():
     call_command('cron reload_question_traffic_stats')
 
 
 # Once per week
-@scheduled_job('cron', month='*', day='*', hour='03', minute='21',
-               day_of_week=3, max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='03', minute='21', day_of_week=3,
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_PURGE_HASHES)
 def job_purge_hashes():
     call_command('purge_hashes')
 
 
-@scheduled_job('cron', month='*', day='*', hour='04', minute='00',
-               day_of_week=5, max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='04', minute='00', day_of_week=5,
+               max_instances=1, coalesce=True, skip=(settings.READ_ONLY or settings.STAGE))
 @babis.decorator(ping_after=settings.DMS_SEND_WEEKLY_READY_FOR_REVIEW_DIGEST)
 def job_send_weekly_ready_for_review_digest():
     call_command('cron send_weekly_ready_for_review_digest')
 
 
-@scheduled_job('cron', month='*', day='*', hour='00', minute='00',
-               day_of_week=0, max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='00', minute='00', day_of_week=0,
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_FIX_CURRENT_REVISIONS)
 def job_fix_current_revisions():
     call_command('cron fix_current_revisions')
 
 
-@scheduled_job('cron', month='*', day='*', hour='00', minute='30',
-               day_of_week=1, max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='*', hour='00', minute='30', day_of_week=1,
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_COHORT_ANALYSIS)
 def job_cohort_analysis():
     call_command('cron cohort_analysis')
 
 
 # Once per month
-@scheduled_job('cron', month='*', day='1', hour='00', minute='30', max_instances=1, coalesce=True)
+@scheduled_job('cron', month='*', day='1', hour='00', minute='30',
+               max_instances=1, coalesce=True, skip=settings.READ_ONLY)
 @babis.decorator(ping_after=settings.DMS_UPDATE_L10N_CONTRIBUTOR_METRICS)
 def job_update_l10n_contributor_metrics():
     call_command('cron update_l10n_contributor_metrics')


### PR DESCRIPTION
Replaces #3097 

Also there're some cron jobs that still check internally whether `STAGE=True`. Those cronjobs are commented out in `scripts/cron.py` b/c they are broken and need a fresh approach altogether.