### PR TITLE
Ll fix js search tests

### DIFF
--- a/kitsune/sumo/static/sumo/js/instant_search.js
+++ b/kitsune/sumo/static/sumo/js/instant_search.js
@@ -1,6 +1,6 @@
 /* globals k:false, jQuery:false, trackEvent:false */
-const detailsInitModule = require('./protocol-details-init');
-const tabsInitModule = require('./sumo-tabs');
+// const detailsInitModule = require('./protocol-details-init');
+// const tabsInitModule = require('./sumo-tabs');
 
 (function($) {
   var searchTimeout;
@@ -52,8 +52,8 @@ const tabsInitModule = require('./sumo-tabs');
 
     $searchContent.html(k.nunjucksEnv.render('search-results.html', context));
 
-    detailsInitModule.detailsInit(); // fold up sidebar on mobile.
-    tabsInitModule.tabsInit();
+    // detailsInit(); // fold up sidebar on mobile.
+    // tabsInit();
     // remove and append search results heading
     $(".home-search-section--content .search-results-heading").remove();
     $(".search-results-heading").appendTo(".home-search-section--content");

--- a/kitsune/sumo/static/sumo/js/instant_search.js
+++ b/kitsune/sumo/static/sumo/js/instant_search.js
@@ -1,6 +1,4 @@
 /* globals k:false, jQuery:false, trackEvent:false */
-// const detailsInitModule = require('./protocol-details-init');
-// const tabsInitModule = require('./sumo-tabs');
 
 (function($) {
   var searchTimeout;
@@ -52,9 +50,10 @@
 
     $searchContent.html(k.nunjucksEnv.render('search-results.html', context));
 
-    // TODO: These functions are necessary to search to match the required functionality.
-    // detailsInit(); // fold up sidebar on mobile.
-    // tabsInit();
+    // These two functions are coming from the global scope, but should be proper
+    // modules when we replace django-compressor with a FE build process.
+    detailsInit(); // fold up sidebar on mobile.
+    tabsInit();
 
     // remove and append search results heading
     $(".home-search-section--content .search-results-heading").remove();

--- a/kitsune/sumo/static/sumo/js/instant_search.js
+++ b/kitsune/sumo/static/sumo/js/instant_search.js
@@ -52,8 +52,10 @@
 
     $searchContent.html(k.nunjucksEnv.render('search-results.html', context));
 
+    // TODO: These functions are necessary to search to match the required functionality.
     // detailsInit(); // fold up sidebar on mobile.
     // tabsInit();
+
     // remove and append search results heading
     $(".home-search-section--content .search-results-heading").remove();
     $(".search-results-heading").appendTo(".home-search-section--content");

--- a/kitsune/sumo/static/sumo/js/protocol-details-init.js
+++ b/kitsune/sumo/static/sumo/js/protocol-details-init.js
@@ -25,8 +25,9 @@ function detailsInit() {
   });
 };
 
-// module.exports = {
-//   detailsInit
-// };
+if (typeof module != 'undefined' && module.exports) {
+  module.exports.detailsInit = detailsInit;
+}
+
 
 detailsInit();

--- a/kitsune/sumo/static/sumo/js/protocol-details-init.js
+++ b/kitsune/sumo/static/sumo/js/protocol-details-init.js
@@ -25,8 +25,8 @@ function detailsInit() {
   });
 };
 
-module.exports = {
-  detailsInit
-};
+// module.exports = {
+//   detailsInit
+// };
 
 detailsInit();

--- a/kitsune/sumo/static/sumo/js/sumo-tabs.js
+++ b/kitsune/sumo/static/sumo/js/sumo-tabs.js
@@ -85,7 +85,7 @@ function tabsInit() {
   }
 }
 
-module.exports = {
-  tabsInit
-};
+// module.exports = {
+//   tabsInit
+// };
 tabsInit();

--- a/kitsune/sumo/static/sumo/js/sumo-tabs.js
+++ b/kitsune/sumo/static/sumo/js/sumo-tabs.js
@@ -85,7 +85,9 @@ function tabsInit() {
   }
 }
 
-// module.exports = {
-//   tabsInit
-// };
+if (typeof module != 'undefined' && module.exports) {
+  module.exports.tabsInit = tabsInit;
+}
+
+
 tabsInit();

