### PR TITLE
put wafflejs script tag behind a waffle switch

### DIFF
--- a/kitsune/sumo/static/sumo/js/instant_search.es6
+++ b/kitsune/sumo/static/sumo/js/instant_search.es6
@@ -12,7 +12,7 @@
   // the local storage flag overrides everything else:
   if (
     localStorageUseV2 ??
-    ($("body").data("readonly") || waffle.flag_is_active("instant_search_v2"))
+    ($("body").data("readonly") || window.waffle?.flag_is_active("instant_search_v2"))
   ) {
     var search = new k.Search("/" + locale + "/search/v2/");
   } else {

--- a/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
@@ -47,7 +47,6 @@ describe('instant search', () => {
       // build process in place.
       global.tabsInit = require('../sumo-tabs.es6').tabsInit;
       global.detailsInit = require('../protocol-details-init.js').detailsInit;
-      global.waffle = { flag_is_active: () => undefined };
 
 
       rerequire('../i18n.js');


### PR DESCRIPTION
always load the script on kb articles which will get cached
avoid blowing up JS when waffle object doesn't exist

https://github.com/mozilla/kitsune/pull/4691#discussion_r580872162