### PR TITLE
Pass PIPELINE_COLLECTOR_ENABLED env var to Pipeline config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and follow the following steps.
    git clone https://github.com/mozilla/kitsune.git
    ```
 
-2. Pull base Kitsune Docker images, create your database, and install node and bower packages.
+2. Pull base Kitsune Docker images, run `collectstatic`, create your database, and install node and bower packages.
    ```
    make init
    ```
@@ -54,6 +54,14 @@ and act much more like developing without Docker as you may be used to. You shou
 instead of `make shell` as the latter does not bind port 8000 which you need to be able to load the site.
 
 Run `make help` to see other helpful commands.
+
+### Compiling LESS files
+
+By default, the `.less` files do not compile in local development because it impacts load times on OSX. If you are working on `.less` files, you can enable compilation with the following environment variable:
+
+  ```
+  echo "PIPELINE_COLLECTOR_ENABLED=True" >> .env
+  ```
 
 ### The Admin
 

--- a/bin/run-bootstrap.sh
+++ b/bin/run-bootstrap.sh
@@ -8,5 +8,7 @@ yarn
 ./node_modules/.bin/bower install --allow-root
 # ensure the DB server is ready
 urlwait
+# run collectstatic
+python manage.py collectstatic
 # run DB migrations
 python manage.py migrate

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -767,6 +767,11 @@ PIPELINE = {
 
     'BROWSERIFY_BINARY': path('node_modules/.bin/browserify'),
     'BROWSERIFY_ARGUMENTS': '-t babelify -t debowerify',
+    'PIPELINE_COLLECTOR_ENABLED': config(
+        'PIPELINE_COLLECTOR_ENABLED',
+        default=not DEBUG,
+        cast=bool,
+    ),
 }
 
 if DEBUG:


### PR DESCRIPTION
On each page refresh, `collectstatic` is run. This makes development extremely slow on OSX due to the way OSX handles shared file systems. For me, each page refresh takes between 10s-20s:

<img width="1219" alt="questions" src="https://user-images.githubusercontent.com/1489696/57036164-7db14180-6c21-11e9-899d-072928c10d94.png">

We can prevent `collectstatic` from being run on every page refresh by passing `PIPELINE_COLLECTOR_ENABLED` to the Pipeline configuration. If that env var is not present, it defaults to `True` which keeps the behaviour consistent with the current dev.

After disabling `PIPELINE_COLLECTOR_ENABLED`, the same page takes 1s instead of 20s:

<img width="1229" alt="question_after" src="https://user-images.githubusercontent.com/1489696/57036282-d7b20700-6c21-11e9-918c-185f4ef3f2d8.png">
