### PR TITLE
fix jquery paths in webpack entrypoint config

### DIFF
--- a/webpack/entrypoints.js
+++ b/webpack/entrypoints.js
@@ -5,7 +5,6 @@ module.exports = {
     "underscore/underscore.js",
     "moment/moment.js",
     "jquery",
-    // "jquery/jquery-migrate.js",
     "sumo/js/libs/jquery.cookie.js",
     "sumo/js/libs/jquery.placeholder.js",
     "sumo/js/templates/macros.js",
@@ -51,7 +50,6 @@ module.exports = {
   ],
   community: [
     "jquery",
-    // "jquery/jquery-migrate.js",
     "community/js/community.js",
     "community/js/select.js",
   ],


### PR DESCRIPTION
remove jquery-migrate, the file doesn't exist, and we've been running fine without it for at least 2 years

https://github.com/mozilla/sumo-project/issues/881