### PR TITLE
remove pickle usage from non-tidings celery tasks

### DIFF
--- a/kitsune/gallery/tests/test_models.py
+++ b/kitsune/gallery/tests/test_models.py
@@ -21,5 +21,6 @@ class ImageTestCase(TestCase):
         self.assertEqual(img.file.url, img.thumbnail_url_if_set())
 
         create_thumbnail_mock.return_value = ContentFile("the dude")
-        generate_thumbnail(img, "file", "thumbnail")
+        generate_thumbnail("gallery.Image", img.id, "file", "thumbnail")
+        img.refresh_from_db()
         self.assertEqual(img.thumbnail.url, img.thumbnail_url_if_set())

--- a/kitsune/gallery/views.py
+++ b/kitsune/gallery/views.py
@@ -68,8 +68,8 @@ def upload(request, media_type="image"):
         image_form = _init_media_form(ImageForm, request, drafts["image"][0])
         if image_form.is_valid():
             img = image_form.save(is_draft=None)
-            generate_thumbnail.delay(img, "file", "thumbnail")
-            compress_image.delay(img, "file")
+            generate_thumbnail.delay("gallery.Image", img.id, "file", "thumbnail")
+            compress_image.delay("gallery.Image", img.id, "file")
             # Rebuild KB
             schedule_rebuild_kb()
             return HttpResponseRedirect(img.get_absolute_url())

--- a/kitsune/sumo/management/commands/enqueue_lag_monitor_task.py
+++ b/kitsune/sumo/management/commands/enqueue_lag_monitor_task.py
@@ -9,4 +9,4 @@ class Command(BaseCommand):
     help = "Fire a task that measures the queue lag."
 
     def handle(self, **options):
-        measure_queue_lag.delay(datetime.now())
+        measure_queue_lag.delay(datetime.now().isoformat())

--- a/kitsune/sumo/tasks.py
+++ b/kitsune/sumo/tasks.py
@@ -7,9 +7,9 @@ from celery import shared_task
 log = logging.getLogger("k.task")
 
 
-@shared_task(serializer="pickle")
+@shared_task
 def measure_queue_lag(queued_time):
     """A task that measures the time it was sitting in the queue."""
-    lag = datetime.now() - queued_time
+    lag = datetime.now() - datetime.fromisoformat(queued_time)
     lag = max((lag.days * 3600 * 24) + lag.seconds, 0)
     log.info(f"Measure queue lag task value is {lag}")

--- a/kitsune/upload/tasks.py
+++ b/kitsune/upload/tasks.py
@@ -5,6 +5,7 @@ import subprocess
 from tempfile import NamedTemporaryFile
 
 from celery import shared_task
+from django.apps import apps
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
@@ -13,41 +14,41 @@ from PIL import Image
 log = logging.getLogger("k.task")
 
 
-@shared_task(rate_limit="15/m", serializer="pickle")
-def generate_thumbnail(for_obj, from_field, to_field, max_size=settings.THUMBNAIL_SIZE):
-    """Generate a thumbnail, given a model instance with from and to fields.
-
-    Optionally specify a max_size.
-
+@shared_task(rate_limit="15/m")
+def generate_thumbnail(
+    obj_model_name, obj_id, from_field, to_field, max_size=settings.THUMBNAIL_SIZE
+):
     """
