### PR TITLE
[Issue 3100] Kubernetes HPA configuration.

### DIFF
--- a/k8s/regions/frankfurt/dev-web-hpa.yaml
+++ b/k8s/regions/frankfurt/dev-web-hpa.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: sumo-dev-web
+  namespace: sumo-dev
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: sumo-dev-web
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/k8s/regions/frankfurt/dev.yaml
+++ b/k8s/regions/frankfurt/dev.yaml
@@ -28,11 +28,11 @@ kubernetes:
         celery:
             command: "./bin/run-celery-worker.sh"
             deployment_name: "sumo-dev-celery"
-            replicas: 3
+            replicas: 1
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-dev-web"
-            replicas: 3
+            replicas: 1
             rollouts:
                 max_surge: 3
                 max_unavailable: 0

--- a/k8s/regions/frankfurt/prod-web-hpa.yaml
+++ b/k8s/regions/frankfurt/prod-web-hpa.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: sumo-prod-web
+  namespace: sumo-prod
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: sumo-prod-web
+  minReplicas: 3
+  maxReplicas: 15
+  targetCPUUtilizationPercentage: 80

--- a/k8s/regions/frankfurt/stage-web-hpa.yaml
+++ b/k8s/regions/frankfurt/stage-web-hpa.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: sumo-stage-web
+  namespace: sumo-stage
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: sumo-stage-web
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/k8s/regions/frankfurt/stage.yaml
+++ b/k8s/regions/frankfurt/stage.yaml
@@ -33,7 +33,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-stage-web"
-            replicas: 3
+            replicas: 1
             rollouts:
                 max_surge: 3
                 max_unavailable: 0

--- a/k8s/regions/oregon/prod-oregon-a.yaml
+++ b/k8s/regions/oregon/prod-oregon-a.yaml
@@ -33,7 +33,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-prod-web"
-            replicas: 3
+            replicas: 5
             rollouts:
                 max_surge: 3
                 max_unavailable: 0

--- a/k8s/regions/oregon/prod-oregon-b.yaml
+++ b/k8s/regions/oregon/prod-oregon-b.yaml
@@ -33,7 +33,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-prod-web"
-            replicas: 3
+            replicas: 5
             rollouts:
                 max_surge: 3
                 max_unavailable: 0

--- a/k8s/regions/oregon/prod-web-hpa.yaml
+++ b/k8s/regions/oregon/prod-web-hpa.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: sumo-prod-web
+  namespace: sumo-prod
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: sumo-prod-web
+  minReplicas: 5
+  maxReplicas: 15
+  targetCPUUtilizationPercentage: 80

--- a/k8s/regions/oregon/stage-oregon-a.yaml
+++ b/k8s/regions/oregon/stage-oregon-a.yaml
@@ -33,7 +33,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-stage-web"
-            replicas: 3
+            replicas: 1
             rollouts:
                 max_surge: 3
                 max_unavailable: 0

--- a/k8s/regions/oregon/stage-oregon-b.yaml
+++ b/k8s/regions/oregon/stage-oregon-b.yaml
@@ -33,7 +33,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-stage-web"
-            replicas: 3
+            replicas: 1
             rollouts:
                 max_surge: 3
                 max_unavailable: 0

--- a/k8s/regions/oregon/stage-web-hpa.yaml
+++ b/k8s/regions/oregon/stage-web-hpa.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: sumo-stage-web
+  namespace: sumo-stage
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: sumo-stage-web
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
Applied to all clusters / deployments.

- dev and stage set to minimum 1 and max 3
- prod in frankfurt set to 3 max 15 so it can handle load on failover and have space to grow
- prod in both oregon clusters set to 5/15 to handle normal load

those should be good enough to get us started and of course values re-evaluated and adjusted when we have actually traffic going in.

@metadave can you please review?