### PR TITLE
update text and links on focus banners

### DIFF
--- a/kitsune/products/jinja2/products/documents.html
+++ b/kitsune/products/jinja2/products/documents.html
@@ -73,12 +73,16 @@
       {% if topic.slug == "Focus-ios" %}
         {{ sumo_banner(
           id="focus-ios-beta-banner",
-          text=_('Experience new functionality and updates by helping us test the Beta and Nightly versions of Firefox Focus for iOS. <a href="https://testflight.apple.com/join/dH8lkFZi">Follow these steps to get started.</a>'),
+          text=_('Experience new functionality and updates by helping us test the Beta and Nightly versions of Firefox Focus for iOS.'),
+          button_text=_('Get started'),
+          button_link="https://testflight.apple.com/join/dH8lkFZi",
         ) }}
       {% elif topic.slug == "firefox-focus-android" %}
         {{ sumo_banner(
           id="focus-android-beta-banner",
-          text=_('Experience new functionality and updates by helping us test the Beta and Nightly versions of Firefox Focus for Android. <a href="">Learn how to get started.</a>'),
+          text=_('Experience new functionality and updates by helping us test the Beta and Nightly versions of Firefox Focus for Android.'),
+          button_text=_('Get started'),
+          button_link=url('wiki.document', 'download-beta-and-nightly-focus-android'),
         ) }}
       {% endif %}
 


### PR DESCRIPTION
![Screenshot 2021-11-29 at 15-02-11 Firefox Focus for Android Firefox Focus Help - 127 0 0 1](https://user-images.githubusercontent.com/755354/143891186-a27ff18a-52a7-46e5-ab76-a963fbe1c470.png)
![Screenshot 2021-11-29 at 15-02-07 Firefox Focus for iOS Firefox Focus Help - 127 0 0 1](https://user-images.githubusercontent.com/755354/143891198-c911be85-b813-49cf-829e-a63bf2944f6e.png)
