### PR TITLE
Fix KeyError in PlusToSpaceMiddleware

### DIFF
--- a/kitsune/sumo/middleware.py
+++ b/kitsune/sumo/middleware.py
@@ -167,7 +167,7 @@ class PlusToSpaceMiddleware(object):
         p = re.compile(r'\+')
         if p.search(request.path_info):
             new = p.sub(' ', request.path_info)
-            if request.META['QUERY_STRING']:
+            if request.META.get('QUERY_STRING'):
                 new = u'%s?%s' % (new,
                                   smart_unicode(request.META['QUERY_STRING']))
             if hasattr(request, 'LANGUAGE_CODE'):

--- a/kitsune/sumo/tests/test_middleware.py
+++ b/kitsune/sumo/tests/test_middleware.py
@@ -78,6 +78,8 @@ class PlusToSpaceTestCase(TestCase):
     def test_plus_to_space(self):
         """Pluses should be converted to %20."""
         request = self.rf.get('/url+with+plus')
+        # should work without a QUERY_STRING key in META
+        del request.META['QUERY_STRING']
         response = self.ptsm.process_request(request)
         assert isinstance(response, HttpResponsePermanentRedirect)
         eq_('/url%20with%20plus', response['location'])


### PR DESCRIPTION
Sometimes the 'QUERY_STRING` key isn't in the META dict.