### PR TITLE
rollup New Relic metrics for Oregon

### DIFF
--- a/k8s/regions/oregon-a/prod.yaml
+++ b/k8s/regions/oregon-a/prod.yaml
@@ -115,7 +115,7 @@ app:
     ga_profile_id: SECRET
     gtm_container_id: "UA-36116321-2"
     media_url: "https://prod-cdn.sumo.mozilla.net/"
-    new_relic_app_name: "sumo-prod-oregon-a"
+    new_relic_app_name: "sumo-prod-oregon-a;sumo-prod-oregon"
     new_relic_license_key: SECRET
     oidc_enable: True
     oidc_op_authorization_endpoint: SECRET

--- a/k8s/regions/oregon-a/stage.yaml
+++ b/k8s/regions/oregon-a/stage.yaml
@@ -113,7 +113,7 @@ app:
     ga_profile_id: SECRET
     gtm_container_id: "UA-36116321-2"
     media_url: "https://stage-cdn.sumo.mozilla.net/"
-    new_relic_app_name: "sumo-stage-oregon-a"
+    new_relic_app_name: "sumo-stage-oregon-a;sumo-stage-oregon"
     new_relic_license_key: SECRET
     oidc_enable: True
     oidc_op_authorization_endpoint: SECRET

--- a/k8s/regions/oregon-b/prod.yaml
+++ b/k8s/regions/oregon-b/prod.yaml
@@ -115,7 +115,7 @@ app:
     ga_profile_id: SECRET
     gtm_container_id: "UA-36116321-2"
     media_url: "https://prod-cdn.sumo.mozilla.net/"
-    new_relic_app_name: "sumo-prod-oregon-b"
+    new_relic_app_name: "sumo-prod-oregon-b;sumo-prod-oregon"
     new_relic_license_key: SECRET
     oidc_enable: True
     oidc_op_authorization_endpoint: SECRET

--- a/k8s/regions/oregon-b/stage.yaml
+++ b/k8s/regions/oregon-b/stage.yaml
@@ -113,7 +113,7 @@ app:
     ga_profile_id: SECRET
     gtm_container_id: "UA-36116321-2"
     media_url: "https://stage-cdn.sumo.mozilla.net/"
-    new_relic_app_name: "sumo-stage-oregon-b"
+    new_relic_app_name: "sumo-stage-oregon-b;sumo-stage-oregon"
     new_relic_license_key: SECRET
     oidc_enable: True
     oidc_op_authorization_endpoint: SECRET


### PR DESCRIPTION
rollup Oregon-A and Oregon-B metrics into additional New Relic applications: `sumo-prod-oregon` 
and `sumo-stage-oregon`.

https://github.com/mozmeao/infra/issues/837


See also: 
- https://docs.newrelic.com/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app
- https://github.com/mozmeao/infra/issues/526#issuecomment-332345756