### PR TITLE
escape the names of uploaded files in aaq/gallery

### DIFF
--- a/kitsune/gallery/utils.py
+++ b/kitsune/gallery/utils.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.files import File
+from django.utils.html import escape
 
 from kitsune.gallery.forms import ImageForm
 from kitsune.gallery.models import Image
@@ -34,10 +35,11 @@ def create_image(files, user):
     # Finally save the image along with uploading the file.
     image.file.save(up_file.name, File(up_file), save=True)
 
+    name = escape(up_file.name)
     (width, height) = _scale_dimensions(image.file.width, image.file.height)
     delete_url = reverse("gallery.delete_media", args=["image", image.id])
     return {
-        "name": up_file.name,
+        "name": name,
         "url": image.get_absolute_url(),
         "thumbnail_url": image.thumbnail_url_if_set(),
         "width": width,

--- a/kitsune/upload/utils.py
+++ b/kitsune/upload/utils.py
@@ -4,9 +4,9 @@ import io
 from django.conf import settings
 from django.core.files import File
 from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.utils.html import escape
 from django.utils.translation import ugettext_lazy as _lazy
 
-import bleach
 from PIL import Image
 
 from kitsune.upload.forms import ImageAttachmentUploadForm
@@ -53,7 +53,7 @@ def create_imageattachment(files, user, obj):
     (width, height) = _scale_dimensions(image.file.width, image.file.height)
 
     # The filename may contain html in it. Escape it.
-    name = bleach.clean(up_file.name)
+    name = escape(up_file.name)
 
     return {
         "name": name,


### PR DESCRIPTION
use django.html.utils.escape rather than bleach.clean, as these names are used in HTML attributes: see "Warning:" https://bleach.readthedocs.io/en/v3.3.0/clean.html

https://bugzilla.mozilla.org/show_bug.cgi?id=1695985