### PR TITLE
Add setup to automatically connect search v2 operations to ES7 cluster.

### DIFF
--- a/kitsune/search/config.py
+++ b/kitsune/search/config.py
@@ -50,3 +50,5 @@ ES_SNOWBALL_LOCALES = {
     'sv': 'Swedish',
     'tr': 'Turkish',
 }
+
+DEFAULT_ES7_CONNECTION = 'es7_default'

--- a/kitsune/search/v2/documents.py
+++ b/kitsune/search/v2/documents.py
@@ -1,10 +1,14 @@
 from django.utils import timezone
 
-from elasticsearch_dsl import field, Document as DSLDocument
+from elasticsearch_dsl import connections, field, Document as DSLDocument
 
 from kitsune.search import config
+from kitsune.search.v2.es7_utils import es7_client
 from kitsune.search.v2.fields import WikiLocaleText
 from kitsune.wiki.config import REDIRECT_HTML
+
+
+connections.add_connection(config.DEFAULT_ES7_CONNECTION, es7_client())
 
 
 class WikiDocument(DSLDocument):
@@ -32,6 +36,7 @@ class WikiDocument(DSLDocument):
 
     class Index:
         name = config.WIKI_DOCUMENT_INDEX_NAME
+        using = config.DEFAULT_ES7_CONNECTION
 
     def prepare_url(self, instance):
         return instance.get_absolute_url()

--- a/kitsune/search/v2/es7_utils.py
+++ b/kitsune/search/v2/es7_utils.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from elasticsearch_dsl import token_filter, analyzer
 
 from kitsune.search import config
+from kitsune.search.v2 import elasticsearch7
 
 
 def _get_locale_specific_analyzer(locale):
@@ -43,3 +44,8 @@ def es_analyzer_for_locale(locale):
     # No specific analyzer found for the locale
     # So use the standard analyzer as default
     return analyzer('default_sumo', tokenizer='standard', filter=['lowercase'])
+
+
+def es7_client():
+    """Return an ES7 Elasticsearch client"""
+    return elasticsearch7.Elasticsearch(settings.ES7_URLS)

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -825,6 +825,10 @@ SESSION_SERIALIZER = config('SESSION_SERIALIZER', default='django.contrib.sessio
 #
 # Connection information for Elastic
 ES_URLS = [config('ES_URLS', default="localhost:9200")]
+
+# Connection information for Elastic 7
+ES7_URLS = config('ES7_URLS', cast=Csv(), default="elasticsearch7:9200")
+
 # Indexes for reading
 ES_INDEXES = {
     'default': config('ES_INDEXES_DEFAULT', default='default'),


### PR DESCRIPTION
* Add config entry for ES7 cluster
* Add helper to create an ES7 client instance
* Add default ES7 connection for elasticsearch-dsl documents