### PR TITLE
Decrease number of pods to 40 for oregon-a and oregon-b.

### DIFF
--- a/k8s/regions/oregon-a/prod-web-hpa.yaml
+++ b/k8s/regions/oregon-a/prod-web-hpa.yaml
@@ -8,6 +8,6 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: sumo-prod-web
-  minReplicas: 50
+  minReplicas: 40
   maxReplicas: 80
   targetCPUUtilizationPercentage: 80

--- a/k8s/regions/oregon-a/prod.yaml
+++ b/k8s/regions/oregon-a/prod.yaml
@@ -37,7 +37,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-prod-web"
-            replicas: 50
+            replicas: 40
             labels:
                 type: "web"
             readiness:

--- a/k8s/regions/oregon-b/prod-web-hpa.yaml
+++ b/k8s/regions/oregon-b/prod-web-hpa.yaml
@@ -8,6 +8,6 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: sumo-prod-web
-  minReplicas: 50
+  minReplicas: 40
   maxReplicas: 80
   targetCPUUtilizationPercentage: 80

--- a/k8s/regions/oregon-b/prod.yaml
+++ b/k8s/regions/oregon-b/prod.yaml
@@ -37,7 +37,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-prod-web"
-            replicas: 50
+            replicas: 40
             labels:
                 type: "web"
             readiness:


### PR DESCRIPTION
Further decrease number of pods for production from 100 (50 + 50) down to 80 (40 + 40) for oregon-a and oregon-b.

Current HPA cpu utilization:
 - 15% for oregon-a
 - 18% for oregon-b 

Current memory usage:
```
$ k8s_oregon_a top pod -n sumo-prod | grep sumo-prod-web | awk '{gsub("Mi", ""); print $3}' | ministat -n
x <stdin>
    N           Min           Max        Median           Avg        Stddev
x  50           731          1014           864        875.44     56.272355
```
```
$ k8s_oregon_b top pod -n sumo-prod | grep sumo-prod-web | awk '{gsub("Mi", ""); print $3}' | ministat -n
x <stdin>
    N           Min           Max        Median           Avg        Stddev
x  50           750          1007           895        900.82      50.23402
```
