### PR TITLE
add timeout option to es7_reindex command

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -346,6 +346,9 @@ ES_PLUGIN_ANALYZERS = ["polish"]
 
 ES_USE_PLUGINS = config("ES_USE_PLUGINS", default=not DEBUG, cast=bool)
 
+ES_BULK_DEFAULT_TIMEOUT = config("ES_BULK_DEFAULT_TIMEOUT", default=10, cast=float)
+ES_BULK_MAX_RETRIES = config("ES_BULK_MAX_RETRIES", default=1, cast=int)
+
 TEXT_DOMAIN = "messages"
 
 SITE_ID = 1


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/704

We probably don't want to completely eliminate the possibility of connection timeouts, as that risks clogging up the celery queue, I think this strikes a sensible compromise: allow us to configure the timeout length, allow a connection to timeout once, sleeping for the length of the timeout, before trying again once, then giving up and raising an exception in sentry if that second attempt fails.