### PR TITLE
Squash feeds response object prior to response

### DIFF
--- a/kitsune/forums/feeds.py
+++ b/kitsune/forums/feeds.py
@@ -1,4 +1,3 @@
-from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.html import strip_tags, escape
@@ -6,6 +5,7 @@ from django.utils.translation import ugettext as _
 
 from kitsune import forums as constants
 from kitsune.forums.models import Forum, Thread
+from kitsune.sumo.feeds import Feed
 
 
 class ThreadsFeed(Feed):

--- a/kitsune/kbforums/feeds.py
+++ b/kitsune/kbforums/feeds.py
@@ -1,4 +1,3 @@
-from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.html import strip_tags, escape
@@ -7,6 +6,7 @@ from django.utils.translation import ugettext as _
 from kitsune import forums as constants
 from kitsune.kbforums.models import Thread
 from kitsune.wiki.models import Document
+from kitsune.sumo.feeds import Feed
 
 
 class ThreadsFeed(Feed):

--- a/kitsune/questions/feeds.py
+++ b/kitsune/questions/feeds.py
@@ -1,4 +1,3 @@
-from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.html import strip_tags, escape
@@ -9,6 +8,7 @@ from taggit.models import Tag
 from kitsune.products.models import Product, Topic
 from kitsune.questions import config
 from kitsune.questions.models import Question
+from kitsune.sumo.feeds import Feed
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.sumo.templatetags.jinja_helpers import urlparams
 

--- a/kitsune/sumo/feeds.py
+++ b/kitsune/sumo/feeds.py
@@ -1,0 +1,17 @@
+from django.contrib.syndication.views import Feed as DjFeed
+
+
+class Feed(DjFeed):
+    """
+    For some reason when running via the Meinheld WSGI worker for Gunicorn, the async
+    nature of the response cycle doesn't properly handle responses that have more than
+    one item in the `Response._container` list. This class squashes that list before
+    returning the HttpResponse object.
+
+    See https://github.com/mozilla/kitsune/issues/3017
+    """
+    def __call__(self, request, *args, **kwargs):
+        response = super(Feed, self).__call__(request, *args, **kwargs)
+        # this squashes the response._container list to a single item
+        response.content = response.content
+        return response


### PR DESCRIPTION
Something about how Meinheld works doesn't like a Response object
that has been written to more than once. This should fix Feeds.

Fix #3017