### PR TITLE
return only lower cases strings in get_browser

### DIFF
--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -336,7 +336,7 @@ def get_browser(user_agent):
 
     match = re.search(r'(?i)(firefox|msie|chrome|safari|trident)', user_agent, re.IGNORECASE)
     if match:
-        browser = match.group(1)
+        browser = match.group(1).lower()
     else:
         browser = None
     return browser


### PR DESCRIPTION
I'm submitting this pull request to solve issue #3330 .

I understand that this function returns a string accordingly to match. If the string returned is not None, adding .lower() should suffice ([reference](https://docs.python.org/2/library/string.html)).

I'm not sure, though, if this works for all python versions. 