### PR TITLE
increase the timeout between sending take question api calls to a minute

### DIFF
--- a/kitsune/sumo/static/sumo/js/questions.js
+++ b/kitsune/sumo/static/sumo/js/questions.js
@@ -61,7 +61,7 @@
         }
       }
 
-      $('#id_content').on('keyup', _.throttle(takeQuestion, 1000));
+      $('#id_content').on('keyup', _.throttle(takeQuestion, 60000));
 
       $(document).on('click', '#details-edit', function(ev) {
         ev.preventDefault();


### PR DESCRIPTION
this was bombarding the backend with calls every second as a user was typing, which in turn would update the database, and reindex the question in elastic