### PR TITLE
Use FXA displayName as SUMO name if name is unavailable #3598

### DIFF
--- a/kitsune/users/auth.py
+++ b/kitsune/users/auth.py
@@ -123,6 +123,7 @@ class FXAAuthBackend(OIDCAuthenticationBackend):
                                       is_fxa_migrated=True,
                                       fxa_uid=claims.get('uid'),
                                       avatar=claims.get('avatar', ''),
+                                      name=claims.get('displayName', ''),
                                       locale=claims.get('locale', ''))
 
         # This is a new sumo profile, redirect to the edit profile page
@@ -193,6 +194,9 @@ class FXAAuthBackend(OIDCAuthenticationBackend):
         if not profile.avatar:
             # Best effort to get an avatar from FxA
             profile.avatar = claims.get('avatar', '')
+
+        if not profile.name:
+            profile.name = claims.get('displayName', '')
 
         profile.save()
         return user

--- a/kitsune/users/tests/test_auth.py
+++ b/kitsune/users/tests/test_auth.py
@@ -28,7 +28,8 @@ class FXAAuthBackendTests(TestCase):
             'email': 'bar@example.com',
             'uid': 'my_unique_fxa_id',
             'avatar': 'http://example.com/avatar',
-            'locale': 'en-US'
+            'locale': 'en-US',
+            'displayName': 'Crazy Joe Davola',
         }
 
         request_mock = Mock(spec=HttpRequest)
@@ -45,6 +46,7 @@ class FXAAuthBackendTests(TestCase):
         eq_(users[0].profile.fxa_uid, 'my_unique_fxa_id')
         eq_(users[0].profile.avatar, 'http://example.com/avatar')
         eq_(users[0].profile.locale, 'en-US')
+        eq_(users[0].profile.name, 'Crazy Joe Davola')
         eq_(0, users[0].groups.count())
         message_mock.info.assert_called_with(request_mock, 'fxa_notification_created')
 
@@ -191,7 +193,8 @@ class FXAAuthBackendTests(TestCase):
         verify_token_mock.return_value = True
 
         user = UserFactory.create(email='sumo@example.com',
-                                  profile__avatar='sumo_avatar')
+                                  profile__avatar='sumo_avatar',
+                                  profile__name='Kenny Bania')
         auth_request = RequestFactory().get('/foo', {'code': 'foo',
                                                      'state': 'bar'})
         auth_request.session = {}
@@ -202,7 +205,8 @@ class FXAAuthBackendTests(TestCase):
             'email': 'fxa@example.com',
             'uid': 'my_unique_fxa_id',
             'avatar': 'http://example.com/avatar',
-            'locale': 'en-US'
+            'locale': 'en-US',
+            'displayName': 'FXA Display name',
         }
         requests_mock.get.return_value = get_json_mock
 
@@ -218,6 +222,7 @@ class FXAAuthBackendTests(TestCase):
         eq_(user.profile.fxa_uid, 'my_unique_fxa_id')
         eq_(user.email, 'fxa@example.com')
         eq_(user.profile.avatar, 'sumo_avatar')
+        eq_(user.profile.name, 'Kenny Bania')
         message_mock.info.assert_called_with(
             auth_request,
             'fxa_notification_updated'


### PR DESCRIPTION
@akatsoulas Here is a PR for part of https://github.com/mozilla/kitsune/issues/3598. We probably want to discuss our approach for FXA avatars, which probably warrants its own ticket. So for #3598, I'm populating the `profile.name` with the `fxa.displayName` if available