### PR TITLE
fix GA service account creds

### DIFF
--- a/kitsune/sumo/googleanalytics.py
+++ b/kitsune/sumo/googleanalytics.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import timedelta
 from functools import wraps
+from io import BytesIO
 
 import httplib2
 from apiclient.discovery import build
@@ -41,7 +42,7 @@ def retry_503(f):
 
 def _build_request():
     scope = "https://www.googleapis.com/auth/analytics.readonly"
-    creds = ServiceAccountCredentials.from_p12_keyfile(account, key, scope)
+    creds = ServiceAccountCredentials.from_p12_keyfile_buffer(account, BytesIO(key), scopes=scope)
     request = creds.authorize(httplib2.Http())
     service = build("analytics", "v3", request)
     return service.data().ga()


### PR DESCRIPTION
this should fix the immediate error, however the library is deprecated and unmaintained: https://google-auth.readthedocs.io/en/latest/oauth2client-deprecation.html

we should switch to google-auth, but from what I can see we'll need to re-issue our GA service account creds in the new json format - I don't think I have the appropriate permissions to do that