### PR TITLE
don't show aaq banner on products with no aaq flow

### DIFF
--- a/kitsune/products/jinja2/products/includes/topic_macros.html
+++ b/kitsune/products/jinja2/products/includes/topic_macros.html
@@ -25,7 +25,7 @@
 {%- endmacro %}
 
 {% macro topic_metadata(topics, product=None, product_key=None) %}
-{% if not settings.READ_ONLY %}
+{% if product_key and not settings.READ_ONLY %}
   <section class="support-callouts mzp-l-content sumo-page-section--inner">
     <div class="card card--ribbon is-inverse heading-is-one-line">
       <div class="card--details">
@@ -48,13 +48,9 @@
             {{ _('We’re here for you. Post a question to our support forums and get answers from our community of experts.') }}
           {% endif %}
         </p>
-        {% if product_key %}
-          {% set aaq_url=url('questions.aaq_step2', product_key=product_key) %}
-        {% else %}
-          {% set aaq_url=url('questions.aaq_step1') %}
-        {% endif %}
+        {% set aaq_url=url('questions.aaq_step2', product_key=product_key) %}
         <a class="sumo-button primary-button button-lg"
-          href={{ aaq_url }} data-event-label="Get support">
+          href="{{ aaq_url }}" data-event-label="Get support">
           {% if product and product.has_subscriptions %}
             {{ _('Get Support') }}
           {% else %}


### PR DESCRIPTION
https://github.com/mozilla/sumo-project/issues/958

Slight modification to current logic, as entering step 1 of the AAQ from products without any flow is a dead end - there's no "other" option, and it encourages posting to the wrong forum.