### PR TITLE
move home directory for kitsune docker user

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,8 +27,13 @@ services:
        - 3001:3001 # browser-sync ui
 
     volumes:
-      # Update this to wherever you want VS Code to mount the folder of your project
-      - .:/workspace:cached
+      - vscode-home:/home/kitsune
 
     # Overrides default command so things don't shut down after the process ends.
     command: /bin/sh -c "while sleep 1000; do :; done"
+
+    environment:
+      - EDITOR=code --wait
+
+volumes:
+  vscode-home:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH="/venv/bin:$PATH"
 
 RUN python -m venv /venv
 RUN pip install --upgrade "pip==21.3.1"
-RUN useradd -d /app -M --uid 1000 --shell /usr/sbin/nologin kitsune
+RUN useradd -m --uid 1000 --shell /usr/sbin/nologin kitsune
 
 RUN apt-get update && apt-get install apt-transport-https && \
     curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \


### PR DESCRIPTION
this avoids vscode creating various files and folders in our source
directory when using a devcontainer

this also fixes pylance maxing out a cpu core when using a devcontainer

additionally, set vscode itself as the editor when commands (such as
git) are opened from its integrated terminal in a devcontainer
