### PR TITLE
avatar size fixes

### DIFF
--- a/kitsune/sumo/static/sumo/less/main.less
+++ b/kitsune/sumo/static/sumo/less/main.less
@@ -653,8 +653,17 @@ form .submit {
 
   .avatar-preview {
     width: 100%;
-    margin-bottom: 10px;
+    display: block;
+    max-width: 400px;
+    margin: 0 auto;
+
+    @media screen and (min-width: 440px) {
+      max-width: 120px;
+      margin: 0;
+    }
   }
+
+
 
   .remove-avatar {
     margin-left: auto;

--- a/kitsune/sumo/static/sumo/less/main.less
+++ b/kitsune/sumo/static/sumo/less/main.less
@@ -655,11 +655,11 @@ form .submit {
     width: 100%;
     display: block;
     max-width: 400px;
-    margin: 0 auto;
+    margin: 0 auto 10px;
 
     @media screen and (min-width: 440px) {
       max-width: 120px;
-      margin: 0;
+      margin: 0 0 10px;
     }
   }
 


### PR DESCRIPTION
At anything bigger than 440px wide, the desktop size is used for avatars. ref #3789

<img width="461" alt="Screen Shot 2019-07-02 at 9 34 06 AM" src="https://user-images.githubusercontent.com/202590/60517004-e4e48400-9cac-11e9-80f5-8a85197f6247.png">

<img width="831" alt="Screen Shot 2019-07-02 at 9 33 24 AM" src="https://user-images.githubusercontent.com/202590/60517014-e746de00-9cac-11e9-8ae9-cb41ebec68ff.png">

