### PR TITLE
[Fix #3174] Fixing order of top contributor list

### DIFF
--- a/kitsune/community/utils.py
+++ b/kitsune/community/utils.py
@@ -1,6 +1,8 @@
 import hashlib
 
 from datetime import datetime, date, timedelta
+from operator import itemgetter
+
 from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Count, F
@@ -140,5 +142,9 @@ def _get_creator_counts(query, count, page):
         }
 
         results.append(data)
+
+    # Descending Order the list according to count.
+    # As the top number of contributor should be at first
+    results = sorted(results, key=itemgetter('count'), reverse=True)
 
     return results, total


### PR DESCRIPTION
Contributor list should be ordered according to contributions count in descending order.
It was skipped from  #3175.
I wonder why it was not caught by any test! 😞 
@glogiotatidis @pmac r?