### PR TITLE
Import NR agent first in wsgi/app.py

### DIFF
--- a/wsgi/app.py
+++ b/wsgi/app.py
@@ -6,6 +6,15 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 """
+# newrelic import & initialization must come first
+# https://docs.newrelic.com/docs/agents/python-agent/installation/python-agent-advanced-integration#manual-integration
+try:
+    import newrelic.agent
+except ImportError:
+    newrelic = False
+else:
+    newrelic.agent.initialize('newrelic.ini')
+
 import os
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'kitsune.settings')  # NOQA
 
@@ -24,9 +33,7 @@ if config('ENABLE_WHITENOISE', default=False, cast=bool):
     application = DjangoWhiteNoise(application)
 
 # Add NewRelic
-newrelic_ini = config('NEW_RELIC_CONFIG_FILE', default='newrelic.ini')
-newrelic_license_key = config('NEW_RELIC_LICENSE_KEY', default=None)
-if newrelic_ini and newrelic_license_key:
-    import newrelic.agent
-    newrelic.agent.initialize(newrelic_ini)
-    application = newrelic.agent.wsgi_application()(application)
+if newrelic:
+    newrelic_license_key = config('NEW_RELIC_LICENSE_KEY', default=None)
+    if newrelic_license_key:
+        application = newrelic.agent.wsgi_application()(application)


### PR DESCRIPTION
This is a port of some [recent changes](https://github.com/mozilla/bedrock/commits/master/wsgi/app.py) to [app/wsgi.py in bedrock](https://github.com/mozilla/bedrock/blob/master/wsgi/app.py) to address similar issues in NR with uninstrumented code due to import order. See https://docs.newrelic.com/docs/agents/python-agent/installation/python-agent-advanced-integration#manual-integration for more details.