### PR TITLE
[Bug 1460649]: Display changes in translation review side by side

### DIFF
--- a/kitsune/sumo/static/sumo/less/wiki.less
+++ b/kitsune/sumo/static/sumo/less/wiki.less
@@ -695,6 +695,11 @@ textarea[name="content"] {
       }
     }
   }
+
+  .half-width {
+    display: inline-block;
+    width: 49%;
+  }
 }
 
 .html-rtl {
@@ -893,6 +898,12 @@ body.translate {
 
 
 body.review {
+  /* Override the review page to have fluid width */
+  .container_12 {
+    margin: 0 25px;
+    width: auto;
+  }
+
   #actions {
     margin: 20px 0;
   }
@@ -902,6 +913,10 @@ body.review {
       height: 250px;
       margin: 5px 0 0;
     }
+  }
+
+  #main-container > aside {
+    float: none;
   }
 }
 

--- a/kitsune/wiki/jinja2/wiki/review_translation.html
+++ b/kitsune/wiki/jinja2/wiki/review_translation.html
@@ -7,7 +7,7 @@
 {% set scripts = ('wiki', 'wiki.diff') %}
 
 {% block content %}
-  <div class="grid_9">
+  <div>
     <article id="review-revision">
       <h1>{{ _('Review Translation of {title}')|f(title=document.parent.title) }}</h1>
       <p>{{ _('Reviewing Translation {id} in {language} by {user}')|f(id=revision.id, user=revision.creator, language=settings.LANGUAGES_DICT[document.locale.lower()]) }}.
@@ -51,13 +51,13 @@
         {# If there is a parent revision to diff, and this translation is not already based on it. #}
         {% if parent_revision and document.current_revision.based_on and
               document.current_revision.based_on != parent_revision %}
-          <details class="h2" open="open">
+          <details class="h2 half-width" open="open">
             <summary>{{ _('Recent English Changes') }}</summary>
             {# Default locale diff #}
             {{ revision_diff(document.current_revision.based_on, parent_revision, show_picker=True) }}
           </details>
         {% endif %}
-        <details class="h2" open="open">
+        <details class="h2 half-width" open="open">
           <summary>{{ _('Submitted Translation Changes') }}</summary>
           {# Current locale diff #}
           {{ revision_diff(document.current_revision, revision, _('Current public translation:'), _('Submitted translation:')) }}


### PR DESCRIPTION
I have tried to set up Kitsune Docker as per the instruction in the README, but even after I somehow bent pip to install all dependencies despite complaining about some incompatible versions, I was unable to make application start. So I this patch is more reverse engineered and tested manually by editing the HTML and CSS generated by Less via DevTools. For that reason I also limited the changes only to the review_translation view and not any another.

@glogiotatidis r?

Note: all the HTML templates look messy to me, and many times duplicated. Is there some plan to change that (make better use of semantic HTML5 etc.)?