### PR TITLE
fix styling issues on rtl aaq progress bar

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_progress-bar.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_progress-bar.scss
@@ -39,7 +39,10 @@
         &:after {
           position: absolute;
           top: 12px;
-          left: 0;
+          @include p.bidi((
+            (left, 0, auto),
+            (right, auto, 0),
+          ));
           z-index: 2;
           width: 50%;
           height: 3px;
@@ -60,8 +63,10 @@
 
       .progress--link-inner {
         &:after {
-          left: auto;
-          right: 0;
+          @include p.bidi((
+            (left, auto, 0),
+            (right, 0, auto),
+          ));
         }
       }
     }
@@ -123,8 +128,10 @@
     &.is-current {
       &:before {
         width: 50%;
-        right: 0;
-        left: auto;
+        @include p.bidi((
+          (right, 0, auto),
+          (left, auto, 0),
+        ));
         background: var(--color-marketing-gray-03);
         z-index: 2;
       }


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/938

![Screen Shot 2021-09-06 at 15 49 37](https://user-images.githubusercontent.com/755354/132234748-ed47b5eb-92db-4e4b-8f2d-417f5ac7186c.png)

Google's design guidelines suggest that progress bars should also run RTL in RTL locales: https://material.io/design/usability/bidirectionality.html#mirroring-layout
> An illustrated sequence of events progresses right to left.