### PR TITLE
Use new version of the Jenkins pipeline library.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('github.com/mozilla-it/jenkins-pipeline@20171123.1')
+@Library('github.com/mozilla-it/jenkins-pipeline@20210601.1')
 def config
 def docker_image
 def dc_name
@@ -112,4 +112,3 @@ conduit {
         sh "bin/slack-notify.sh --status success --stage 'Docker image ready to deploy: ${docker_image}'"
     }
 }
-


### PR DESCRIPTION
The new library version includes a fix to the way it logs in to Docker, which [fixes the bulid](https://ci.sumo.mozit.cloud/job/sumo-dev-multipipeline/job/update-jenkins-lib/1/).