### PR TITLE
use timezone-aware datetimes in search v2

### DIFF
--- a/docs/search-v2.md
+++ b/docs/search-v2.md
@@ -57,3 +57,27 @@ Consider using some combination of
 [`prefetch_related`](https://docs.djangoproject.com/en/dev/ref/models/querysets/#prefetch-related)
 or [annotations](https://docs.djangoproject.com/en/dev/ref/models/querysets/#annotate)
 to bring that number down.
+
+### Datetimes and timezones
+
+As a first step in our migration to using timezone-aware datetimes throughout the application,
+all datetimes stored in Elastic should be timezone-aware,
+so as to avoid having to migrate them later.
+
+If inheriting from `SumoDocument`,
+any naive datetime set in a `Date` field will be automatically converted into a timezone-aware datetime,
+with the naive datetime assumed to be in the application's `TIME_ZONE`.
+
+To avoid loss of precision around DST switches,
+where possible aware datetimes should be set.
+To generate an aware datetime do:
+
+```python
+import datetime, timezone
+
+datetime.now(timezone.utc)
+```
+
+This should be used instead of
+[`django.utils.timezone.now()`](https://docs.djangoproject.com/en/2.2/ref/utils/#django.utils.timezone.now)
+as that returns a naive or aware datetime depending on the value of `USE_TZ`, whereas we want datetimes in Elastic to always be timezone-aware.

--- a/kitsune/community/utils.py
+++ b/kitsune/community/utils.py
@@ -1,5 +1,5 @@
 import hashlib
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from operator import itemgetter
 
 from django.conf import settings
@@ -65,7 +65,7 @@ def top_contributors_questions(start=None, end=None, locale=None, product=None, 
         if bucket.key != user.meta.id:
             raise RuntimeError("ES returned profiles out of order")
         last_activity = datetime.fromisoformat(bucket.latest.hits.hits[0]._source.created)
-        days_since_last_activity = (datetime.now() - last_activity).days
+        days_since_last_activity = (datetime.now(tz=timezone.utc) - last_activity).days
         top_contributors.append(
             {
                 "count": bucket.doc_count,

--- a/kitsune/search/v2/base.py
+++ b/kitsune/search/v2/base.py
@@ -40,7 +40,11 @@ class SumoDocument(DSLDocument):
                 if locale and value:
                     obj[f] = {locale: value}
             else:
-                if isinstance(field_type, field.Date) and timezone.is_naive(value):
+                if (
+                    isinstance(field_type, field.Date)
+                    and isinstance(value, datetime)
+                    and timezone.is_naive(value)
+                ):
                     # set is_dst=False to avoid errors when an ambiguous time is sent:
                     # https://docs.djangoproject.com/en/2.2/ref/utils/#django.utils.timezone.make_aware
                     value = timezone.make_aware(value, is_dst=False).astimezone(timezone.utc)


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/658

Setting `USE_TZ=True`, even when avoiding the database migration issue by setting up `DATABASE.TIME_ZONE`, is a rather large yak I'm not sure we should shave quite yet.

This PR allows/forces us to use aware datetimes in ES, regardless of the `USE_TZ` value.