### PR TITLE
instant search: add/remove hash from url when opening/closing

### DIFF
--- a/kitsune/sumo/static/sumo/js/instant_search.es6
+++ b/kitsune/sumo/static/sumo/js/instant_search.es6
@@ -78,9 +78,9 @@
     if (history.state?.query) {
       // if a search is already the latest point in history, replace it
       // to avoid filling history with partial searches
-      history.replaceState(historyState, searchTitle);
+      history.replaceState(historyState, searchTitle, "#search");
     } else {
-      history.pushState(historyState, searchTitle);
+      history.pushState(historyState, searchTitle, "#search");
     }
 
     var base_url = search.lastQueryUrl();
@@ -144,7 +144,7 @@
       window.k.InstantSearchSettings.showContent();
 
       if (history.state?.query) {
-        history.pushState({}, searchTitle);
+        history.pushState({}, searchTitle, location.href.replace("#search", ""));
       }
     } else if ($this.val() !== search.lastQuery) {
       if (searchTimeout) {


### PR DESCRIPTION
chrome doesn't update history.state when navigating to the same url
as the one currently in the address bar: this had the effect of
re-opening instant search when clicking on the homepage link,
when instant search has been opened from the homepage

adding a hash to the url means it changes, and works around this
behaviour in chrome

https://github.com/mozilla/sumo-project/issues/795