### PR TITLE
protect 'add-on' and 'add on' from tokenization

### DIFF
--- a/kitsune/search/config.py
+++ b/kitsune/search/config.py
@@ -19,10 +19,19 @@ FORUM_INDEX_NAME = get_index_name("forum_document")
 # number of times to retry updates if a conflict happens before raising
 UPDATE_RETRY_ON_CONFLICT = 2
 
+ES_MAPPINGS = [
+    "add-on => addon",
+    "add on => addon",
+]
+
+ES_DEFAULT_ANALYZER_NAME = "default_sumo"
 ES_DEFAULT_ANALYZER = {
     "tokenizer": "standard",
     "filter": ["lowercase", "stop"],
-    "char_filter": ["html_strip"],
+    "char_filter": [
+        "html_strip",
+        {"type": "mapping", "mappings": ES_MAPPINGS},
+    ],
 }
 
 # by and large copied from
@@ -137,6 +146,7 @@ ES_LOCALE_ANALYZERS = {
         "char_filter": [
             {"type": "mapping", "mappings": ["\\u200C=>\\u0020"]},
             "html_strip",
+            {"type": "mapping", "mappings": ES_MAPPINGS},
         ],
     },
     "fi": {

--- a/kitsune/search/v2/base.py
+++ b/kitsune/search/v2/base.py
@@ -221,6 +221,9 @@ class SumoSearch(ABC):
             query=query,
             default_operator=default_operator,
             fields=self.get_fields(),
+            # everything apart from WHITESPACE as that interferes with mappings
+            # and synonyms with whitespace in them:
+            flags="AND|ESCAPE|FUZZY|NEAR|NOT|OR|PHRASE|PRECEDENCE|PREFIX|SLOP",
         )
 
         # add highlights for the search class' highlight_fields


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/748

a nice side-effect is this causes "add-ons" to be highlighted properly in search results, before:

![Screenshot_2021-02-02 Mozilla Support - 127 0 0 1](https://user-images.githubusercontent.com/755354/106598893-45563a00-6550-11eb-99cc-d7fd5410e445.png)

after:

![Screenshot_2021-02-02 Mozilla Support - 127 0 0 1(2)](https://user-images.githubusercontent.com/755354/106599044-733b7e80-6550-11eb-8c6d-8f84078658a4.png)