### PR TITLE
instant search: trim query before submitting

### DIFF
--- a/kitsune/sumo/static/sumo/js/instant_search.es6
+++ b/kitsune/sumo/static/sumo/js/instant_search.es6
@@ -177,7 +177,7 @@
         }
         search.unsetParam("page");
         search.setParams(params);
-        let query = $this.val();
+        let query = $this.val().trim();
         queries.push(query);
         search.query(query, k.InstantSearchSettings.render);
         trackEvent('Instant Search', 'Search', search.lastQueryUrl());


### PR DESCRIPTION
django trims the whitespace around the query, which is returned in
the response, causing problems when determining what order queries
were submitted in

also has the bonus of not submitting another request when a user
adds a space to a query then pauses

https://github.com/mozilla/sumo-project/issues/800