### PR TITLE
only lazyload images in kb preview

### DIFF
--- a/kitsune/sumo/static/sumo/js/ajaxpreview.js
+++ b/kitsune/sumo/static/sumo/js/ajaxpreview.js
@@ -68,7 +68,9 @@
 
       $(self).bind('show-preview', function(e, success, html) {
         $preview.html(html);
-        $preview.find('img.lazy').lazyload();
+        if ($.fn.lazyload) {
+          $preview.find('img.lazy').lazyload();
+        }
         if (changeHash) {
           document.location.hash = $preview.attr('id');
         }


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/346#issuecomment-614591678

without this fix previewing outside the kb (e.g. in a forum post reply) causes an error﻿
