### PR TITLE
handle external aaq better in preparation for premium aaq

### DIFF
--- a/kitsune/products/jinja2/products/documents.html
+++ b/kitsune/products/jinja2/products/documents.html
@@ -24,10 +24,7 @@
   {{ search_box(settings, id='support-search-sidebar', params=search_params) }}
 </div>
 
-{% set aaq_product = request.session.get('product_key') %}
-{% if aaq_product %}
-  {{ aaq_widget(aaq_product, user, "topic") }}
-{% endif %}
+{{ aaq_widget(request, "topic") }}
 
 {{ topic_sidebar(topics[:10], subtopics, product, topic, subtopic) }}
 {% endblock %}

--- a/kitsune/products/jinja2/products/includes/topic_macros.html
+++ b/kitsune/products/jinja2/products/includes/topic_macros.html
@@ -1,4 +1,4 @@
-{% macro help_topics(topics, show_community_support=False, product_slug=None, new_tab=False) -%}
+{% macro help_topics(topics, product_slug=None, new_tab=False) -%}
 
   <div class="sumo-card-grid" style="--cg-count: {{ topics|length }};">
     <div class="scroll-wrap">
@@ -24,9 +24,8 @@
   </div>
 {%- endmacro %}
 
-{% macro topic_metadata(topics, show_community_support=False, product_key=None) %}
+{% macro topic_metadata(topics, product_key=None) %}
 <section class="support-callouts mzp-l-content sumo-page-section--inner">
-  {% if show_community_support %}
   <div class="card card--ribbon is-inverse heading-is-one-line">
     <div class="card--details">
       <h3 class="card--title">
@@ -47,13 +46,12 @@
       {% else %}
         {% set aaq_url=url('questions.aaq_step1') %}
       {% endif %}
-      <a class="sumo-button primary-button button-lg" 
+      <a class="sumo-button primary-button button-lg"
         href={{ aaq_url }} data-event-label="Get community support">
         {{ _('Ask the Community') }}
       </a>
     </div>
   </div>
-  {% endif %}
 </section>
 
 {% if settings.OIDC_ENABLE and product.id in subscribed_products_ids %}

--- a/kitsune/products/jinja2/products/product.html
+++ b/kitsune/products/jinja2/products/product.html
@@ -149,10 +149,10 @@
       </div>
       {% endif %}
     </div>
-    {{ help_topics(topics, show_community_support=product.questions_enabled(request.LANGUAGE_CODE)) }}
+    {{ help_topics(topics) }}
   </div>
 
-  {{ topic_metadata(topics, show_community_support=product.questions_enabled(request.LANGUAGE_CODE), product_key=product_key) }}
+  {{ topic_metadata(topics, product_key=product_key) }}
 
 {% if featured %}
   <section class="mzp-l-content mzp-l-content sumo-page-section--inner">

--- a/kitsune/questions/jinja2/questions/includes/aaq_macros.html
+++ b/kitsune/questions/jinja2/questions/includes/aaq_macros.html
@@ -84,23 +84,31 @@
   </ul>
 {%- endmacro %}
 
