### PR TITLE
add snippet of content to users' latest answers pages

### DIFF
--- a/kitsune/users/jinja2/users/answers_contributed.html
+++ b/kitsune/users/jinja2/users/answers_contributed.html
@@ -14,9 +14,10 @@
     {% endif %}
     <ul class="mzp-u-list-styled">
       {% for answer in answers %}
-        <a href="{{ answer.get_absolute_url() }}">
-          <li>{{ answer.question.title }}</li>
-        </a>
+        <li>
+          <a href="{{ answer.get_absolute_url() }}">{{ answer.question.title }}</a>
+          <blockquote>{{ answer.content|striptags|truncatechars(180) }}</blockquote>
+        </li>
       {% endfor %}
     </ul>
   </article>


### PR DESCRIPTION
to distinguish different answers on the same question from each other
use the unparsed content to avoid hitting the cache up to 100 times