### PR TITLE
still render show_for logged out users

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
+++ b/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
@@ -4,13 +4,15 @@
   {% if not parent %}
     {% set parent = document %}
   {% endif %}
-  {% if user.is_authenticated() %}
   <nav id="doc-tools">
     <ul class="sidebar-nav sidebar-folding">
       <li id="editing-tools-sidebar">
-        <h3 class="sidebar-subheading large-only">{{ _('Editing Tools') }}</h3>
+        {% if user.is_authenticated() %}
+          <h3 class="sidebar-subheading large-only">{{ _('Editing Tools') }}</h3>
+        {% endif %}
         <span class="details-heading"></span>
         <ul class="sidebar-nav--list">
+        {% if user.is_authenticated() %}
           {% if document %}
             <li {{ active|class_selected('article') }}>
               <a href="{{ url('wiki.document', document.slug) }}">{{ _('Article') }}</a>
@@ -54,19 +56,19 @@
               <a href="{{ url('wiki.document_revisions', document.slug) }}">{{ _('Show History') }}</a>
             </li>
           {% endif %}
-          {% if include_showfor %}
-            <li>
-              {{ show_for((document or parent).get_products(), header=False) }}
-            </li>
-          {% endif %}
             <li>
               <div class="email">{{ document_watch(document, user) }}</div>
             </li>
+        {% endif %}
+        {% if include_showfor %}
+          <li>
+            {{ show_for((document or parent).get_products(), header=False) }}
+          </li>
+        {% endif %}
         </ul>
       </li>
     </ul>
   </nav>
-  {% endif %}
 {%- endmacro %}
 
 {% macro document_notifications(document, user) -%}


### PR DESCRIPTION
This is a rough fix for https://github.com/mozilla/sumo-project/issues/307#issuecomment-605893728

@kkellydesign I'm not too familiar with the sidebar behaviour, so you might want to neaten this up a little bit.

For instance, we have duplicated headings on mobile:

![Screen Shot 2020-03-30 at 13 54 33](https://user-images.githubusercontent.com/755354/77914561-04392d80-728e-11ea-85d5-d22ab62ebea9.png)