### PR TITLE
remove deactivated accounts from user autocomplete

### DIFF
--- a/kitsune/users/templatetags/jinja_helpers.py
+++ b/kitsune/users/templatetags/jinja_helpers.py
@@ -34,7 +34,7 @@ def profile_url(user, edit=False):
 def profile_avatar(user, size=200):
     """Return a URL to the user's avatar."""
     try:  # This is mostly for tests.
-        profile = Profile.objects.get(user_id=user.id)
+        profile = user.profile
     except (Profile.DoesNotExist, AttributeError):
         avatar = settings.STATIC_URL + settings.DEFAULT_AVATAR
         profile = None


### PR DESCRIPTION
also optimise queries, mostly by removing ordering by length

I decided against using django-autocomplete-light for a few reasons:
* we still have to supply it with a queryset, so it's not going to do any magical optimisations for us
* it depends on jquery, which we may or may not want to remove
* this dropdown is used not only in messages, but also groups and kb revisions

Optimising this was pretty fun, measurements from django debug toolbar with the mariadb query cache disabled:

With a query of "z", for which there are >10 users which match in db:

Before:

![before with "z"](https://user-images.githubusercontent.com/755354/97024769-15f66100-154f-11eb-84c7-8e10a01dec54.png)

After:

![after with "z"](https://user-images.githubusercontent.com/755354/97024800-1d1d6f00-154f-11eb-9313-73dfbf95f9c7.png)

With a query of "leo m", for which there are <10 users which match in db:

Before:

![before with "leo m"](https://user-images.githubusercontent.com/755354/97024955-56ee7580-154f-11eb-9acb-6dfd3f34823b.png)

After:

![after with "leo m"](https://user-images.githubusercontent.com/755354/97024782-1858bb00-154f-11eb-9f2d-bea3f57896e8.png)
