### PR TITLE
instant search: render out of order responses correctly

### DIFF
--- a/kitsune/sumo/static/sumo/js/instant_search.js
+++ b/kitsune/sumo/static/sumo/js/instant_search.js
@@ -12,6 +12,9 @@
   var cxhr = new k.CachedXHR();
   var aaq_explore_step = $("#question-search-masthead").length > 0;
 
+  const queries = [];
+  let renderedQuery;
+
   function hideContent() {
     $('#main-content').hide();
     $('#main-content').siblings('aside').hide();
@@ -40,6 +43,14 @@
 
   function render(data) {
     var context = $.extend({}, data);
+
+    let query = context.q;
+    if (queries.lastIndexOf(query) < queries.lastIndexOf(renderedQuery)) {
+      // this query was sent before the query already rendered, don't render it
+      return;
+    }
+    renderedQuery = query;
+
     var base_url = search.lastQueryUrl();
     var $searchContent;
     context.base_url = base_url;
@@ -164,7 +175,9 @@
           trackEvent('Instant Search', 'Exit Search', search.lastQueryUrl());
         }
         search.setParams(params);
-        search.query($this.val(), k.InstantSearchSettings.render);
+        let query = $this.val();
+        queries.push(query);
+        search.query(query, k.InstantSearchSettings.render);
         trackEvent('Instant Search', 'Search', search.lastQueryUrl());
       }, 200);
 


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/707

Something like this really helps with testing:

```
diff --git a/kitsune/search/v2/views.py b/kitsune/search/v2/views.py
index 59bd512c0..585221217 100644
--- a/kitsune/search/v2/views.py
+++ b/kitsune/search/v2/views.py
@@ -18,6 +18,10 @@ from kitsune.search.v2.search import CompoundSearch, QuestionSearch, WikiSearch
 def simple_search(request):
     search_form = SimpleSearchForm(request.GET, auto_id=False)
 
+    from time import sleep
+    from random import randint
+    sleep(randint(1, 10))
+
     if not search_form.is_valid():
         return HttpResponse(
             json.dumps({"error": _("Invalid search data.")}),
```