### PR TITLE
fix geoip-suggestion message bar

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -125,7 +125,7 @@
 {# end TrafficCop #}
 
 <div id="announcements">
-  {% call announcement_bar('geoip-suggestion', 'warning') %}{% endcall %}
+  {% call announcement_bar('geoip-suggestion', 'warning', close_memory="remember", close_type="remove") %}{% endcall %}
 
   {% for announ in get_announcements() %}
       {% call announcement_bar(announ.id, 'warn') %}

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -287,9 +287,16 @@
     This is the contents of the bar.
   {% endcall %}
 #}
-{% macro announcement_bar(id, level) -%}
+{% macro announcement_bar(id, level, close_memory="", close_type="") -%}
   <div id="announce-{{ id }}" class="mzp-c-notification-bar mzp-t-{{ level }}">
-    <button class="mzp-c-notification-bar-button close-button" data-close-id="announce-{{ id }}" type="button"></button>
+    <button
+      class="mzp-c-notification-bar-button close-button"
+      data-close-id="announce-{{ id }}"
+      type="button"
+      {% if close_memory %}data-close-memory="{{ close_memory }}"{% endif %}
+      {% if close_type %}data-close-type="{{ close_type }}"{% endif %}
+    >
+    </button>
     <p>{{ caller() }}</p>
   </div>
 {% endmacro %}

--- a/kitsune/sumo/static/sumo/js/geoip-locale.js
+++ b/kitsune/sumo/static/sumo/js/geoip-locale.js
@@ -13,11 +13,12 @@
   if (!countryData.country_name) {
     $.ajax({
       method: 'GET',
-      url: GeoIPUrl
+      url: GeoIPUrl,
+      beforeSend: function() {} // don't send X-CSRFToken header
     })
     .done(function(data) {
-      $.cookie('geoip_country_name', data.country_name);
-      $.cookie('geoip_country_code', data.country_code);
+      $.cookie('geoip_country_name', data.country_name, { path: '/' });
+      $.cookie('geoip_country_code', data.country_code, { path: '/' });
       countryData = data;
     })
     .fail(function(error) {
@@ -37,7 +38,7 @@ function handleLocale(countryName) {
   var languageSuggestions = {
     'en-US': {
       Indonesia: 'id',
-      Bangladesh: 'bn-BD',
+      Bangladesh: 'bn',
     },
   };
 
@@ -78,18 +79,18 @@ function handleLocale(countryName) {
         {language: languageInNativeLocale},
         true);
 
-      var $container = $announceBar.find('.container_12');
-      var $message = $container.find('.grid_12');
+      $announceBar.show();
+      var $message = $announceBar.find('p');
 
-      $message.append($('<span/>').text(currentLocaleSuggestion));
-      $message.append($('<button class="btn confirm" />').text(data[currentLocale].confirm));
-      $message.append($('<button class="btn cancel" />').text(data[currentLocale].cancel));
+      $message.text(currentLocaleSuggestion);
+      $message.append($('<button class="sumo-button button-sm confirm" />').text(data[currentLocale].confirm));
+      $message.append($('<button class="sumo-button button-sm cancel" />').text(data[currentLocale].cancel));
 
       if (data[currentLocale].suggestion !== data[suggestedLocale].suggestion) {
-        $message = $('<div class="grid_12" />').appendTo($container);
-        $message.append($('<span/>').text(suggestedLocaleSuggestion));
-        $message.append($('<button class="btn confirm" />').text(data[suggestedLocale].confirm));
-        $message.append($('<button class="btn cancel" />').text(data[suggestedLocale].cancel));
+        var $localisedMessage = $('<p />').appendTo($announceBar);
+        $localisedMessage.text(suggestedLocaleSuggestion);
+        $localisedMessage.append($('<button class="sumo-button button-sm confirm" />').text(data[suggestedLocale].confirm));
+        $localisedMessage.append($('<button class="sumo-button button-sm cancel" />').text(data[suggestedLocale].cancel));
       }
 
       trackEvent('Geo IP Targeting', 'show banner');
@@ -98,7 +99,7 @@ function handleLocale(countryName) {
       console.error('GeoIP suggestion error', err);
     });
 
-    $announceBar.on('click', '.btn', function(ev) {
+    $announceBar.on('click', 'p button', function(ev) {
       /* If the user clicks "yes", close the bar (so it remembers) and navigate
       * to the new locale. If the user clicks "no", just close the bar.
       * Either way, the announce bar UI code (in ui.js) will remember this action

--- a/kitsune/sumo/static/sumo/scss/components/_notifications.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_notifications.scss
@@ -61,3 +61,12 @@
     max-width: none;
   }
 }
+
+#announce-geoip-suggestion {
+  display: none;
+
+  p button {
+    margin-left: p.$spacing-xs;
+    margin-top: p.$spacing-xs;
+  }
+}


### PR DESCRIPTION
* update to reflect responsive redesign
* don't flash empty bar
* use bn as suggested locale now that bn-BD and bn-IN have been merged https://discourse.mozilla.org/t/44554
* ensure bar remains hidden once closed

![Screenshot_2020-05-21 Firefox Help - 127 0 0 1](https://user-images.githubusercontent.com/755354/82555418-a1626500-9b5f-11ea-8bbe-60e2efd9973d.png)

This PR should reinstate the prior behaviour of this bar. That behaviour was:

* When a user is visiting the en-US version of the site:
  * if they're in Indonesia, prompt them to switch to the Indonesian version of the site
  * if they're in Bangladesh, prompt them to switch to the Bengali version of the site
* Once a user has acted on, or dismissed the notification, don't show it again

The rationale behind this behaviour is explained here: https://bugzilla.mozilla.org/show_bug.cgi?id=1032825

## My big question:

The reasoning from the bug for just including Indonesia and Bangladesh seems to be that they have a high number of users using en-US Firefox bouncing, and so could be wanting to see localised content. Do we have metrics for the bounce rate per country when using en-US Firefox? Do we know if this is true for any other countries?

What if we just expand this to *all* countries with supported locales in SUMO? It means we don't have to keep up with what countries have a high proportion of en-US users who might want to see localised content, and for those users who do want to see English content - they'll only see the banner once: once it's dismissed it'll never show again (on the same profile).

We already have an endpoint to fetch all supported locales in SUMO, so I feel like expanding to all countries and locales is a bit of a free lunch.