### PR TITLE
fix: searching for impossible dates in instant search won't timeout

### DIFF
--- a/kitsune/search/base.py
+++ b/kitsune/search/base.py
@@ -323,7 +323,7 @@ class SumoSearch(SumoSearchInterface):
 
     query: str = ""
     default_operator: str = "AND"
-    parse_query: bool = True
+    parse_query: bool = dfield(default=True, init=False)
 
     def __len__(self):
         return self.total
@@ -384,10 +384,12 @@ class SumoSearch(SumoSearchInterface):
         # perform search
         try:
             result = search.execute()
-        except RequestError:
-            # try search again, but without parsing any advanced syntax
-            self.parse_query = False
-            return self.run(key)
+        except RequestError as e:
+            if self.parse_query:
+                # try search again, but without parsing any advanced syntax
+                self.parse_query = False
+                return self.run(key)
+            raise e
 
         self.hits = result.hits
         self.last_key = key

--- a/kitsune/search/search.py
+++ b/kitsune/search/search.py
@@ -321,6 +321,18 @@ class CompoundSearch(SumoSearch):
     """Combine a number of SumoSearch classes into one search."""
 
     _children: list[SumoSearch] = dfield(default_factory=list, init=False)
+    _parse_query: bool = True
+
+    @property
+    def parse_query(self):
+        return self._parse_query
+
+    @parse_query.setter
+    def parse_query(self, value):
+        """Set value of parse_query across all children."""
+        self._parse_query = value
+        for child in self._children:
+            child.parse_query = value
 
     def add(self, child):
         """Add a SumoSearch instance to search over. Chainable."""


### PR DESCRIPTION
I accidentally created an infinite recursion, because the value of self.parse_query wasn't propagating to child searches in a CompoundSearch

https://github.com/mozilla/sumo-project/issues/931
