### PR TITLE
[fix issue #3179] Switch product icons from sprite to real product icon.

### DIFF
--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -33,13 +33,6 @@ Next, Add a new item to the ``products`` dictionary using something like::
 
 ``'product-slug'`` should be the slug of the ``Product`` object for this product.
 
-You will also need to add a new 96x96 icon to the ``img/logos.large.sprite.png`` and
-will need to update the ``.logo-sprite`` class in ``questions.less`` to account for the new logo.
-
-The same changes will need to be made to ``img/mobile/logos-sprite-2x.png`` and a
-non-retina (half size) version ``img/mobile/logos-sprite.png``. Finally update the
-``.logo-sprite`` class in ``mobile/main.less``.
-
 
 Question States
 ===============

--- a/kitsune/dashboards/jinja2/dashboards/includes/macros.html
+++ b/kitsune/dashboards/jinja2/dashboards/includes/macros.html
@@ -213,7 +213,7 @@
         <img src="{{ STATIC_URL }}sumo/img/blank.png" class="logo-sprite small sumo">
         <span>{{ _('All Products') }}</span>
       {% else %}
-        <img src="{{ STATIC_URL }}sumo/img/blank.png" class="logo-sprite small" style="{% if current.image %}background-image: url({{ current.sprite_url(retina=False) }}); background-position: -50px -{{ 50 + (current.image_offset * 148) }}px;{% else %}background-image: url({{ current.image_url }}){% endif %}" alt="" />
+        <img src="{{ current.image_url }}" class="logo-sprite small" alt="" />
         <span>{{ pgettext('DB: products.Product.title', current.title) }}</span>
       {% endif %}
     </div>
@@ -227,7 +227,7 @@
       {% for p in products %}
         <li {{ current|class_selected(p) }}>
           <a href="{{ url_|urlparams(product=p.slug, category=category) }}">
-            <img src="{{ STATIC_URL }}sumo/img/blank.png" class="logo-sprite small" style="{% if p.image %}background-image: url({{ p.sprite_url(retina=False) }}); background-position: -50px -{{ 50 + (p.image_offset * 148) }}px;{% else %}background-image: url({{ p.image_url }}){% endif %}" alt="" />
+                <img src="{{ p.image_url }}" class="logo-sprite small" alt="" />
             <span>{{ pgettext('DB: products.Product.title', p.title) }}</span>
           </a>
         </li>

--- a/kitsune/products/jinja2/products/includes/product_macros.html
+++ b/kitsune/products/jinja2/products/includes/product_macros.html
@@ -8,7 +8,7 @@
           {% set prod_url = url('products.product', slug=product.slug) %}
         {% endif %}
         <a class="cf" href="{{ prod_url }}" data-event-category="link click" data-event-action="product" data-event-label="{{ product.title }}">
-          <img src="{{ STATIC_URL }}sumo/img/blank.png" class="logo-sprite" style="{% if product.image and product.image_offset %}background-image: url({{ product.sprite_url() }}); background-position: -100px -{{ 100 + (product.image_offset * 296) }}px;{% else %}background-image: url({{ product.image_url }}){% endif %}" alt="" />
+            <img src="{{ product.image_url }}" class="logo-sprite" alt="{{ pgettext('DB: products.Product.title', product.title) }}" />
           <span class="title">{{ pgettext('DB: products.Product.title', product.title) }}</span>
           <span class="description">{{ pgettext('DB: products.Product.description', product.description) }}</span>
         </a>

--- a/kitsune/products/jinja2/products/mobile/products.html
+++ b/kitsune/products/jinja2/products/mobile/products.html
@@ -8,31 +8,12 @@
   <ul id="products">
     {% for product in products %}
       <li>
-        <a class="cf" href="{{ url('products.product', slug=product.slug) }}"  data-event-category="link click" data-event-action="product" data-event-label="{{ product.title }}">
-          <img src="{{ STATIC_URL }}sumo/img/blank.png" class="logo-sprite" {% if product.image and product.image_offset %}style="background-position: -50px -{{ 50 + (product.image_offset * 148) }}px;"{% endif %} alt="">
+          <a class="cf" href="{{ url('products.product', slug=product.slug) }}"  data-event-category="link click" data-event-action="product" data-event-label="{{ product.title }}">
+              <img src="{{ product.image_url }}" class="logo-sprite" alt="{{ pgettext('DB: products.Product.title', product.title) }}">
           <span class="title">{{ pgettext('DB: products.Product.title', product.title) }}</span>
           {{ pgettext('DB: products.Product.description', product.description) }}
         </a>
       </li>
     {% endfor %}
   </ul>
-{% endblock %}
-
-{% block head %}
-  {% if products %}
-    <style>
-      #products > li > a > .logo-sprite {
-        background-image: url({{ products[0].sprite_url(retina=False) }});
-      }
-
-      @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2) {
-        #products > li > a > .logo-sprite {
-          background-image: url({{ products[0].sprite_url() }});
-          -webkit-background-size: 148px {{ products[0].sprite_height }}px;
-          -moz-background-size: 148px {{ products[0].sprite_height }}px;
-          background-size: 148px {{ products[0].sprite_height }}px;
-        }
-      }
-    </style>
-  {% endif %}
 {% endblock %}

