### PR TITLE
Add Locale Code column and Date Filter to WikiMetric Admin

### DIFF
--- a/kitsune/dashboards/admin.py
+++ b/kitsune/dashboards/admin.py
@@ -4,8 +4,17 @@ from kitsune.dashboards.models import WikiMetric
 
 
 class WikiMetricAdmin(admin.ModelAdmin):
-    list_display = ['code', 'date', 'locale', 'product', 'value']
+    list_display = [
+        'code', 'date', 'locale',
+        'locale_code', 'product', 'value'
+    ]
     list_filter = ['code', 'product', 'locale']
+    date_hierarchy = 'date'
+
+    def locale_code(self, obj):
+        return obj.locale
+
+    locale_code.short_description = "Locale Code"
 
 
 admin.site.register(WikiMetric, WikiMetricAdmin)


### PR DESCRIPTION
ref: https://github.com/mozilla/kitsune/issues/3464

Added `Locale Code` column to `list_display` and Date filter to `WikiMetricAdmin`.