### PR TITLE
run collectstatic with noinput

### DIFF
--- a/bin/run-bootstrap.sh
+++ b/bin/run-bootstrap.sh
@@ -9,6 +9,6 @@ yarn
 # ensure the DB server is ready
 urlwait
 # run collectstatic
-python manage.py collectstatic
+python manage.py collectstatic --noinput
 # run DB migrations
 python manage.py migrate


### PR DESCRIPTION
when running `make init` to setup the project locally the script stops and asks for input. this will run `collectstatic` with `--noinput`