### PR TITLE
specify py38 in black config as it doesn't support py39 as a target yet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     hooks:
       - id: black
         exclude: "^.*/migrations/.*$|kitsune/sumo/db_strings.py"
+        language_version: python3.9
   - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.8.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,7 @@
 [tool.black]
 line-length = 99
-target-version = ['py39']
+# NB: this can only be updated once black supports the target python version,
+# so may lag behind the version of python we're using. This shouldn't matter
+# unless we're using completely new syntax:
+target-version = ['py38']
 exclude = "^.*/migrations/.*$|kitsune/sumo/db_strings.py"


### PR DESCRIPTION
but run black using python3.9 in pre-commit