### PR TITLE
Change IRC links to Matrix

### DIFF
--- a/kitsune/community/jinja2/community/email/first_answer.html
+++ b/kitsune/community/jinja2/community/email/first_answer.html
@@ -23,17 +23,17 @@
   <p><strong>{{ _('Tell us about yourself!') }}</strong></p>
 
   <p>
-    {% trans intro_url='/forums/contributors', irc_url='https://client01.chat.mibbit.com/?server=irc.mozilla.org&channel=#sumo' %}
+    {% trans intro_url='/forums/contributors', matrix_url='https://chat.mozilla.org/#/room/#SUMO:mozilla.org' %}
       We are always very happy to hear from new people who like helping
       on the forums so if you haven’t met our community yet
       <a href="{{ intro_url }}">
         please take a minute to introduce yourself
       </a>.
       If you want to stay low-profile, that’s also ok :). You can also
-      find us all hanging out on IRC, on the
-      <a href="{{ irc_url }}">
-        #sumo channel
-      </a>.
+      find us all hanging out in the
+      <a href="{{ matrix_url }}">
+        #SUMO channel
+      </a> on Matrix.
     {% endtrans %}
   </p>
 

--- a/kitsune/community/jinja2/community/email/first_answer.ltxt
+++ b/kitsune/community/jinja2/community/email/first_answer.ltxt
@@ -21,11 +21,11 @@ help up to 1000 users a day!
 We are always very happy to hear from new people who like helping on the forums
 so if you haven’t met our community yet please take a minute to introduce
 yourself. If you want to stay low-profile, that’s also ok :). You can also find
-us all hanging out on IRC, on the #sumo channel on irc.mozilla.org.
+us all hanging out in the #SUMO channel on Matrix.
 {% endtrans %}
 
 * Introductions - https://{{ host }}/forums/contributors
-* IRC - https://www.mibbit.com/?server=irc.mozilla.org&channel=#sumo
+* Matrix - https://chat.mozilla.org/#/room/#SUMO:mozilla.org
 
 {% trans url='https://' + host + '/forums/contributors' %}
 The community forum is at {{ url }} .

--- a/kitsune/community/jinja2/community/email/first_l10n.html
+++ b/kitsune/community/jinja2/community/email/first_l10n.html
@@ -33,13 +33,9 @@
     <a href="/forums/l10n-forum/711196?last=64679">
       go to our l10n forums
     </a>.
-    You can also find people hanging out on IRC at
-    <a href="https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo-l10ns">
-      #sumo-l10ns
-    </a>
-    and
-    <a href="https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo">
-      #sumo.
+    You can also find people hanging out on Matrix in
+    <a href="https://chat.mozilla.org/#/room/#SUMO:mozilla.org">
+      #SUMO.
     </a>
   </p>
 

--- a/kitsune/community/jinja2/community/email/first_l10n.ltxt
+++ b/kitsune/community/jinja2/community/email/first_l10n.ltxt
@@ -22,11 +22,10 @@ localizing skills!
 * Locale Page - https://{{ host }}/kb/locales
 
 If you want to get in touch with other people localizing SUMO in your language
-you can check out the forums or our IRC channels.
+you can check out the forums or our Matrix channel.
 
 * L10n forums - https://{{ host }}/forums/l10n-forum/711196?last=64679
-* L10n IRC channel - https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo-l10ns
-* General SUMO IRC channel - https://www.mibbit.com/?server=irc.mozilla.org&channel=%23sumo
+* General SUMO Matrix channel - https://chat.mozilla.org/#/room/#SUMO:mozilla.org
 
 ---
 Stay in touch

--- a/kitsune/users/jinja2/users/email/contributor.ltxt
+++ b/kitsune/users/jinja2/users/email/contributor.ltxt
@@ -75,11 +75,11 @@ http://mzl.la/1CGbET4
 
 {# L10n: This is an email.  Whitespace matters! #}
 {% trans %}
-Lastly, find others in the community just like you on the #sumo IRC channel. That is right Mozilla has a live chat channel for contributors.
-irc.mozilla.org #sumo - web-based IRC:
+Lastly, find others in the community just like you in the #SUMO Matrix channel. That is right Mozilla has a live chat channel for contributors.
+chat.mozilla.org #SUMO - web-based Matrix:
 {% endtrans %}
 
-{{ add_utm('https://kiwiirc.com/client/irc.mozilla.org/sumo', 'get-involved', source='new-contributor') }}
+{{ add_utm('https://chat.mozilla.org/#/room/#SUMO:mozilla.org', 'get-involved', source='new-contributor') }}
 
 {# L10n: This is at the end of an email. #}
 {{ _('Welcome to SUMO!') }}


### PR DESCRIPTION
Replace instances of irc.mozilla.org with a sane link/reference to Matrix