### PR TITLE
add missing dms_rebuild_kb secret back to k8s yaml files

### DIFF
--- a/k8s/regions/frankfurt/dev.yaml
+++ b/k8s/regions/frankfurt/dev.yaml
@@ -66,6 +66,7 @@ app:
     dms_enqueue_lag_monitor_task: SECRET
     dms_fix_current_revisions: SECRET
     dms_generate_missing_share_links: SECRET
+    dms_rebuild_kb: SECRET
     dms_reindex_es7: SECRET
     dms_reload_question_traffic_stats: SECRET
     dms_reload_wiki_traffic_stats: SECRET

--- a/k8s/regions/frankfurt/prod.yaml
+++ b/k8s/regions/frankfurt/prod.yaml
@@ -64,6 +64,7 @@ app:
     dms_enqueue_lag_monitor_task: SECRET
     dms_fix_current_revisions: SECRET
     dms_generate_missing_share_links: SECRET
+    dms_rebuild_kb: SECRET
     dms_reindex_es7: SECRET
     dms_reload_question_traffic_stats: SECRET
     dms_reload_wiki_traffic_stats: SECRET

--- a/k8s/regions/frankfurt/stage.yaml
+++ b/k8s/regions/frankfurt/stage.yaml
@@ -67,6 +67,7 @@ app:
     dms_enqueue_lag_monitor_task: SECRET
     dms_fix_current_revisions: SECRET
     dms_generate_missing_share_links: SECRET
+    dms_rebuild_kb: SECRET
     dms_reindex_es7: SECRET
     dms_reload_question_traffic_stats: SECRET
     dms_reload_wiki_traffic_stats: SECRET

--- a/k8s/regions/frankfurt/test.yaml
+++ b/k8s/regions/frankfurt/test.yaml
@@ -66,6 +66,7 @@ app:
     dms_enqueue_lag_monitor_task: SECRET
     dms_fix_current_revisions: SECRET
     dms_generate_missing_share_links: SECRET
+    dms_rebuild_kb: SECRET
     dms_reindex_es7: SECRET
     dms_reload_question_traffic_stats: SECRET
     dms_reload_wiki_traffic_stats: SECRET

--- a/k8s/regions/oregon-a/prod.yaml
+++ b/k8s/regions/oregon-a/prod.yaml
@@ -68,6 +68,7 @@ app:
     dms_enqueue_lag_monitor_task: SECRET
     dms_fix_current_revisions: SECRET
     dms_generate_missing_share_links: SECRET
+    dms_rebuild_kb: SECRET
     dms_reindex_es7: SECRET
     dms_reload_question_traffic_stats: SECRET
     dms_reload_wiki_traffic_stats: SECRET

--- a/k8s/regions/oregon-a/stage.yaml
+++ b/k8s/regions/oregon-a/stage.yaml
@@ -67,6 +67,7 @@ app:
     dms_enqueue_lag_monitor_task: SECRET
     dms_fix_current_revisions: SECRET
     dms_generate_missing_share_links: SECRET
+    dms_rebuild_kb: SECRET
     dms_reindex_es7: SECRET
     dms_reload_question_traffic_stats: SECRET
     dms_reload_wiki_traffic_stats: SECRET

--- a/k8s/regions/oregon-b/prod.yaml
+++ b/k8s/regions/oregon-b/prod.yaml
@@ -68,6 +68,7 @@ app:
     dms_enqueue_lag_monitor_task: SECRET
     dms_fix_current_revisions: SECRET
     dms_generate_missing_share_links: SECRET
+    dms_rebuild_kb: SECRET
     dms_reindex_es7: SECRET
     dms_reload_question_traffic_stats: SECRET
     dms_reload_wiki_traffic_stats: SECRET

--- a/k8s/regions/oregon-b/stage.yaml
+++ b/k8s/regions/oregon-b/stage.yaml
@@ -67,6 +67,7 @@ app:
     dms_enqueue_lag_monitor_task: SECRET
     dms_fix_current_revisions: SECRET
     dms_generate_missing_share_links: SECRET
+    dms_rebuild_kb: SECRET
     dms_reindex_es7: SECRET
     dms_reload_question_traffic_stats: SECRET
     dms_reload_wiki_traffic_stats: SECRET


### PR DESCRIPTION
accidentally removed in 2ef9d706a23a015f47ec48e3d7adfb2496bb4779
