### PR TITLE
Swap feed views for 404 handler when DISABLE_FEEDS is True

### DIFF
--- a/kitsune/forums/urls.py
+++ b/kitsune/forums/urls.py
@@ -7,6 +7,13 @@ from kitsune.forums.models import Post
 from kitsune.flagit import views as flagit_views
 
 
+if settings.DISABLE_FEEDS:
+    threads_feed_view = 'kitsune.sumo.views.handle404'
+    posts_feed_view = 'kitsune.sumo.views.handle404'
+else:
+    threads_feed_view = ThreadsFeed()
+    posts_feed_view = PostsFeed()
+
 # These patterns inherit (?P<forum_slug>\d+).
 forum_patterns = patterns(
     'kitsune.forums.views',
@@ -14,6 +21,8 @@ forum_patterns = patterns(
     url(r'^/new$', 'new_thread', name='forums.new_thread'),
     url(r'^/(?P<thread_id>\d+)$', 'posts', name='forums.posts'),
     url(r'^/(?P<thread_id>\d+)/reply$', 'reply', name='forums.reply'),
+    url(r'^/feed$', threads_feed_view, name="forums.threads.feed"),
+    url(r'^/(?P<thread_id>\d+)/feed$', posts_feed_view, name="forums.posts.feed"),
     url(r'^/(?P<thread_id>\d+)/lock$', 'lock_thread',
         name='forums.lock_thread'),
     url(r'^/(?P<thread_id>\d+)/sticky$', 'sticky_thread',
@@ -37,13 +46,6 @@ forum_patterns = patterns(
         {'content_type': ContentType.objects.get_for_model(Post).id},
         name='forums.flag_post'),
 )
-
-if not settings.DISABLE_FEEDS:
-    forum_patterns += patterns(
-        '',
-        url(r'^/feed$', ThreadsFeed(), name="forums.threads.feed"),
-        url(r'^/(?P<thread_id>\d+)/feed$', PostsFeed(), name="forums.posts.feed"),
-    )
 
 urlpatterns = patterns(
     'kitsune.forums.views',

--- a/kitsune/kbforums/urls.py
+++ b/kitsune/kbforums/urls.py
@@ -7,15 +7,25 @@ from kitsune.kbforums.models import Post
 from kitsune.flagit import views as flagit_views
 
 
+if settings.DISABLE_FEEDS:
+    threads_feed_view = 'kitsune.sumo.views.handle404'
+    posts_feed_view = 'kitsune.sumo.views.handle404'
+else:
+    threads_feed_view = ThreadsFeed()
+    posts_feed_view = PostsFeed()
+
 # These patterns inherit from /document/discuss
 urlpatterns = patterns(
     'kitsune.kbforums.views',
     url(r'^$', 'threads', name='wiki.discuss.threads'),
+    url(r'^/feed', threads_feed_view, name='wiki.discuss.threads.feed'),
     url(r'^/new', 'new_thread', name='wiki.discuss.new_thread'),
     url(r'^/watch', 'watch_forum', name='wiki.discuss.watch_forum'),
     url(r'^/post-preview-async$', 'post_preview_async',
         name='wiki.discuss.post_preview_async'),
     url(r'^/(?P<thread_id>\d+)$', 'posts', name='wiki.discuss.posts'),
+    url(r'^/(?P<thread_id>\d+)/feed$', posts_feed_view,
+        name='wiki.discuss.posts.feed'),
     url(r'^/(?P<thread_id>\d+)/watch$', 'watch_thread',
         name='wiki.discuss.watch_thread'),
     url(r'^/(?P<thread_id>\d+)/reply$', 'reply', name='wiki.discuss.reply'),
@@ -36,11 +46,3 @@ urlpatterns = patterns(
         {'content_type': ContentType.objects.get_for_model(Post).id},
         name='wiki.discuss.flag_post'),
 )
-
-if not settings.DISABLE_FEEDS:
-    urlpatterns += patterns(
-        '',
-        url(r'^/feed', ThreadsFeed(), name='wiki.discuss.threads.feed'),
-        url(r'^/(?P<thread_id>\d+)/feed$', PostsFeed(),
-            name='wiki.discuss.posts.feed'),
-    )

--- a/kitsune/questions/urls.py
+++ b/kitsune/questions/urls.py
@@ -8,6 +8,15 @@ from kitsune.questions.models import Question, Answer
 from kitsune.flagit import views as flagit_views
 
 
+if settings.DISABLE_FEEDS:
+    questions_feed_view = 'kitsune.sumo.views.handle404'
+    answers_feed_view = 'kitsune.sumo.views.handle404'
+    tagged_feed_view = 'kitsune.sumo.views.handle404'
+else:
+    questions_feed_view = QuestionsFeed()
+    answers_feed_view = AnswersFeed()
+    tagged_feed_view = TaggedQuestionsFeed()
+
 urlpatterns = patterns(
     'kitsune.questions.views',
     url(r'^$', 'product_list', name='questions.home'),
@@ -77,23 +86,16 @@ urlpatterns = patterns(
         name='questions.remove_tag_async'),
     url(r'^/(?P<question_id>\d+)/screen-share/$', 'screen_share',
         name='questions.screen_share'),
-)
 
-if not settings.DISABLE_FEEDS:
-    urlpatterns += patterns(
-        '',
-        # Feeds
-        # Note: this needs to be above questions.list because "feed"
-        # matches the product slug regex.
-        url(r'^/feed$', QuestionsFeed(), name='questions.feed'),
-        url(r'^/(?P<question_id>\d+)/feed$', AnswersFeed(),
-            name='questions.answers.feed'),
-        url(r'^/tagged/(?P<tag_slug>[\w\-]+)/feed$', TaggedQuestionsFeed(),
-            name='questions.tagged_feed'),
-    )
+    # Feeds
+    # Note: this needs to be above questions.list because "feed"
+    # matches the product slug regex.
+    url(r'^/feed$', questions_feed_view, name='questions.feed'),
+    url(r'^/(?P<question_id>\d+)/feed$', answers_feed_view,
+        name='questions.answers.feed'),
+    url(r'^/tagged/(?P<tag_slug>[\w\-]+)/feed$', tagged_feed_view,
+        name='questions.tagged_feed'),
 
-urlpatterns += patterns(
-    'kitsune.questions.views',
     # Mark as spam
     url(r'^/mark_spam$', 'mark_spam', name='questions.mark_spam'),
     url(r'^/unmark_spam$', 'unmark_spam', name='questions.unmark_spam'),


### PR DESCRIPTION
Previous change was throwing errors since the feed urls are looked up via reverse(), so when they didn't exist it was throwing NoReverseMatch.