### PR TITLE
fix view diff button on recent revisions page

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/recent_revisions_fragment.html
+++ b/kitsune/wiki/jinja2/wiki/includes/recent_revisions_fragment.html
@@ -13,11 +13,11 @@
         {% set diff_url = url('wiki.compare_revisions', rev.document.slug) %}
         {% set diff_url = diff_url|urlparams(from=prev_rev.id, to=rev.id, locale=rev.document.locale) %}
         <a class="show-diff" href="{{ diff_url }}">
-          <img class="icon-search" src="{{ STATIC_URL }}sumo/img/blank.png" alt="{{ _('View Diff') }}" />
+          <img src="{{ STATIC_URL }}protocol/img/icons/search.svg" alt="{{ _('View Diff') }}" />
         </a>
         <img class="loading" src="{{ STATIC_URL }}sumo/img/wait-trans.gif" alt="" />
         <a class="close-diff" href="">
-          <img class="icon-back" src="{{ STATIC_URL }}sumo/img/blank.png" alt="{{ _('Close Diff') }}" />
+          <img src="{{ STATIC_URL }}protocol/img/icons/close.svg" alt="{{ _('Close Diff') }}" />
         </a>
       {% endif %}
     </div>


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/395﻿

![Screenshot_2020-04-23 Recent Revisions Mozilla Support - 127 0 0 1](https://user-images.githubusercontent.com/755354/80091616-54d43b80-8559-11ea-8e2f-8c871fb763d4.png)
