### PR TITLE
Fixes #4500, collections depreciated

### DIFF
--- a/kitsune/wiki/widgets.py
+++ b/kitsune/wiki/widgets.py
@@ -1,5 +1,3 @@
-import sys
-
 
 from django import forms
 from django.template.loader import render_to_string

--- a/kitsune/wiki/widgets.py
+++ b/kitsune/wiki/widgets.py
@@ -1,4 +1,9 @@
-import collections
+import sys
+
+if sys.version_info >= (3,3):
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 from django import forms
 from django.template.loader import render_to_string
@@ -35,7 +40,7 @@ class ProductTopicsAndSubtopicsWidget(forms.widgets.SelectMultiple):
             topic.checked = True
         elif (
             not isinstance(value, str)
-            and isinstance(value, collections.Iterable)
+            and isinstance(value, Iterable)
             and topic.id in value
         ):
             topic.checked = True
@@ -49,7 +54,7 @@ class RelatedDocumentsWidget(forms.widgets.SelectMultiple):
     def render(self, name, value, attrs=None, renderer=None):
         if isinstance(value, int):
             related_documents = Document.objects.filter(id__in=[value])
-        elif not isinstance(value, str) and isinstance(value, collections.Iterable):
+        elif not isinstance(value, str) and isinstance(value, Iterable):
             related_documents = Document.objects.filter(id__in=value)
         else:
             related_documents = Document.objects.none()

--- a/kitsune/wiki/widgets.py
+++ b/kitsune/wiki/widgets.py
@@ -7,9 +7,9 @@ from django.template.loader import render_to_string
 from kitsune.products.models import Topic
 from kitsune.wiki.models import Document
 
-if sys.version_info >= (3,3):
+try:
     from collections.abc import Iterable
-else:
+except ImportError:
     from collections import Iterable
 
 

--- a/kitsune/wiki/widgets.py
+++ b/kitsune/wiki/widgets.py
@@ -1,15 +1,16 @@
 import sys
 
-if sys.version_info >= (3,3):
-    from collections.abc import Iterable
-else:
-    from collections import Iterable
 
 from django import forms
 from django.template.loader import render_to_string
 
 from kitsune.products.models import Topic
 from kitsune.wiki.models import Document
+
+if sys.version_info >= (3,3):
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 
 class ProductTopicsAndSubtopicsWidget(forms.widgets.SelectMultiple):


### PR DESCRIPTION
AS of Python 3.10, `collections` will be depreciated in terms of abstract classes. Added a check if Python is >= 3.3, and imports `collections.abc`