### PR TITLE
Update wiki.less

### DIFF
--- a/kitsune/sumo/static/sumo/less/wiki.less
+++ b/kitsune/sumo/static/sumo/less/wiki.less
@@ -254,28 +254,25 @@ article {
     .help-title-prefix {
       color: #000;
       float: left;
-      font-size: 24px;
-      padding-left: 5px;
+      font-size: 16px;
     }
 
     .help-title {
       color: #000;
-      float: left;
-      font-size: 24px;
-      padding-left: 15px;
+      font-size: 16px;
+      padding-left: 10px;
       width: 32%;
     }
 
     .contributors {
-      float: right;
-      padding-left: 40px;
+      padding-left: 10px;
       width: 54%;
     }
 
     .help-link {
       color: #000;
       float: right;
-      padding-top: 10px;
+      padding-top: 50px;
     }
 
     a.user, a.user:visited, a.user:hover {


### PR DESCRIPTION
![screenshot 298](https://user-images.githubusercontent.com/19530635/50792262-59d09580-12ea-11e9-8058-c5cae4d4002e.png)

Solved issue* Please make the "These fine people helped write this article" smaller #3433* which occurs at the end on searching an issue on support.mozilla.org where the contributors to the article are given.
Changed its font size of it and aligned it.