### PR TITLE
set is_draft to null when saving image on edit

### DIFF
--- a/kitsune/gallery/views.py
+++ b/kitsune/gallery/views.py
@@ -188,7 +188,7 @@ def edit_media(request, media_id, media_type="image"):
         raise Http404
 
     if request.method == "POST" and media_form.is_valid():
-        media = media_form.save(update_user=request.user, is_draft=False)
+        media = media_form.save(update_user=request.user, is_draft=None)
         return HttpResponseRedirect(reverse("gallery.media", args=[media_type, media_id]))
 
     return render(


### PR DESCRIPTION
Fixes mozilla/sumo#358

After some time exploring other options, I decided that for now the best resolution was this very simple one, although the unique constraint on the combination of the `is_draft` and `creator_id` fields of images remains an issue. That constraint was [established over 11 years ago](https://github.com/mozilla/kitsune/commit/eeb2903b12b774cf821a8e59fa4d78845eac8e01#diff-ee1d1692eba138df1d940daf22c94423e70ed341b19114be547debf5109af734) with the intention of limiting a user to a single `is_draft=True` image, but the way it exists it also limits the user to a single `is_draft=False` image. That's why we set `is_draft=None` to ensure a non-draft image that won't trigger the constraint when saving an edit to the image.

A better fix would be to make the constraint conditional, one that only applies when `is_draft=True`, which I think we could do in Django something like the following:

```python
    class Meta:
        ...
        constraints = [..., models.UniqueConstraint(fields=['creator'], condition=Q(is_draft=True), name='unique_draft_creator')]
```

However, our current database, MySQL/MariaDB, doesn't support conditional indexes/constraints, so that's not an option until we move to PostgreSQL.