### PR TITLE
reduce memory demands when uploading images

### DIFF
--- a/kitsune/gallery/tests/test_utils.py
+++ b/kitsune/gallery/tests/test_utils.py
@@ -70,3 +70,26 @@ class CreateImageTestCase(TestCase):
             url=image.get_absolute_url(),
             thumbnail_url=image.file.url,
         )
+
+    def test_create_image_when_animated(self):
+        """
+        An image is created from an uploaded animated GIF file.
+
+        Verifies all appropriate fields are correctly set.
+        """
+        filepath = "kitsune/upload/tests/media/animated.gif"
+        with open(filepath, "rb") as f:
+            up_file = File(f)
+            file_info = create_image({"image": up_file}, self.user)
+
+        image = Image.objects.all()[0]
+        delete_url = reverse("gallery.delete_media", args=["image", image.id])
+        check_file_info(
+            file_info,
+            name=filepath,
+            width=120,
+            height=120,
+            delete_url=delete_url,
+            url=image.get_absolute_url(),
+            thumbnail_url=image.file.url,
+        )

--- a/kitsune/upload/tests/__init__.py
+++ b/kitsune/upload/tests/__init__.py
@@ -83,6 +83,28 @@ class CreateImageAttachmentTestCase(TestCase):
             thumbnail_url=image.thumbnail.url,
         )
 
+    def test_create_imageattachment_when_animated(self):
+        """
+        An image attachment is created from an uploaded animated GIF file.
+
+        Verifies all appropriate fields are correctly set.
+        """
+        filepath = "kitsune/upload/tests/media/animated.gif"
+        with open(filepath, "rb") as f:
+            up_file = File(f)
+            file_info = create_imageattachment({"image": up_file}, self.user, self.obj)
+
+        image = ImageAttachment.objects.all()[0]
+        check_file_info(
+            file_info,
+            name=filepath,
+            width=120,
+            height=120,
+            delete_url=image.get_delete_url(),
+            url=image.get_absolute_url(),
+            thumbnail_url=image.thumbnail.url,
+        )
+
 
 class FileNameTestCase(TestCase):
     def _match_file_name(self, name, name_end):


### PR DESCRIPTION
mozilla/sumo#1049
mozilla/sumo#1051
https://bugzilla.mozilla.org/show_bug.cgi?id=1766239

The root cause of mozilla/sumo#1049 and mozilla/sumo#1051 seems to be the excessive memory demands of [the `_image_to_png` function](https://github.com/mozilla/kitsune/blob/fcefeeaa119120e08fdf03a24da4dd7207138467/kitsune/upload/utils.py#L67). On both stage and prod, I discovered that the gunicorn process that handled the [`upload_async` view](https://github.com/mozilla/kitsune/blob/fcefeeaa119120e08fdf03a24da4dd7207138467/kitsune/gallery/views.py#L219) when uploading a new 3.1MB JPEG image, was killed due to an OOM (out-of-memory) error. Here's an example from stage:

```
[7828836.870120] oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=b6bade5c9da876bd065fc4cb367d0e5fdd970cccb2b0840b9949f84cfc45544a,mems_allowed=0,oom_memcg=/kubepods/burstable/pod7184e294-1e3b-4a31-8722-bd346eabd7eb,task_memcg=/kubepods/burstable/pod7184e294-1e3b-4a31-8722-bd346eabd7eb/b6bade5c9da876bd065fc4cb367d0e5fdd970cccb2b0840b9949f84cfc45544a,task=gunicorn,pid=19244,uid=1000
[7828836.891506] Memory cgroup out of memory: Killed process 19244 (gunicorn) total-vm:1145804kB, anon-rss:893092kB, file-rss:23160kB, shmem-rss:0kB, UID:1000 pgtables:1956kB oom_score_adj:976
[7828836.931252] oom_reaper: reaped process 19244 (gunicorn), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
```

After that discovery, I was able to reproduce the error in my local Docker-based development environment by reducing my Docker `Memory` resource to 1GB, and then discovered that I needed at least 2.25GB of memory dedicated to Docker in order to successfully upload my 3.1MB JPEG image.

The excessive memory demands of the `_image_to_png` function are almost exclusively due to the way the current code checks for an animated image, and primarily [this line of code](https://github.com/mozilla/kitsune/blob/fcefeeaa119120e08fdf03a24da4dd7207138467/kitsune/upload/utils.py#L70) (the line below it contributed as well). The good news is that the `Image` class provided by our current `pillow` package provides a new, simple, and efficient way to perform the animation check. 

This PR does the following:
- Uses the [`pillow`-recommended approach for checking for an animated image](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.is_animated), significantly reducing memory demands when uploading images. I've tested this change locally, and the results were dramatic. I was able to successfully upload my 3.1MB JPEG image using only 1GB of memory dedicated to Docker, while without the change, I needed more than double the memory (~2.25GB). I've also confirmed that the animation check works, by uploading and successfully detecting an animated GIF image.
- Closes the `pillow` image when we're done with it (hopefully encourages faster garbage collection).
- Adds tests for animated images to ensure those still work as expected.

This change, by itself, may allow us to upload images with sizes up to our limit of 10MB, but we also plan to increase the K8s memory resource limit for the `sumo-(stage|prod)-web` deployments, which should contribute towards resolving mozilla/sumo#1049 and mozilla/sumo#1051 as well.

