### PR TITLE
fix showfor on revision pages

### DIFF
--- a/kitsune/sumo/static/sumo/js/revision.js
+++ b/kitsune/sumo/static/sumo/js/revision.js
@@ -1,0 +1,6 @@
+import "sumo/js/libs/jquery.lazyload";
+import ShowFor from "sumo/js/showfor";
+
+new ShowFor();
+
+$("img.lazy").lazyload();

--- a/kitsune/wiki/jinja2/wiki/revision.html
+++ b/kitsune/wiki/jinja2/wiki/revision.html
@@ -1,11 +1,11 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
-{% from "wiki/includes/document_macros.html" import show_for with context %}
 {# L10n: {n} is the revision number, {t} is the title of the document. {c} is the category. #}
 {% set title = _('Revision {n} | {t} | {c}')|f(n=revision.id, t=document.title, c=document.get_category_display()) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  (None, _('Revision {num}')|f(num=revision.id))] %}
 {% set classes = 'document' %}
+{% set scripts = ('document',) %}
 {% set meta = [('robots', 'noindex, nofollow')] %}
 
 {% block content %}
@@ -91,11 +91,5 @@
 {% endblock %}
 
 {% block side_top %}
-  {{ document_tools(document, document.parent, user, '', settings) }}
-{% endblock %}
-
-{% block side_bottom %}
-  <div>
-    {{ show_for(document.get_products(), header=_('Article is for:')) }}
-  </div>
+  {{ document_tools(document, document.parent, user, '', settings, include_showfor=True) }}
 {% endblock %}

--- a/kitsune/wiki/jinja2/wiki/revision.html
+++ b/kitsune/wiki/jinja2/wiki/revision.html
@@ -1,11 +1,12 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
+{% from "wiki/includes/document_macros.html" import show_for with context %}
 {# L10n: {n} is the revision number, {t} is the title of the document. {c} is the category. #}
 {% set title = _('Revision {n} | {t} | {c}')|f(n=revision.id, t=document.title, c=document.get_category_display()) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  (None, _('Revision {num}')|f(num=revision.id))] %}
 {% set classes = 'document' %}
-{% set scripts = ('document',) %}
+{% set scripts = ('revision',) %}
 {% set meta = [('robots', 'noindex, nofollow')] %}
 
 {% block content %}
@@ -91,5 +92,11 @@
 {% endblock %}
 
 {% block side_top %}
-  {{ document_tools(document, document.parent, user, '', settings, include_showfor=True) }}
+  {{ document_tools(document, document.parent, user, '', settings) }}
+{% endblock %}
+
+{% block side_bottom %}
+  <div>
+    {{ show_for(document.get_products(), header=_('Article is for:')) }}
+  </div>
 {% endblock %}

--- a/webpack/entrypoints.js
+++ b/webpack/entrypoints.js
@@ -33,6 +33,9 @@ const entrypoints = {
     "sumo/js/document.js",
     "sumo/js/wiki.metrics.js",
   ],
+  revision: [
+    "sumo/js/revision.js",
+  ],
   questions: [
     "sumo/js/questions.js",
     "sumo/js/tags.filter.js",


### PR DESCRIPTION
fix mozilla/sumo#1043

The "show_for" selector on revision pages currently doesn't work because the revision pages include `kitsune/sumo/static/sumo/js/wiki.js` but that code doesn't call `new ShowFor()` for revision pages.

This PR does two things:
- It includes `kitsune/sumo/static/sumo/js/document.js` instead of `kitsune/sumo/static/sumo/js/wiki.js` for revision pages, because `kitsune/sumo/static/sumo/js/document.js` calls `new ShowFor()` by default, and because it seems to be better suited to the revision page in the sense that it doesn't include superfluous JS code.
- It also uses the `include_showfor=True` keyword argument of the `document_tools` macro to generate the `show_for` selector instead of using the `show_for` macro with a header. It makes for a better looking page that's more consistent with the document pages.