--- a/kitsune/products/jinja2/products/product.html
+++ b/kitsune/products/jinja2/products/product.html
@@ -13,11 +13,10 @@
 
 {% block content %}
   <div class="grid_12">
-    <h1 class="product-title cf">
-      <img src="{{ STATIC_URL }}sumo/img/blank.png" alt="" class="logo-sprite"
-        style="{% if product.image and product.image_offset %}background-image: url({{ product.sprite_url() }}); background-position: -100px -{{ 100 + (product.image_offset * 296) }}px;{% else %}background-image: url({{ product.image_url }}){% endif %}" />
-      {{ pgettext('DB: products.Product.title', product.title) }}
-    </h1>
+      <h1 class="product-title cf">
+          <img src="{{ product.image_url }}" alt="" class="logo-sprite" />
+          {{ pgettext('DB: products.Product.title', product.title) }}
+      </h1>
 
     {% if product.slug == 'firefox' %}
       <div class="download-firefox">

--- a/kitsune/products/models.py
+++ b/kitsune/products/models.py
@@ -1,11 +1,8 @@
-import io
 import os
 
 from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _lazy
-from PIL import Image
-from uuid import uuid4
 
 from kitsune.sumo.models import ModelBase
 from kitsune.sumo.urlresolvers import reverse
@@ -51,63 +48,8 @@ class Product(ModelBase):
             return self.image.url
         return os.path.join(settings.STATIC_URL, 'products', 'img', 'product_placeholder.png')
 
-    def sprite_url(self, retina=True):
-        fn = 'logo-sprite-2x.png' if retina else 'logo-sprite.png'
-        url = os.path.join(settings.MEDIA_URL, settings.PRODUCT_IMAGE_PATH, fn)
-        return '%s?%s' % (url, self.image_cachebuster)
-
     def questions_enabled(self, locale):
         return self.questions_locales.filter(locale=locale).exists()
-
-    def save(self, force_insert=False, force_update=False, using=None,
-             update_fields=None, regenerate_sprite=True):
-        super(Product, self).save(force_insert=force_insert,
-                                  force_update=force_update, using=using,
-                                  update_fields=update_fields)
-
-        if regenerate_sprite:
-            cachebust = uuid4().hex
-            logos = []
-            offset = 0
-            products = Product.objects.order_by('id').all()
-
-            for product in products:
-                if product.image:
-                    product.image_offset = offset
-                    offset += 1
-                    logo_file = io.BytesIO(product.image.file.read())
-                    logos.append(Image.open(logo_file))
-                else:
-                    product.image_offset = None
-
-                product.image_cachebuster = cachebust
-
-            for product in products:
-                product.sprite_height = 148 * len(logos)
-                product.save(regenerate_sprite=False)
-
-            if len(logos):
-                large_sprite = Image.new(mode='RGBA',
-                                         size=(296, 296 * len(logos)),
-                                         color=(0, 0, 0, 0))
-
-                small_sprite = Image.new(mode='RGBA',
-                                         size=(148, 148 * len(logos)),
-                                         color=(0, 0, 0, 0))
-
-                for offset, logo in enumerate(logos):
-                    large_sprite.paste(logo, (100, 100 + (296 * offset)))
-
-                    small_logo = logo.resize((48, 48), Image.ANTIALIAS)
-                    small_sprite.paste(small_logo, (50, 50 + (148 * offset)))
-
-                large_sprite.save(os.path.join(
-                    settings.MEDIA_ROOT, settings.PRODUCT_IMAGE_PATH,
-                    'logo-sprite-2x.png'))
-
-                small_sprite.save(os.path.join(
-                    settings.MEDIA_ROOT, settings.PRODUCT_IMAGE_PATH,
-                    'logo-sprite.png'))
 
     def get_absolute_url(self):
         return reverse('products.product', kwargs={'slug': self.slug})

