### PR TITLE
footer text typo fixes

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -331,9 +331,14 @@
       </div>
       <div class="mzp-c-footer-legal-col">
         <p>
-          {{ _('Mozilla Corporation’s not-for-profit parent, the Mozilla Foundation.') }}
+          {% trans %}
+          Visit <a href="https://www.mozilla.org" rel="external noopener" data-link-type="footer" data-link-name="Mozilla Corporation">Mozilla Corporation’s</a> not-for-profit parent, the <a href="https://foundation.mozilla.org" rel="external noopener" data-link-type="footer" data-link-name="Mozilla Foundation">Mozilla Foundation</a>.
+          {% endtrans %}
         </p>
-        <p>{{ _('Portions of this content are c.1998–2019 by individual mozilla.org contributors. Content availbe under a Creative Common license.') }}
+        <p>
+          {% trans %}
+          Portions of this content are ©1998–2020 by individual mozilla.org contributors. Content available under a <a rrel="external noopener" href="https://www.mozilla.org/foundation/licensing/website-content/">Creative Commons license</a>.
+          {% endtrans %}
         </p>
       </div>
     </nav>


### PR DESCRIPTION
This was not a filed bug, but there were a couple of typos in the footer. I've made them match the text exactly from mozilla.org, and changed the links to point to the correct spots on that site. There were no links before, and a couple of typos. 

@akatsoulas please check that my `{% trans %}` tags are how you'd structure them. And @madasan, please check that the text is ok. 