### PR TITLE
Set CACHE_MIDDLEWARE_SECONDS to 0 for oregon prod.

### DIFF
--- a/k8s/regions/oregon/prod-oregon-a.yaml
+++ b/k8s/regions/oregon/prod-oregon-a.yaml
@@ -58,6 +58,7 @@ app:
     aws_secret_access_key: SECRET
     aws_storage_bucket_name: SECRET
     broker_url: SECRET
+    cache_middleware_seconds: 0
     cache_url: SECRET
     celery_already_eager: False
     csrf_cookie_secure: True

--- a/k8s/regions/oregon/prod-oregon-b.yaml
+++ b/k8s/regions/oregon/prod-oregon-b.yaml
@@ -58,6 +58,7 @@ app:
     aws_secret_access_key: SECRET
     aws_storage_bucket_name: SECRET
     broker_url: SECRET
+    cache_middleware_seconds: 0
     cache_url: SECRET
     celery_already_eager: False
     csrf_cookie_secure: True


### PR DESCRIPTION
Disable cache for oregon-prod since it serves as a live copy of SCL3 atm.

See also #3112 