--- a/kitsune/questions/config.py
+++ b/kitsune/questions/config.py
@@ -357,6 +357,7 @@ products = SortedDict([
     ('other', {
         'name': _lazy(u'Other Mozilla products'),
         'subtitle': '',
+        'product': '',
         'html': _lazy(u'This site only provides support for some of our products. '
                       u'For other support, please find your product below.'
                       u'<ul class="product-support">'

--- a/kitsune/questions/jinja2/questions/includes/aaq_macros.html
+++ b/kitsune/questions/jinja2/questions/includes/aaq_macros.html
@@ -22,11 +22,13 @@
   <ul id="product-picker" class="card-grid cf">
     {% for key, product in products.iteritems() %}
       <li>
-        <a class="cf" href="{{ url('questions.aaq_step2', product_key=key) }}"
-        data-event-category="link click"
-        data-event-action="product"
-        data-event-label="{{ product.name }}">
-          <img src="{{ STATIC_URL }}sumo/img/blank.png" alt="" class="logo-sprite logo-{{ key }}">
+          <a class="cf" href="{{ url('questions.aaq_step2', product_key=key) }}"
+              data-event-category="link click"
+              data-event-action="product"
+              data-event-label="{{ product.name }}">
+              <img src="{{ image_for_product(product.product) }}"
+                  alt="{{ pgettext('DB: products.Product.title', product.title) }}"
+                  class="logo-sprite">
           <span class="title">{{ product.name }}</span>
           <span class="description">{{ product.subtitle }}</span>
         </a>

--- a/kitsune/questions/jinja2/questions/mobile/new_question.html
+++ b/kitsune/questions/jinja2/questions/mobile/new_question.html
@@ -27,7 +27,9 @@
             <li class="{% if product == current_product %}selected{% endif %}">
               <a href="{{ url('questions.aaq_step2', product_key=key) }}" data-event-category="link click"
               data-event-action="product" data-event-label="{{ product.name }}">
-                <span class="logo-sprite logo-{{ key }}"></span>
+                  <span class="logo"
+                      style="background-image: url({{ image_for_product(product.product) }}">
+                  </span>
                 {{ product.name }}
               </a>
             </li>

--- a/kitsune/questions/jinja2/questions/mobile/product_list.html
+++ b/kitsune/questions/jinja2/questions/mobile/product_list.html
@@ -9,8 +9,8 @@
   <ul id="products">
     {% for product in products %}
       <li>
-        <a class="cf" href="{{ url('questions.list', product.slug) }}">
-          <img src="{{ STATIC_URL }}sumo/img/blank.png" class="logo-sprite" {% if product.image and product.image_offset %}style="background-position: -50px -{{ 50 + (product.image_offset * 148) }}px;"{% endif %} alt="">
+          <a class="cf" href="{{ url('questions.list', product.slug) }}">
+              <img src="{{ product.image_url }}" class="logo-sprite">
           <span class="title">{{ _('<strong>{product}</strong> Support Forum')|fe(product=pgettext('DB: products.Product.title', product.title)) }}</span>
           {{ pgettext('DB: products.Product.description', product.description) }}
         </a>
@@ -23,23 +23,4 @@
       </a>
     </li>
   </ul>
-{% endblock %}
-
-{% block head %}
-  {% if products %}
-    <style>
-      #products > li > a > .logo-sprite {
-        background-image: url({{ products[0].sprite_url(retina=False) }});
-      }
-
-      @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2) {
-        #products > li > a > .logo-sprite {
-          background-image: url({{ products[0].sprite_url() }});
-          -webkit-background-size: 148px {{ products[0].sprite_height }}px;
-          -moz-background-size: 148px {{ products[0].sprite_height }}px;
-          background-size: 148px {{ products[0].sprite_height }}px;
-        }
-      }
-    </style>
-  {% endif %}
 {% endblock %}

--- a/kitsune/questions/jinja2/questions/product_list.html
+++ b/kitsune/questions/jinja2/questions/product_list.html
@@ -15,8 +15,8 @@
     <article class="product-list">
       {% for product in products %}
         <div class="product grid_5">
-          <a class="cf" href="{{ url('questions.list', product.slug) }}">
-            <img src="{{ STATIC_URL }}sumo/img/blank.png" class="logo-sprite" style="{% if product.image and product.image_offset %}background-image: url({{ product.sprite_url() }}); background-position: -100px -{{ 100 + (product.image_offset * 296) }}px;{% else %}background-image: url({{ product.image_url }}){% endif %}" alt="" />
+            <a class="cf" href="{{ url('questions.list', product.slug) }}">
+                <img src="{{ product.image_url }}" class="logo-sprite" alt="{{ pgettext('DB: products.Product.title', product.title) }}" />
             <span class="title">{{ _('<strong>{product}</strong> Support Forum')|fe(product=pgettext('DB: products.Product.title', product.title)) }}</span>
             <span class="description">{{ pgettext('DB: products.Product.description', product.description) }}</span>
           </a>

--- a/kitsune/questions/jinja2/questions/question_list.html
+++ b/kitsune/questions/jinja2/questions/question_list.html
@@ -172,7 +172,7 @@
                     {% set topic = question.topic %}
                     <li>
                       <a href="{{ url('questions.list', topic.product.slug)|urlparams(None, request.GET, topic=None) }}">
-                        <img src="{{ STATIC_URL }}sumo/img/blank.png" class="logo-sprite-tiny logo-{{ topic.product.slug }}">
+                        <img src="{{ topic.product.image_url }}" class="logo-sprite-tiny">
                         {{ pgettext('DB: products.Product.title', topic.product.title) }}
                       </a>
                     </li>

--- a/kitsune/questions/tests/test_templates.py
+++ b/kitsune/questions/tests/test_templates.py
@@ -1243,7 +1243,7 @@ class QuestionsTemplateTestCase(TestCaseBase):
         doc = pq(response.content)
         tag = doc('#question-{id} .tag-list li img'.format(id=q.id))
         # Even though there are no tags, the product should be displayed.
-        assert 'logo-{}'.format(p.slug) in tag.attr('class')
+        assert 'logo-sprite-tiny' in tag.attr('class')
 
 
 class QuestionsTemplateTestCaseNoFixtures(TestCase):

--- a/kitsune/sumo/static/sumo/less/mobile/includes/product-switcher.less
+++ b/kitsune/sumo/static/sumo/less/mobile/includes/product-switcher.less
@@ -33,6 +33,10 @@
         }
       }
 
