### PR TITLE
Remove user registration from AAQ flow (#3541)

### DIFF
--- a/kitsune/questions/jinja2/questions/includes/aaq_macros.html
+++ b/kitsune/questions/jinja2/questions/includes/aaq_macros.html
@@ -1,16 +1,17 @@
-{% from "users/includes/macros.html" import login_form, register_form with context %}
-
 {% macro aaq_progress(step=0) -%}
-  {% set percent = step * 20 %}
-  {% set steps = (_('Pick a product'), _('Pick a topic and try some solutions'),
-                  _('Register or Sign In'), _('Fill in details'),
-                  _('Confirm registration'), _('DONE')) %}
+  {% set percent = step * 33.3 %}
+  {% set steps = (
+      _('Pick a product'),
+      _('Pick a topic and try some solutions'),
+      _('Fill in details')
+    )
+  %}
   <div id="aaq_progress" class="cf">
     <div class="progress-bar{% if percent == 100 %} complete{% endif %}">
       <div style="width: {{ percent }}%;"></div>
       <ul class="legend">
         {% for step_name in steps %}
-          <li {% if steps.index(step_name) == step %}class="current"{% endif %}>{{ step_name }}</li>
+          <li {% if steps.index(step_name) == step %}class="current"{% endif %}><span>{{ step_name }}</span></li>
         {% endfor %}
       </ul>
     </div>
@@ -134,34 +135,6 @@
     <input type="hidden" name="step" value="{% if user.is_authenticated() %}aaq-question{% else %}aaq-register{% endif %}" />
     <input type="submit" id="show-form-btn" class="btn" value="{{ button_text }}" />
   </form>
-{%- endmacro %}
-
-{% macro register_login_forms(register, login) -%}
-  {{ aaq_progress(step=2) }}
-  <div id="register-form" class="grid_12 alpha omega">
-    <h2>{{ _('Almost there! We just need you to create a support forum account!') }}</h2>
-    <h4>{{ _('Having an account on the support forums lets us notify you when you get a response on your question') }}</h4>
-    {{ register_form(register, action='', aaq=True) }}
-  </div>
-
-  <h3 id="show-login"><a href="#login-form">{{ _('I already have an account') }}</a></h3>
-  <div id="login-form" class="grid_12 alpha omega">
-    <h2>{{ _('Log in to an existing account') }}</h2>
-    {{ login_form(login, action='', only_pwreset=True) }}
-  </div>
-{%- endmacro %}
-
-{% macro mobile_register_forms(register) -%}
-  <h2>{{ _('To post your question, please create a support account') }}</h2>
-  <p>
-    {{ _('A support account lets us alert you when people respond to your question.') }}
-    <span class="btn btn-login" data-overlay="login-overlay">{{ _('Already have an account? Sign in') }}</span>
-  </p>
-  <div id="register-form" class="grid_6 alpha">
-    <h2>{{ _('Create a support account') }}</h2>
-    {{ register_form(register, action='') }}
-    <span class="btn btn-login" data-overlay="login-overlay">{{ _('Already have an account? Sign in') }}</span>
-  </div>
 {%- endmacro %}
 
 {% macro marketplace_category(category_slug, form, error_message) -%}

--- a/kitsune/questions/tests/test_views.py
+++ b/kitsune/questions/tests/test_views.py
@@ -27,7 +27,9 @@ from kitsune.users.tests import UserFactory, add_permission
 from kitsune.wiki.tests import DocumentFactory, RevisionFactory
 
 
-class AAQTests(ElasticTestCase):
+# Note:
+# Tests using the ElasticTestCase are not being run bc of this line: `-a '!search_tests'`
+class AAQSearchTests(ElasticTestCase):
     client_class = LocalizingClient
 
     def test_bleaching(self):
@@ -232,12 +234,6 @@ class MobileAAQTests(MobileTestCase):
             return self.client.post(url, self.data, follow=True)
         return self.client.get(url, follow=True)
 
-    def test_logged_out(self):
-        """New question is posted through mobile."""
-        response = self._new_question()
-        eq_(200, response.status_code)
-        assert template_used(response, 'questions/mobile/new_question_login.html')
-
     @mock.patch.object(Site.objects, 'get_current')
     def test_logged_in_get(self, get_current):
         """New question is posted through mobile."""
@@ -262,43 +258,48 @@ class MobileAAQTests(MobileTestCase):
         eq_(200, response.status_code)
         assert Question.objects.filter(title='A test question')
 
-    @mock.patch.object(Site.objects, 'get_current')
-    def test_aaq_new_question_inactive(self, get_current):
-        """New question is posted through mobile."""
-        get_current.return_value.domain = 'testserver'
 
-        # Log in first.
-        u = UserFactory()
-        self.client.login(username=u.username, password='testpass')
-
-        # Then become inactive.
-        u.is_active = False
-        u.save()
-
-        # Set 'in-aaq' for the session. It isn't already set because this
-        # test doesn't do a GET of the form first.
-        s = self.client.session
-        s['in-aaq'] = True
-        s.save()
-
-        response = self._new_question(post_it=True)
-        eq_(200, response.status_code)
-        assert template_used(response, 'questions/mobile/confirm_email.html')
-
-    def test_aaq_login_form(self):
-        """The AAQ authentication forms contain the identifying fields.
-
-        Added this test because it is hard to debug what happened when this
-        fields somehow go missing.
+class AAQTests(TestCaseBase):
+    def test_non_authenticated_user(self):
         """
-        res = self._new_question()
-        doc = pq(res.content)
-        eq_(1, len(doc('#login-form input[name=login]')))
-        eq_(1, len(doc('#register-form input[name=register]')))
+        A non-authenticated user cannot access the AAQ flow and will be redirected to auth screen
+        """
+        url = reverse('questions.aaq_step1')
+        response = self.client.get(url, follow=True)
+        assert template_used(response, 'users/auth.html')
+
+    def test_inactive_user(self):
+        """
+        An inactive user cannot access the AAQ flow
+        """
+        user = UserFactory(is_superuser=False)
+        self.client.login(username=user.username, password='testpass')
+
+        # After log in, set user to inactive
+        user.is_active = False
+        user.save()
+
+        url = reverse('questions.aaq_step1')
+        response = self.client.get(url, follow=True)
+        assert not template_used(response, 'questions/new_question.html')
+
+    def test_authenticated_user(self):
+        """
+        An active, authenticated user can access the AAQ flow
+        """
+        user = UserFactory(is_superuser=False)
+        self.client.login(username=user.username, password='testpass')
+        url = reverse('questions.aaq_step1')
+        response = self.client.get(url, follow=True)
+        assert not template_used(response, 'users/auth.html')
+        assert template_used(response, 'questions/new_question.html')
 
 
 @set_waffle_flag('new_aaq')
 class ReactAAQTests(TestCaseBase):
+    def setUp(self):
+        u = UserFactory(is_superuser=False)
+        self.client.login(username=u.username, password='testpass')
 
     def test_waffle_flag(self):
         url = reverse('questions.aaq_step1')

--- a/kitsune/questions/urls.py
+++ b/kitsune/questions/urls.py
@@ -29,7 +29,6 @@ urlpatterns = [
 
     # AAQ
     url(r'^/new$', views.aaq, name='questions.aaq_step1'),
-    url(r'^/new/confirm$', views.aaq_confirm, name='questions.aaq_confirm'),
     url(r'^/new/(?P<product_key>[\w\-]+)$',
         views.aaq_step2, name='questions.aaq_step2'),
     url(r'^/new/(?P<product_key>[\w\-]+)/(?P<category_key>[\w\-]+)$',

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -5,7 +5,6 @@ import time
 from datetime import date, datetime, timedelta
 
 from django.conf import settings
-from django.contrib import auth
 from django.contrib import messages
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.contenttypes.models import ContentType
@@ -61,7 +60,6 @@ from kitsune.upload.views import upload_imageattachment
 from kitsune.users.forms import RegisterForm
 from kitsune.users.templatetags.jinja_helpers import display_name
 from kitsune.users.models import Setting
-from kitsune.users.utils import handle_login, handle_register
 from kitsune.wiki.facets import documents_for, topics_for
 from kitsune.wiki.models import Document, DocumentMappingType
 
@@ -484,6 +482,7 @@ def aaq_react(request):
 
 
 @ssl_required
+@login_required
 @mobile_template('questions/{mobile/}new_question.html')
 def aaq(request, product_key=None, category_key=None, showform=False,
         template=None, step=0):
@@ -645,53 +644,6 @@ def aaq(request, product_key=None, category_key=None, showform=False,
             'deadend': deadend,
             'host': Site.objects.get_current().domain})
 
-    # Handle the form post.
-    if not request.user.is_authenticated():
-        if request.POST.get('login'):
-            login_form = handle_login(request, only_active=False)
-            statsd.incr('questions.user.login')
-            register_form = RegisterForm()
-
-            if login_form.is_valid():
-                statsd.incr('questions.user.login.success')
-            else:
-                statsd.incr('questions.user.login.fail')
-
-        elif request.POST.get('register'):
-            login_form = AuthenticationForm()
-            register_form = handle_register(
-                request=request,
-                text_template='users/email/activate.ltxt',
-                html_template='users/email/activate.html',
-                subject=_('Please confirm your Firefox Help question'),
-                email_data=request.GET.get('search'),
-                reg='aaq')
-
-            if register_form.is_valid():  # Now try to log in.
-                user = auth.authenticate(
-                    username=request.POST.get('username'),
-                    password=request.POST.get('password'))
-                auth.login(request, user)
-                statsd.incr('questions.user.register')
-        else:
-            # L10n: This shouldn't happen unless people tamper with POST data.
-            message = _lazy('Request type not recognized.')
-            return render(request, 'handlers/400.html', {'message': message}, status=400)
-
-        if request.user.is_authenticated():
-            # Redirect to GET the current URL replacing the step parameter.
-            # This is also required for the csrf middleware to set the auth'd
-            # tokens appropriately.
-            url = urlparams(request.get_full_path(), step='aaq-question')
-            return HttpResponseRedirect(url)
-        else:
-            return render(request, login_t, {
-                'product': product_config,
-                'category': category_config,
-                'title': request.POST.get('title'),
-                'register_form': register_form,
-                'login_form': login_form})
-
     form = NewQuestionForm(product=product_config, category=category_config, data=request.POST)
 
     # NOJS: upload image
@@ -743,18 +695,15 @@ def aaq(request, product_key=None, category_key=None, showform=False,
         # Submitting the question counts as a vote
         question_vote(request, question.id)
 
-        if request.user.is_active:
-            messages.add_message(
-                request, messages.SUCCESS,
-                _('Done! Your question is now posted on the Mozilla community support forum.'))
+        messages.add_message(
+            request, messages.SUCCESS,
+            _('Done! Your question is now posted on the Mozilla community support forum.'))
 
-            # Done with AAQ.
-            request.session['in-aaq'] = False
+        # Done with AAQ.
+        request.session['in-aaq'] = False
 
-            url = reverse('questions.details', kwargs={'question_id': question.id})
-            return HttpResponseRedirect(url)
-
-        return HttpResponseRedirect(reverse('questions.aaq_confirm'))
+        url = reverse('questions.details', kwargs={'question_id': question.id})
+        return HttpResponseRedirect(url)
 
     if getattr(request, 'limited', False):
         raise PermissionDenied
@@ -798,24 +747,7 @@ def aaq_step4(request, product_key, category_key):
 def aaq_step5(request, product_key, category_key):
     """Step 5: Show full question form."""
     return aaq(request, product_key=product_key, category_key=category_key,
-               showform=True, step=3)
-
-
-def aaq_confirm(request):
-    """AAQ confirm email step for new users."""
-    if request.user.is_authenticated():
-        email = request.user.email
-        auth.logout(request)
-        statsd.incr('questions.user.logout')
-    else:
-        email = None
-
-    # Done with AAQ.
-    request.session['in-aaq'] = False
-
-    confirm_t = ('questions/mobile/confirm_email.html' if request.MOBILE
-                 else 'questions/confirm_email.html')
-    return render(request, confirm_t, {'email': email})
+               showform=True, step=2)
 
 
 @require_http_methods(['GET', 'POST'])

--- a/kitsune/sumo/static/sumo/less/questions.less
+++ b/kitsune/sumo/static/sumo/less/questions.less
@@ -1010,25 +1010,30 @@ h2 {
   margin: 0 78px;
 
   .legend {
+    display: flex;
     color: @textGrey;
     font-size: 12px;
     font-weight: normal;
     line-height: 16px;
     list-style: none;
-    margin: 5px -78px;
+    margin: 5px 0;
     padding: 0;
     position: relative;
     z-index: 0;
 
     li {
-      float: left;
-      margin: 0 10px;
+      width: 33.3%;
+      margin: 0;
       position: relative;
-      text-align: center;
-      width: 136px;
+      text-align: left;
 
       &.current {
         font-weight: bold;
+      }
+
+      span {
+        display: block;
+        max-width: 140px;
       }
 
       &:before {
@@ -1036,8 +1041,7 @@ h2 {
         border-right: 1px solid rgba(255, 255, 255, 0.5);
         content: '';
         height: 24px;
-        left: 50%;
-        margin-left: -1px;
+        left: 0;
         position: absolute;
         top: -34px;
         width: 0;
@@ -1058,7 +1062,6 @@ h2 {
     > div {
       height: 8px;
       min-width: 12px;
-      padding-right: 12px;
     }
 
     .legend {


### PR DESCRIPTION
- Remove user login and registration in the AAQ flow
- Add `login_required` to the AAQ view

@akatsoulas  I have made comments on particular lines just to draw your attention to a few things.