### PR TITLE
Add Help articles header above products on home page.

### DIFF
--- a/kitsune/landings/jinja2/landings/home.html
+++ b/kitsune/landings/jinja2/landings/home.html
@@ -8,6 +8,7 @@
     {{ search_box(settings, id='support-search-home', params=search_params) }}
   </div>
   <div class="grid_12">
+    <h2 class="help-articles-title">{{ _('Help articles') }}</h2>
     <section id="products-and-services">
       {{ product_cards(products) }}
     </section>

--- a/kitsune/sumo/static/sumo/less/home.less
+++ b/kitsune/sumo/static/sumo/less/home.less
@@ -31,3 +31,13 @@
     margin-top: 8px;
   }
 }
+
+.help-articles-title {
+  text-align: left;
+}
+
+.html-rtl {
+  .help-articles-title {
+    text-align: right;
+  }
+}


### PR DESCRIPTION
* Merged latest may-2018-redesign to resolve conflicts
* Add **Help articles** title above product cards on home page.

This will likely have some conflicts with this open PR #3243