### PR TITLE
drop IE-specific files: html5-shiv.js, browserconfig.xml

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -54,11 +54,6 @@
     <link rel="canonical" href="{{ canonical_url|safe }}" />
   {% endif %}
 
-  <!--[if lt IE 9]>
-  {# html5-shiv.js must be inside <head/> to work. #}
-  <script src="{{ STATIC_URL }}sumo/js/libs/html5-shiv.js"></script>
-  <![endif]-->
-
   {% include "includes/google-analytics.html" %}
 </head>
 

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -386,7 +386,6 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{ STATIC_URL }}sumo/img/favicon-16x16.png">
 <link rel="manifest" href="{{ STATIC_URL }}sumo/manifest.json">
 <link rel="shortcut icon" href="{{ STATIC_URL }}sumo/img/favicon.ico">
-<meta name="msapplication-config" content="{{ STATIC_URL }}sumo/browserconfig.xml">
 <meta name="theme-color" content="#ffffff">
 {% endmacro %}
 

--- a/kitsune/sumo/static/sumo/browserconfig.xml
+++ b/kitsune/sumo/static/sumo/browserconfig.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<browserconfig>
-    <msapplication>
-        <tile>
-            <square150x150logo src="/static/sumo/img/mstile-150x150.png"/>
-            <TileColor>#da532c</TileColor>
-        </tile>
-    </msapplication>
-</browserconfig>

--- a/kitsune/sumo/static/sumo/js/libs/html5-shiv.js
+++ b/kitsune/sumo/static/sumo/js/libs/html5-shiv.js
@@ -1,2 +1,0 @@
-// For discussion and comments, see: http://remysharp.com/2009/01/07/html5-enabling-script/ (credit to @jdalton for minif)
-/*@cc_on'abbr article aside audio canvas details figcaption figure footer header hgroup mark meter nav output progress section summary time video'.replace(/\w+/g,function(n){document.createElement(n)})@*/


### PR DESCRIPTION
html5-shiv.js: adds support for html5 elements for IE<9, however prod already renders incredibly badly for our <0.01% of users on IE 8 and below

browserconfig.xml: webmanifest equivalent for live tiles in windows, not supported in MS Edge

https://github.com/mozilla/sumo-project/issues/893
