### PR TITLE
Try filtering only pods in the running state for executing post-deploy

### DIFF
--- a/k8s/commander.sh
+++ b/k8s/commander.sh
@@ -52,7 +52,8 @@ function post-deploy {
 
     # run post-deployment tasks
     echo "Running post-deployment tasks"
-    SUMO_POD=$(${KUBECTL_BIN} -n "${K8S_NAMESPACE}" get pods -o=jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | egrep 'sumo-.*-web' | head -1)
+    # Get the name of a running web pod on which we can run the post-deploy script
+    SUMO_POD=$(${KUBECTL_BIN} -n "${K8S_NAMESPACE}" get pods | egrep 'sumo-.*-web' | grep Running | head -1 | awk '{ print $1 }'
     ${KUBECTL_BIN} -n "${K8S_NAMESPACE}" exec "${SUMO_POD}" bin/run-post-deploy.sh
 }
 


### PR DESCRIPTION
The last change to commander.sh sometimes ends up running the post-deploy.sh script on a terminating node and so fails.  Filter out only running nodes for this.