### PR TITLE
Disable Django URL warnings about trailing slashes

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -1080,6 +1080,7 @@ ACTSTREAM_SETTINGS = {
 SILENCED_SYSTEM_CHECKS = [
     'fields.W340',  # null has no effect on ManyToManyField.
     'fields.W342',  # ForeignKey(unique=True) is usually better served by a OneToOneField
+    'urls.W002',  # Disable warning about slashes before URLs
 ]
 
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='', cast=Csv())


### PR DESCRIPTION
When the development server starts, there are 150+ warnings from Django about our URL patterns. 
<img width="1314" alt="before" src="https://user-images.githubusercontent.com/1489696/57882267-49c54700-77f1-11e9-8827-04b457b3a4e3.png">

For instance, we get a warning on `/users/watches`:

```
?: (urls.W002) Your URL pattern '^/watches$' [name='users.edit_watch_list'] has a regex beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
```

This is because there is a prepending slash on `watches`:
```
url(r'^users', include(users_patterns)),
url(r'^/watches$', views.edit_watch_list, name='users.edit_watch_list'),
```

Django would prefer that there be a trailing slash on `users` instead:
```
url(r'^users/', include(users_patterns)),
url(r'^watches$', views.edit_watch_list, name='users.edit_watch_list'),
```

However, the way URLs in this repo are configured is not wrong; Django is reporting a false positive. [See this Stack Overflow answer](https://stackoverflow.com/a/41450355/1264156). With that in mind, we can disable the warnings:

<img width="1314" alt="after" src="https://user-images.githubusercontent.com/1489696/57882336-74170480-77f1-11e9-933d-29d05a8b6aa2.png">


If we would prefer _not_ to disable the warning, we can set `APPEND_SLASH = False` in our settings file. From the [docs](https://docs.djangoproject.com/en/2.2/ref/settings/#append-slash):

> When set to True, if the request URL does not match any of the patterns in the URLconf and it doesn’t end in a slash, an HTTP redirect is issued to the same URL with a slash appended. Note that the redirect may cause any data submitted in a POST request to be lost.

Locally, adding `APPEND_SLASH = False` did not cause tests to fail. That said, I don't know this project well enough to introduce this sort of change.