### PR TITLE
use aliases to simplify deploying changes to indices

### DIFF
--- a/bin/run-unit-tests.sh
+++ b/bin/run-unit-tests.sh
@@ -5,6 +5,6 @@ set -ex
 # wait on database in DATABASE_URL to be ready
 urlwait
 
-./manage.py es7_init --delete
+./manage.py es7_init --migrate-writes --migrate-reads
 
 ./manage.py test --noinput --nologcapture -a '!search_tests' --with-nicedots

--- a/kitsune/search/config.py
+++ b/kitsune/search/config.py
@@ -1,20 +1,6 @@
-from django.conf import settings
-
-
-def get_index_name(index_name):
-    name_format = "{prefix}_{suffix}"
-    name = name_format.format(prefix=settings.ES_INDEX_PREFIX, suffix=index_name)
-    return name
-
-
 ES_SYNONYM_LOCALES = [
     "en-US",
 ]
-
-WIKI_DOCUMENT_INDEX_NAME = get_index_name("wiki_document")
-QUESTION_INDEX_NAME = get_index_name("question")
-USER_INDEX_NAME = get_index_name("user")
-FORUM_INDEX_NAME = get_index_name("forum_document")
 
 # number of times to retry updates if a conflict happens before raising
 UPDATE_RETRY_ON_CONFLICT = 2

--- a/kitsune/search/v2/documents.py
+++ b/kitsune/search/v2/documents.py
@@ -31,8 +31,7 @@ class WikiDocument(SumoDocument):
     doc_id = SumoLocaleAwareKeywordField(store=True)
 
     class Index:
-        name = config.WIKI_DOCUMENT_INDEX_NAME
-        using = config.DEFAULT_ES7_CONNECTION
+        pass
 
     @classmethod
     @property
@@ -143,8 +142,7 @@ class QuestionDocument(SumoDocument):
     locale = field.Keyword()
 
     class Index:
-        name = config.QUESTION_INDEX_NAME
-        using = config.DEFAULT_ES7_CONNECTION
+        pass
 
     @classmethod
     def prepare(cls, instance):
@@ -325,8 +323,7 @@ class ProfileDocument(SumoDocument):
     group_ids = field.Keyword(multi=True)
 
     class Index:
-        name = config.USER_INDEX_NAME
-        using = config.DEFAULT_ES7_CONNECTION
+        pass
 
     @classmethod
     def prepare(cls, instance):
@@ -386,8 +383,7 @@ class ForumDocument(SumoDocument):
     updated_by_id = field.Keyword()
 
     class Index:
-        name = config.FORUM_INDEX_NAME
-        using = config.DEFAULT_ES7_CONNECTION
+        pass
 
     def get_field_value(self, field, instance, *args):
         if field.startswith("thread_"):


### PR DESCRIPTION
add es7_init to run-post-deploy script

make es7_init print and skip indices it cannot change the configuration on

https://github.com/mozilla/sumo-project/issues/627