### PR TITLE
add readthedocs config so we can specify python 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  version: 3.8
+  install:
+    - requirements: requirements/docs.txt


### PR DESCRIPTION
The RTD build [is still failing](https://readthedocs.org/projects/kitsune/builds/11467918/) because it defaults to python 3.7, we can't specify 3.8 through the admin interface we need to add this config file.

I tested this config on my fork, and it successfully builds:
https://readthedocs.org/projects/leomca-kitsune/builds/11468241/
https://leomca-kitsune.readthedocs.io/en/latest/