-{% macro aaq_widget(key, user, location="aaq") %}
-  <div class="aaq-widget card elevation-01 text-center radius-md">
-    <h2 class="card--title has-bottom-margin">{{ _('Ask the Community') }}</h2>
-    {% if user.is_authenticated %}
-      <p>{{ _('Continue to post your question and get help.') }}</p>
-    {% else %}
-      <p>{{ _('Sign in/up to post your question and get help.') }}</p>
-    {% endif %}
-    <a class="sumo-button primary-button feature-box"
-       href="{{ url('questions.aaq_step3', product_key=key) }}"
-       data-event-category="link click"
-       data-event-action="{{ location }}"
-       data-event-label="aaq widget">{{ _('Ask Now') }}</a>
-  </div>
+{% macro aaq_widget(request, location="aaq") %}
+  {% set aaq_context = request.session.get("aaq_context") %}
+  {% if aaq_context %}
+    <div class="aaq-widget card elevation-01 text-center radius-md">
+      <h2 class="card--title has-bottom-margin">{{ _('Ask the Community') }}</h2>
+      {% if request.user.is_authenticated %}
+        <p>{{ _('Continue to post your question and get help.') }}</p>
+      {% else %}
+        <p>{{ _('Sign in/up to post your question and get help.') }}</p>
+      {% endif %}
+      {% if not aaq_context.has_public_forum and not aaq_context.has_subscriptions %}
+        {% set next_step = url('wiki.document', 'get-community-support')|urlparams(exit_aaq=1) %}
+      {% else %}
+        {% set next_step = url('questions.aaq_step3', product_key=aaq_context.key) %}
+      {% endif %}
+      <a class="sumo-button primary-button feature-box"
+        href="{{ next_step }}"
+        data-event-category="link click"
+        data-event-action="{{ location }}"
+        data-event-label="aaq widget">{{ _('Ask Now') }}</a>
+    </div>
+  {% endif %}
 {%- endmacro %}
 
-{% macro explore_solutions(product, search_box, featured, topics, user) -%}
+{% macro explore_solutions(product, search_box, featured, topics, request) -%}
 {% set search_params = {'product': product.product} %}
 <section class="sumo-page-section question-masthead shade-bg">
   <div class="mzp-l-content">
@@ -122,7 +130,7 @@
         </p>
       </div>
       <div class="sumo-l-two-col--sidebar">
-        {{ aaq_widget(product.key, user) }}
+        {{ aaq_widget(request) }}
       </div>
     </div>
   </div>

--- a/kitsune/questions/jinja2/questions/new_question.html
+++ b/kitsune/questions/jinja2/questions/new_question.html
@@ -20,7 +20,7 @@
 
 {% block contentwrap %}
   {% if current_step == 2 %}
-    {{ explore_solutions(current_product, search_box, featured, topics, user) }}
+    {{ explore_solutions(current_product, search_box, featured, topics, request) }}
   {% else %}
     {{ super() }}
   {% endif %}

--- a/kitsune/questions/jinja2/questions/question_details.html
+++ b/kitsune/questions/jinja2/questions/question_details.html
@@ -304,10 +304,7 @@
   {{ search_box(settings, id='support-search-sidebar', params=search_params, placeholder=_('Search Support')) }}
 </div>
 
-{% set aaq_product = request.session.get('product_key') %}
-{% if aaq_product %}
-  {{ aaq_widget(aaq_product, user, "question") }}
-{% endif %}
+{{ aaq_widget(request, "question") }}
 
 <div class="questions-sidebar">
   <nav class="sidebar-nav is-action-list" id="question-tools">

--- a/kitsune/questions/jinja2/questions/question_details.html
+++ b/kitsune/questions/jinja2/questions/question_details.html
@@ -270,20 +270,16 @@
         </form>
       {% elif question.editable and not user.is_authenticated %}
         <div class="question-tools ask-a-question card is-shaded">
-          {% if request.LANGUAGE_CODE in AAQ_LANGUAGES %}
-            {% set ask_url = url('questions.aaq_step1') %}
-          {% else %}
-            {% set ask_url = url('wiki.document', 'get-community-support') %}
-          {% endif %}
+          {% set ask_url = url('questions.aaq_step1') %}
           {% if answers.object_list and not question.has_voted(request) %}
