### PR TITLE
[fix #3436] Auto detect Firefox Lite on mobile AAQ start page.

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -519,14 +519,19 @@ def aaq(request, product_key=None, category_key=None, showform=False,
     if product_key is None:
         product_key = request.GET.get('product')
         if request.MOBILE and product_key is None:
+            ua = request.META.get('HTTP_USER_AGENT', '').lower()
+
             # Firefox OS is weird. The best way we can detect it is to
             # look for a mobile Firefox that is not Android.
-            ua = request.META.get('HTTP_USER_AGENT', '').lower()
             if 'firefox' in ua and 'android' not in ua:
                 product_key = 'firefox-os'
+            # 'Rocket' is currently in the UA, but may be replaced with 'Lite' later on
+            elif any(s in ua for s in ['rocket', 'lite']):
+                product_key = 'firefox-lite'
             elif 'fxios' in ua:
                 product_key = 'ios'
             else:
+                # android
                 product_key = 'mobile'
 
     product_config = config.products.get(product_key)

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -525,8 +525,9 @@ def aaq(request, product_key=None, category_key=None, showform=False,
             # look for a mobile Firefox that is not Android.
             if 'firefox' in ua and 'android' not in ua:
                 product_key = 'firefox-os'
-            # 'Rocket' is currently in the UA, but may be replaced with 'Lite' later on
-            elif any(s in ua for s in ['rocket', 'lite']):
+            # 'Rocket' is currently in the UA and is expected to remain
+            # https://github.com/mozilla-tw/FirefoxLite/issues/3004#issuecomment-455245375
+            elif 'rocket' in ua:
                 product_key = 'firefox-lite'
             elif 'fxios' in ua:
                 product_key = 'ios'


### PR DESCRIPTION
I _think_ this will do the trick, but should test on dev first.

UA string for Lite Nightly (Night Litely?) provided in #rocket: 

`Mozilla/5.0 (Linux; Android 8.0.0; moto e5 Build/OPP27.91-176; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/1.0.9(9399).nightly Chrome/71.0.3578.99 Mobile Safari/537.36`