### PR TITLE
remove use of jquery-ui datepicker outside of rickshaw dashboards

### DIFF
--- a/kitsune/sumo/monkeypatch.py
+++ b/kitsune/sumo/monkeypatch.py
@@ -11,9 +11,19 @@ TESTING = (len(sys.argv) > 1 and sys.argv[1] == "test") or sys.argv[0].endswith(
 class DateWidget(fields.DateField.widget):
     input_type = "date"
 
+    def __init__(self, *args, **kwargs):
+        # force format to be what <input type="date"> expects, regardless of locale
+        kwargs["format"] = "%Y-%m-%d"
+        super().__init__(*args, **kwargs)
+
 
 class TimeWidget(fields.TimeField.widget):
     input_type = "time"
+
+    def __init__(self, *args, **kwargs):
+        # force format to be what <input type="time"> expects, regardless of locale
+        kwargs["format"] = "%H:%M"
+        super().__init__(*args, **kwargs)
 
 
 def patch():

--- a/kitsune/sumo/static/sumo/js/search.js
+++ b/kitsune/sumo/static/sumo/js/search.js
@@ -1,4 +1,3 @@
-import "jquery-ui/ui/widgets/datepicker";
 import "jquery-ui/ui/widgets/tabs";
 
 $(document).ready(function() {
@@ -13,9 +12,6 @@ $(document).ready(function() {
       }
     });
   });
-
-  $('.datepicker').attr('type','text').datepicker();
-  $('.datepicker').attr('readonly', 'readonly').css('background', '#ddd');
 
   $('select', cache_search_date).change(function () {
     if ($(this).val() === 0) {

--- a/kitsune/sumo/static/sumo/js/ui.js
+++ b/kitsune/sumo/static/sumo/js/ui.js
@@ -1,4 +1,3 @@
-import "jquery-ui/ui/widgets/datepicker";
 import _throttle from "underscore/modules/throttle";
 import UITour from "./libs/uitour";
 import trackEvent from "sumo/js/analytics";
@@ -27,10 +26,6 @@ import trackEvent from "sumo/js/analytics";
         $('body').removeClass('scroll-header');
       }
     }, 100));
-
-    if ($.datepicker) {
-      $('input[type="date"]').attr('type', 'text').datepicker();
-    }
 
     $('.ui-truncatable .show-more-link').click(function(ev) {
       ev.preventDefault();

--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -3,7 +3,6 @@ import "sumo/js/libs/jquery.cookie";
 import "sumo/js/libs/jquery.lazyload";
 import KBox from "sumo/js/kbox";
 import "sumo/js/libs/django/prepopulate";
-import "jquery-ui/ui/widgets/datepicker";
 import CodeMirror from "codemirror";
 import "codemirror/addon/mode/simple";
 import "codemirror/addon/hint/show-hint";
@@ -702,8 +701,6 @@ import ShowFor from "sumo/js/showfor";
         return false;
       }
     });
-
-    $form.find('input[type=date]').attr('type', 'text').datepicker();
   }
 
   $(document).ready(init);


### PR DESCRIPTION
those rely on a yy-mm-dd format which <input type=date> doesn't support

this still removes the jquery datepicker from the common chunk

https://github.com/mozilla/sumo/issues/985

Example urls:
`/en-US/kb/revisions`
`/en-US/kb/end-support-windows-xp-and-vista/edit` (expiry date near the bottom)