### PR TITLE
fix running tests locally with django debug toolbar enabled

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -1046,10 +1046,15 @@ AXES_BEHIND_REVERSE_PROXY = config("AXES_BEHIND_REVERSE_PROXY", default=not DEBU
 AXES_REVERSE_PROXY_HEADER = config("AXES_REVERSE_PROXY_HEADER", default="HTTP_X_CLUSTER_CLIENT_IP")
 
 USE_DEBUG_TOOLBAR = config("USE_DEBUG_TOOLBAR", default=False, cast=bool)
-if DEBUG and USE_DEBUG_TOOLBAR:
 
-    def show_toolbar_callback(request):
-        return True
+
+def show_toolbar_callback(*args):
+    return DEBUG and USE_DEBUG_TOOLBAR
+
+
+SHOW_DEBUG_TOOLBAR = show_toolbar_callback()
+
+if SHOW_DEBUG_TOOLBAR:
 
     DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": "kitsune.settings.show_toolbar_callback"}
 

--- a/kitsune/urls.py
+++ b/kitsune/urls.py
@@ -100,12 +100,13 @@ if settings.DEBUG:
             {"document_root": settings.MEDIA_ROOT},
         ),
     ]
-    if settings.USE_DEBUG_TOOLBAR:
-        import debug_toolbar
 
-        urlpatterns += [
-            url("__debug__/", include(debug_toolbar.urls)),
-        ]
+if settings.SHOW_DEBUG_TOOLBAR:
+    import debug_toolbar
+
+    urlpatterns += [
+        url("__debug__/", include(debug_toolbar.urls)),
+    ]
 
 
 if settings.ENABLE_ADMIN:


### PR DESCRIPTION
the problem seemed to be that `./manage.py test` will force
settings.DEBUG to False, even if DEBUG=True, so djdt was being
enabled in settings.py but its routes weren't being included
in urls.py