### PR TITLE
position download firefox button better on kb topics+articles

### DIFF
--- a/kitsune/products/jinja2/products/documents.html
+++ b/kitsune/products/jinja2/products/documents.html
@@ -33,6 +33,9 @@
           <div class="documents-product-title">
             {% set prod_url = url('products.product', slug=product.slug) %}
             <a href="{{ prod_url }}"><img src="{{ product.image_alternate_url }}" height="48" width="48" alt="" /></a>
+            {% if product.slug == 'firefox' %}
+              {{ download_firefox() }}
+            {% endif %}
           </div>
 
           {% if subtopic %}
@@ -61,11 +64,6 @@
           </p>
         {% endif %}
         </div>
-        {% if product.slug == 'firefox' %}
-        <div class="sumo-article-header--meta">
-          {{ download_firefox() }}
-        </div>
-        {% endif %}
       </header>
 
       {{ topic_tabs(topics[:10], subtopics, product, topic, subtopic) }}

--- a/kitsune/sumo/static/sumo/scss/layout/_products.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_products.scss
@@ -36,25 +36,3 @@
 .refresh-firefox {
   display: none;
 }
-
-.documents-product-title {
-  display: flex;
-  align-items: center;
-  margin-bottom: p.$spacing-lg;
-  // @include p.bidi(((flex-direction, row, row-reverse),));
-  // @include p.bidi(((justify-content, flex-start, flex-end),));
-
-  img {
-    @include p.bidi(((margin-right, 12px, 0),));
-    @include p.bidi(((margin-left, 0, 12px),));
-  }
-
-  a {
-    color: var(--color-text);
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: none;
-    }
-  }
-}

--- a/kitsune/sumo/static/sumo/scss/layout/_topic-page.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_topic-page.scss
@@ -61,6 +61,8 @@
     flex: 1 1 auto;
 
     .documents-product-title {
+      display: flex;
+      flex-direction: column-reverse;
       margin-bottom: p.$spacing-md;
 
       img {
@@ -68,8 +70,16 @@
       }
 
       @media #{p.$mq-md} {
+        flex-direction: row;
+        align-items: flex-end;
+        justify-content: space-between;
+
         img {
           width: p.$spacing-2xl;
+        }
+
+        .download-buttons {
+          margin-bottom: 0;
         }
       }
     }

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -62,12 +62,12 @@
           <a href="{{ prod_url }}" title="{{ pgettext('DB: products.Product.title', product.title) }}">
             <img src="{{ product.image_alternate_url }}" height="48" width="48" alt="" />
           </a>
+          {% if product.slug == 'firefox' %}
+            {{ download_firefox() }}
+          {% endif %}
         </div>
         {{ document_title(document) }}
       </div>
-      {% if product.slug == 'firefox' %}
-      {{ download_firefox() }}
-      {% endif %}
     </header>
 
     <article class="wiki-doc">


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/376

before:

![Screenshot_2020-04-23 Control Center - manage site privacy and security controls Firefox Help - 127 0 0 1(1)](https://user-images.githubusercontent.com/755354/80108597-5f4ffe80-8574-11ea-842c-a129ff9065f0.png)

after:

![Screenshot_2020-04-23 Control Center - manage site privacy and security controls Firefox Help - 127 0 0 1](https://user-images.githubusercontent.com/755354/80108604-637c1c00-8574-11ea-94b2-7905c4a30c18.png)
