### PR TITLE
Revert "Disable sentry in prod due to issues caused by increased IO"

### DIFF
--- a/k8s/regions/frankfurt/prod.yaml
+++ b/k8s/regions/frankfurt/prod.yaml
@@ -118,6 +118,7 @@ app:
     redis_default_url: SECRET
     redis_helpfulvotes_url: SECRET
     secret_key: SECRET
+    sentry_dsn: SECRET
     session_cookie_secure: True
     stage: False
     static_url: "/static/"

--- a/k8s/regions/oregon-a/prod.yaml
+++ b/k8s/regions/oregon-a/prod.yaml
@@ -125,6 +125,7 @@ app:
     redis_helpfulvotes_url: SECRET
     run_migrate: "true"
     secret_key: SECRET
+    sentry_dsn: SECRET
     session_cookie_secure: True
     stage: False
     static_url: "https://static-media-prod-cdn.sumo.mozilla.net/static/"

--- a/k8s/regions/oregon-b/prod.yaml
+++ b/k8s/regions/oregon-b/prod.yaml
@@ -124,6 +124,7 @@ app:
     redis_default_url: SECRET
     redis_helpfulvotes_url: SECRET
     secret_key: SECRET
+    sentry_dsn: SECRET
     session_cookie_secure: True
     stage: False
     static_url: "https://static-media-prod-cdn.sumo.mozilla.net/static/"


### PR DESCRIPTION
Reverts mozilla/kitsune#3497