### PR TITLE
ensure (s)css is handled properly by svelte

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Part 2: Developer's Guide
    localization
    search
    frontend
+   svelte
    browser_permissions
    zendesk
    notes

--- a/docs/svelte.md
+++ b/docs/svelte.md
@@ -1,0 +1,48 @@
+# Svelte
+
+## CSS/SASS
+
+Svelte supports writing CSS directly in a component within `<style>` tags,
+as well as writing compiled-to-CSS languages like SASS within `<style lang="scss">` tags.
+
+CSS written this way is automatically scoped to the component:
+[read more in the Svelte docs](https://svelte.dev/docs#component-format-style).
+
+This SASS to CSS compilation is handled by `svelte-preprocess`,
+and the resulting CSS is handed to Wepback for further processing.
+Since Webpack isn't involved in SASS compilation within Svelte components,
+care must be taken in a few areas:
+
+1. Because Webpack isn't handling `@use` and `@import` resolution,
+   it's not possible to use its aliases to reference paths to other SASS files.
+   Instead paths relative to the Svelte component,
+   or full node module paths,
+   must be used.
+   This _doesn't_ include paths not processed by the SASS compiler,
+   such as paths to images in `url()` functions,
+   as these are still handled by Webpack.
+   To illustrate:
+
+```scss
+@use "@mozilla-protocol/core/protocol/css/includes/lib" as p;
+@use "../../kitsune/sumo/static/sumo/scss/config/typography-mixins";
+// ^ here we must use a full or relative path, as svelte-preprocess is resolving this
+
+div {
+    background: url("protocol/img/icons/reader-mode.svg");
+    // ^ here we can use a webpack alias, as webpack is resolving this
+    background-size: p.$spacing-md;
+    @include typography-mixins.text-display-sm;
+}
+```
+
+2. As a knock-on effect of the above,
+   any partials used in both our main CSS bundle,
+   as well as a Svelte component (like the `typography-mixins` above)
+   must not use Webpack aliases in their own imports,
+   otherwise `svelte-preprocess` won't be able to resolve them.
+
+3. Partials should be careful to not accidentally include or import CSS blocks outside of mixin defintions.
+   This is because neither `svelte-preprocess` nor the Webpack `sass-loader` are able to chunk split `@import`s and `@use`s,
+   or even de-duplicate their use across Svelte components (due to the scoped nature of the CSS within).
+   Not doing this will lead to unnecessarily duplicated code.

--- a/kitsune/sumo/static/sumo/scss/base/_definition-list.scss
+++ b/kitsune/sumo/static/sumo/scss/base/_definition-list.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 .sumo-dl {
   display: flex;

--- a/kitsune/sumo/static/sumo/scss/base/_table.scss
+++ b/kitsune/sumo/static/sumo/scss/base/_table.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 // Tables

--- a/kitsune/sumo/static/sumo/scss/base/_typography.scss
+++ b/kitsune/sumo/static/sumo/scss/base/_typography.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Typography
 //

--- a/kitsune/sumo/static/sumo/scss/base/_utilities.scss
+++ b/kitsune/sumo/static/sumo/scss/base/_utilities.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Expanded link utility
 //

--- a/kitsune/sumo/static/sumo/scss/base/forms/_button-wrap.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_button-wrap.scss
@@ -1,5 +1,5 @@
 @use '../../config' as c;
-@use '../../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Button Wrap element
 //

--- a/kitsune/sumo/static/sumo/scss/base/forms/_buttons.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_buttons.scss
@@ -1,5 +1,5 @@
 @use '../../config' as c;
-@use '../../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Buttons
 //
@@ -238,7 +238,7 @@ input[type=submit]:focus {
   background: transparent;
   font: 0/0 a;
   color: transparent;
-  background-image: url('#{p.$image-path}/icons/more-vertical.svg');
+  background-image: url('protocol/img/icons/more-vertical.svg');
   background-size: p.$spacing-lg p.$spacing-lg;
   background-position: center center;
   background-repeat: no-repeat;

--- a/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
@@ -1,5 +1,5 @@
-@use '../../config'as c;
-@use '../../protocol'as p;
+@use '../../config' as c;
+@use 'protocol/css/includes/lib' as p;
 
 :root {
   --field-border-color-default: var(--color-marketing-gray-05);

--- a/kitsune/sumo/static/sumo/scss/base/forms/_radios-checkboxes.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_radios-checkboxes.scss
@@ -1,5 +1,5 @@
 @use '../../config' as c;
-@use '../../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Checkboxes
 //

--- a/kitsune/sumo/static/sumo/scss/base/forms/_range.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_range.scss
@@ -1,5 +1,5 @@
 @use '../../config' as c;
-@use '../../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Range inputs
 //

--- a/kitsune/sumo/static/sumo/scss/base/forms/_simple-search-form.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_simple-search-form.scss
@@ -1,5 +1,5 @@
 @use '../../config' as c;
-@use '../../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 .simple-search-form {
   position: relative;
@@ -45,7 +45,7 @@
   height: p.$spacing-xl;
   border: none;
   border-radius: p.$spacing-xs;
-  background-image: url('#{p.$image-path}/icons/search.svg');
+  background-image: url('protocol/img/icons/search.svg');
   background-color: transparent;
   background-position: center center;
   background-repeat: no-repeat;

--- a/kitsune/sumo/static/sumo/scss/base/forms/_toggles.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_toggles.scss
@@ -1,5 +1,5 @@
 @use '../../config' as c;
-@use '../../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Toggles
 //

--- a/kitsune/sumo/static/sumo/scss/components/_avatar-group.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_avatar-group.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 .avatar-group {
   @include c.grid-row();

--- a/kitsune/sumo/static/sumo/scss/components/_banner.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_banner.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Banners
 //

--- a/kitsune/sumo/static/sumo/scss/components/_breadcrumbs.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_breadcrumbs.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Breadcrumbs
 //

--- a/kitsune/sumo/static/sumo/scss/components/_card-grid.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_card-grid.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Card Grid
 //

--- a/kitsune/sumo/static/sumo/scss/components/_card.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_card.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Cards
 //

--- a/kitsune/sumo/static/sumo/scss/components/_editor-tools.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_editor-tools.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 div.editor-tools {
   &:not(:empty) {

--- a/kitsune/sumo/static/sumo/scss/components/_icon-links.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_icon-links.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 .has-icon,
 .is-details .mzp-c-menu-list-item a.has-icon {

--- a/kitsune/sumo/static/sumo/scss/components/_inbox.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_inbox.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 .message-list {

--- a/kitsune/sumo/static/sumo/scss/components/_kbox--todo-remove.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_kbox--todo-remove.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // This component should be replaced with Protocol's modal system, because
 // it doesn't make sense to include two of them. However, this plugin is doing

--- a/kitsune/sumo/static/sumo/scss/components/_modal.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_modal.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 .mzp-c-modal-inner {
@@ -11,7 +11,7 @@
 }
 
 .mzp-c-modal-close .mzp-c-modal-button-close {
-  background: transparent url("#{p.$image-path}/icons/close.svg") center center no-repeat;
+  background: transparent url("protocol/img/icons/close.svg") center center no-repeat;
 }
 
 

--- a/kitsune/sumo/static/sumo/scss/components/_notifications.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_notifications.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // This is a container for Protocol notifications. See
 // https://protocol.mozilla.org/patterns/molecules/notification-bar.html

--- a/kitsune/sumo/static/sumo/scss/components/_pagination.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_pagination.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Pagination
 //

--- a/kitsune/sumo/static/sumo/scss/components/_product-picker-dropdown.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_product-picker-dropdown.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 .is-details.mzp-c-menu-list.featured-dropdown,
 .is-details.mzp-c-menu-list.subheading-dropdown, {

--- a/kitsune/sumo/static/sumo/scss/components/_progress-bar.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_progress-bar.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Progress Bar
 //

--- a/kitsune/sumo/static/sumo/scss/components/_sidebar-nav.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_sidebar-nav.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Sidebar navigation
 //
@@ -62,7 +62,7 @@
   .related-document,
   .related-question {
     @include c.text-body-md;
-    background-image: url("#{p.$image-path}/icons/blog.svg");
+    background-image: url("protocol/img/icons/blog.svg");
     background-repeat: no-repeat;
     background-position: 0px 6px;
     background-size: p.$spacing-md p.$spacing-md;
@@ -70,7 +70,7 @@
   }
 
   .related-document {
-    background-image: url("#{p.$image-path}/icons/reader-mode.svg");
+    background-image: url("protocol/img/icons/reader-mode.svg");
   }
 
   li.selected > :link,

--- a/kitsune/sumo/static/sumo/scss/components/_tabs.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_tabs.scss
@@ -11,7 +11,7 @@
 // Style guide: tabs
 
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 %link-styles {
   appearance: none;

--- a/kitsune/sumo/static/sumo/scss/components/_users.autocomplete.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_users.autocomplete.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // .editable .edit-mode {
 //   display: none;

--- a/kitsune/sumo/static/sumo/scss/components/_wiki.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_wiki.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 // These styles were pulled directly from the less files.
@@ -412,23 +412,23 @@ article {
 
   .delete {
     a {
-      background-image: url("#{p.$image-path}/icons/delete.svg");
+      background-image: url("protocol/img/icons/delete.svg");
     }
   }
 
   .l10n {
     a {
       &.yes {
-        background-image: url("#{p.$image-path}/icons/check.svg");
+        background-image: url("protocol/img/icons/check.svg");
       }
 
       &.markasready,
       &.no {
-        background-image: url("#{p.$image-path}/icons/close.svg");
+        background-image: url("protocol/img/icons/close.svg");
       }
 
       &.markasready:hover {
-        background-image: url("#{p.$image-path}/icons/check.svg");
+        background-image: url("protocol/img/icons/check.svg");
         cursor: pointer;
       }
     }

--- a/kitsune/sumo/static/sumo/scss/config/_grid.scss
+++ b/kitsune/sumo/static/sumo/scss/config/_grid.scss
@@ -1,4 +1,4 @@
-@use '../protocol' as p;
+@use '@mozilla-protocol/core/protocol/css/includes/lib' as p;
 @use './variables' as c;
 
 

--- a/kitsune/sumo/static/sumo/scss/config/_mixins.scss
+++ b/kitsune/sumo/static/sumo/scss/config/_mixins.scss
@@ -1,5 +1,5 @@
 @use './color-swatches';
-@use '../protocol' as p;
+@use '@mozilla-protocol/core/protocol/css/includes/lib' as p;
 @use 'sass:map';
 
 // Think in pixels, but use rems. Takes a whole number.

--- a/kitsune/sumo/static/sumo/scss/config/_project-theme.scss
+++ b/kitsune/sumo/static/sumo/scss/config/_project-theme.scss
@@ -1,5 +1,5 @@
 @use './mixins' as c;
-@use '../protocol' as p;
+@use '@mozilla-protocol/core/protocol/css/includes/lib' as p;
 @use './color-swatches' as swatches;
 
 :root {

--- a/kitsune/sumo/static/sumo/scss/config/_typography-mixins.scss
+++ b/kitsune/sumo/static/sumo/scss/config/_typography-mixins.scss
@@ -1,4 +1,4 @@
-@use '../protocol' as p;
+@use '@mozilla-protocol/core/protocol/css/includes/lib' as p;
 @use './mixins' as c;
 
 

--- a/kitsune/sumo/static/sumo/scss/layout/_aaq.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_aaq.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 .aaq {

--- a/kitsune/sumo/static/sumo/scss/layout/_auth.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_auth.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 .sumo-auth {

--- a/kitsune/sumo/static/sumo/scss/layout/_community.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_community.scss
@@ -1,4 +1,4 @@
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 @use '../config' as c;
 
 .results-user {
@@ -56,7 +56,7 @@
     height: p.$spacing-md;
     border: none;
     border-radius: p.$spacing-xs;
-    background-image: url('#{p.$image-path}/icons/check.svg');
+    background-image: url('protocol/img/icons/check.svg');
     background-color: transparent;
     background-position: center center;
     background-repeat: no-repeat;

--- a/kitsune/sumo/static/sumo/scss/layout/_containers.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_containers.scss
@@ -1,4 +1,4 @@
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 @use '../config' as c;
 
 // Containers

--- a/kitsune/sumo/static/sumo/scss/layout/_contributors.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_contributors.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 .contributor-list {

--- a/kitsune/sumo/static/sumo/scss/layout/_document.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_document.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 .document {

--- a/kitsune/sumo/static/sumo/scss/layout/_footer.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_footer.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Footer
 //

--- a/kitsune/sumo/static/sumo/scss/layout/_forum.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_forum.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 .forum {
   &--question-item {

--- a/kitsune/sumo/static/sumo/scss/layout/_nav.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_nav.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 // Navigation
 //
@@ -191,7 +191,7 @@
     height: p.$spacing-xl;
     border: none;
     border-radius: p.$spacing-xs;
-    background-image: url('#{p.$image-path}/icons/menu.svg');
+    background-image: url('protocol/img/icons/menu.svg');
     background-color: transparent;
     background-position: center center;
     background-repeat: no-repeat;
@@ -215,7 +215,7 @@
       (margin-left, auto, 0),
       (margin-right, 0, auto),
     ));
-    background-image: url('#{p.$image-path}/icons/search.svg');
+    background-image: url('protocol/img/icons/search.svg');
   }
 
   .simple-search-form {

--- a/kitsune/sumo/static/sumo/scss/layout/_products.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_products.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 .sumo-page-subheader {

--- a/kitsune/sumo/static/sumo/scss/layout/_profile.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_profile.scss
@@ -1,5 +1,5 @@
-@use '../config'as c;
-@use '../protocol'as p;
+@use '../config' as c;
+@use 'protocol/css/includes/lib' as p;
 
 .badges-list {
   display: flex;

--- a/kitsune/sumo/static/sumo/scss/layout/_search-page.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_search-page.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 
 // this class is added to the body when the instant search is active. It should

--- a/kitsune/sumo/static/sumo/scss/layout/_topic-page.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_topic-page.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 .topic-article {
   display: flex;

--- a/kitsune/sumo/static/sumo/scss/layout/two-columns.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/two-columns.scss
@@ -1,5 +1,5 @@
 @use '../config' as c;
-@use '../protocol' as p;
+@use 'protocol/css/includes/lib' as p;
 
 .sumo-l-two-col {
   @include c.grid-row();

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "stylelint-order": "^5.0.0",
         "stylelint-scss": "^4.1.0",
         "svelte-loader": "^3.1.2",
+        "svelte-preprocess": "^4.10.2",
         "webpack": "^5.65.0",
         "webpack-bundle-analyzer": "^4.4.2",
         "webpack-cli": "^4.7.2",
@@ -1931,6 +1932,21 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "node_modules/@types/pug": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
+      "integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
+      "dev": true
+    },
+    "node_modules/@types/sass": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
+      "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -4771,6 +4787,15 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detective": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
@@ -5292,6 +5317,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -8519,6 +8550,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -11365,6 +11405,30 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+      "dev": true,
+      "dependencies": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      }
+    },
+    "node_modules/sander/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/sass": {
       "version": "1.45.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.45.2.tgz",
@@ -12003,6 +12067,21 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/sorcery": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
+      },
+      "bin": {
+        "sorcery": "bin/index.js"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -12063,6 +12142,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/spawn-command": {
       "version": "0.0.2-1",
@@ -12642,6 +12727,72 @@
       },
       "peerDependencies": {
         "svelte": "3.x"
+      }
+    },
+    "node_modules/svelte-preprocess": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.2.tgz",
+      "integrity": "sha512-aPpkCreSo8EL/y8kJSa1trhiX0oyAtTjlNNM7BNjRAsMJ8Yy2LtqHt0zyd4pQPXt+D4PzbO3qTjjio3kwOxDlA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/pug": "^2.0.4",
+        "@types/sass": "^1.16.0",
+        "detect-indent": "^6.0.0",
+        "magic-string": "^0.25.7",
+        "sorcery": "^0.10.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 9.11.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.2",
+        "coffeescript": "^2.5.1",
+        "less": "^3.11.3 || ^4.0.0",
+        "postcss": "^7 || ^8",
+        "postcss-load-config": "^2.1.0 || ^3.0.0",
+        "pug": "^3.0.0",
+        "sass": "^1.26.8",
+        "stylus": "^0.55.0",
+        "sugarss": "^2.0.0",
+        "svelte": "^3.23.0",
+        "typescript": "^4.5.2"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "coffeescript": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "postcss-load-config": {
+          "optional": true
+        },
+        "pug": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/svelte2tsx": {
@@ -15683,6 +15834,21 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/pug": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
+      "integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
+      "dev": true
+    },
+    "@types/sass": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
+      "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -17925,6 +18091,12 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true
+    },
     "detective": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
@@ -18332,6 +18504,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -20759,6 +20937,15 @@
         "yallist": "^4.0.0"
       }
     },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -22805,6 +22992,29 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sander": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+      "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "sass": {
       "version": "1.45.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.45.2.tgz",
@@ -23337,6 +23547,18 @@
         }
       }
     },
+    "sorcery": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+      "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
+      }
+    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -23384,6 +23606,12 @@
           "dev": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spawn-command": {
       "version": "0.0.2-1",
@@ -23822,6 +24050,20 @@
       "integrity": "sha512-CGTaexasSLpUaTSN2AlYqii0JeisIgg7uZbm8XCLKlpM9Qv3IltlJ7Nvh90Xw9ND97KqtGOjNJ3LNwMN1ABV0w==",
       "requires": {
         "svelte2tsx": "^0.1.151"
+      }
+    },
+    "svelte-preprocess": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.2.tgz",
+      "integrity": "sha512-aPpkCreSo8EL/y8kJSa1trhiX0oyAtTjlNNM7BNjRAsMJ8Yy2LtqHt0zyd4pQPXt+D4PzbO3qTjjio3kwOxDlA==",
+      "dev": true,
+      "requires": {
+        "@types/pug": "^2.0.4",
+        "@types/sass": "^1.16.0",
+        "detect-indent": "^6.0.0",
+        "magic-string": "^0.25.7",
+        "sorcery": "^0.10.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "svelte2tsx": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "stylelint-order": "^5.0.0",
     "stylelint-scss": "^4.1.0",
     "svelte-loader": "^3.1.2",
+    "svelte-preprocess": "^4.10.2",
     "webpack": "^5.65.0",
     "webpack-bundle-analyzer": "^4.4.2",
     "webpack-cli": "^4.7.2",

--- a/svelte/contribute/Contribute.svelte
+++ b/svelte/contribute/Contribute.svelte
@@ -31,3 +31,11 @@
         </Route>
     </Router>
 </div>
+
+<style lang="scss">
+    @use "../../kitsune/sumo/static/sumo/scss/config/typography-mixins";
+
+    h1 {
+        @include typography-mixins.text-display-sm;
+    }
+</style>

--- a/svelte/contribute/Link.svelte
+++ b/svelte/contribute/Link.svelte
@@ -7,3 +7,17 @@
 <li>
     <Link {to}><slot /></Link>
 </li>
+
+<style lang="scss">
+    @use "@mozilla-protocol/core/protocol/css/includes/lib" as p;
+
+    li {
+        &::before {
+            content: "";
+            background: url("protocol/img/icons/reader-mode.svg");
+            background-repeat: no-repeat;
+            background-size: p.$spacing-md p.$spacing-md;
+            padding-left: p.$spacing-lg;
+        }
+    }
+</style>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,7 @@
 const webpack = require("webpack");
 const path = require("path");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const sveltePreprocess = require("svelte-preprocess");
 
 module.exports = {
   mode: "development",
@@ -10,10 +11,10 @@ module.exports = {
       sumo: path.resolve(__dirname, "kitsune/sumo/static/sumo"),
       community: path.resolve(__dirname, "kitsune/community/static/community"),
       kpi: path.resolve(__dirname, "kitsune/kpi/static/kpi"),
-      svelte: path.resolve('node_modules', 'svelte')
+      svelte: path.resolve("node_modules", "svelte"),
     },
-    extensions: ['.mjs', '.js', '.svelte'],
-    mainFields: ['svelte', 'browser', 'module', 'main']
+    extensions: [".mjs", ".js", ".svelte"],
+    mainFields: ["svelte", "browser", "module", "main"],
   },
   module: {
     rules: [
@@ -35,17 +36,23 @@ module.exports = {
       },
       {
         test: /\.svelte$/,
-        use: "svelte-loader",
+        use: {
+          loader: "svelte-loader",
+          options: {
+            emitCss: true,
+            preprocess: sveltePreprocess(),
+          },
+        },
       },
       {
         // required to prevent errors from Svelte on Webpack 5+
         test: /node_modules\/svelte\/.*\.mjs$/,
         resolve: {
-          fullySpecified: false
-        }
+          fullySpecified: false,
+        },
       },
       {
-        test: /\.scss$/,
+        test: /\.s?css$/,
         use: [
           MiniCssExtractPlugin.loader,
           "css-loader",


### PR DESCRIPTION
involved some re-jigging of our scss files to ensure that unnecessary
bits of css weren't imported into svelte components when attempting to
import mixins or variables, as well as ensure imports are resolvable
by svelte-preprocess

https://github.com/mozilla/sumo/issues/1001
