### PR TITLE
[docs] mention complete command

### DIFF
--- a/docs/hacking_howto.md
+++ b/docs/hacking_howto.md
@@ -131,7 +131,7 @@ running this command::
 ### Install linting tools
 
 ```eval_rst
-Kitsune uses `Yelps Pre-commit <http://pre-commit.com/>`_ for linting. It is
+Kitsune uses `Yelps Pre-commit <https://pre-commit.com/>`_ for linting. It is
 installed as a part of the dev dependencies in ``requirements/dev.txt``. To
 install it as a Git pre-commit hook, run it::
 
@@ -147,7 +147,7 @@ checks for all files::
 
    $ venv/bin/pre-commit run --all-files
 
-For more details see the `Pre-commit docs <http://pre-commit.com/>`_.
+For more details see the `Pre-commit docs <https://pre-commit.com/>`_.
 ```
 
 ### Product Details Initialization

--- a/docs/hacking_howto.md
+++ b/docs/hacking_howto.md
@@ -96,10 +96,26 @@ After the above you can do some optional steps if you want to use the admin:
 
 First, make sure you have run the "Create some data" step above.
 
-1. Enter the web container: `docker-compose exec web bash`
-2. Build the indicies: `./manage.py esreindex` (You may need to pass the `--delete` flag)
-3. Precompile the nunjucks templates: `./manage.py nunjucks_precompile`
-4. Now, exit from web's bash shell: `exit`
+1. Enter into the web container
+    ```
+    docker-compose exec web bash
+    ```
+
+2. Build the indicies
+    ```
+    $ ./manage.py esreindex
+    ```
+  (You may need to pass the `--delete` flag.)
+
+3. Precompile the nunjucks templates
+    ```
+    $ ./manage.py nunjucks_precompile
+    ```
+
+4. Now, exit from web's bash shell
+    ```
+    $ exit
+    ```
 
 ## Further setup
 
@@ -153,7 +169,6 @@ templates get updated from time to time and you will need to pre-compile them
 to ensure that they render correctly::
 
       docker-compose exec web ./manage.py nunjucks_precompile
-
 ```
 
 ## Running the tests

--- a/docs/hacking_howto.md
+++ b/docs/hacking_howto.md
@@ -99,6 +99,7 @@ First, make sure you have run the "Create some data" step above.
 1. Enter the web container: `docker-compose exec web bash`
 2. Build the indicies: `./manage.py esreindex` (You may need to pass the `--delete` flag)
 3. Precompile the nunjucks templates: `./manage.py nunjucks_precompile`
+4. Now, exit from web's bash shell: `exit`
 
 ## Further setup
 
@@ -108,7 +109,7 @@ First, make sure you have run the "Create some data" step above.
 We include some sample data to get you started. You can install it by
 running this command::
 
-    $ ./manage.py generatedata
+    docker-compose exec web ./manage.py generatedata
 ```
 
 ### Install linting tools
@@ -141,7 +142,7 @@ JSON files containing historical Firefox version data and write them
 within its package directory. To set this up, run this command to do
 the initial fetch::
 
-    $ ./manage.py update_product_details
+    docker-compose exec web ./manage.py update_product_details
 ```
 
 ### Pre-compiling JavaScript Templates
@@ -151,7 +152,7 @@ We use nunjucks to render Jinja-style templates for front-end use. These
 templates get updated from time to time and you will need to pre-compile them
 to ensure that they render correctly::
 
-      $ ./manage.py nunjucks_precompile
+      docker-compose exec web ./manage.py nunjucks_precompile
 
 ```
 


### PR DESCRIPTION
New user who is setting-up development environment may get confused,
where they should run `./manage.py generatedata` command. So it would be
nice idea to mention complete command, whenever it could be possible.