### PR TITLE
Migrate from raven to sentry-sdk

### DIFF
--- a/kitsune/log_settings.py
+++ b/kitsune/log_settings.py
@@ -7,10 +7,6 @@ from django.utils.log import dictConfig
 config = {
     'version': 1,
     'disable_existing_loggers': True,
-    'root': {
-        'level': logging.ERROR,
-        'handlers': ['sentry'],
-    },
     'formatters': {
         'default': {
             'format': '{0}: %(asctime)s %(name)s:%(levelname)s %(message)s: '
@@ -26,10 +22,6 @@ config = {
         },
         'mail_admins': {
             'class': 'django.utils.log.AdminEmailHandler',
-            'level': logging.ERROR,
-        },
-        'sentry': {
-            'class': 'raven.contrib.django.handlers.SentryHandler',
             'level': logging.ERROR,
         },
         'console': {
@@ -53,16 +45,6 @@ config = {
             'handlers': ['console'],
             'propogate': True,
             'level': settings.LOG_LEVEL,
-        },
-        'raven': {
-            'level': logging.ERROR,
-            'handlers': ['console', 'mail_admins'],
-            'propagate': False,
-        },
-        'sentry.errors': {
-            'level': logging.ERROR,
-            'handlers': ['console', 'mail_admins'],
-            'propagate': False,
         },
     },
 }

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -668,9 +668,6 @@ INSTALLED_APPS = (
     'watchman',
     # 'axes',
 
-    # App for Sentry:
-    'raven.contrib.django',
-
     # Extra apps for testing.
     'django_nose',
 
@@ -1102,14 +1099,17 @@ STATSD_PORT = config('STATSD_PORT', 8125, cast=int)
 STATSD_PREFIX = config('STATSD_PREFIX', default='')
 
 
-RAVEN_CONFIG = {
-    'dsn': config('SENTRY_DSN', default=None),
-    'release': config('GIT_SHA', default=None),
-    'tags': {
-        'server_full_name': PLATFORM_NAME,
-        'environment': config('SENTRY_ENVIRONMENT', default=''),
-    }
-}
+if config('SENTRY_DSN', None):
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
+    sentry_sdk.init(
+        dsn=config('SENTRY_DSN'),
+        integrations=[DjangoIntegration()],
+        release=config('GIT_SHA', default=None),
+        server_name=PLATFORM_NAME,
+        environment=config('SENTRY_ENVIRONMENT', default=''),
+    )
 
 
 PIPELINE_ENABLED = config('PIPELINE_ENABLED', default=False, cast=bool)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -347,8 +347,6 @@ pytz==2013b \
     --hash=sha256:65eb49cc05b7917fddc61e1fe6d8a4512c295cb53891dd5ec816bcccdce3f1a5 \
     --hash=sha256:0797293d12ca2f7e5dd5bc0807f521f39d5b60a2c347c48f8362f9fd0174af3f \
     --hash=sha256:6c42f767873c44d69f6f0514c5f1f97394ab5d817e1e6116ad6d087ab5a17253
-https://github.com/getsentry/raven-python/archive/ab53d276262a0fa2932588b34de4e68ffe22d930.tar.gz#egg=raven==3.6.1 \
---hash=sha256:d09c69a4fd4604f2c29d1e2066d75eb742a3381c822c7075fa543549965274d5
 recaptcha-client==1.0.6 \
     --hash=sha256:28c6853c1d13d365b7dc71a6b05e5ffb56471f70a850de318af50d3d7c0dea2f
 requests==2.20.0 \
@@ -365,8 +363,8 @@ translate-toolkit==1.6.0 \
     --hash=sha256:02832f3b1b071efacb235b4590fd54c7ed0d8911de8d72f46b087d0c86b21350
 twython==3.2.0 \
     --hash=sha256:ab0dec52286677e944ddc00eaf6a0eb89af48b1a6696324ea29351342d1c483f
-urllib3==1.8 \
-    --hash=sha256:1a89fa1b43d277cfadf228cc90b9c75f254818ea3a1aab7bffb0223cbb7bb15d
+urllib3==1.24 \
+    --hash=sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59
 Werkzeug==0.5.1 \
     --hash=sha256:ff638b44eaca81c9a1c8c492b957c1b8d1b44b2147e50216355ff9c99daa8637
 https://github.com/eventbrite/zendesk/archive/1b256c3b827a8f3c6bbd3bd1fc09b7b0e2e82347.tar.gz#egg=zendesk \
@@ -482,3 +480,5 @@ chardet==3.0.2 \
 certifi==2017.4.17 \
     --hash=sha256:f4318671072f030a33c7ca6acaef720ddd50ff124d1388e50c1bda4cbd6d7010 \
     --hash=sha256:f7527ebf7461582ce95f7a9e03dd141ce810d40590834f4ec20cddd54234c10a
+sentry-sdk==0.5.1 \
+    --hash=sha256:c18552010648e6303b557310dc6e4babda3c942c6e4145995699547c64d3982f

--- a/wsgi/app.py
+++ b/wsgi/app.py
@@ -19,10 +19,6 @@ os.environ['CELERY_LOADER'] = 'django'
 
 application = get_wsgi_application()
 
-if config('SENTRY_DSN', None):
-    from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
-    application = Sentry(application)
-
 if config('ENABLE_WHITENOISE', default=False, cast=bool):
     from whitenoise.django import DjangoWhiteNoise
     application = DjangoWhiteNoise(application)


### PR DESCRIPTION
Fix #3393

- Removed raven / sentry config from `kitsune.log_settings`, since the logging info is now set up by default in the new package.
- `sentry-sdk` has `certifi` as a peer dependency, added that to specify hash. Also it required an upgrade of `urllib3`
- No separate WSGI configuration needed.

Confirmed working using `runserver` and `gunicorn`