### PR TITLE
re-allow empty query in advanced search

### DIFF
--- a/kitsune/search/forms.py
+++ b/kitsune/search/forms.py
@@ -79,7 +79,8 @@ class SimpleSearchForm(BaseSearchForm):
 class AdvancedSearchForm(BaseSearchForm):
     """Django form for handling display and validation"""
 
-    # Common fields
+    q = forms.CharField(required=False, max_length=MAX_QUERY_LENGTH)
+
     # TODO: get rid of this.
     a = forms.IntegerField(required=False, widget=forms.HiddenInput)
 


### PR DESCRIPTION
5472d99edf8320e20eab38f7b35aa1d9a14928da accidentally made the q parameter required

https://bugzilla.mozilla.org/show_bug.cgi?id=1707552