### PR TITLE
add priority to celery queue

### DIFF
--- a/bin/run-celery-worker.sh
+++ b/bin/run-celery-worker.sh
@@ -1,3 +1,15 @@
 #!/bin/bash
 
-exec newrelic-admin run-program celery -A kitsune worker --maxtasksperchild=${CELERY_WORKER_MAX_TASKS_PER_CHILD:-25}
+exec newrelic-admin run-program celery -A kitsune worker -n default@%h --maxtasksperchild=${CELERY_WORKER_MAX_TASKS_PER_CHILD:-25} &
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Failed to start default worker: $status"
+  exit $status
+fi
+
+exec newrelic-admin run-program celery -A kitsune worker -Q fxa -n fxa@%h --maxtasksperchild=${CELERY_WORKER_MAX_TASKS_PER_CHILD:-25} &
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Failed to start fxa worker: $status"
+  exit $status
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - elasticsearch
       - redis
       - celery
+      - celery-fxa
       - celery-flower
       - celery-beat
     ports:
@@ -144,6 +145,17 @@ services:
   celery:
     image: itsre/sumo-kitsune:base-dev-${GIT_COMMIT_SHORT:-latest}
     command: celery -A kitsune worker -l info
+    env_file: .env
+    volumes:
+      - ./:/app:delegated
+    user: ${UID:-kitsune}
+    depends_on:
+      - mariadb
+      - redis
+
+  celery-fxa:
+    image: itsre/sumo-kitsune:base-dev-${GIT_COMMIT_SHORT:-latest}
+    command: celery -A kitsune worker -Q fxa -l info
     env_file: .env
     volumes:
       - ./:/app:delegated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
 
   celery:
     image: itsre/sumo-kitsune:base-dev-${GIT_COMMIT_SHORT:-latest}
-    command: celery -A kitsune worker -l info
+    command: celery -A kitsune worker -l info -n default@%h
     env_file: .env
     volumes:
       - ./:/app:delegated
@@ -155,7 +155,7 @@ services:
 
   celery-fxa:
     image: itsre/sumo-kitsune:base-dev-${GIT_COMMIT_SHORT:-latest}
-    command: celery -A kitsune worker -Q fxa -l info
+    command: celery -A kitsune worker -Q fxa -l info -n fxa@%h
     env_file: .env
     volumes:
       - ./:/app:delegated

--- a/kitsune/celery.py
+++ b/kitsune/celery.py
@@ -7,4 +7,14 @@ from django.conf import settings  # noqa
 
 app = Celery("kitsune")
 app.config_from_object("django.conf:settings", namespace="CELERY")
+app.conf.broker_transport_options = {
+    'queue_order_strategy': 'priority'
+}
+app.conf.task_default_priority = 5
+app.conf.task_inherit_parent_priority = True
+app.conf.task_routes = {
+    'kitsune.users.tasks.process_event_*': {
+        'queue': 'fxa',
+    }
+}
 app.autodiscover_tasks()

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -920,6 +920,7 @@ if not CELERY_TASK_ALWAYS_EAGER:
 CELERY_WORKER_CONCURRENCY = config('CELERY_WORKER_CONCURRENCY', default=4, cast=int)
 CELERY_TASK_EAGER_PROPAGATES = config('CELERY_TASK_EAGER_PROPAGATES', default=True, cast=bool)  # Explode loudly during tests.
 CELERY_WORKER_HIJACK_ROOT_LOGGER = config('CELERY_WORKER_HIJACK_ROOT_LOGGER', default=False, cast=bool)
+CELERY_WORKER_PREFETCH_MULTIPLIER = config('CELERY_WORKER_PREFETCH_MULTIPLIER', default=1, cast=int)
 
 # Wiki rebuild settings
 WIKI_REBUILD_TOKEN = 'sumo:wiki:full-rebuild'


### PR DESCRIPTION
Slightly confusingly `0` is the highest priority, and `9` is the lowest.

`CELERY_WORKER_PREFETCH_MULTIPLIER` is reduced to 1, so a load of lower priority tasks won't be fetched and clog up the queue for higher priority tasks.

I placed some settings in celery.py as opposed to settings.py as those struck me as much more integral to the behaviour of the application (if we change the default, or inheriting from parents, then we need to rewrite the priorities we assign tasks), than that in settings.py which is more of a configurable performance setting.

We should set the priority for the fxa event tasks once py3 is merged into master.

Confusingly, the docs indicate that some of these settings only work for RabbitMQ, when through testing I've determined that they work for Redis too:
https://docs.celeryproject.org/en/stable/userguide/routing.html#rabbitmq-message-priorities