--- a/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
@@ -36,15 +36,20 @@ describe('instant search', () => {
           addListener: () => {}
         }
       }
+
+      // These functions are pulled from the global scope. They're not
+      // actually tested below, but are required to get the rest of the
+      // tests to pass. This should be revisited when we have a frontend
+      // build process in place.
+      global.tabsInit = require('../sumo-tabs.js').tabsInit;
+      global.detailsInit = require('../protocol-details-init.js').detailsInit;
+
+
       global.matchMedia = window.matchMedia;
       window.Mzp = {};
 
       rerequire('../i18n.js');
       global.interpolate = global.window.interpolate;
-      // rerequire('../../../../../../node_modules/@mozilla-protocol/core/protocol/js/protocol-base.js');
-      // rerequire('../../../../../../node_modules/@mozilla-protocol/core/protocol/js/protocol-details.js');
-      // rerequire('../protocol-details-init.js');
-      // rerequire('../sumo-tabs.js');
       rerequire('../search_utils.js');
       rerequire('../instant_search.js');
 

--- a/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
@@ -37,6 +37,9 @@ describe('instant search', () => {
         }
       }
 
+      global.matchMedia = window.matchMedia;
+      window.Mzp = {};
+
       // These functions are pulled from the global scope. They're not
       // actually tested below, but are required to get the rest of the
       // tests to pass. This should be revisited when we have a frontend
@@ -44,9 +47,6 @@ describe('instant search', () => {
       global.tabsInit = require('../sumo-tabs.js').tabsInit;
       global.detailsInit = require('../protocol-details-init.js').detailsInit;
 
-
-      global.matchMedia = window.matchMedia;
-      window.Mzp = {};
 
       rerequire('../i18n.js');
       global.interpolate = global.window.interpolate;

--- a/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
@@ -41,6 +41,10 @@ describe('instant search', () => {
 
       rerequire('../i18n.js');
       global.interpolate = global.window.interpolate;
+      // rerequire('../../../../../../node_modules/@mozilla-protocol/core/protocol/js/protocol-base.js');
+      // rerequire('../../../../../../node_modules/@mozilla-protocol/core/protocol/js/protocol-details.js');
+      // rerequire('../protocol-details-init.js');
+      // rerequire('../sumo-tabs.js');
       rerequire('../search_utils.js');
       rerequire('../instant_search.js');
 

--- a/kitsune/sumo/static/sumo/tpl/search-results-list.html
+++ b/kitsune/sumo/static/sumo/tpl/search-results-list.html
@@ -3,8 +3,8 @@
 {% if num_results > 0 %}
   <h2 class="text-display-xs search-results-heading">
     {# L10n: {n} is the number of search results, {q} is the search query, {product} is the product. #}
-    {{ ngettext('Found %(n)s result for <span>‘%(q)s’</span> for <span>‘%(product)s’</span>',
-                'Found %(n)s results for <span>‘%(q)s’</span> for <span>‘%(product)s’</span>',
+    {{ ngettext('Found %(n)s result for ‘<span>%(q)s</span>’ for ‘<span>%(product)s</span>’',
+                'Found %(n)s results for ‘<span>%(q)s</span>’ for ‘<span>%(product)s</span>’',
                 num_results)
        | f({n: num_results, q: q, product: product_titles}, true)
        | safe }}
@@ -37,7 +37,7 @@
 {% else %}
   <h2 class="text-display-xs search-results-heading">
     {# L10n: {q} is the search query, {l} is the language searched. #}
-    {{ _("We couldn't find any results for ‘%(q)s’ in ‘%(l)s’. Maybe one of these articles will be helpful?")
+    {{ _("We couldn't find any results for ‘<span>%(q)s</span>’ in ‘<span>%(l)s</span>’. Maybe one of these articles will be helpful?")
         | f({q: q, l: lang_name}, true)
         | safe }}
   </h2>


### PR DESCRIPTION
Tests are passing in this branch, and search is back to the previous functionality. As in, it works, but without the couple of new javascript plugins that are required from protocol. This will at least let us deploy code and test on tickets that don't apply to the react-based instant search. 