### PR TITLE
instant search: show all results for filtered second query

### DIFF
--- a/kitsune/bundles.py
+++ b/kitsune/bundles.py
@@ -16,7 +16,7 @@ PIPELINE_JS = {
             "nunjucks/browser/nunjucks-slim.js",
             "sumo/js/nunjucks.js",
             "sumo/js/cached_xhr.js",
-            "sumo/js/search_utils.js",
+            "sumo/js/search_utils.es6",
             "sumo/js/browserdetect.js",
             "sumo/js/libs/uitour.js",
             "sumo/js/kbox.js",

--- a/kitsune/search/v2/views.py
+++ b/kitsune/search/v2/views.py
@@ -8,7 +8,6 @@ from django.utils.translation import ugettext as _, pgettext
 from kitsune import search as constants
 from kitsune.search.forms import SimpleSearchForm
 from kitsune.sumo.api_utils import JSONRenderer
-from kitsune.sumo.utils import build_paged_url
 from kitsune.products.models import Product
 from kitsune.search.views import _fallback_results
 from kitsune.search.utils import locale_or_default
@@ -108,7 +107,6 @@ def _make_pagination(request, page, total):
         "num_pages": num_pages,
         "has_next": page < num_pages,
         "has_previous": page > num_pages,
-        "url": build_paged_url(request),
         "page_range": page_range,
         "dotted_upper": num_pages not in page_range,
         "dotted_lower": 1 not in page_range,

--- a/kitsune/sumo/static/sumo/js/instant_search.es6
+++ b/kitsune/sumo/static/sumo/js/instant_search.es6
@@ -191,7 +191,7 @@
     var $this = $(this);
 
     if (search.hasLastQuery) {
-      trackEvent('Instant Search', 'Exit Search', search.queryUrl(search.lastQuery));
+      trackEvent('Instant Search', 'Exit Search', search.queryUrl());
     }
 
     var setParams = $this.data('instant-search-set-params');
@@ -211,13 +211,8 @@
       });
     }
 
-    trackEvent('Instant Search', 'Search', $this.data('href'));
-
-    cxhr.request($this.data('href'), {
-      data: {format: 'json'},
-      dataType: 'json',
-      success: k.InstantSearchSettings.render
-    });
+    search.query(null, k.InstantSearchSettings.render);
+    trackEvent("Instant Search", "Search", search.lastQueryUrl());
   });
 
   // 'Popular searches' feature

--- a/kitsune/sumo/static/sumo/js/search_utils.es6
+++ b/kitsune/sumo/static/sumo/js/search_utils.es6
@@ -49,7 +49,7 @@
     return this._buildQueryUrl(this.lastQuery, this.lastParams);
   };
 
-  Search.prototype.queryUrl = function(query) {
+  Search.prototype.queryUrl = function() {
     return this._buildQueryUrl(this.lastQuery, this.serializeParams());
   };
 
@@ -64,6 +64,7 @@
   };
 
   Search.prototype.query = function(string, callback) {
+    string ||= this.lastQuery;
     var data = $.extend({}, this.params, {q: string});
 
     this.lastQuery = string;

--- a/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
@@ -51,7 +51,7 @@ describe('instant search', () => {
 
       rerequire('../i18n.js');
       global.interpolate = global.window.interpolate;
-      rerequire('../search_utils.js');
+      rerequire('../search_utils.es6');
       rerequire('../instant_search.es6');
 
       let content = (
@@ -122,28 +122,6 @@ describe('instant search', () => {
 
       const queryElem = document.querySelectorAll('.search-results-heading span')[0];
       expect(queryElem.innerHTML).to.equal('&lt;');
-    });
-
-    it('escape the query in the sidebar filters', () => {
-      const query = '<';
-      const requestExpectation = cxhrMock.expects('request');
-
-      const $searchInput = $('#search-q');
-      $searchInput.val(query);
-      $searchInput.keyup();
-
-      clock.tick(200);
-      // call the callback to actually render things
-      requestExpectation.firstCall.args[1].success({
-        num_results: 0,
-        q: query,
-      });
-
-      const sideBarLinks = Array.from(document.querySelectorAll('.search-filter [data-href]'));
-      for (let link of sideBarLinks) {
-        expect(link.attributes['data-href'].value).to.contain('q=%3C');
-        expect(link.attributes['data-href'].value).to.not.contain('<');
-      }
     });
   });
 });

--- a/kitsune/sumo/static/sumo/tpl/search-results-list.html
+++ b/kitsune/sumo/static/sumo/tpl/search-results-list.html
@@ -15,17 +15,17 @@
   <nav class="tabs">
   <ul id="doctype-filter" class="tabs--list search-filter cf">
     <li class="tabs--item">
-      <a {{ w|class_selected(3) }} href="#" data-instant-search-set-params="w=3" data-instant-search="link" data-href="{{ base_doctype_url|encodeURI }}">
+      <a {{ w|class_selected(3) }} href="#" data-instant-search-set-params="w=3" data-instant-search="link">
         <span>{{ _('View All') }}</span>
       </a>
     </li>
     <li class="tabs--item">
