### PR TITLE
adding next_url to same page after auth of contributor

### DIFF
--- a/kitsune/landings/jinja2/landings/get-involved-kb.html
+++ b/kitsune/landings/jinja2/landings/get-involved-kb.html
@@ -27,8 +27,8 @@
 </section>
   {% set user_is_contributor = is_contributor(user) %}
   {% set signup_headline = _('Improve our help articles') %}
+  {% set next_url = url('landings.get_involved_kb') %}
   {% include 'landings/includes/register_contributor.html' %}
-
 
   <section class="sumo-page-section has-moz-headings pick-a-way text-left">
     <div class="sumo-l-two-col align-center">

--- a/kitsune/landings/jinja2/landings/get-involved-l10n.html
+++ b/kitsune/landings/jinja2/landings/get-involved-l10n.html
@@ -26,6 +26,7 @@
 </section>
 {% set user_is_contributor = is_contributor(user) %}
 {% set signup_headline = _('Translate help articles to your language') %}
+{% set next_url = url('landings.get_involved_l10n') %}
 {% include 'landings/includes/register_contributor.html' %}
 
   <section class="sumo-page-section has-moz-headings pick-a-way text-left">

--- a/kitsune/landings/jinja2/landings/get-involved-questions.html
+++ b/kitsune/landings/jinja2/landings/get-involved-questions.html
@@ -28,6 +28,7 @@
 
   {% set user_is_contributor = is_contributor(user) %}
   {% set signup_headline = _('Help users in the forums') %}
+  {% set next_url = url('landings.get_involved_questions') %}
   {% include 'landings/includes/register_contributor.html' %}
 
 <section class="sumo-page-section has-moz-headings">

--- a/kitsune/landings/jinja2/landings/includes/register_contributor.html
+++ b/kitsune/landings/jinja2/landings/includes/register_contributor.html
@@ -24,7 +24,7 @@
         <button id="sign-up-contributor" class="sumo-button primary-button button-lg" data-event-category="Sign Me Up Click" data-event-action="Logged In">{{ _('Sign me up') }} &raquo;</button>
       </form>
     {% else %}
-      <a id="sign-up-contributor" class="sumo-button primary-button" href="{{ url('users.fxa_authentication_init') }}?next={{ next_url }}&is_contributor=True" data-event-category="Sign Me Up Click" data-event-action="Logged In">
+      <a id="sign-up-contributor" class="sumo-button primary-button" href="/{{ url('users.fxa_authentication_init') }}?next={{ next_url }}&is_contributor=True" data-event-category="Sign Me Up Click" data-event-action="Logged In">
         {{ _('Sign me up') }} &raquo;
       </a>
     {% endif %}

--- a/kitsune/landings/jinja2/landings/includes/register_contributor.html
+++ b/kitsune/landings/jinja2/landings/includes/register_contributor.html
@@ -24,7 +24,7 @@
         <button id="sign-up-contributor" class="sumo-button primary-button button-lg" data-event-category="Sign Me Up Click" data-event-action="Logged In">{{ _('Sign me up') }} &raquo;</button>
       </form>
     {% else %}
-      <a id="sign-up-contributor" class="sumo-button primary-button" href="/{{ url('users.fxa_authentication_init') }}?next={{ next_url }}&is_contributor=True" data-event-category="Sign Me Up Click" data-event-action="Logged In">
+      <a id="sign-up-contributor" class="sumo-button primary-button" href="{{ url('users.fxa_authentication_init') }}?next={{ next_url }}&is_contributor=True" data-event-category="Sign Me Up Click" data-event-action="Logged In">
         {{ _('Sign me up') }} &raquo;
       </a>
     {% endif %}

--- a/kitsune/landings/jinja2/landings/includes/register_contributor.html
+++ b/kitsune/landings/jinja2/landings/includes/register_contributor.html
@@ -24,7 +24,7 @@
         <button id="sign-up-contributor" class="sumo-button primary-button button-lg" data-event-category="Sign Me Up Click" data-event-action="Logged In">{{ _('Sign me up') }} &raquo;</button>
       </form>
     {% else %}
-      <a id="sign-up-contributor" class="sumo-button primary-button" href="{{ url('users.fxa_authentication_init') }}?is_contributor=True" data-event-category="Sign Me Up Click" data-event-action="Logged In">
+      <a id="sign-up-contributor" class="sumo-button primary-button" href="{{ url('users.fxa_authentication_init') }}?next={{ next_url }}&is_contributor=True" data-event-category="Sign Me Up Click" data-event-action="Logged In">
         {{ _('Sign me up') }} &raquo;
       </a>
     {% endif %}


### PR DESCRIPTION
@LeoMcA, I have made a few changes, can you look into this PR? 
It solves, [issue#308](https://github.com/mozilla/sumo-project/issues/308)

Redirecting by "?next=" is working, you can check by making a request
[https://support.allizom.org/en-US/fxa/authenticate/?next=/en-US/get-involved/kb&is_contributor=True](https://support.allizom.org/en-US/fxa/authenticate/?next=/en-US/get-involved/kb&is_contributor=True)
