### PR TITLE
enable docker layer caching in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,7 @@ jobs:
             pre-commit run --all-files
       - setup_remote_docker:
           version: 17.10.0-ce
-      - run:
-          name: Download docker images for cache
-          command: make pull
+          docker_layer_caching: true
       - run:
           name: Build docker images
           command: make build-ci


### PR DESCRIPTION
remove "Download docker images for cache" step as we don't need it any more

https://github.com/mozilla/sumo-project/issues/910

cuts build time by over 5 mins: https://app.circleci.com/pipelines/github/mozilla/kitsune?branch=circle-docker-cache

~15mins -> ~9mins