### PR TITLE
landing page revisions, ref #3774. grid exception, ref #3775

### DIFF
--- a/kitsune/landings/jinja2/landings/get-involved.html
+++ b/kitsune/landings/jinja2/landings/get-involved.html
@@ -8,6 +8,7 @@
 {% block content %}
   <div class="grid_12">
     <div class="hero-bar cf">
+      <img class="hero-butler" src="{{ STATIC_URL }}sumo/img/gi-hero-butler.png" alt="">
       <h1>{{ _('Save the world') }}</h1>
       <h2>{{ _('from the comfort of your couch') }}</h2>
       <div class="column">
@@ -25,7 +26,6 @@
           you can do it from the comfort of your couch!
         {% endtrans %}
       </div>
-      <img class="hero-butler" src="{{ STATIC_URL }}sumo/img/gi-hero-butler.png" alt="">
     </div>
   </div>
 

--- a/kitsune/sumo/static/sumo/less/landings/get-involved.less
+++ b/kitsune/sumo/static/sumo/less/landings/get-involved.less
@@ -56,8 +56,11 @@ h4 {
 }
 
 .content-box {
-  padding-bottom: 20px;
-  padding-top: 20px;
+  padding: 30px 20px 0 0;
+
+  h3 {
+    font-size: 26px;
+  }
 }
 
 .get-involved-icon {
@@ -113,22 +116,41 @@ h4 {
   }
 }
 
+@media screen and (max-width: 969px) {
+  .moz-heroes {
+    margin: 10px 0 0 -10px;
+    max-width: 100%;
+  }
+}
+
 .hero-bar {
   background: none no-repeat right center #fff;
-  padding: 30px;
+  padding: 0;
   margin: 0 0 30px 0;
   position: relative;
 
   .column {
-    float: left;
-    margin: 0 30px 30px 0;
-    width: 210px;
+    margin-bottom: 20px;
   }
 
-  .hero-butler {
-    bottom: -20px;
-    position: absolute;
-    right: -30px;
+  @media screen and (min-width: 970px) {
+    padding: 60px 0 30px;
+
+    .column {
+      float: left;
+      margin: 0 30px 30px 0;
+      width: 210px;
+    }
+  }
+
+
+
+  @media screen and (min-width: 960px) {
+    .hero-butler {
+      bottom: -20px;
+      position: absolute;
+      right: -30px;
+    }
   }
 
   &.secondary {

--- a/kitsune/sumo/static/sumo/less/main.less
+++ b/kitsune/sumo/static/sumo/less/main.less
@@ -1825,16 +1825,24 @@ input[type="submit"]{
     }
   }
 
-  @media screen and (min-width: 970px) {
+  @media screen and (min-width: 600px) {
     &.card-grid {
       margin-left: -12px;
       margin-right: -12px;
 
       > li {
         margin: 0 12px 28px;
-        width: 30%;
-        width: ~"calc(33% - 26px)";
+        width: 40%;
+        width: ~"calc(50% - 30px)";
       }
+    }
+  }
+
+
+  @media screen and (min-width: 970px) {
+    &.card-grid > li {
+      width: 30%;
+      width: ~"calc(33% - 26px)";
     }
   }
 


### PR DESCRIPTION
I just made a revision to the grid on the front page so that on tablet sizes, it's two-wide. I also made some design revisions to the get-involved page so that the images don't overlap. 

<img width="836" alt="Screen Shot 2019-07-01 at 9 23 18 AM" src="https://user-images.githubusercontent.com/202590/60440427-cd40c900-9be2-11e9-9166-2446b9d5e7de.png">

<img width="481" alt="Screen Shot 2019-07-01 at 9 31 13 AM" src="https://user-images.githubusercontent.com/202590/60440538-04af7580-9be3-11e9-8612-3c7ef0da2eb7.png">
