### PR TITLE
Integrating with simplesearch view and fix the tests

### DIFF
--- a/kitsune/questions/models.py
+++ b/kitsune/questions/models.py
@@ -574,7 +574,7 @@ class Question(ModelBase, BigVocabTaggableMixin, SearchMixin):
 
         return questions
 
-    @cached_property
+    @property
     def answer_values(self):
         return self.answers.filter(is_spam=False).values('content', 'creator__username')
 
@@ -1273,11 +1273,6 @@ def reindex_questions_answers(sender, instance, **kw):
     if instance.id:
         answer_ids = instance.answers.all().values_list('id', flat=True)
         index_task.delay(AnswerMetricsMappingType, list(answer_ids))
-
-post_save.connect(
-    reindex_questions_answers, sender=Question,
-    dispatch_uid='questions_reindex_answers')
-
 
 def user_pre_save(sender, instance, **kw):
     """When a user's username is changed, we must reindex the questions

--- a/kitsune/search/models.py
+++ b/kitsune/search/models.py
@@ -301,8 +301,6 @@ def generate_tasks(**kwargs):
     tasks.clear()
 
 
-signals.request_finished.connect(generate_tasks)
-
 
 class RecordManager(models.Manager):
     def outstanding(self):

--- a/kitsune/search/tasks.py
+++ b/kitsune/search/tasks.py
@@ -9,8 +9,8 @@ from django_elasticsearch_dsl.registries import registry
 from django_statsd.clients import statsd
 from multidb.pinning import pin_this_thread, unpin_this_thread
 
-from kitsune.search.es_utils import index_chunk, UnindexMeBro, write_index, get_analysis, \
-    es_analyzer_for_locale
+from kitsune.search.es_utils import (index_chunk, UnindexMeBro, write_index,
+                                     get_analysis, es_analyzer_for_locale)
 from kitsune.search.utils import from_class_path
 from kitsune.sumo.decorators import timeit
 

--- a/kitsune/search/tests/__init__.py
+++ b/kitsune/search/tests/__init__.py
@@ -1,11 +1,16 @@
+import re
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 import factory
+from django_elasticsearch_dsl.registries import registry
+from elasticsearch_dsl import IndexTemplate
+from elasticsearch_dsl.connections import get_connection
+from elasticsearch_dsl.query import MatchAll
 
 from kitsune.search.models import Synonym
 from kitsune.sumo.tests import TestCase
-
+from django.core.management import call_command
 
 # Dummy request for passing to question_searcher() and brethren.
 dummy_request = RequestFactory().get('/')
@@ -15,6 +20,35 @@ dummy_request = RequestFactory().get('/')
 class ElasticTestCase(TestCase):
     """Base class for Elastic Search tests, providing some conveniences"""
     search_tests = True
+
+
+class ElasticDSLTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(ElasticDSLTestCase, cls).setUpClass()
+        call_command('esindex')
+
+    def delete_all_documents(self):
+        # Use low level Elasticsearch API to delete all the documents
+        query = {
+            "query": {
+                "match_all": {}
+            }
+        }
+        connection = get_connection()
+        connection.delete_by_query(index='_all', body=query, conflicts='proceed')
+        connection.indices.clear_cache()
+
+    def setUp(self):
+        self.delete_all_documents()
+
+        super(ElasticDSLTestCase, self).setUp()
+
+    def tearDown(self):
+        self.delete_all_documents()
+
+        super(ElasticDSLTestCase, self).tearDown()
 
 
 class SynonymFactory(factory.DjangoModelFactory):

--- a/kitsune/search/tests/test_search_simple.py
+++ b/kitsune/search/tests/test_search_simple.py
@@ -9,13 +9,13 @@ from pyquery import PyQuery as pq
 from kitsune.forums.tests import PostFactory, ThreadFactory
 from kitsune.products.tests import ProductFactory
 from kitsune.questions.tests import QuestionFactory, AnswerFactory, AnswerVoteFactory
-from kitsune.search.tests.test_es import ElasticTestCase
+from kitsune.search.tests.test_es import ElasticDSLTestCase
 from kitsune.sumo.tests import LocalizingClient
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.wiki.tests import DocumentFactory, ApprovedRevisionFactory, RevisionFactory
 
 
-class SimpleSearchTests(ElasticTestCase):
+class SimpleSearchTests(ElasticDSLTestCase):
     client_class = LocalizingClient
 
     def test_content(self):
@@ -85,7 +85,6 @@ class SimpleSearchTests(ElasticTestCase):
             tags=u'desktop')
         ApprovedRevisionFactory(document=doc)
 
-        self.refresh()
 
         response = self.client.get(reverse('search'), {
             'q': 'audio',
@@ -101,7 +100,6 @@ class SimpleSearchTests(ElasticTestCase):
         a = AnswerFactory(question=q)
         AnswerVoteFactory(answer=a, helpful=True)
 
-        self.refresh()
 
         response = self.client.get(reverse('search'), {'q': 'audio'})
         eq_(200, response.status_code)
@@ -116,8 +114,6 @@ class SimpleSearchTests(ElasticTestCase):
         RevisionFactory(document=doc, is_approved=True)
         doc = DocumentFactory(title=u'audio2', locale=u'en-US', category=10, products=[firefox])
         RevisionFactory(document=doc, is_approved=True)
-
-        self.refresh()
 
         # Verify there are no real results but 2 fallback results are rendered
         response = self.client.get(reverse('search'), {'q': 'piranha'})
@@ -152,8 +148,6 @@ class SimpleSearchTests(ElasticTestCase):
         ans = AnswerFactory(question=ques, content=u'volume')
         AnswerVoteFactory(answer=ans, helpful=True)
 
-        self.refresh()
-
         qs = {'q': 'audio', 'page': 81}
         response = self.client.get(reverse('search'), qs)
         eq_(200, response.status_code)
@@ -172,8 +166,6 @@ class SimpleSearchTests(ElasticTestCase):
         ques = QuestionFactory(title=u'audio', product=p)
         ans = AnswerFactory(question=ques, content=u'volume')
         AnswerVoteFactory(answer=ans, helpful=True)
-
-        self.refresh()
 
         # This is the search that you get when you start on the sumo
         # homepage and do a search from the box with two differences:
@@ -210,8 +202,6 @@ class SimpleSearchTests(ElasticTestCase):
         doc.products.add(ProductFactory(title=u'firefox', slug=u'desktop'))
         RevisionFactory(document=doc, is_approved=True)
 
-        self.refresh()
-
         # This is the search that you get when you start on the sumo
         # homepage and do a search from the box with two differences:
         # first, we do it in json since it's easier to deal with
@@ -247,8 +237,6 @@ class SimpleSearchTests(ElasticTestCase):
         thread1 = ThreadFactory(title=u'audio')
         PostFactory(thread=thread1)
 
-        self.refresh()
-
         response = self.client.get(reverse('search'), {
             'q': 'audio', 'format': 'json'})
 
@@ -263,8 +251,6 @@ class SimpleSearchTests(ElasticTestCase):
         ques.save()
         doc.is_archived = True
         doc.save()
-
-        self.refresh()
 
         response = self.client.get(reverse('search'), {
             'q': 'audio', 'format': 'json'})
@@ -286,7 +272,6 @@ class SimpleSearchTests(ElasticTestCase):
         doc.products.add(mobile)
         RevisionFactory(document=doc, is_approved=True)
 
-        self.refresh()
 
         # There should be 2 results for desktop and 1 for mobile.
         response = self.client.get(reverse('search'), {
@@ -312,8 +297,6 @@ class SimpleSearchTests(ElasticTestCase):
 
         doc = DocumentFactory(title=u'audio too', locale=u'en-US', category=10, products=[desktop])
         RevisionFactory(document=doc, is_approved=True)
-
-        self.refresh()
 
         # There should be 2 results for kb (w=1) and 1 for questions (w=2).
         response = self.client.get(reverse('search'), {

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -775,6 +775,8 @@ ELASTICSEARCH_DSL = {
         },
 }
 ES_TASK_CHUNK_SIZE = 100
+ELASTICSEARCH_DSL_INDEX_SETTINGS = {"number_of_replicas": 0,
+                                    "number_of_shards": 1}
 
 # Indexes for indexing--set this to ES_INDEXES if you want to read to
 # and write to the same index.


### PR DESCRIPTION
This will integrate `SimpleSearch` (implemented in #3417) with the `simple_search` view. All the tests of `simple_search` view seems to be passing! 💯 
Maybe we have progress one step towards upgrading to Elasticsearch 6.x! 😄 
@pmac what do you think?