### PR TITLE
make # of replies the most important meta property

### DIFF
--- a/kitsune/questions/jinja2/questions/question_list.html
+++ b/kitsune/questions/jinja2/questions/question_list.html
@@ -128,10 +128,6 @@
           {% for question in questions.object_list %}
             <section id="question-{{ question.id }}" class="cf">
               <div class="question-meta {% if not question.num_answers %}urgent{% endif %}">
-                <div class="have-problem-this-week">
-                  <h4>{{ question.num_votes_past_week }}</h4>
-                  {{ _('votes this week') }}
-                </div>
                 <div class="replies">
                   <h4>{{ question.num_answers }}</h4>
                   {% trans count=question.num_answers %}
@@ -139,6 +135,10 @@
                     {% pluralize %}
                     replies
                   {% endtrans %}
+                </div>
+                <div class="have-problem-this-week">
+                  <h4>{{ question.num_votes_past_week }}</h4>
+                  {{ _('votes this week') }}
                 </div>
                 {% if question.num_visits %}
                   <div class="views">


### PR DESCRIPTION
when i browse the list of questions in the support forum as a contributor, the # of replies field is one of the most important factors to determine if i should go into a thread - if there are no replies the user should get an answer as soon as possible; if there are already many replies it's likely a thread with a long history so i'll leave it to those already involved if i don't want to read up on it.

i think it would be more logical in the new redesign to show the number of replies on the left and then have it followed by votes and views (both some measurements of popularity of a thread) - sample:

![grafik](https://user-images.githubusercontent.com/1524147/46972299-88115100-d0be-11e8-923f-178490249be4.png)
