### PR TITLE
prevent None timezone in session

### DIFF
--- a/kitsune/sumo/templatetags/jinja_helpers.py
+++ b/kitsune/sumo/templatetags/jinja_helpers.py
@@ -266,7 +266,7 @@ def datetimeformat(context, value, format="shortdatetime"):
                     pass
             request.session["timezone"] = convert_tzinfo
         else:
-            convert_tzinfo = request.session["timezone"]
+            convert_tzinfo = request.session["timezone"] or default_tzinfo
 
     convert_value = new_value.astimezone(convert_tzinfo)
     locale = _babel_locale(_contextual_locale(context))

--- a/kitsune/users/views.py
+++ b/kitsune/users/views.py
@@ -469,9 +469,10 @@ def edit_profile(request, username=None):
         if form.is_valid():
             user_profile = form.save()
             new_timezone = user_profile.timezone
-            tz_changed = request.session.get('timezone', None) != new_timezone
-            if tz_changed and user == request.user:
-                request.session['timezone'] = new_timezone
+            if new_timezone:
+                tz_changed = request.session.get('timezone', None) != new_timezone
+                if tz_changed and user == request.user:
+                    request.session['timezone'] = new_timezone
             return HttpResponseRedirect(reverse('users.profile',
                                                 args=[user.username]))
     else:  # request.method == 'GET'


### PR DESCRIPTION
This prevents the `astimezone() argument 1 must be datetime.tzinfo, not None` exception in two ways:

First, if `session['timezone']` is already `None`, default to the server timezone when converting the value.

Then, never allow a user in future to set their `session['timezone']` value to None by only updating the value in session if the user has set a timezone.

Before these changes the exception could be triggered on a fresh profile by:

1. Create a new profile, with a None timezone.
2. Set the profile's timezone to a value.
3. Through the user's preferences, set the profile's timezone back to None (appears as `-------` in the dropdown).
4. Visit the forum page, see the exception.

This commit should probably be cherry picked on top of master, because this is an issue in prod, and doesn't seem to affect/be affected by the responsive redesign.