### PR TITLE
Fix management commands using argparse

### DIFF
--- a/kitsune/search/management/commands/esreindex.py
+++ b/kitsune/search/management/commands/esreindex.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
             '--seconds-ago', type=int, dest='seconds_ago', default=0,
             help='Reindex things updated N seconds ago')
         parser.add_argument(
-            '--mapping_types', type=str, dest='mapping_types',
+            '--mapping_types', dest='mapping_types',
             default=None,
             help='Comma-separated list of mapping types to index')
         parser.add_argument(

--- a/kitsune/search/management/commands/essearch.py
+++ b/kitsune/search/management/commands/essearch.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--pages', type='int', dest='pages', default=1,
+            '--pages', type=int, dest='pages', default=1,
             help='Number of pages of results you want to see')
 
     def handle(self, *args, **options):


### PR DESCRIPTION
Part of the Django update moved to argparse for management commands. Argparse doesn't take a string for the `type` argument, it has to be a callable.