### PR TITLE
Do not use signals for timeout.

### DIFF
--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -323,7 +323,7 @@ def has_blocked_link(data):
     return False
 
 
-@timeout(seconds=settings.REGEX_TIMEOUT)
+@timeout(seconds=settings.REGEX_TIMEOUT, use_signals=False)
 def match_regex_with_timeout(compiled_regex, data):
     """Matches the specified regex.
 


### PR DESCRIPTION
Signals are only propagated on the main thread, causing problems when the function wrapped with the `timeout` decorator is not executed on the main