### PR TITLE
use bulk indexing

### DIFF
--- a/kitsune/search/v2/management/commands/es7_reindex.py
+++ b/kitsune/search/v2/management/commands/es7_reindex.py
@@ -1,6 +1,7 @@
+from math import ceil
 from django.core.management.base import BaseCommand
 
-from kitsune.search.v2.es7_utils import get_doc_types, index_object
+from kitsune.search.v2.es7_utils import get_doc_types, index_objects_bulk
 
 
 class Command(BaseCommand):
@@ -15,7 +16,12 @@ class Command(BaseCommand):
             default="",
             help="Limit to specific doc types",
         )
-        parser.add_argument("--percentage", type=float, default=None)
+        parser.add_argument(
+            "--percentage", type=float, default=100,
+        )
+        parser.add_argument(
+            "--bulk-count", type=int, default=100,
+        )
 
     def handle(self, *args, **kwargs):
         doc_types = get_doc_types()
@@ -32,17 +38,19 @@ class Command(BaseCommand):
             model = dt.get_model()
             qs = model.objects.all()
             count = qs.count()
-            if percentage := kwargs["percentage"]:
-                total = count
+
+            percentage = kwargs["percentage"]
+            total = count
+            if percentage < 100:
                 count = int(count * percentage / 100)
-                print("Indexing {}%, so {} documents out of {}".format(percentage, count, total))
                 qs = qs[:count]
-            progress = 0
+            print("Indexing {}%, so {} documents out of {}".format(percentage, count, total))
 
-            for obj in qs:
-                index_object.delay(dt.__name__, obj.pk)
+            id_list = list(qs.values_list("pk", flat=True))
+            bulk_count = kwargs["bulk_count"]
 
-                progress += 1
-                if progress % 100 == 0:
-                    msg = progress_msg.format(progress=progress, count=count)
-                    self.stdout.write(msg)
+            for x in range(ceil(count / bulk_count)):
+                start = x * bulk_count
+                end = start + bulk_count
+                index_objects_bulk.delay(dt.__name__, id_list[start:end])
+                print(progress_msg.format(progress=min(end, count), count=count))


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/605

this is about twice as fast:

```
time CELERY_TASK_ALWAYS_EAGER=True ./manage.py es7_reindex --limit AnswerDocument --percentage 1
Indexing 1.0%, so 11917 documents out of 1191764

for index_object:
real    2m5.361s
user    1m26.720s
sys     0m2.778s

for index_objects_bulk:
real    1m2.397s
user    0m48.990s
sys     0m1.825s
```