### PR TITLE
make elastic bulk updates retry on conflicts

### DIFF
--- a/kitsune/search/config.py
+++ b/kitsune/search/config.py
@@ -16,6 +16,9 @@ QUESTION_INDEX_NAME = get_index_name("question")
 USER_INDEX_NAME = get_index_name("user")
 FORUM_INDEX_NAME = get_index_name("forum_document")
 
+# number of times to retry updates if a conflict happens before raising
+UPDATE_RETRY_ON_CONFLICT = 2
+
 ES_DEFAULT_ANALYZER = {
     "tokenizer": "standard",
     "filter": ["lowercase", "stop"],

--- a/kitsune/search/v2/base.py
+++ b/kitsune/search/v2/base.py
@@ -10,6 +10,7 @@ from elasticsearch_dsl import field
 
 from kitsune.search import HIGHLIGHT_TAG, SNIPPET_LENGTH
 from kitsune.search.v2.es7_utils import es7_client
+from kitsune.search.config import UPDATE_RETRY_ON_CONFLICT
 
 
 class SumoDocument(DSLDocument):
@@ -122,7 +123,12 @@ class SumoDocument(DSLDocument):
                 # we need to return the payload and let elasticsearch-py bulk method deal with
                 # the update
                 payload["doc"] = payload["_source"]
-                payload.update({"_op_type": "update"})
+                payload.update(
+                    {
+                        "_op_type": "update",
+                        "retry_on_conflict": UPDATE_RETRY_ON_CONFLICT,
+                    }
+                )
                 del payload["_source"]
                 return payload
             return self.update(**payload)


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/718

I haven't found a way to reproduce these bulk index conflict errors we were setting, so I can't really test this.

However, bulk wiki indexing still works, and the JSON being sent to Elastic matches the format [the documentation specifies](https://github.com/mozilla/sumo-project/issues/718#issuecomment-756263984), with the "retry_on_conflict" key in the action line, not the payload line:

With a breakpoint on L235 in `/vendor/elasticsearch/helpers/actions.py`:
```
bulk_actions[0]
'{"update":{"_id":1,"_index":"sumo_wiki_document","retry_on_conflict":2}}'
```