### PR TITLE
rate limit POST's to questions.watch endpoint

### DIFF
--- a/kitsune/questions/tests/test_views.py
+++ b/kitsune/questions/tests/test_views.py
@@ -14,6 +14,7 @@ from kitsune.search.tests import Elastic7TestCase
 from kitsune.sumo.templatetags.jinja_helpers import urlparams
 from kitsune.sumo.tests import LocalizingClient, eq_msg, get, template_used
 from kitsune.sumo.urlresolvers import reverse
+from kitsune.tidings.models import Watch
 from kitsune.users.tests import UserFactory, add_permission
 
 
@@ -534,6 +535,15 @@ class TestRateLimiting(TestCaseBase):
             self.client.post(url, {"content": content})
 
         self.assertEqual(4, Answer.objects.count())
+
+    def test_question_watch_limit(self):
+        """Test limit of watches on questions per day."""
+        q = QuestionFactory()
+        url = reverse("questions.watch", args=[q.id], locale="en-US")
+        for i in range(15):
+            self.client.post(url, dict(event_type="solution", email=f"ringo{i}@beatles.com"))
+
+        self.assertEqual(Watch.objects.filter(object_id=q.id).count(), 10)
 
 
 class TestEditDetails(TestCaseBase):


### PR DESCRIPTION
fix mozilla/sumo#1053

### Notes
- I thought a limit of 10 question "watches" per day seemed reasonable, but perhaps it should be more?
- For the limit to be counted separately from all of the other rate limits of `10/d`, this PR depends on #5160. Until #5160 is merged, all rate limits that use `10/d` will be lumped together.
- I check `request.limited` first thing in the `watch_question` view to avoid hitting the database for rate-limited requests.

### Message on Rate Limit for AJAX Request
<img width="514" alt="image" src="https://user-images.githubusercontent.com/3743693/174413111-26ebe363-e7b8-40e4-8d5a-c7b272f090a4.png">

### Message on Rate Limit for Non-AJAX Request
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/3743693/174412698-5c15a3bc-d67c-45c6-93f4-30b0968f93aa.png">

