### PR TITLE
ensure prepare_django_assets picks up updated dependencies in dev

### DIFF
--- a/prepare_django_assets.js
+++ b/prepare_django_assets.js
@@ -9,9 +9,6 @@ Object.keys(packageJson.dependencies).forEach(function (packageName) {
   cpx.copy(
     util.format("node_modules/%s/**", packageName),
     util.format("assets/%s", packageName),
-    {
-      "update": true
-    },
     function(err){
       if(err) {
         console.log(util.format("cpx error for %s: %s", packageName, err));


### PR DESCRIPTION
counterintuitively update: true's behaviour is to *not* overwrite files if the source is older than the dest