### PR TITLE
[Bug 1444044]Changed the Welcome Community Message 

### DIFF
--- a/kitsune/users/templates/users/email/contributor.html
+++ b/kitsune/users/templates/users/email/contributor.html
@@ -48,6 +48,11 @@
         - Respond to tweets about Firefox.
       {% endtrans %}
     </li>
+    {% trans url=add_utm('https://support.mozilla.org/social-support-guidelines', 'get-involved', source='new-contributor') %}
+        <a href="{{ url }}">Social Support Contributor</a>
+        - Respond to tweets about Firefox as the Firefox Brand account.
+      {% endtrans %}
+    </li>
     <li>
       {% trans url=add_utm('https://support.mozilla.org/contributors/need-changes', 'get-involved', source='new-contributor') %}
         <a href="{{ url }}">KB Editor</a>
@@ -71,23 +76,12 @@
     {% endtrans %}
   </p>
 
-  <p>
-    {% trans %}
-      You can also apply to our Buddy Program and get guidance from our more
-      experienced contributors. Just introduce yourself in the forum for New
-      Contributors by starting a new thread. Put your name on the thread title and
-      tell us a bit about yourself:
-    {% endtrans %}
-    <br /><a href="http://mzl.la/1CGbET4">http://mzl.la/1CGbET4</a>
-  </p>
-
   <p>{{ _('Welcome to SUMO!') }}</p>
 
-  <p>Madalina</p>
+  <p>Michał and Rachel </p>
 
   <p>
-    mana@mozilla.com
-    <br />SUMO Community Manager
+    <br />SUMO Community Managers
   </p>
 {% endblock %}
 

--- a/kitsune/users/templates/users/email/contributor.ltxt
+++ b/kitsune/users/templates/users/email/contributor.ltxt
@@ -36,29 +36,10 @@ most-requested but have no replies:
 
 {# L10n: This is an email.  Whitespace matters! #}
 {% trans %}
-As you get started answering questions that look easy you
-might run into a few questions. Like, what happens when an
-angry user does not want a work around or what happens next?
-The Contributor Quality Training may have these answered. It
-is possible to get started here:
+Social Support Helper - Respond to tweets about Firefoxand as the Firefox brand account:
 {% endtrans %}
 
-http://goo.gl/pKis5g
-
-{# L10n: This is an email.  Whitespace matters! #}
-{% trans %}
-Twitter Contributor - Respond to tweets about Firefox:
-{% endtrans %}
-
-{{ add_utm('https://support.mozilla.org/army-of-awesome', 'get-involved', source='new-contributor') }}
-
-{# L10n: This is an email.  Whitespace matters! #}
-{% trans %}
-Social Support Contributor - Respond to tweets about Support Questions as the Firefox brand account:
-{% endtrans %}
-
-{{ add_utm('https://support.mozilla.org/social-support-guidelines', 'get-involved', source='new-contributor') }}
-
+{{ add_utm('https://support.mozilla.org/en-US/kb/social-support-guidelines', 'get-involved', source='new-contributor') }}
 
 {# L10n: This is an email.  Whitespace matters! #}
 {% trans %}
@@ -91,6 +72,14 @@ tell us a bit about yourself:
 {% endtrans %}
 
 http://mzl.la/1CGbET4
+
+{# L10n: This is an email.  Whitespace matters! #}
+{% trans %}
+Lastly, find others in the community just like you on the #sumo IRC channel. That is right Mozilla has a live chat channel for contributors.
+irc.mozilla.org #sumo - web-based IRC: 
+{% endtrans %}
+
+{{ add_utm('https://kiwiirc.com/client/irc.mozilla.org/sumo', 'get-involved', source='new-contributor') }}
 
 {# L10n: This is at the end of an email. #}
 {{ _('Welcome to SUMO!') }}

--- a/kitsune/users/templates/users/email/contributor.ltxt
+++ b/kitsune/users/templates/users/email/contributor.ltxt
@@ -54,6 +54,14 @@ Twitter Contributor - Respond to tweets about Firefox:
 
 {# L10n: This is an email.  Whitespace matters! #}
 {% trans %}
+Social Support Contributor - Respond to tweets about Support Questions as the Firefox brand account:
+{% endtrans %}
+
+{{ add_utm('https://support.mozilla.org/social-support-guidelines', 'get-involved', source='new-contributor') }}
+
+
+{# L10n: This is an email.  Whitespace matters! #}
+{% trans %}
 KB Editor - Help to update knowledge base articles that
 need changes or write new articles:
 {% endtrans %}
@@ -77,8 +85,7 @@ and we’ll help you get started. It’s great to have you onboard!
 
 {# L10n: This is an email.  Whitespace matters! #}
 {% trans %}
-You can also apply to our Buddy Program and get guidance from our more
-experienced contributors. Just introduce yourself in the forum for New
+Just introduce yourself in the forum for New
 Contributors by starting a new thread. Put your name on the thread title and
 tell us a bit about yourself:
 {% endtrans %}
@@ -88,6 +95,5 @@ http://mzl.la/1CGbET4
 {# L10n: This is at the end of an email. #}
 {{ _('Welcome to SUMO!') }}
 
-Madalina
-mana@mozilla.com
+Michał and Rachel 
 SUMO Community Manager{% endautoescape %}


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1444044#c7
It looked like it should be pretty easy to update the text with updated information for this message that is triggered when a user signs up as a contributor then makes their first contribution. 

+r