### PR TITLE
fix ratelimit and is_ratelimited

### DIFF
--- a/kitsune/sumo/decorators.py
+++ b/kitsune/sumo/decorators.py
@@ -116,7 +116,7 @@ def cors_enabled(origin, methods=["GET"]):
     return decorator
 
 
-def ratelimit(name, rate, method=["POST"], skip_if=lambda r: False):
+def ratelimit(name, rate, method="POST"):
     """
     Reimplement ``ratelimit.decorators.ratelimit``, using a sumo-specic ``is_ratelimited``.
 
@@ -127,7 +127,7 @@ def ratelimit(name, rate, method=["POST"], skip_if=lambda r: False):
         @wraps(fn)
         def _wrapped(request, *args, **kwargs):
             # Sets ``request.limited`` on ``request``.
-            is_ratelimited(request, name, rate, method, skip_if)
+            is_ratelimited(request, name, rate, method)
             return fn(request, *args, **kwargs)
 
         return _wrapped

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -12,7 +12,7 @@ from django.db.models.signals import pre_delete
 from django.templatetags.static import static
 from django.utils import translation
 from django.utils.http import is_safe_url, urlencode
-from ratelimit.utils import is_ratelimited as rl_is_ratelimited
+from ratelimit.core import is_ratelimited as is_ratelimited_core
 from timeout_decorator import timeout
 
 from kitsune.journal.models import Record
@@ -254,32 +254,34 @@ class Progress(object):
         sys.stdout.flush()
 
 
-def is_ratelimited(request, name, rate, method=["POST"], skip_if=lambda r: False):
+def is_ratelimited(request, name, rate, method="POST"):
     """
-    Reimplement ``ratelimit.helpers.is_ratelimited``, with sumo-specific details:
+    Wraps ``ratelimit.core.is_ratelimited`` with sumo-specific details:
 
     * Always check for the bypass rate limit permission.
     * Log times when users are rate limited.
     * Always uses ``user_or_ip`` for the rate limit key.
+    * Adds the Boolean attribute "limited" to the request.
     """
-    if skip_if(request) or request.user.has_perm("sumo.bypass_ratelimit"):
+    if request.user.has_perm("sumo.bypass_ratelimit"):
         request.limited = False
     else:
-        # TODO: make sure 'group' value below is sufficient
-        # TODO: make sure 'user_or_ip' is a valid replacement for
-        # old/deleted custom user_or_ip method
-        rl_is_ratelimited(
-            request, increment=True, group="sumo.utils.is_ratelimited", rate=rate, key="user_or_ip"
+        limited = is_ratelimited_core(
+            request, group=name, key="user_or_ip", rate=rate, method=method, increment=True
         )
-        if request.limited:
+        if limited:
+            # We only record a ratelimit event for this counter.
             if hasattr(request, "user") and request.user.is_authenticated:
                 key = 'user "{}"'.format(request.user.username)
             else:
-                ip = request.META.get("HTTP_X_CLUSTER_CLIENT_IP", request.META["REMOTE_ADDR"])
-                key = "anonymous user ({})".format(ip)
+                key = "anonymous user ({})".format(request.META["REMOTE_ADDR"])
             Record.objects.info(
                 "sumo.ratelimit", "{key} hit the rate limit for {name}", key=key, name=name
             )
+
+        # If the request was already limited, keep it that way.
+        request.limited = getattr(request, "limited", False) or limited
+
     return request.limited
 
 

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -272,9 +272,9 @@ def is_ratelimited(request, name, rate, method="POST"):
     ):
         # We only record a ratelimit event for this counter.
         if request.user.is_authenticated:
-            key = f'user "{request.user.username}"'
+            key = f"user '{request.user.username}'"
         else:
-            key = f'anonymous user {request.META["REMOTE_ADDR"]}'
+            key = f"anonymous user {request.META['REMOTE_ADDR']}"
         Record.objects.info(
             "sumo.ratelimit", "{key} hit the rate limit for {name}", key=key, name=name
         )


### PR DESCRIPTION
mozilla/sumo#1052

This PR changes the `ratelimit` and `is_ratelimited` SUMO utils to respect the `name` and `method` arguments. This will introduce the following changes from the way things currently work:
- only POST requests will count against rate limits, unless of course another method or methods are explicitly specified using the `method` argument (as far as I can tell, this will not change anything, since all rate-limited endpoints currently only accept POST requests anyway)
- `forum-post` and `aaq-day` will be counted separately (so a limit of 5 POST requests for each separately)
- `kbforum-post-day` and `primate-message-day` will be counted separately (so a limit of 50 POST requests for each separately)
- `question-vote`, `answer-vote`, and `document-vote` will be counted separately (so a limit of 10 POST requests for each separately)

I suspect those changes will make SUMO work as originally intended, but if one or more of those aren't acceptable, we can of course change the names to consolidate groups as desired. So for example, if we'd like to limit the number of any kind of vote to 10, we could change each of the names `question-vote`, `answer-vote`, and `document-vote` to just `vote`.

Some final points:
- Instead of importing and using `ratelimit.utils.is_ratelimited`, I now import and use `ratelimit.core.is_ratelimited`. As of `django-ratelimit` version `3`, `ratelimit.core` is the preferred public interface, so we should use that going forward. Note that unlike `ratelimit.utils.is_ratelimited`, `ratelimit.core.is_ratelimited` does **not** set `request.limited`, so that's now handled completely within `kitsune.sumo.utils.is_ratelimited`.
- I removed the `skip_if` argument from the `ratelimit` and `is_ratelimited` functions since it wasn't used anywhere.
- When recording a rate limit event, [we're currently using`request.META.get("HTTP_X_CLUSTER_CLIENT_IP", request.META["REMOTE_ADDR"])`](https://github.com/mozilla/kitsune/blob/db6aefb19b65eb27dfb400293c97c0f1de5072f5/kitsune/sumo/utils.py#L278) to get the offending IP address. We should use the same IP address that `ratelimit.core.is_ratelimited` uses, so I've changed that to use `request.META["REMOTE_ADDR"]`.