### PR TITLE
fix reply textarea size, mozilla/kitsune#3812

### DIFF
--- a/kitsune/sumo/static/sumo/less/forums.less
+++ b/kitsune/sumo/static/sumo/less/forums.less
@@ -226,11 +226,13 @@
   #thread-reply {
     background: #fff;
     margin-left: 130px;
-    padding: 30px;
+    padding: 0;
 
     textarea {
       margin-top: 10px;
-      width: 510px;
+      width: 100%;
+      height: 400px;
+      font-size: 16px;
     }
 
     .editor-tools {


### PR DESCRIPTION
<img width="858" alt="Screen Shot 2019-07-10 at 3 29 27 PM" src="https://user-images.githubusercontent.com/202590/60998734-8b70fa80-a327-11e9-97de-1059c4db9d2e.png">
