### PR TITLE
Revert "Decrease number of pods to 40 for oregon-a and oregon-b."

### DIFF
--- a/k8s/regions/oregon-a/prod-web-hpa.yaml
+++ b/k8s/regions/oregon-a/prod-web-hpa.yaml
@@ -8,6 +8,6 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: sumo-prod-web
-  minReplicas: 40
+  minReplicas: 50
   maxReplicas: 80
   targetCPUUtilizationPercentage: 80

--- a/k8s/regions/oregon-a/prod.yaml
+++ b/k8s/regions/oregon-a/prod.yaml
@@ -37,7 +37,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-prod-web"
-            replicas: 40
+            replicas: 50
             labels:
                 type: "web"
             readiness:

--- a/k8s/regions/oregon-b/prod-web-hpa.yaml
+++ b/k8s/regions/oregon-b/prod-web-hpa.yaml
@@ -8,6 +8,6 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: sumo-prod-web
-  minReplicas: 40
+  minReplicas: 50
   maxReplicas: 80
   targetCPUUtilizationPercentage: 80

--- a/k8s/regions/oregon-b/prod.yaml
+++ b/k8s/regions/oregon-b/prod.yaml
@@ -37,7 +37,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-prod-web"
-            replicas: 40
+            replicas: 50
             labels:
                 type: "web"
             readiness:


### PR DESCRIPTION
This reverts commit 6345c4dc1c972ddad4e3e985c531bd6804fc793f.

We got NR alerts, increased latency and high RDS  cpu. Maybe related to #3173 and #3174 and not to the decrease of the number of pods but the timing was suspicious so we reverted.