### PR TITLE
Promotions experiment splits clicks to 3 destinations

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -12,22 +12,6 @@
 
   {{ favicon() }}
 
-  {# TrafficCop experiment_fxa_cta_topbar #}
-  {% set run_experiments = False %}
-  {% if waffle.flag('experiment_fxa_cta_topbar') %}
-    {% if request.path in ['/en-US/kb/install-firefox-android-device-using-google-play',
-                           '/en-US/kb/will-firefox-work-my-mobile-device',
-                           '/en-US/kb/get-started-firefox-overview-main-features',
-                           '/en-US/kb/update-firefox-latest-version',
-                           '/en-US/kb/install-firefox-your-ipad-iphone-or-ipod'] %}
-      {% set run_experiments = True %}
-    {% endif %}
-  {% endif %}
-  {% if run_experiments %}
-    {% javascript 'experiment_fxa_cta_topbar' %}
-  {% endif %}
-  {# end TrafficCop #}
-
   <link rel="search" type="application/opensearchdescription+xml" title="{{ _('Mozilla Support') }}" href="{{ url('search.plugin') }}"/>
   {% if feeds %}
     {% for feed in feeds %}
@@ -75,6 +59,23 @@
   <![endif]-->
 
   {% include "includes/google-analytics.html" %}
+
+  {# TrafficCop experiment_fxa_cta_topbar #}
+  {% set run_experiments = False %}
+  {% if waffle.flag('experiment_fxa_cta_topbar') %}
+    {% if request.path in ['/en-US/kb/install-firefox-android-device-using-google-play',
+                           '/en-US/kb/will-firefox-work-my-mobile-device',
+                           '/en-US/kb/get-started-firefox-overview-main-features',
+                           '/en-US/kb/update-firefox-latest-version',
+                           '/en-US/kb/install-firefox-your-ipad-iphone-or-ipod'] %}
+      {% set run_experiments = True %}
+    {% endif %}
+  {% endif %}
+  {% if run_experiments %}
+    {% javascript 'experiment_fxa_cta_topbar' %}
+  {% endif %}
+  {# end TrafficCop #}
+
 </head>
 <body class="html-{{ DIR }} logged-{% if user.is_authenticated() %}in{% else %}out{% endif %} {{ classes }} {{ request.LANGUAGE_CODE }}"
       data-readonly="{{ settings.READ_ONLY|json }}"
@@ -133,12 +134,11 @@
 {# TrafficCop experiment_fxa_cta_topbar #}
 {% if run_experiments %}
   <div id="promotions" class="hidden">
-    <span data-variation="a" class="hidden">Sync Firefox with your phone.</span>
-    <span data-variation="b" class="hidden">Sync your Firefox bookmarks, tabs and more to your phone.</span>
-    <span data-variation="c" class="hidden">Browsing is better with a Firefox Account.</span>
-    <span data-variation="d" class="hidden">Connect Firefox on your computer and phone.</span>
+    Sync your Firefox bookmarks, tabs and more to your phone.
     <a href="https://www.mozilla.org/firefox/features/sync/?utm_source=support.mozilla.org&utm_medium=referral&utm_campaign=sumo_promotions">Learn more</a>
-    <a href="https://accounts.firefox.com/?utm_source=support.mozilla.org&utm_medium=referral&utm_campaign=sumo_promotions">Get started</a>
+    <a class="hidden" data-variation="a" href="https://accounts.firefox.com/?utm_source=support.mozilla.org&utm_medium=referral&utm_campaign=sumo_promotions">Get started</a>
+    <a class="hidden" data-variation="b" href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=support.mozilla.org&utm_campaign=sumo_promotions">Get started</a>
+    <a class="hidden" data-variation="c" href="https://www.mozilla.org/firefox/accounts/features/?utm_source=support.mozilla.org&utm_medium=referral&utm_campaign=sumo_promotions">Get started</a>
   </div>
 {% endif %}
 {# end TrafficCop #}

--- a/kitsune/sumo/static/sumo/js/experiment-fxa-cta-topbar.js
+++ b/kitsune/sumo/static/sumo/js/experiment-fxa-cta-topbar.js
@@ -12,15 +12,24 @@
       var showPromotion = function(variation) {
         document.addEventListener('DOMContentLoaded', function() {
           var promotions = document.getElementById('promotions');
-          var showSpan = promotions.querySelector('span[data-variation="'+variation+'"]');
+          var showContent = promotions.querySelector('a[data-variation="'+variation+'"]');
           var links = promotions.getElementsByTagName('a');
 
           for (var i=0; i<links.length; i++) {
             links[i].href = links[i].href + '&utm_term=' + variation;
           }
 
-          showSpan.className = showSpan.className.replace('hidden', '');
+          showContent.className = showContent.className.replace('hidden', '');
           promotions.className = promotions.className.replace('hidden', '');
+
+          // fire a non-interactive analytics event indicating this variation appeared on the screen
+          if (window.gtag) {
+            window.gtag('event', 'view', {
+              'event_category': 'experiment-fxa-cta-topbar',
+              'event_label': variation,
+              'nonInteraction': true
+            });
+          }
         });
       };
 
@@ -28,10 +37,9 @@
         id: 'experiment-fxa-cta-topbar',
         customCallback: showPromotion,
         variations: {
-          'a': 25,
-          'b': 25,
-          'c': 25,
-          'd': 25
+          'a': 34,
+          'b': 33,
+          'c': 33
         }
       });
 
@@ -39,10 +47,13 @@
     }
   };
 
-  // only run on Firefox
-  var isFirefox = /\sFirefox/.test(navigator.userAgent);
+  // only run on Firefox 40+
+  var isRecentFirefox = (function() {
+    var matches = /Firefox\/(\d+(?:\.\d+){1,2})/.exec(navigator.userAgent);
+    return (matches && Number(matches[1]) >= 40);
+  })();
 
-  if (isFirefox) {
+  if (isRecentFirefox) {
     var event = new CustomEvent('mozUITour', {
       bubbles: true,
       detail: {


### PR DESCRIPTION
This addresses https://bugzilla.mozilla.org/show_bug.cgi?id=1441583#c2.

Functional testing I did:

- [x] Works on Firefox, not on other browsers
- [x] Works on Firefox 40+, not Firefox 39 (UA spoofing)
- [x] Works when signed out of sync, not when signed in
- [x] Works on particular URLs, not on all URLs
- [x] Works in en-US, not in different locale
- [x] Text as expected
- [x] Link variations as expected
- [x] GA events fire as expected