### PR TITLE
fix db problems in local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - docker-entrypoint.sh
       - --character-set-server=utf8
       - --collation-server=utf8_unicode_ci
+      - --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
     volumes:
       - mysqlvolume:/var/lib/mysql
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -71,9 +71,9 @@ distlib==0.3.4 \
 django-cache-panel==0.1 \
     --hash=sha256:42619072257d859c07bf91177070dc2ac925417d4010c8e6b40c23741cb9c46a
     # via -r requirements/dev.in
-django-debug-toolbar==3.2.3 \
-    --hash=sha256:516702e1d71302bbc06059fa3c41efd1a3bd9cbb5580fc793343118d95b309e0 \
-    --hash=sha256:95880677ea846ba1077d02305fd5e2b25e1da096e1d4a735b665e3340fa2ae79
+django-debug-toolbar==3.2.4 \
+    --hash=sha256:644bbd5c428d3283aa9115722471769cac1bec189edf3a0c855fd8ff870375a9 \
+    --hash=sha256:6b633b6cfee24f232d73569870f19aa86c819d750e7f3e833f2344a9eb4b4409
     # via -r requirements/dev.in
 django-sslserver==0.22 \
     --hash=sha256:c598a363d2ccdc2421c08ddb3d8b0973f80e8e47a3a5b74e4a2896f21c2947c5


### PR DESCRIPTION
django-debug-toolbar 3.2.3 was causing strings to be truncated when saving to db
mariadb >=10.2.4 includes STRICT_TRANS_TABLES by default, which was causing errors
