### PR TITLE
[fix #3347] Add UTM params to Fx download buttons.

### DIFF
--- a/kitsune/products/jinja2/products/documents.html
+++ b/kitsune/products/jinja2/products/documents.html
@@ -32,7 +32,7 @@
     <div class="firefox-download-button hidden">
       <div class="documents-download-buttons download-buttons">
         <div class="download-firefox">
-          <a href="https://www.mozilla.org/firefox/download/thanks/" class="download-button"
+          <a href="https://www.mozilla.org/firefox/download/thanks/?utm_source=support.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=non-fx-button&amp;utm_content=body-download-button" class="download-button"
             data-event-category="Download Button"
             data-event-action="Panel Opening"
             data-event-label="{{ latest_version }}">

--- a/kitsune/products/jinja2/products/product.html
+++ b/kitsune/products/jinja2/products/product.html
@@ -21,7 +21,7 @@
     <div class="firefox-download-button hidden">
       <div class="grid_12 download-buttons">
         <div class="download-firefox">
-          <a href="https://www.mozilla.org/firefox/download/thanks/" class="download-button"
+          <a href="https://www.mozilla.org/firefox/download/thanks/?utm_source=support.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=non-fx-button&amp;utm_content=body-download-button" class="download-button"
             data-event-category="Download Button"
             data-event-action="Panel Opening"
             data-event-label="{{ latest_version }}">

--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -189,7 +189,7 @@
       {% if show_header_fx_download() %}
         {# show-fx-download.js will remove the 'hidden' class below if the visitor is *NOT* using Firefox #}
         <li>
-          <a href="https://www.mozilla.org/firefox/download/thanks/" class="firefox-download-button hidden" data-event-category="Download Button" data-event-action="Firefox for Desktop">{{ _('Download Firefox') }}</a>
+          <a href="https://www.mozilla.org/firefox/download/thanks/?utm_source=support.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=non-fx-button&amp;utm_content=header-download-button" class="firefox-download-button hidden" data-event-category="Download Button" data-event-action="Firefox for Desktop">{{ _('Download Firefox') }}</a>
         </li>
       {% endif %}
       {% if not user.is_authenticated() %}

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -53,7 +53,7 @@
     <div class="firefox-download-button hidden">
       <div class="download-buttons">
         <div class="download-firefox">
-          <a href="https://www.mozilla.org/firefox/download/thanks/" class="download-button"
+          <a href="https://www.mozilla.org/firefox/download/thanks/?utm_source=support.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=non-fx-button&amp;utm_content=body-download-button" class="download-button"
             data-event-category="Download Button"
             data-event-action="Panel Opening"
             data-event-label="{{ latest_version }}">


### PR DESCRIPTION
For reference, here's the [original bugzilla comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1495841#c1). (Note the updated URLs in a [later comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1495841#c3).)