-      <a {{ w|class_selected(1) }} href="#" data-instant-search-set-params="w=1" data-instant-search="link" data-href="{{ base_doctype_url|urlparams(w=1)|encodeURI }}">
+      <a {{ w|class_selected(1) }} href="#" data-instant-search-set-params="w=1" data-instant-search="link">
         <span>{{ _('Help Articles Only') }}</span>
       </a>
     </li>
     <li class="tabs--item">
-      <a {{ w|class_selected(2) }} href="#" data-instant-search-set-params="w=2" data-instant-search="link" data-href="{{ base_doctype_url|urlparams(w=2)|encodeURI }}">
+      <a {{ w|class_selected(2) }} href="#" data-instant-search-set-params="w=2" data-instant-search="link">
         <span>{{ _('Community Discussion Only') }}</span>
       </a>
     </li>
@@ -81,7 +81,7 @@
   <ol class="pagination">
   {% if pagination.has_previous %}
     <li class="prev">
-      <a class="btn-page btn-page-prev" href="#" data-instant-search="link" data-href="{{ pagination.url|urlparams({page: pagination.number - 1}) }}">
+      <a class="btn-page btn-page-prev" href="#" data-instant-search="link" data-instant-search-set-params="page={{ pagination.number - 1 }}">
         <svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
                 <polyline stroke="currentColor" stroke-width="2" points="15 5 8 12 15 19"></polyline>
@@ -92,25 +92,25 @@
     </li>
   {% endif %}
   {% if pagination.dotted_lower %}
-    <li><a href="#" data-instant-search="link" data-href="{{ pagination.url|urlparams({page: 1}) }}">{{ 1 }}</a></li>
+    <li><a href="#" data-instant-search="link" data-instant-search-set-params="page=1">{{ 1 }}</a></li>
     {% if pagination.page_range[0] != 2 %}
       <li class="skip">&hellip;</li>
     {% endif %}
   {% endif %}
   {% for x in pagination.page_range %}
     <li {{ x|class_selected(pagination.number) }}>
-      <a href="#" class="{% if x == pagination.number %}btn-page{% endif %}" data-instant-search="link" data-href="{{ pagination.url|urlparams({page: x}) }}">{{ x }}</a>
+      <a href="#" class="{% if x == pagination.number %}btn-page{% endif %}" data-instant-search="link" data-instant-search-set-params="page={{ x }}">{{ x }}</a>
     </li>
   {% endfor %}
   {% if pagination.dotted_upper %}
     {% if pagination.page_range[-1] != pagination.num_pages-1 %}
       <li class="skip">&hellip;</li>
     {% endif %}
-    <li><a href="#" data-instant-search="link" data-href="{{ pagination.url|urlparams({page: pagination.num_pages}) }}">{{ pagination.num_pages }}</a></li>
+    <li><a href="#" data-instant-search="link" data-instant-search-set-params="page={{ pagination.num_pages }}">{{ pagination.num_pages }}</a></li>
   {% endif %}
   {% if pagination.has_next %}
     <li class="next">
-      <a href="#" data-instant-search="link" data-href="{{ pagination.url|urlparams({page: pagination.number + 1}) }}">
+      <a href="#" data-instant-search="link" data-instant-search-set-params="page={{ pagination.number + 1 }}">
         <span class="sr-only">{{ _('Next') }}</span>
         <svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">

--- a/kitsune/sumo/static/sumo/tpl/search-results.html
+++ b/kitsune/sumo/static/sumo/tpl/search-results.html
@@ -5,25 +5,17 @@
     {% if num_results > 0 %}
     <aside class="sumo-l-two-col--sidebar">
       <h3 class="sidebar-subheading">{{ _('Filter by product') }}</h3>
-      {% set base_doctype_url = base_url %}
-      {% if product %}
-        {% set base_doctype_url = base_doctype_url|urlparams(product=product.slug) %}
-      {% endif %}
-      {% set base_product_url = base_url %}
-      {% if w != 3 %}
-        {% set base_product_url = base_product_url|urlparams(w=w) %}
-      {% endif %}
       <nav class="sidebar-nav">
       <a class="details-heading">Menu Title</a>
       <ul id="product-filter" class="search-filter sidebar-nav--list">
         <li {{ product|class_selected(null) }}>
-          <a href="#" data-instant-search-unset-params="product" data-instant-search-set-params="all_products=1" data-instant-search="link" data-href="{{ base_product_url|urlparams(all_products=1)|encodeURI }}">
+          <a href="#" data-instant-search-unset-params="product" data-instant-search-set-params="all_products=1" data-instant-search="link">
             {{ _('All Products') }}
           </a>
         </li>
         {% for p in products %}
           <li {{ product|class_selected(p.slug) }}>
-            <a href="#" data-instant-search-set-params="product={{ p.slug }}" data-instant-search-unset-params="all_products" data-instant-search="link" data-href="{{ base_product_url|urlparams(product=p.slug)|encodeURI }}">
+            <a href="#" data-instant-search-set-params="product={{ p.slug }}" data-instant-search-unset-params="all_products" data-instant-search="link">
               {{ p.title }}
             </a>
           </li>


### PR DESCRIPTION
data-href was duplicating functionality with data-instant-search-(un)set-params,
and was the cause of the bug, so we can remove it, DRY the code, and fix the bug

https://github.com/mozilla/sumo-project/issues/131