### PR TITLE
Scale up frankfurt failover deployment

### DIFF
--- a/k8s/regions/frankfurt/prod-web-hpa.yaml
+++ b/k8s/regions/frankfurt/prod-web-hpa.yaml
@@ -8,6 +8,6 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: sumo-prod-web
-  minReplicas: 5
-  maxReplicas: 15
+  minReplicas: 25
+  maxReplicas: 50
   targetCPUUtilizationPercentage: 80

--- a/k8s/regions/frankfurt/prod.yaml
+++ b/k8s/regions/frankfurt/prod.yaml
@@ -34,7 +34,7 @@ kubernetes:
         web:
             command: "./bin/run-prod.sh"
             deployment_name: "sumo-prod-web"
-            replicas: 5
+            replicas: 25
             labels:
                 type: "web"
             liveness:


### PR DESCRIPTION
This change has already been applied manually in response to an outage this weekend where the failover cluster was unable to handle the initial load and then couldn't autoscale up to meet it. This is to make the change permanent