### PR TITLE
deep link to instant search results pages

### DIFF
--- a/kitsune/search/jinja2/search/instant-search.html
+++ b/kitsune/search/jinja2/search/instant-search.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block breadcrumbs %}
+{% endblock %}
+
+{% block hidden_search_masthead %}
+{% endblock %}
+
+{% block masthead %}
+<section class="home-search-section sumo-page-section--lg extra-pad-bottom shade-bg">
+  <div class="mzp-l-content narrow">
+    <div class="home-search-section--content">
+      <h1 class="sumo-page-heading-xl">{{ _('Search Support') }}</h1>
+      {{ search_box(settings, id='support-search-masthead', query=query) }}
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+{% endblock %}

--- a/kitsune/search/v2/views.py
+++ b/kitsune/search/v2/views.py
@@ -3,6 +3,7 @@ from math import ceil
 
 from django.conf import settings
 from django.http import HttpResponse
+from django.shortcuts import render
 from django.utils.translation import pgettext
 from django.utils.translation import ugettext as _
 
@@ -25,6 +26,10 @@ def _get_product_title(product_title):
 
 
 def simple_search(request):
+    is_json = request.GET.get("format") == "json"
+    if not is_json:
+        return render(request, "search/instant-search.html", {"query": request.GET.get("q")})
+
     search_form = SimpleSearchForm(request.GET, auto_id=False)
 
     if not search_form.is_valid():

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -1,13 +1,24 @@
 {% macro search_box(settings, id=False, prefix=None, target=None,
                     placeholder=_('Find help...'),
-                    params=None) %}
+                    params=None, query=None) %}
   <form data-instant-search="form" {% if id %}id="{{ id }}"{% endif %} action="{{ url('search') }}" method="get" {% if target %} target="{{ target }}"{% endif %} class="simple-search-form">
     {% if params %}
       {% for k, v in params.items() %}
         <input type="hidden" name="{{ k }}" value="{{ v }}" />
       {% endfor %}
     {% endif %}
-    <input type="search" autocomplete="off" name="q" aria-required="true" placeholder="{{ placeholder }}" class="searchbox" id="search-q" />
+    <input
+      type="search"
+      autocomplete="off"
+      name="q"
+      aria-required="true"
+      placeholder="{{ placeholder }}"
+      class="searchbox"
+      id="search-q"
+      {% if query %}
+        value="{{ query }}"
+      {% endif %}
+    />
     <button type="submit" title="{{ _('Search') }}" class="search-button">{{ _('Search') }}</button>
   </form>
 {% endmacro %}

--- a/kitsune/sumo/static/sumo/js/search_utils.es6
+++ b/kitsune/sumo/static/sumo/js/search_utils.es6
@@ -65,7 +65,7 @@
 
   Search.prototype.query = function(string, callback) {
     string ||= this.lastQuery;
-    var data = $.extend({}, this.params, {q: string});
+    var data = $.extend({}, this.params, {q: string, format: "json"});
 
     this.lastQuery = string;
     this.lastParams = this.serializeParams({q: string});

--- a/kitsune/sumo/static/sumo/js/showfor.js
+++ b/kitsune/sumo/static/sumo/js/showfor.js
@@ -64,7 +64,7 @@
 // Bind events for ShowFor.
   ShowFor.prototype.initEvents = function() {
     window.onpopstate = this.updateUI.bind(this);
-    this.$container.on('change keyup', 'input, select', this.onUIChange.bind(this));
+    this.$container.find("#showfor-panel").on('change keyup', 'input, select', this.onUIChange.bind(this));
   };
 
   /* Selects an option from a showfor selectbox, adding it if appropriate.


### PR DESCRIPTION
update browser url to deep link while searching with v2
serve stub that launches instant search from /search/v2/
stop showfor from interfering with instant search

https://github.com/mozilla/sumo-project/issues/818