-    from_ = getattr(for_obj, from_field)
-    to_ = getattr(for_obj, to_field)
+    Generate a thumbnail, given an object's model name, id, "from" and "to" fields, and
+    optionally the "max_size" of its longest side. The model name must be in the form of
+    "<app>.<model-name>", so for example, "gallery.Image" or "upload.ImageAttachment".
+    """
 
-    # Bail silently if nothing to generate from, image was probably deleted.
+    # Get the model of the object, and then get the object itself.
+    model = apps.get_model(obj_model_name)
+    obj = model.objects.get(id=obj_id)
+
+    from_ = getattr(obj, from_field)
+    to_ = getattr(obj, to_field)
+
+    # Bail silently if nothing to generate from. The image was probably deleted.
     if not (from_ and default_storage.exists(from_.name)):
-        log_msg = "No file to generate from: {model} {id}, {from_f} -> {to_f}"
         log.info(
-            log_msg.format(
-                model=for_obj.__class__.__name__, id=for_obj.id, from_f=from_field, to_f=to_field
-            )
+            f"No file to generate from: {obj_model_name} {obj.id}, {from_field} -> {to_field}"
         )
         return
 
-    log_msg = "Generating thumbnail for {model} {id}: {from_f} -> {to_f}"
-    log.info(
-        log_msg.format(
-            model=for_obj.__class__.__name__, id=for_obj.id, from_f=from_field, to_f=to_field
-        )
-    )
+    log.info(f"Generating thumbnail for {obj_model_name} {obj.id}: {from_field} -> {to_field}")
     thumb_content = _create_image_thumbnail(from_.file, longest_side=max_size)
-    if to_:  # Clean up old file before creating new one.
+    if to_:
+        # Clean up old file before creating new one.
         to_.delete(save=False)
     # Don't modify the object.
     to_.save(from_.name, thumb_content, save=False)
     # Use update to avoid race conditions with updating different fields.
     # E.g. when generating two thumbnails for different fields of a single
     # object.
-    for_obj.update(**{to_field: to_.name})
+    obj.update(**{to_field: to_.name})
 
 
 def _create_image_thumbnail(fileobj, longest_side=settings.THUMBNAIL_SIZE, pad=False):
@@ -100,27 +101,27 @@ def _scale_dimensions(width, height, longest_side=settings.THUMBNAIL_SIZE):
     return (new_width, new_height)
 
 
-@shared_task(rate_limit="15/m", serializer="pickle")
-def compress_image(for_obj, for_field):
+@shared_task(rate_limit="15/m")
+def compress_image(obj_model_name, obj_id, for_field):
     """Compress an image of given field for given object."""
 
-    for_ = getattr(for_obj, for_field)
+    # Get the model of the object, and then get the object itself.
+    model = apps.get_model(obj_model_name)
+    obj = model.objects.get(id=obj_id)
 
-    # Bail silently if nothing to compress, image was probably deleted.
+    for_ = getattr(obj, for_field)
+
+    # Bail silently if nothing to compress. The image was probably deleted.
     if not (for_ and default_storage.exists(for_.name)):
-        log_msg = "No file to compress for: {model} {id}, {for_f}"
-        log.info(log_msg.format(model=for_obj.__class__.__name__, id=for_obj.id, for_f=for_field))
+        log.info(f"No file to compress for: {obj_model_name} {obj.id}, {for_field}")
         return
 
     # Bail silently if not a PNG.
     if not (os.path.splitext(for_.name)[1].lower() == ".png"):
-        log_msg = "File is not PNG for: {model} {id}, {for_f}"
-        log.info(log_msg.format(model=for_obj.__class__.__name__, id=for_obj.id, for_f=for_field))
+        log.info(f"File is not PNG for: {obj_model_name} {obj.id}, {for_field}")
         return
 
-    log_msg = "Compressing {model} {id}: {for_f}"
-    log.info(log_msg.format(model=for_obj.__class__.__name__, id=for_obj.id, for_f=for_field))
-
+    log.info(f"Compressing {obj_model_name} {obj.id}: {for_field}")
     _optipng(for_.name)
 
 

--- a/kitsune/upload/tests/test_models.py
+++ b/kitsune/upload/tests/test_models.py
@@ -29,5 +29,6 @@ class ImageAttachmentTestCase(TestCase):
 
         self.assertEqual(image.file, image.thumbnail_if_set())
 
-        generate_thumbnail(image, "file", "thumbnail")
+        generate_thumbnail("upload.ImageAttachment", image.id, "file", "thumbnail")
+        image.refresh_from_db()
         self.assertEqual(image.thumbnail, image.thumbnail_if_set())

--- a/kitsune/upload/utils.py
+++ b/kitsune/upload/utils.py
@@ -42,9 +42,9 @@ def create_imageattachment(files, user, obj):
     image.file.save(up_file.name, File(up_file), save=True)
 
     # Compress and generate thumbnail off thread
-    generate_thumbnail.delay(image, "file", "thumbnail")
+    generate_thumbnail.delay("upload.ImageAttachment", image.id, "file", "thumbnail")
     if not is_animated:
-        compress_image.delay(image, "file")
+        compress_image.delay("upload.ImageAttachment", image.id, "file")
 
     # Refresh because the image may have been changed by tasks.
     image.refresh_from_db()


### PR DESCRIPTION
mozilla/sumo#1066

This PR removes the need for `pickle` serialization from our non-`tidings` Celery tasks.