+      .logo {
+          background-size: 48px 48px;
+      }
+
       &.selected {
         &:before {
           background: rgba(0, 0, 0, 0.3);

--- a/kitsune/sumo/static/sumo/less/mobile/main.less
+++ b/kitsune/sumo/static/sumo/less/mobile/main.less
@@ -404,52 +404,8 @@ input[type="submit"]:visited {
 }
 
 .logo-sprite {
-  background: url('../../img/mobile/logos-sprite.png?v=7') -50px -50px no-repeat;
   height: 48px;
   width: 48px;
-
-  /* Vertical position = 50px + i * 148 */
-
-  &.logo-firefox {
-    background-position: -50px -50px;
-  }
-
-  &.logo-thunderbird {
-    background-position: -50px -198px;
-  }
-
-  &.logo-mobile {
-    background-position: -50px -346px;
-  }
-
-  &.logo-firefox-os {
-    background-position: -50px -494px;
-  }
-
-  &.logo-webmaker {
-    background-position: -50px -642px;
-  }
-
-  &.logo-other {
-    background-position: -50px -790px;
-  }
-
-  &.logo-ios {
-    background-position: -50px -938px;
-  }
-
-  &.logo-focus {
-    background-position: -50px -1234px;
-  }
-
-  &.logo-firefox-rocket {
-      background-position: -50px -1382px;
-  }
-
-  // Uses Firefox logo
-  &.logo-firefox-fire-tv {
-      background-position: -50px -50px;
-  }
 }
 
 .header-overlay {
@@ -996,7 +952,6 @@ input[type="submit"]:visited {
   }
 
   .logo-sprite {
-    background-image: url('../../img/mobile/logos-sprite-2x.png?v=6');
     background-size: 148px 1480px;
   }
 

--- a/kitsune/sumo/static/sumo/less/questions.less
+++ b/kitsune/sumo/static/sumo/less/questions.less
@@ -628,103 +628,14 @@ h2 {
 }
 
 .logo-sprite {
-  background: url('../img/logos.large.sprite.png?v=10') -100px -100px no-repeat;
   height: 96px;
   width: 96px;
-
-  /* Vertical position = 100px + i * 296 */
-
-  &.logo-firefox {
-    background-position: -100px -100px;
-  }
-
-  &.logo-thunderbird {
-    background-position: -100px -396px;
-  }
-
-  &.logo-mobile {
-    background-position: -100px -692px;
-  }
-
-  &.logo-firefox-os {
-    background-position: -100px -988px;
-  }
-
-  &.logo-webmaker {
-    background-position: -100px -1284px;
-  }
-
-  &.logo-other {
-    background-position: -100px -1580px;
-  }
-
-  &.logo-ios {
-    background-position: -100px -1876px;
-  }
-
-  &.logo-focus {
-    background-position: -100px -2468px;
-  }
-
-  &.logo-firefox-rocket {
-      background-position: -100px -2764px;
-  }
-
-  // Uses Firefox logo.
-  &.logo-firefox-fire-tv {
-      background-position: -100px -100px;
-  }
-
 }
 
 .logo-sprite-tiny {
-  background: url('../img/logos.large.sprite.png?v=10') -12px -12px no-repeat;
   background-size: 42px;
   height: 16px;
   width: 16px;
-
-  /* Vertical position = 11px + i * 42 */
-
-  &.logo-firefox {
-    background-position: -12px -11px;
-  }
-
-  &.logo-thunderbird {
-    background-position: -12px -53px;
-  }
-
-  &.logo-mobile {
-    background-position: -12px -95px;
-  }
-
-  &.logo-firefox-os {
-    background-position: -12px -137px;
-  }
-
-  &.logo-webmaker {
-    background-position: -12px -179px;
-  }
-
-  &.logo-other {
-    background-position: -12px -221px;
-  }
-
-  &.logo-ios {
-    background-position: -12px -263px;
-  }
-
-  &.logo-focus {
-    background-position: -12px -347px;
-  }
-
-  &.logo-firefox-rocket {
-      background-position: -12px -389px;
-  }
-
-  // Uses Firefox logo
-  &.logo-firefox-fire-tv {
-      background-position: -12px -11px;
-  }
 }
 
 .questions {

--- a/kitsune/sumo/templatetags/jinja_helpers.py
+++ b/kitsune/sumo/templatetags/jinja_helpers.py
@@ -1,6 +1,7 @@
 import datetime
 import json as jsonlib
 import logging
+import os
 import re
 import urlparse
 
@@ -26,6 +27,7 @@ from pytz import timezone
 from kitsune.sumo import parser
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.users.models import Profile
+from kitsune.products.models import Product
 from kitsune.wiki.showfor import showfor_data as _showfor_data
 
 
@@ -492,3 +494,16 @@ def fe(format_string, *args, **kwargs):
         format_string = unicode(format_string)
 
     return jinja2.Markup(format_string.format(*args, **kwargs))
+
+
+@library.global_function
+def image_for_product(product_slug):
+    """
+    Return image for product slug
+    """
+
+    try:
+        obj = Product.objects.get(slug=product_slug)
+    except Product.DoesNotExist:
+        return os.path.join(settings.STATIC_URL, 'products', 'img', 'product_placeholder.png')
+    return obj.image_url


### PR DESCRIPTION
Kitsune Products featured code to auto-generate a sprite with all product icons
on every product save. This code broken when we switched to the AWS S3 backed
user media backend.

Instead of fixing this code, we opted for removing the sprite functionality
altogether because:

  - it was not used in all places (i.e. questions used a different manually
    created sprite)

  - it raised serious concerns on how we can atomically update the auto
    generated sprite on S3 while avoiding errors.

  - The whole implementation was a hack which saved files without using
    default_storage engine.

Now product images are directly used on desktop and mobile and as a bonus the
same images -which can be managed through the admin interface- are used in both
product listing and AAQ.

Partially fixes bug 1196475 too.