### PR TITLE
support windows 11 in browserdetect

### DIFF
--- a/kitsune/questions/config.py
+++ b/kitsune/questions/config.py
@@ -26,7 +26,7 @@ products = OrderedDict(
             {
                 "name": _lazy("Firefox"),
                 "subtitle": _lazy("Web browser for Windows, Mac and Linux"),
-                "extra_fields": ["troubleshooting", "ff_version", "os", "plugins"],
+                "extra_fields": ["troubleshooting", "ff_version", "os"],
                 "tags": ["desktop"],
                 "product": "firefox",
                 "categories": OrderedDict(
@@ -132,7 +132,7 @@ products = OrderedDict(
             {
                 "name": _lazy("Firefox for Android"),
                 "subtitle": _lazy("Web browser for Android smartphones and tablets"),
-                "extra_fields": ["ff_version", "os", "plugins"],
+                "extra_fields": ["ff_version", "os"],
                 "tags": ["mobile"],
                 "product": "mobile",
                 "categories": OrderedDict(
@@ -238,7 +238,7 @@ products = OrderedDict(
             {
                 "name": _lazy("Firefox for iOS"),
                 "subtitle": _lazy("Firefox for iPhone, iPad and iPod touch devices"),
-                "extra_fields": ["ff_version", "os", "plugins"],
+                "extra_fields": ["ff_version", "os"],
                 "tags": ["ios"],
                 "product": "ios",
                 "categories": OrderedDict(
@@ -308,7 +308,7 @@ products = OrderedDict(
             {
                 "name": _lazy("Firefox Focus"),
                 "subtitle": _lazy("Automatic privacy browser and content blocker"),
-                "extra_fields": [],
+                "extra_fields": ["ff_version", "os"],
                 "tags": ["focus-firefox"],
                 "product": "focus-firefox",
                 "categories": OrderedDict(
@@ -467,7 +467,7 @@ products = OrderedDict(
             {
                 "name": _lazy("Firefox for Enterprise"),
                 "subtitle": _lazy("Firefox Quantum for businesses"),
-                "extra_fields": [],
+                "extra_fields": ["ff_version", "os"],
                 "tags": [],
                 "product": "firefox-enterprise",
                 "categories": OrderedDict(

--- a/kitsune/questions/forms.py
+++ b/kitsune/questions/forms.py
@@ -132,24 +132,10 @@ class EditQuestionForm(forms.ModelForm):
                 required=False,
             )
 
-        if "device" in extra_fields:
-            self.fields["device"] = forms.CharField(
-                label=DEVICE_LABEL,
-                required=False,
-            )
-
         if "os" in extra_fields:
             self.fields["os"] = forms.CharField(
                 label=OS_LABEL,
                 required=False,
-            )
-
-        if "plugins" in extra_fields:
-            widget = forms.Textarea(attrs={"class": "plugins"})
-            self.fields["plugins"] = forms.CharField(
-                label=PLUGINS_LABEL,
-                required=False,
-                widget=widget,
             )
 
         if "troubleshooting" in extra_fields:

--- a/kitsune/questions/jinja2/questions/includes/question_editing_frame.html
+++ b/kitsune/questions/jinja2/questions/includes/question_editing_frame.html
@@ -106,7 +106,7 @@ we can compute the edit-title URL.
                 {% for field in form.visible_fields() if not field.name == 'notifications' %}
 
                   {% if not has_subscriptions %}
-                    {% if field.name == 'ff_version' or field.name == 'device' %}
+                    {% if field.name == 'ff_version' %}
                       <li class="system-details-info show">
                         <p>
                           {{ _("We've made some educated guesses about your current browser and operating system.") }}
@@ -116,7 +116,7 @@ we can compute the edit-title URL.
                       </li>
                     {% endif %}
 
-                    {% if field.name == 'ff_version' or field.name == 'device' or field.name == 'os' or field.name == 'plugins' %}
+                    {% if field.name == 'ff_version' or field.name == 'os' %}
                       {% set li_class='details' %}
                     {% endif %}
                   {% endif %}

--- a/kitsune/questions/tests/test_forms.py
+++ b/kitsune/questions/tests/test_forms.py
@@ -62,10 +62,10 @@ class TestNewQuestionForm(TestCaseBase):
                     )
                 ]
             ),
-            "extra_fields": ["troubleshooting", "ff_version", "os", "plugins"],
+            "extra_fields": ["troubleshooting", "ff_version", "os"],
         }
         form = NewQuestionForm(product=product)
-        expected = ["troubleshooting", "ff_version", "os", "plugins", "useragent", "category"]
+        expected = ["troubleshooting", "ff_version", "os", "useragent", "category"]
         actual = form.metadata_field_keys
         self.assertEqual(sorted(expected), sorted(actual))
 
@@ -88,7 +88,7 @@ class TestNewQuestionForm(TestCaseBase):
                     )
                 ]
             ),
-            "extra_fields": ["troubleshooting", "ff_version", "os", "plugins"],
+            "extra_fields": ["troubleshooting", "ff_version", "os"],
         }
         form = NewQuestionForm(product=product, data=data)
         form.is_valid()

--- a/kitsune/sumo/static/sumo/js/aaq.js
+++ b/kitsune/sumo/static/sumo/js/aaq.js
@@ -1,203 +1,75 @@
 import BrowserDetect from "./browserdetect";
-import remoteTroubleshooting from "./remote";
+import RemoteTroubleshooting from "./remote";
 
 /*
  * Prepopulate system info in AAQ form
  */
 
-export default function AAQSystemInfo($form) {
-  AAQSystemInfo.prototype.init.call(this, $form);
-}
+export default class AAQSystemInfo {
+  static slugs = {
+    desktop: ["desktop", "firefox-enterprise"],
+    mobile: ["mobile", "ios", "focus"],
+  };
 
-AAQSystemInfo.prototype = {
-  init: function($form) {
-    var self = this,
-      $input;
+  constructor(form) {
+    this.form = form;
 
     // Autofill the user agent
-    $form.find('input[name="useragent"]').val(navigator.userAgent);
+    form.querySelector('input[name="useragent"]').value = navigator.userAgent;
 
-    // Only guess at OS, FF version, plugins if we are on the desktop
-    // asking a firefox desktop question (or s/desktop/mobile/).
-    if (
-      (BrowserDetect.browser === "fx" && self.isDesktopFF()) ||
-      (BrowserDetect.browser === "m" && self.isMobileFF()) ||
-      (BrowserDetect.browser === "fxios" && self.isFirefoxForIOS())
-    ) {
-      $input = $form.find('input[name="os"]');
-      if (!$input.val()) {
-        $input.val(self.getOS());
-      }
-      $input = $form.find('input[name="ff_version"]');
-      if (!$input.val()) {
-        $input.val(self.getFirefoxVersion());
-      }
-      $input = $form.find('input[name="device"]');
-      if (!$input.val()) {
-        $input.val(self.getDevice());
-      }
-      $input = $form.find('textarea[name="plugins"]');
-      if (!$input.val()) {
-        $input.val(self.getPlugins());
-      }
-    } else {
-      $form.find('li.system-details-info').hide();
+    this.setupTroubleshootingInfo();
+  }
+
+  async fillDetails() {
+    const detect = new BrowserDetect();
+    const platform = await detect.getOS();
+
+    const path = document.location.pathname;
+    const platformMatchesSlug = Boolean(
+      AAQSystemInfo.slugs[platform.mobile ? "mobile" : "desktop"].find((s) =>
+        path.includes(s)
+      )
+    );
+    if (!platformMatchesSlug) {
+      return;
     }
 
-    self.getTroubleshootingInfo();
-  },
-  getOS: function() {
-    // Returns a string representing the user's operating system
-    var os = [
-        ["Android", /Android/i],
-        ["Maemo", /Maemo/i],
-        ["Windows 3.11", /Win16/i],
-        ["Windows 95", /(Windows 95)|(Win95)|(Windows_95)/i],
-        ["Windows 98", /(Windows 98)|(Win98)/i],
-        ["Windows 2000", /(Windows NT 5.0)|(Windows 2000)/i],
-        ["Windows XP", /(Windows NT 5.1)|(Windows XP)/i],
-        ["Windows Server 2003", /(Windows NT 5.2)/i],
-        ["Windows Vista", /(Windows NT 6.0)/i],
-        ["Windows 7", /(Windows NT 6.1)/i],
-        ["Windows 8", /(Windows NT 6.2)/i],
-        ["Windows 8.1", /(Windows NT 6.3)/i],
-        ["Windows 10", /(Windows NT 6.4)|(Windows NT 10.0)/i],
-        ["Windows NT 4.0", /(Windows NT 4.0)|(WinNT4.0)/i],
-        ["Windows ME", /Windows ME/i],
-        ["Windows", /(Windows)|(WinNT)/i],
-        ["OpenBSD", /OpenBSD/i],
-        ["SunOS", /SunOS/i],
-        ["Linux", /(Linux)|(X11)/i],
-        ["iOS", /(iPhone)|(iPad)|(iPod touch)/i],
-        ["Mac OS X 10.4", /(Mac OS X 10.4)/i],
-        ["Mac OS X 10.5", /(Mac OS X 10.5)/i],
-        ["Mac OS X 10.6", /(Mac OS X 10.6)/i],
-        ["Mac OS X 10.7", /(Mac OS X 10.7)/i],
-        ["Mac OS X 10.8", /(Mac OS X 10.8)/i],
-        ["Mac OS X 10.9", /(Mac OS X 10.9)/i],
-        ["Mac OS X 10.10", /(Mac OS X 10.10)/i],
-        ["Mac OS", /(Mac_PowerPC)|(Macintosh)/i],
-        ["QNX", /QNX/i],
-        ["BeOS", /BeOS/i],
-        ["OS/2", /OS\/2/i]
-      ],
-      ua = navigator.userAgent,
-      i,
-      l;
-    for (i = 0, l = os.length; i < l; i++) {
-      if (os[i][1].test(ua)) {
-        return os[i][0];
-      }
-    }
-    return navigator.oscpu || "";
-  },
-  getPlugins: function() {
-    // Returns wiki markup for the list of plugins
-    var plugins = [],
-      i,
-      d;
-    for (i = 0; i < navigator.plugins.length; i++) {
-      d = navigator.plugins[i].description.replace(/<[^>]+>/gi, "");
-      if (plugins.indexOf(d) === -1) {
-        plugins.push(d);
-      }
-    }
-    if (plugins.length > 0) {
-      plugins = "* " + plugins.join("\n* ");
-    } else {
-      plugins = "";
-    }
-    return plugins;
-  },
-  getFirefoxVersion: function() {
-    // Returns a string with the version of Firefox
-    var version = /Firefox\/(\S+)/i.exec(navigator.userAgent);
-    if (version) {
-      return version[1];
-    }
-    version = /FxiOS\/(\S+)/i.exec(navigator.userAgent);
-    if (version) {
-      return version[1];
-    }
-    return "";
-  },
-  getDevice: function() {
-    // Returns a string with the device being used
-    var device = /\(Mobile; (.+); .+\)/i.exec(navigator.userAgent);
-    if (device) {
-      return device[1];
-    }
-    device = /\((iPad|iPhone|iPod touch);/.exec(navigator.userAgent);
-    if (device) {
-      return device[1];
-    }
-    return "";
-  },
-  isDesktopFF: function() {
-    // Is the question for FF on the desktop?
-    return document.location.pathname.indexOf("desktop") >= 0 ||
-      document.location.pathname.indexOf("firefox-enterprise") >= 0;
-  },
-  isMobileFF: function() {
-    // Is the question for FF on mobile?
-    return document.location.pathname.indexOf("mobile") >= 0
-  },
-  isFirefoxForIOS: function() {
-    // Is the question for Firefox for iOS?
-    return document.location.pathname.indexOf("ios") >= 0;
-  },
-  getTroubleshootingInfo: function(addEvent) {
-    var self = this;
-    var browserData;
+    this.form.querySelector('input[name="os"]').value = platform.toString();
 
-    if (addEvent === undefined) {
-      addEvent = true;
+    const browser = await detect.getBrowser();
+    if (browser.mozilla) {
+      this.form.querySelector('input[name="ff_version"]').value =
+        browser.version.toString();
     }
+  }
 
+  async setupTroubleshootingInfo(addEvent) {
     // If the troubleshoot input exists, try to get the data.
-    if ($("#id_troubleshooting").length === 0) {
+    if (!this.form.querySelector("#id_troubleshooting")) {
       // No troubleshooting form, so no point in trying to get the data.
       return;
     }
 
-    // First we try to use the builtin API:
-    remoteTroubleshooting.available(function(yesno) {
-      if (yesno) {
-        remoteTroubleshooting.getData(function(data) {
-          browserData = data;
-        });
+    const remote = new RemoteTroubleshooting();
+    const dataPromise = remote.getData();
 
-        $("#share-data").click(function(e) {
-          // The user must click button to save the data.
-          e.preventDefault();
-          handleData(browserData);
-          return false;
-        });
-      } else {
-        $("#share-data").click(function (e) {
-          e.preventDefault();
-          $("#troubleshooting-button").hide();
-          $("#troubleshooting-manual").show();
-          $("#troubleshooting-field").show();
-          return false;
-        });
-      }
-    });
-
-    // Handle the troubleshooting JSON data.
-    function handleData(data) {
-      var modifiedPreferences = data.modifiedPreferences;
-      data.modifiedPreferences = {};
-      for (var key in modifiedPreferences) {
-        if (key.indexOf("print.") !== 0) {
-          data.modifiedPreferences[key] = modifiedPreferences[key];
+    this.form
+      .querySelector("#share-data")
+      .addEventListener("click", async (e) => {
+        e.preventDefault();
+        const data = await dataPromise;
+        if (data?.application) {
+          const json = JSON.stringify(data, null, 2);
+          this.form.querySelector("#id_troubleshooting").value = json;
+        } else {
+          this.form.querySelector("#troubleshooting-button").style.display =
+            "none";
+          this.form.querySelector("#troubleshooting-manual").style.display =
+            "block";
         }
-      }
-      // The last two parameters cause this to pretty print,
-      // in case anyone looks at it.
-      data = JSON.stringify(data, null, "  ");
-      $("#id_troubleshooting").val(data);
-      $("#troubleshooting-field").show();
-    }
+        this.form.querySelector("#troubleshooting-field").style.display =
+          "block";
+        return false;
+      });
   }
-};
+}

--- a/kitsune/sumo/static/sumo/js/browserdetect.js
+++ b/kitsune/sumo/static/sumo/js/browserdetect.js
@@ -1,183 +1,274 @@
-import _reduce from "underscore/modules/reduce";
+import RemoteTroubleshooting from "sumo/js/remote";
 
-/* Detect the set of OSes and browsers we care about in the wiki and AAQ.
- * Adapted from http://www.quirksmode.org/js/detect.html with these changes:
- *
- * - Changed the dataOS identity properties to lowercase to match the {for}
- *   abbreviations in models.OPERATING_SYSTEMS.
- * - Added Maemo and Android OS detection. Removed iPhone.
- * - Added Fennec browser detection.
- * - Changed Firefox's browser identity to "fx" and Fennec's to "m" to match
- *   {for} syntax and avoid yet another representation.
- * - Removed fallbacks to the string "an unknown ____" in favor of just
- *   returning undefined.
- * - Deleted the browsers we don't care about.
- */
-const BrowserDetect = {
-  init: function () {
-    var detected = this.detect();
-    this.browser = detected[0];
-    this.version = detected[1];
-    this.OS = detected[2];
-  },
+export class Version {
+  major;
+  minor;
+  patch;
+  label;
 
-  detect: function(inputString) {
-    var browser = this.searchString(this.dataBrowser, inputString);
-    var version;
-    if (inputString) {
-      version = this.searchVersion(inputString);
-    } else {
-      version = this.searchVersion(navigator.userAgent, inputString) ||
-        this.searchVersion(navigator.appVersion, inputString);
-    }
-    var os = this.searchString(this.dataOS, inputString);
+  static order = ["major", "minor", "patch", "label"];
 
-    var res = this.fxosSpecialCase(inputString, browser, version, os);
+  constructor(string = "") {
+    [, string, this.label] = string.match(/([\d\.]*)([ab]\d*)?/i);
+    [this.major, this.minor, this.patch] = string
+      .split(".")
+      .map((x) => parseInt(x, 10));
+  }
 
-    return res;
-  },
-
-  searchString: function (data, inputString) {
-    for (var i = 0, l = data.length; i < l; i++) {
-      // If an inputString is specified (for testing), use that.
-      var matchedAll,
-        dataString = inputString || data[i].string;
-
-      this.versionSearchString = data[i].versionSearch || data[i].identity;
-
-      // Check if all subStrings are in the dataString.
-      matchedAll = _reduce(data[i].subStrings, function(memo, sub) {
-        if (sub instanceof RegExp) {
-          return memo && sub.exec(dataString);
-        } else {
-          return memo && (dataString.indexOf(sub) !== -1);
+  toString(cutoff) {
+    let string = "";
+    for (const position of Version.order) {
+      const number = this[position];
+      if (position === "label") {
+        if (number) {
+          string += number;
         }
-      }, true);
-
-      if (matchedAll) {
-        return data[i].identity;
+      } else if (cutoff && isNaN(number)) {
+        string += ".0";
+      } else if (isNaN(number)) {
+        break;
+      } else {
+        string += "." + number.toString();
+      }
+      if (cutoff === position) {
+        break;
       }
     }
-  },
-
-  searchVersion: function (dataString) {
-    var index = dataString.indexOf(this.versionSearchString);
-    if (index === -1) {
-      return null;
-    }
-    return parseFloat(dataString.substring(index + this.versionSearchString.length + 1));  // Turns '1.1.1' into 1.1 rather than 1.11. :-(
-  },
-
-  fxosSpecialCase: function(ua, browser, version, os) {
-    ua = ua || navigator.userAgent;
-    var match = /Gecko\/([\d.]+)/.exec(ua);
-    if (os === 'fxos' && !!match) {
-      var geckoVersion = parseFloat(match[1]);
-      version = this.dataGeckoToFxOS[geckoVersion];
-      browser = 'fxos';
-    }
-    return [browser, version, os];
-  },
-
-  dataBrowser: [
-    {
-      string: navigator.userAgent,
-      subStrings: ['Fennec'],
-      versionSearch: 'Fennec',
-      identity: 'm'
-    },
-    { // Fennec's UA changed in v14 to:
-      // Mozilla/5.0 (Android; Mobile; rv:14.0) Gecko/14.0 Firefox/14.0
-      // Now we need to look for the presence of both 'Mobile'
-      // and 'Firefox'.
-      string: navigator.userAgent,
-      subStrings: ['Android', 'Firefox'],
-      versionSearch: 'Firefox',
-      identity: 'm'
-    },
-    {
-      string: navigator.userAgent,
-      subStrings: ['Firefox'],
-      versionSearch: 'Firefox',
-      identity: 'fx'
-    },
-    {
-      string: navigator.userAgent,
-      subStrings: ['FxiOS'],
-      identity: 'fxios',
-      versionSearch: 'FxiOS',
-    }
-  ],
-  dataOS: [
-    {
-      // 6.2 is Windows 8. 6.3 is Windows 8.1.
-      string: navigator.userAgent,
-      subStrings: [/Windows NT 6.[23]/],
-      identity: 'win8'
-    },
-    {   // 6.0 is Vista, 6.1 is Windows 7. We lump them together here.
-      string: navigator.userAgent,
-      subStrings: [/Windows NT 6\.[01]/],
-      identity: 'win7'
-    },
-    {   // This lumps together Windows 2000 and Windows XP
-      string: navigator.userAgent,
-      subStrings: [/Windows NT 5\./],
-      identity: 'winxp'
-    },
-    {   // Windows 10
-      string: navigator.userAgent,
-      subStrings: [/Windows NT 10\./],
-      identity: 'win10'
-    },
-    {   // If we can't figure out what version, fallback.
-      // This probably means they are running something like Windows ME.
-      string: navigator.platform,
-      subStrings: ['Win'],
-      identity: 'win'
-    },
-    {
-      string: navigator.userAgent,
-      subStrings: [/iPad|iPhone|iPod Touch/],
-      identity: 'ios',
-    },
-    {
-      string: navigator.platform,
-      subStrings: ['Mac'],
-      identity: 'mac'
-    },
-    {
-      string: navigator.userAgent,
-      subStrings: ['Android'],
-      identity: 'android'
-    },
-    {
-      string: navigator.userAgent,
-      subStrings: ['Maemo'],
-      identity: 'maemo'
-    },
-    {
-      string: navigator.platform,
-      subStrings: [/Linux|FreeBSD/],
-      identity: 'linux'
-    },
-    {
-      string: navigator.userAgent,
-      subStrings: ['Firefox'],
-      identity: 'fxos'
-    }
-  ],
-  dataGeckoToFxOS: {
-    18.0: 1.0,
-    18.1: 1.1,
-    26.0: 1.2,
-    28.0: 1.3,
-    30.0: 1.4,
-    32.0: 2.0,
-    34.0: 2.1,
-    37.0: 2.2,
-    44.0: 2.5
+    return string.slice(1);
   }
-};
-BrowserDetect.init();  // TODO: Do this lazily.
-export default BrowserDetect;
+}
+
+class Browser {
+  mozilla = false;
+  brands;
+  version;
+}
+
+class OS {
+  name;
+  version;
+
+  get mobile() {
+    return ["Android", "iOS"].includes(this.name);
+  }
+
+  toString() {
+    let string = this.name;
+    if (this.version) {
+      string += " " + this.version;
+    }
+    return string;
+  }
+
+  static versionNormalization = {
+    Windows: {
+      "nt 5.1": "XP",
+      "nt 5.2": "XP",
+      "nt 6.0": "Vista",
+      "nt 6.1": "7",
+      "nt 6.2": "8",
+      "nt 6.3": "8.1",
+      "nt 6.4": "10",
+      "nt 10.0": "10",
+    },
+  };
+}
+
+class GenericDetector {
+  async browser(browser = new Browser()) {
+    return browser;
+  }
+
+  async os(os = new OS()) {
+    return os;
+  }
+}
+
+export class UADetector extends GenericDetector {
+  uaString;
+
+  constructor(uaString = navigator.userAgent) {
+    super();
+    this.uaString = uaString;
+  }
+
+  async browser(browser = new Browser()) {
+    let isMozilla = this.uaString.match(UADetector.mozillaRegex);
+    if (isMozilla) {
+      browser.mozilla = true;
+      let { name, version } = isMozilla.groups;
+      name = name.toLowerCase();
+
+      let brands = UADetector.brandNormalization[name] ?? [];
+      let os = await this.os();
+      if (!os.mobile) {
+        // remove Focus from possible brands if we're not on mobile
+        brands = brands.filter((x) => x !== "Firefox Focus");
+      }
+
+      browser.brands = brands;
+      browser.version = new Version(version);
+    }
+    return browser;
+  }
+
+  static mozillaRegex =
+    /(?<name>Firefox|FxiOS|Fennec|Focus|Klar|Thunderbird)\/(?<version>[0-9\._]+)?/i;
+
+  static brandNormalization = {
+    firefox: ["Firefox", "Firefox Focus"],
+    fxios: ["Firefox", "Firefox Focus"],
+    fennec: ["Firefox"],
+    focus: ["Firefox Focus"],
+    klar: ["Firefox Focus"],
+    thunderbird: ["Thunderbird"],
+  };
+
+  async os(os = new OS()) {
+    for (const [name, regex] of UADetector.osRegexps) {
+      const matches = this.uaString.match(regex);
+      if (matches) {
+        let version = matches?.groups?.version.toLowerCase();
+        version = OS.versionNormalization?.[name]?.[version] ?? version;
+        os.name = name;
+        os.version = version;
+        return os;
+      }
+    }
+  }
+
+  static osRegexps = [
+    ["Windows", /Windows ?(?<version>(?:NT )?[0-9a-z\._]+)?/i],
+    ["iOS", /(iPhone)|(iPad)|(iPod)/i],
+    ["Mac OS", /Mac OS ?(?<version>X [0-9\._]+)?/i],
+    ["Android", /Android/i],
+    ["Linux", /Linux|X11|BSD|GNU/i],
+  ];
+}
+
+class FakeUAData {
+  constructor(data) {
+    for (const key in data) {
+      this[key] = data[key];
+    }
+  }
+
+  async getHighEntropyValues(keys) {
+    return this;
+  }
+}
+
+export class UADataDetector extends GenericDetector {
+  uaData = navigator.userAgentData;
+
+  constructor(fakeData) {
+    super();
+    if (fakeData) {
+      this.uaData = new FakeUAData(fakeData);
+    }
+  }
+
+  async os(os = new OS()) {
+    if (!this.uaData?.platform) {
+      return os;
+    }
+
+    os.name = this.uaData.platform;
+    let platformVersion;
+
+    try {
+      ({ platformVersion } = await this.uaData.getHighEntropyValues([
+        "platformVersion",
+      ]));
+    } catch {
+      return os;
+    }
+
+    if (this.uaData.platform === "Windows") {
+      let major = new Version(platformVersion).major;
+      if (major >= 13) {
+        os.version = "11";
+      } else if (major >= 1) {
+        os.version = "10";
+      }
+    }
+
+    return os;
+  }
+}
+
+class FakeTroubleshooting {
+  constructor(data) {
+    this.data = data;
+  }
+
+  async getData() {
+    return this.data;
+  }
+}
+
+export class TroubleshootingDetector extends GenericDetector {
+  remote = new RemoteTroubleshooting();
+
+  constructor(fakeData) {
+    super();
+    if (fakeData) {
+      this.remote = new FakeTroubleshooting(fakeData);
+    }
+  }
+
+  async browser(browser = new Browser()) {
+    let { application: { name, version } = {} } = await this.remote.getData();
+    if (name && version) {
+      browser.mozilla = true;
+      browser.brands = [name];
+      browser.version = new Version(version);
+    }
+    return browser;
+  }
+
+  async os(os = new OS()) {
+    let { application: { osVersion } = {} } = await this.remote.getData();
+    const isWin11 = TroubleshootingDetector.windows11Regex.test(osVersion);
+    if (isWin11) {
+      os.name = "Windows";
+      os.version = "11";
+    }
+    return os;
+  }
+
+  static windows11Regex = /^Windows_NT 10\.0 2[0-9]{4}$/i;
+}
+
+export default class BrowserDetect {
+  constructor(fakeUA, fakeUAData, fakeTroubleshooting) {
+    this.uaDetector = new UADetector(fakeUA);
+    this.uaDataDetector = new UADataDetector(fakeUAData);
+    this.troubleshootingDetector = new TroubleshootingDetector(
+      fakeTroubleshooting
+    );
+  }
+
+  async getBrowser() {
+    let browser = await this.uaDetector.browser();
+    let os = await this.uaDetector.os();
+    if (browser.mozilla && !os.mobile) {
+      browser = await this.troubleshootingDetector.browser(browser);
+    }
+    return browser;
+  }
+
+  async getOS() {
+    let os = await this.uaDetector.os();
+    if (os.name === "Windows" && os.version === "10") {
+      // could be windows 11
+      let browser = await this.uaDetector.browser();
+      if (browser.mozilla && !os.mobile) {
+        os = await this.troubleshootingDetector.os(os);
+      } else {
+        os = await this.uaDataDetector.os(os);
+      }
+    }
+    return os;
+  }
+}

--- a/kitsune/sumo/static/sumo/js/libs/diff_match_patch_uncompressed.js
+++ b/kitsune/sumo/static/sumo/js/libs/diff_match_patch_uncompressed.js
@@ -2185,12 +2185,4 @@ diff_match_patch.patch_obj.prototype.toString = function() {
   return text.join('').replace(/%20/g, ' ');
 };
 
-
-// Export these global variables so that they survive Google's JS compiler.
-// In a browser, 'this' will be 'window'.
-// Users of node.js should 'require' the uncompressed version since Google's
-// JS compiler may break the following exports for non-browser environments.
-this['diff_match_patch'] = diff_match_patch;
-this['DIFF_DELETE'] = DIFF_DELETE;
-this['DIFF_INSERT'] = DIFF_INSERT;
-this['DIFF_EQUAL'] = DIFF_EQUAL;
+export { diff_match_patch, DIFF_DELETE, DIFF_INSERT, DIFF_EQUAL };

--- a/kitsune/sumo/static/sumo/js/questions.js
+++ b/kitsune/sumo/static/sumo/js/questions.js
@@ -111,12 +111,13 @@ function init() {
 * Initialize the new/edit question page/form
 */
 function initQuestion(action) {
-  var $questionForm = $('#question-form');
-  var aaq = new AAQSystemInfo($questionForm);
+  const questionForm = document.querySelector('#question-form');
+  if (!questionForm) return;
   if (action === "editing") {
-    $("#troubleshooting-field").show();
+    questionForm.querySelector("#troubleshooting-field").style.display = "block";
   } else {
-    hideDetails($questionForm, aaq);
+    new AAQSystemInfo(questionForm).fillDetails();
+    hideDetails(questionForm);
   }
 }
 
@@ -158,16 +159,18 @@ function initEditDetails() {
 
 // Hide the browser/system details for users on FF with js enabled
 // and are submitting a question for FF on desktop.
-function hideDetails($form, aaq) {
-  $form.find('ul').addClass('hide-details');
-  $form.find('a.show, a.hide').click(function(ev) {
-    ev.preventDefault();
-    $(this).closest('li')
-    .toggleClass('show')
-    .toggleClass('hide')
-    .closest('ul')
-    .toggleClass('show-details');
-  });
+function hideDetails(form) {
+  form.querySelector('ul').classList.add('hide-details');
+  for (const link of form.querySelectorAll('a.show, a.hide')) {
+    link.addEventListener("click", e => {
+      e.preventDefault();
+      const li = e.currentTarget.closest("li");
+      li.classList.toggle("show");
+      li.classList.toggle("hide");
+      const ui = li.closest("ul");
+      ui.classList.toggle("show-details");
+    });
+  }
 }
 
 /*

--- a/kitsune/sumo/static/sumo/js/remote.js
+++ b/kitsune/sumo/static/sumo/js/remote.js
@@ -1,112 +1,55 @@
-const remoteTroubleshooting = {};
-var data;
-
-/**
- * Async method for retrieving remote-troubleshooting data.
- *
- * Tries to console.log problems to help diagnose issues.
- *
- * @param {function} callback - Callback function to call when
- * the data arrives. It should take a single argument which
- * will be the data packet.
- *
- * @param {integer} timeout - Timeout in milliseconds for calling
- * the callback with {} if the event hasn't yet gotten dispatched.
- * Defaults to 1000 ms (aka 1 second).
- *
- * @returns {object} with data in it or {}
- */
-remoteTroubleshooting.getData = function(callback, timeout) {
-  var timeoutId;
-
-  // If we've already gotten the data, return that.
-  if (data) {
-    window.setTimeout(function() { callback(data); });
-    return;
-  }
-
-  // If the browser is missing certain features, then asking for
-  // remote-troubleshooting data is moot, so just drop out as
-  // soon as we know important things are missing.
-  if (!window.addEventListener) {
-    // console.log('remoteTroubleshooting: browser does not support addEventListener');
-    data = {};
-    window.setTimeout(function() { callback(data); });
-    return;
-  }
-
-  if (!(window.hasOwnProperty('CustomEvent') && typeof window.CustomEvent === 'function')) {
-    // console.log('remoteTroubleshooting: browser does not support CustomEvent');
-    data = {};
-    window.setTimeout(function() { callback(data); });
-    return;
-  }
-
-  timeout = timeout || 1000;
-
+export default class RemoteTroubleshooting {
   /**
-  * If the interval passes and the event listener hasn't kicked off then
-  * there's nothing listening, so we abort.
-  */
-  function eject() {
-    // console.log('remoteTroubleshooting: interval ' + timeout + ' has passed.');
-    data = {};
-    callback(data);
+   * Async method for retrieving remote-troubleshooting data.
+   *
+   * @param {integer} timeout - Timeout in milliseconds for calling
+   * the callback with {} if the event hasn't yet gotten dispatched.
+   * Defaults to 1000 ms (aka 1 second).
+   *
+   * @returns {object} with data in it or {}
+   */
+  async getData(timeout = 1000) {
+    // If we've already gotten the data, return that.
+    if (this.data) {
+      return this.data;
+    }
+
+    // Listen to the WebChannelMessageToContent event and handle
+    // incoming remote-troubleshooting messages.
+    const dataPromise = new Promise((resolve, reject) => {
+      window.addEventListener("WebChannelMessageToContent", (e) => {
+        if (e.detail.id === "remote-troubleshooting") {
+          let data = e.detail.message;
+          if (data) {
+            return resolve(data);
+          }
+        }
+        reject();
+      });
+    });
+
+    const timeoutPromise = new Promise((resolve, reject) => {
+      window.setTimeout(() => reject(), timeout);
+    });
+
+    // Create the remote-troubleshooting event requesting data and
+    // kick it off.
+    const request = new window.CustomEvent("WebChannelMessageToChrome", {
+      detail: {
+        id: "remote-troubleshooting",
+        message: {
+          command: "request",
+        },
+      },
+    });
+    window.dispatchEvent(request);
+
+    try {
+      this.data = await Promise.race([dataPromise, timeoutPromise]);
+    } catch {
+      this.data = {};
+    }
+
+    return this.data;
   }
-
-  // Listen to the WebChannelMessageToContent event and handle
-  // incoming remote-troubleshooting messages.
-  window.addEventListener('WebChannelMessageToContent', function (e) {
-    // FIXME: handle failure cases
-    if (e.detail.id === 'remote-troubleshooting') {
-      window.clearTimeout(timeoutId);
-
-      data = e.detail.message;
-      if (data === undefined) {
-        // console.log('remoteTroubleshooting: data is {}. ' +
-        //             'permission error? using http instead of https?');
-        data = {};
-      }
-
-      window.setTimeout(function() { callback(data); });
-    }
-  });
-
-  // Create the remote-troubleshooting event requesting data and
-  // kick it off.
-  var event = new window.CustomEvent('WebChannelMessageToChrome', {
-    detail: {
-      id: 'remote-troubleshooting',
-      message: {
-        command: 'request'
-      }
-    }
-  });
-  window.dispatchEvent(event);
-  timeoutId = window.setTimeout(eject, timeout);
-};
-
-/**
-* Returns whether or not the remote-troubleshooting data is
-* available.
-*
-* @param {function} callback - Callback function to call when
-* the data arrives. It should take a single argument which
-* will be the data packet.
-*
-* @param {integer} timeout - Timeout in milliseconds for calling
-* the callback with {} if the event hasn't yet gotten dispatched.
-* Defaults to 1000 ms (aka 1 second).
-*
-* @returns {bool} true if it's available, false if it isn't
-*/
-remoteTroubleshooting.available = function(callback, timeout) {
-  remoteTroubleshooting.getData(function (troubleShootingData) {
-    // FIXME: This relies on the fact that 'application' is a
-    // valid key with data in it. If it's not then, this will
-    // be wrong.
-    callback(!!troubleShootingData.application);
-  }, timeout);
-};
-
-export default remoteTroubleshooting;
+}

--- a/kitsune/sumo/static/sumo/js/tests/browserdetecttests.js
+++ b/kitsune/sumo/static/sumo/js/tests/browserdetecttests.js
@@ -1,145 +1,454 @@
-import {expect} from 'chai';
+import { expect } from "chai";
 
-import BrowserDetect from "sumo/js/browserdetect";
+import BrowserDetect, { Version } from "sumo/js/browserdetect";
 
-describe('BrowserDetect', () => {
-  describe('Fennec versions', () => {
-    it('should detect Fennec 7', () => {
-      let ua = 'Mozilla/5.0 (Android; Linux armv7l; rv:7.0.1) Gecko/ Firefox/7.0.1 Fennec/7.0.1';
-      expect(BrowserDetect.searchString(BrowserDetect.dataBrowser, ua)).to.equal('m');
-      expect(BrowserDetect.searchVersion(ua)).to.equal(7);
-      expect(BrowserDetect.detect(ua)).to.deep.equal(['m', 7, 'android']);
+describe("BrowserDetect", () => {
+  const cases = [
+    {
+      description: "Windows 11, Firefox with alpha label",
+      ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0",
+      application: {
+        name: "Firefox",
+        version: "98.0a1",
+        osVersion: "Windows_NT 10.0 22000",
+      },
+      browser: {
+        mozilla: true,
+        brands: ["Firefox"],
+        version: {
+          major: 98,
+          minor: 0,
+          patch: undefined,
+          label: "a1",
+        },
+      },
+      os: {
+        name: "Windows",
+        version: "11",
+      },
+    },
+    {
+      description: "Windows 11, Firefox no remote troubleshooting",
+      ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0",
+      browser: {
+        mozilla: true,
+        brands: ["Firefox"],
+        version: {
+          major: 100,
+          minor: 0,
+          patch: undefined,
+          label: undefined,
+        },
+      },
+      os: {
+        name: "Windows",
+        version: "10",
+      },
+    },
+    {
+      description: "Windows 10, Firefox",
+      ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:96.0) Gecko/20100101 Firefox/96.0",
+      application: {
+        name: "Firefox",
+        version: "96.0.1",
+        osVersion: "Windows_NT 10.0 19044",
+      },
+      browser: {
+        mozilla: true,
+        brands: ["Firefox"],
+        version: {
+          major: 96,
+          minor: 0,
+          patch: 1,
+          label: undefined,
+        },
+      },
+      os: {
+        name: "Windows",
+        version: "10",
+      },
+    },
+    {
+      description: "Windows 7, Firefox",
+      ua: "Mozilla/5.0 (Windows NT 6.1; rv:95.0) Gecko/20100101 Firefox/95.0",
+      application: {
+        name: "Firefox",
+        version: "95.0.2",
+        osVersion: "Windows_NT 6.1 7601",
+      },
+      browser: {
+        mozilla: true,
+        brands: ["Firefox"],
+        version: {
+          major: 95,
+          minor: 0,
+          patch: 2,
+          label: undefined,
+        },
+      },
+      os: {
+        name: "Windows",
+        version: "7",
+      },
+    },
+    {
+      description: "Mac OS, Firefox with patch version",
+      ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:95.0) Gecko/20100101 Firefox/95.0",
+      application: {
+        name: "Firefox",
+        version: "95.0.2",
+        osVersion:
+          "Darwin 20.6.0 Darwin Kernel Version 20.6.0: Mon Aug 30 06:12:21 PDT 2021;",
+      },
+      browser: {
+        mozilla: true,
+        brands: ["Firefox"],
+        version: {
+          major: 95,
+          minor: 0,
+          patch: 2,
+          label: undefined,
+        },
+      },
+      os: {
+        name: "Mac OS",
+        version: "x 10.15",
+      },
+    },
+    {
+      description: "Linux, Firefox",
+      ua: "Mozilla/5.0 (X11; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0",
+      application: {
+        name: "Firefox",
+        version: "95.0",
+        osVersion:
+          "Linux 5.15.7-arch1-1 #1 SMP PREEMPT Wed, 08 Dec 2021 14:33:16 +0000",
+      },
+      browser: {
+        mozilla: true,
+        brands: ["Firefox"],
+        version: {
+          major: 95,
+          minor: 0,
+          patch: undefined,
+          label: undefined,
+        },
+      },
+      os: {
+        name: "Linux",
+        version: undefined,
+      },
+    },
+    {
+      description: "Android, Firefox",
+      ua: "Mozilla/5.0 (Android 12; Mobile; rv:98.0) Gecko/98.0 Firefox/98.0",
+      browser: {
+        mozilla: true,
+        brands: ["Firefox", "Firefox Focus"],
+        version: {
+          major: 98,
+          minor: 0,
+          patch: undefined,
+          label: undefined,
+        },
+      },
+      os: {
+        name: "Android",
+        version: undefined,
+      },
+    },
+    {
+      description: "Android, Firefox Focus",
+      ua: "Mozilla/5.0 (Android 12; Mobile; rv:95.0) Gecko/95.0 Firefox/95.0",
+      browser: {
+        mozilla: true,
+        brands: ["Firefox", "Firefox Focus"],
+        version: {
+          major: 95,
+          minor: 0,
+          patch: undefined,
+          label: undefined,
+        },
+      },
+      os: {
+        name: "Android",
+        version: undefined,
+      },
+    },
+    {
+      description: "iOS, Firefox",
+      ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/40.2 Mobile/15E148 Safari/605.1.15",
+      browser: {
+        mozilla: true,
+        brands: ["Firefox", "Firefox Focus"],
+        version: {
+          major: 40,
+          minor: 2,
+          patch: undefined,
+          label: undefined,
+        },
+      },
+      os: {
+        name: "iOS",
+        version: undefined,
+      },
+    },
+    {
+      description: "iOS, Firefox Focus",
+      ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/7.0.4 Mobile/16B91 Safari/605.1.15",
+      browser: {
+        mozilla: true,
+        brands: ["Firefox", "Firefox Focus"],
+        version: {
+          major: 7,
+          minor: 0,
+          patch: 4,
+          label: undefined,
+        },
+      },
+      os: {
+        name: "iOS",
+        version: undefined,
+      },
+    },
+    {
+      description: "iPadOS, Firefox", // bug: https://github.com/mozilla-mobile/firefox-ios/issues/6620
+      ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15",
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Mac OS",
+        version: "x 10_15_4",
+      },
+    },
+    {
+      description: "iPadOS, Firefox Focus", // bug: https://github.com/mozilla-mobile/firefox-ios/issues/6620
+      ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15",
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Mac OS",
+        version: "x 10_15_6",
+      },
+    },
+    {
+      description: "Windows 11, Edge",
+      ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36 Edg/96.0.1054.62",
+      hints: {
+        platform: "Windows",
+        platformVersion: "14.0.0",
+      },
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Windows",
+        version: "11",
+      },
+    },
+    {
+      description: "Windows 11, Edge no UA hints",
+      ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36 Edg/96.0.1054.62",
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Windows",
+        version: "10",
+      },
+    },
+    {
+      description: "Windows 10, Edge",
+      ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36 Edg/97.0.1072.62",
+      hints: {
+        platform: "Windows",
+        platformVersion: "10.0.0",
+      },
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Windows",
+        version: "10",
+      },
+    },
+    {
+      description: "Windows 7, Edge",
+      ua: "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36 Edg/97.0.1072.62",
+      hints: {
+        platform: "Windows",
+        platformVersion: "0.0.0",
+      },
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Windows",
+        version: "7",
+      },
+    },
+    {
+      description: "Mac OS, Safari",
+      ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15",
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Mac OS",
+        version: "x 10_15_7",
+      },
+    },
+    {
+      description: "Linux, Chromium",
+      ua: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Linux",
+        version: undefined,
+      },
+    },
+    {
+      description: "Android, Chrome",
+      ua: "Mozilla/5.0 (Linux; Android 12; Pixel 6 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.87 Mobile Safari/537.36",
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Android",
+        version: undefined,
+      },
+    },
+    {
+      description: "iOS, Safari",
+      ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 15_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Mobile/15E148 Safari/604.1",
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "iOS",
+        version: undefined,
+      },
+    },
+    {
+      description: "iPadOS, Safari",
+      ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15",
+      browser: {
+        mozilla: false,
+        brands: undefined,
+        version: undefined,
+      },
+      os: {
+        name: "Mac OS",
+        version: "x 10_15_6",
+      },
+    },
+  ];
+
+  for (const { description, ua, application, hints, browser, os } of cases) {
+    it(`handles ${description}`, async () => {
+      const detect = new BrowserDetect(ua, hints, { application });
+      let detectedBrowser = await detect.getBrowser();
+      let detectedOS = await detect.getOS();
+      expect(detectedBrowser).to.deep.equal(browser);
+      expect(detectedOS).to.deep.equal(os);
     });
+  }
 
-    it('should detect Fennec 10', () => {
-      let ua = 'Mozilla/5.0 (Android; Mobile; rv:10.0.4) Gecko/10.0.4 Firefox/10.0.4 Fennec/10.0.4';
-      expect(BrowserDetect.searchString(BrowserDetect.dataBrowser, ua)).to.equal('m');
-      expect(BrowserDetect.searchVersion(ua)).to.equal(10);
-      expect(BrowserDetect.detect(ua)).to.deep.equal(['m', 10, 'android']);
-    });
-
-    it('should detect Fennec 14', () => {
-      let ua = 'Mozilla/5.0 (Android; Mobile; rv:14.0) Gecko/14.0 Firefox/14.0';
-      expect(BrowserDetect.searchString(BrowserDetect.dataBrowser, ua)).to.equal('m');
-      expect(BrowserDetect.searchVersion(ua)).to.equal(14);
-      expect(BrowserDetect.detect(ua)).to.deep.equal(['m', 14, 'android']);
-    });
-  });
-
-  describe('Firefox versions', () => {
-    it('should detect Firefox 4', () => {
-      let ua = 'Mozilla/5.0 (X11; Linux i686; rv:2.0) Gecko/20100101 Firefox/4.0';
-      expect(BrowserDetect.searchString(BrowserDetect.dataBrowser, ua)).to.equal('fx');
-      expect(BrowserDetect.searchVersion(ua)).to.equal(4);
-      expect(BrowserDetect.detect(ua)).to.deep.equal(['fx', 4, 'linux']);
-    });
-
-    it('should detect Firefox 12', () => function() {
-      let ua = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:12.0) Gecko/20100101 Firefox/12.0';
-      expect(BrowserDetect.searchString(BrowserDetect.dataBrowser, ua)).to.equal('fx');
-      expect(BrowserDetect.searchVersion(ua)).to.equal(12);
-      expect(BrowserDetect.detect(ua)).to.deep.equal(['fx', 12, 'win7']);
-    });
-  });
-
-  describe('Windows versions', () => {
-    let cases = [
-      {
-        ua: 'Mozilla/5.0 (Windows NT 5.0; WOW64; rv:12.0) Gecko/20100101 Firefox/12.0',
-        expected: ['fx', 12, 'winxp'],
-      },
-      {
-        ua: 'Mozilla/5.0 (Windows NT 5.01; WOW64; rv:12.0) Gecko/20100101 Firefox/13.0',
-        expected: ['fx', 13, 'winxp'],
-      },
-      {
-        ua: 'Mozilla/5.0 (Windows NT 5.1; WOW64; rv:12.0) Gecko/20100101 Firefox/14.0',
-        expected: ['fx', 14, 'winxp'],
-      },
-      {
-        ua: 'Mozilla/5.0 (Windows NT 6.0; WOW64; rv:12.0) Gecko/20100101 Firefox/15.0',
-        expected: ['fx', 15, 'win7'],
-      },
-      {
-        ua: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:12.0) Gecko/20100101 Firefox/16.0',
-        expected: ['fx', 16, 'win7'],
-      },
-      {
-        ua: 'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:12.0) Gecko/20100101 Firefox/17.0',
-        expected: ['fx', 17, 'win8'],
-      },
-      {
-        ua: 'Mozilla/5.0 (Windows NT 4.0; WOW64; rv:12.0) Gecko/20100101 Firefox/4.0',
-        expected: ['fx', 4, 'win'],
-      },
-    ];
-
-    for (let case_ of cases) {
-      it(`should detect ${case_.expected}`, () => {
-        expect(BrowserDetect.searchString(BrowserDetect.dataOS, case_.ua)).to.equal(case_.expected[2]);
-        expect(BrowserDetect.detect(case_.ua)).to.deep.equal(case_.expected);
-      });
-    }
-  });
-
-  describe('Firefox OS', function() {
-    let cases = [
-      {
-        ua: 'Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0',
-        expected: ['fxos', 1, 'fxos'],
-      },
-      {
-        ua: 'Mozilla/5.0 (Mobile; nnnn; rv:18.1) Gecko/18.1 Firefox/18.1',
-        expected: ['fxos', 1.1, 'fxos'],
-      },
-      {
-        ua: 'Mozilla/5.0 (Mobile; nnnn; rv:26.0) Gecko/26.0 Firefox/26.0',
-        expected: ['fxos', 1.2, 'fxos'],
-      },
-      {
-        ua: 'Mozilla/5.0 (Mobile; nnnn; rv:28.0) Gecko/28.0 Firefox/28.0',
-        expected: ['fxos', 1.3, 'fxos'],
-      },
-    ];
-
-    for (let case_ of cases) {
-      it(`should detect ${case_.expected}`, () => {
-        expect(BrowserDetect.detect(case_.ua)).to.deep.equal(case_.expected);
-      });
-    }
-  });
-
-  describe('Firefox for iOS', () => {
-    it('all platforms', () => {
-      let uas = [
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
-        'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
-        'Mozilla/5.0 (iPod touch; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12H143 Safari/600.1.4'
+  describe("Version", () => {
+    describe("toString", () => {
+      const stringCases = [
+        {
+          input: "1",
+          empty: "1",
+          major: "1",
+          minor: "1.0",
+          patch: "1.0.0",
+          label: "1.0.0",
+        },
+        {
+          input: "1.2",
+          empty: "1.2",
+          major: "1",
+          minor: "1.2",
+          patch: "1.2.0",
+          label: "1.2.0",
+        },
+        {
+          input: "1.2.3",
+          empty: "1.2.3",
+          major: "1",
+          minor: "1.2",
+          patch: "1.2.3",
+          label: "1.2.3",
+        },
+        {
+          input: "1.2.3.4",
+          empty: "1.2.3",
+          major: "1",
+          minor: "1.2",
+          patch: "1.2.3",
+          label: "1.2.3",
+        },
+        {
+          input: "1.2.3a1",
+          empty: "1.2.3a1",
+          major: "1",
+          minor: "1.2",
+          patch: "1.2.3",
+          label: "1.2.3a1",
+        },
+        {
+          input: "1.2.3z1",
+          empty: "1.2.3",
+          major: "1",
+          minor: "1.2",
+          patch: "1.2.3",
+          label: "1.2.3",
+        },
+        {
+          input: "foobar",
+          empty: "",
+          major: "0",
+          minor: "0.0",
+          patch: "0.0.0",
+          label: "0.0.0",
+        },
       ];
-      for (let ua of uas) {
-        expect(BrowserDetect.detect(ua)).to.deep.equal(['fxios', 1.0, 'ios']);
+
+      for (const { input, empty, major, minor, patch, label } of stringCases) {
+        it(`handles ${input}`, () => {
+          let version = new Version(input);
+          expect(version.toString()).to.equal(empty);
+          expect(version.toString("major")).to.equal(major);
+          expect(version.toString("minor")).to.equal(minor);
+          expect(version.toString("patch")).to.equal(patch);
+          expect(version.toString("label")).to.equal(label);
+        });
       }
     });
-
-    let cases = [
-      {
-        ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0.0 Mobile/12D508 Safari/600.1.4',
-        version: 1.0,
-      },
-      {
-        ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0.1 Mobile/12D508 Safari/600.1.4',
-        version: 1.0,
-      },
-      {
-        ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.1.0 Mobile/12D508 Safari/600.1.4',
-        version: 1.1,
-      },
-    ];
-
-    for (let case_ of cases) {
-      it(`version ${case_.version}`, () => {
-        expect(BrowserDetect.detect(case_.ua)[1]).to.equal(case_.version);
-      });
-    }
   });
 });

--- a/kitsune/sumo/static/sumo/js/tests/showfortests.js
+++ b/kitsune/sumo/static/sumo/js/tests/showfortests.js
@@ -3,7 +3,7 @@ import {default as chai, expect} from 'chai';
 import chaiLint from 'chai-lint';
 import sinon from 'sinon';
 
-import BrowserDetect from 'sumo/js/browserdetect';
+import { TroubleshootingDetector } from 'sumo/js/browserdetect';
 import ShowFor from "sumo/js/showfor";
 
 chai.use(chaiLint);
@@ -119,13 +119,15 @@ describe('ShowFor', () => {
     React.render(sandbox, document.body);
     showFor = showForNoInit($('body'));
 
-    BrowserDetect.browser = "firefox";
-    BrowserDetect.version = 25.0;
-    BrowserDetect.OS = "winxp";
+    sinon.stub(navigator, "userAgent").get(() =>
+      "Mozilla/5.0 (Windows NT 5.1;) Gecko/20100101 Firefox/25.0"
+    );
+    // avoid slowing down tests while we wait for remote troubleshooting api call to timeout:
+    sinon.stub(TroubleshootingDetector.prototype, "browser").resolvesArg(0);
   });
 
   afterEach(() => {
-    BrowserDetect.init();
+    sinon.restore();
   });
 
   describe('loadData', () => {
@@ -147,12 +149,12 @@ describe('ShowFor', () => {
 
   describe('updateUI', () => {
     describe('Firefox 26 on Windows XP', () => {
-      beforeEach(() => {
-        BrowserDetect.browser = "fx"
-        BrowserDetect.version = 26.0
-        BrowserDetect.OS = "winxp"
+      beforeEach(async () => {
+        sinon.stub(navigator, "userAgent").get(() =>
+          "Mozilla/5.0 (Windows NT 5.1;) Gecko/20100101 Firefox/26.0"
+        );
         showFor.loadData();
-        showFor.updateUI();
+        await showFor.updateUI();
       });
 
       it('should populate the UI with the values from BrowserDetect', () => {
@@ -162,12 +164,12 @@ describe('ShowFor', () => {
     });
 
     describe('Firefox for Android 23', () => {
-      beforeEach(() => {
-        BrowserDetect.browser = "m"
-        BrowserDetect.version = 23.0
-        BrowserDetect.OS = "android"
+      beforeEach(async () => {
+        sinon.stub(navigator, "userAgent").get(() =>
+          "Mozilla/5.0 (Android;) Gecko/20100101 Firefox/23.0"
+        );
         showFor.loadData();
-        showFor.updateUI();
+        await showFor.updateUI();
       });
 
       it('should populate the UI with the values from BrowserDetect', () => {
@@ -179,9 +181,9 @@ describe('ShowFor', () => {
 
   describe('updateState', () => {
 
-    beforeEach(() => {
+    beforeEach(async () => {
       showFor.loadData();
-      showFor.updateUI();
+      await showFor.updateUI();
       showFor.updateState();
     });
 
@@ -238,10 +240,10 @@ describe('ShowFor', () => {
 
   describe('initShowFuncs', () => {
 
-    beforeEach(() => {
+    beforeEach(async () => {
       sinon.stub(showFor, 'matchesCriteria');
       showFor.loadData();
-      showFor.updateUI();
+      await showFor.updateUI();
       showFor.updateState();
       showFor.initShowFuncs();
     });
@@ -269,9 +271,9 @@ describe('ShowFor', () => {
 
   describe('showAndHide', () => {
 
-    beforeEach(() => {
+    beforeEach(async () => {
       showFor.loadData();
-      showFor.updateUI();
+      await showFor.updateUI();
       showFor.updateState();
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "kitsune",
       "license": "MPL-2.0",
       "dependencies": {
+        "@babel/runtime": "^7.16.7",
         "codemirror": "^5.65.0",
         "d3": "^3.1.5",
         "jquery": "1.11.3",
@@ -17,6 +18,7 @@
       "devDependencies": {
         "@babel/core": "^7.16.7",
         "@babel/plugin-transform-react-jsx": "^7.16.7",
+        "@babel/plugin-transform-runtime": "^7.16.7",
         "@babel/preset-env": "^7.16.7",
         "@mozilla-protocol/core": "10.0.1",
         "autoprefixer": "^10.4.1",
@@ -1389,6 +1391,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-runtime": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.7.tgz",
+      "integrity": "sha512-2FoHiSAWkdq4L06uaDN3rS43i6x28desUVxq+zAFuE6kbWYQeiLPJI5IC7Sg9xKYVcrBKSQkVUfH6aeQYbl9QA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
@@ -1604,7 +1626,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
       "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -11144,8 +11165,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -15223,6 +15243,20 @@
         "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.7.tgz",
+      "integrity": "sha512-2FoHiSAWkdq4L06uaDN3rS43i6x28desUVxq+zAFuE6kbWYQeiLPJI5IC7Sg9xKYVcrBKSQkVUfH6aeQYbl9QA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
@@ -15387,7 +15421,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
       "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -22611,8 +22644,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
+    "@babel/runtime": "^7.16.7",
     "codemirror": "^5.65.0",
     "d3": "^3.1.5",
     "jquery": "1.11.3",
@@ -41,6 +42,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@babel/plugin-transform-react-jsx": "^7.16.7",
+    "@babel/plugin-transform-runtime": "^7.16.7",
     "@babel/preset-env": "^7.16.7",
     "@mozilla-protocol/core": "10.0.1",
     "autoprefixer": "^10.4.1",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -21,6 +21,14 @@ module.exports = {
           loader: "babel-loader",
           options: {
             presets: ["@babel/preset-env"],
+            plugins: [
+              [
+                "@babel/plugin-transform-runtime",
+                {
+                  version: "^7.16.7",
+                },
+              ],
+            ],
           },
         },
       },

--- a/webpack/eslintrc.js
+++ b/webpack/eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
         "browser": true
     },
     "parserOptions": {
-        "ecmaVersion": 2021,
+        "ecmaVersion": "latest",
         "sourceType": "module",
     },
     "rules": {


### PR DESCRIPTION
rewrite BrowserDetect to support multiple detection methods (ua, hints, remote troubleshooting)
rewrite AAQSystemInfo to remove duplicated UA parsing, and rely on BrowserDetect instead
modify RemoteTroubleshooting to use async
remove unused/unusable fields from AAQ config (device and plugins)

https://github.com/mozilla/sumo/issues/966
