### PR TITLE
Double WSGI_NUM_WORKERS & halve pods in oregon-b

### DIFF
--- a/k8s/regions/oregon-b/prod-web-hpa.yaml
+++ b/k8s/regions/oregon-b/prod-web-hpa.yaml
@@ -8,6 +8,6 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: sumo-prod-web
-  minReplicas: 50
-  maxReplicas: 80
+  minReplicas: 25
+  maxReplicas: 40
   targetCPUUtilizationPercentage: 80

--- a/k8s/regions/oregon-b/prod.yaml
+++ b/k8s/regions/oregon-b/prod.yaml
@@ -145,3 +145,4 @@ app:
     surveygizmo_api_token: SECRET
     surveygizmo_api_token_secret: SECRET
     wsgi_keep_alive: 60
+    wsgi_num_workers: 4


### PR DESCRIPTION
Apply same settings as in oregon-a by #3187 for mozmeao/infra#782