### PR TITLE
Add setting for using the x-forwarded-host header

### DIFF
--- a/k8s/regions/frankfurt/prod.yaml
+++ b/k8s/regions/frankfurt/prod.yaml
@@ -125,7 +125,7 @@ app:
     sentry_dsn: SECRET
     session_cookie_secure: True
     stage: False
-    static_url: "https://static-media-prod-cdn.sumo.mozilla.net/static/"
+    static_url: "/static/"
     statsd_client: SECRET
     statsd_host: SECRET
     statsd_prefix: "sumo-prod.frankfurt"
@@ -137,3 +137,4 @@ app:
     surveygizmo_password: SECRET
     surveygizmo_api_token: SECRET
     surveygizmo_api_token_secret: SECRET
+    use_x_forwarded_host: True

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -544,6 +544,7 @@ SECURE_REDIRECT_EXEMPT = [
     r'^healthz/$',
     r'^readiness/$',
 ]
+USE_X_FORWARDED_HOST = config('USE_X_FORWARDED_HOST', default=False, cast=bool)
 if config('USE_SECURE_PROXY_HEADER', default=SECURE_SSL_REDIRECT, cast=bool):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 


### PR DESCRIPTION
Turn on said setting for frankfurt prod. Also change the static_url setting to just SUMO in frankfurt prod since it is a CDN.

Ref https://github.com/mozmeao/infra/pull/747