### PR TITLE
[fix #3359] Use square product icons where appropriate.

### DIFF
--- a/kitsune/questions/jinja2/questions/product_list.html
+++ b/kitsune/questions/jinja2/questions/product_list.html
@@ -16,7 +16,7 @@
     {% for product in products %}
       <div class="product grid_5">
         <a class="cf" href="{{ url('questions.list', product.slug) }}">
-          <img src="{{ product.image_url }}" class="logo-sprite" alt="{{ pgettext('DB: products.Product.title', product.title) }}" />
+          <img src="{{ product.image_alternate_url }}" class="logo-sprite" alt="{{ pgettext('DB: products.Product.title', product.title) }}" />
           <div class="title-description-wrapper">
             <span class="title">{{ _('<strong>{product}</strong> Support Forum')|fe(product=pgettext('DB: products.Product.title', product.title)) }}</span>
             <span class="description">{{ pgettext('DB: products.Product.description', product.description) }}</span>

--- a/kitsune/sumo/static/sumo/less/mobile/includes/product-switcher.less
+++ b/kitsune/sumo/static/sumo/less/mobile/includes/product-switcher.less
@@ -26,17 +26,15 @@
           content: '';
           height: 48px;
           left: 50%;
-          margin-left: -35px;
+          margin-left: -24px;
           position: absolute;
           top: 10px;
-          width: 70px;
+          width: 48px;
         }
       }
 
       .logo {
-          background-position: center center;
-          background-repeat: no-repeat;
-          background-size: 70px auto;
+          background-size: 48px 48px;
       }
 
       &.selected {

--- a/kitsune/sumo/static/sumo/less/questions.less
+++ b/kitsune/sumo/static/sumo/less/questions.less
@@ -1196,9 +1196,7 @@ h2 {
 
       > img {
         float: left;
-        height: auto;
         margin: 8px 15px 8px 0;
-        width: 100px;
       }
 
       > span {
@@ -1216,7 +1214,7 @@ h2 {
 
         &.description {
           display: block;
-          margin: 0 0 0 115px;
+          margin: 0 0 0 99px;
         }
       }
     }

--- a/kitsune/sumo/templatetags/jinja_helpers.py
+++ b/kitsune/sumo/templatetags/jinja_helpers.py
@@ -499,14 +499,15 @@ def fe(format_string, *args, **kwargs):
 @library.global_function
 def image_for_product(product_slug):
     """
-    Return image for product slug
+    Return square/alternate image for product slug
     """
 
     try:
         obj = Product.objects.get(slug=product_slug)
     except Product.DoesNotExist:
-        return os.path.join(settings.STATIC_URL, 'products', 'img', 'product_placeholder.png')
-    return obj.image_url
+        return os.path.join(settings.STATIC_URL, 'products', 'img',
+                            'product_placeholder_alternate.png')
+    return obj.image_alternate_url
 
 
 @jinja2.contextfunction


### PR DESCRIPTION
Much of this PR is a reversion of #3331 (as we now again have square icons).