-          {# Only show the button again if there are answers in between #}
-          <div class="me-too sumo-button-stack">
-            <a class="sumo-button primary-button button-lg" href="{{ ask_url }}">{{ _('Ask a question') }}</a>
-            <form action="{{ url('questions.vote', question_id=question.id) }}" method="post">
-              <button class="sumo-button secondary-button button-lg" type="submit">{{ _('I have this problem, too') }}</button>
-            </form>
-          </div>
-        {% endif %}
+            {# Only show the button again if there are answers in between #}
+            <div class="me-too sumo-button-stack">
+              <a class="sumo-button primary-button button-lg" href="{{ ask_url }}">{{ _('Ask a question') }}</a>
+              <form action="{{ url('questions.vote', question_id=question.id) }}" method="post">
+                <button class="sumo-button secondary-button button-lg" type="submit">{{ _('I have this problem, too') }}</button>
+              </form>
+            </div>
+          {% endif %}
           <p>
             {{ _('You must <a href="{login_url}">log in to your account</a> to reply to posts. Please <a href="{ask_url}">start a new question</a>, if you do not have an account yet.')|fe(login_url=url('users.auth'), ask_url=ask_url) }}
           </p>

--- a/kitsune/questions/jinja2/questions/question_list.html
+++ b/kitsune/questions/jinja2/questions/question_list.html
@@ -101,7 +101,7 @@
         {% else %}
         <a
           class="sumo-button primary-button button-lg feature-box"
-          href="{{ url('wiki.document', 'get-community-support') }}">
+          href="{{ url('questions.aaq_step1') }}">
           {{ _('Ask the Community') }}
         </a>
         {% endif %}

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -45,13 +45,6 @@
 {% endmacro %}
 
 {% macro aux_nav(user, hide_aaq_link=False) %}
-{% if not settings.READ_ONLY %}
-{% if request.LANGUAGE_CODE in AAQ_LANGUAGES %}
-{% set ask_url = url('questions.aaq_step1') %}
-{% else %}
-{% set ask_url = url('wiki.document', 'get-community-support') %}
-{% endif %}
-{% endif %}
 <li class="mzp-c-menu-category mzp-has-drop-down mzp-js-expandable">
   <a class="mzp-c-menu-title sumo-nav--link" href="{{ url('questions.home') }}" aria-haspopup="true"
     aria-controls="mzp-c-menu-panel-help">{{ _('Get Help') }}</a>
@@ -62,7 +55,7 @@
           aria-controls="mzp-c-menu-panel-example">{{ _('Close Firefox menu') }}</button>
         <div class="sumo-nav--dropdown-col">
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
-            <a class="mzp-c-menu-item-link" href="{{ ask_url }}">
+            <a class="mzp-c-menu-item-link" href="{{ url('questions.aaq_step1') }}">
               <svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24">
                 <g stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"

--- a/kitsune/sumo/middleware.py
+++ b/kitsune/sumo/middleware.py
@@ -322,9 +322,10 @@ class InAAQMiddleware(MiddlewareMixin):
             return None
         if "aaq" in view_name:
             request.session["in-aaq"] = True
-            request.session["product_key"] = callback_kwargs.get("product_key")
         else:
             request.session["in-aaq"] = False
-            if "/questions/new" not in request.META.get("HTTP_REFERER", ""):
-                request.session["product_key"] = ""
+            if ("/questions/new" not in request.META.get("HTTP_REFERER", "")) or (
+                "exit_aaq" in request.GET
+            ):
+                request.session["aaq_context"] = {}
         return None

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -43,10 +43,7 @@
     {{ search_box(settings, id='support-search-sidebar', params=search_params) }}
   </div>
 
-  {% set aaq_product = request.session.get('product_key') %}
-  {% if aaq_product %}
-    {{ aaq_widget(aaq_product, user, "document") }}
-  {% endif %}
+  {{ aaq_widget(request, "document") }}
 
   {% if fallback_reason == 'no_translation' %}
     {# If there is no translation, there is no document and the (future) parent is document. #}


### PR DESCRIPTION
- aaq: move en-US redirect to step 3
- aaq: step 2 ask now link goes to kb for non-premium
- aaq: remove get-community-support kb links from everywhere but step 2
- show aaq banner on all products regardless of locale

https://github.com/mozilla/sumo-project/issues/915