### PR TITLE
[BUG 1680203] Layout issue for localized user profiles

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_avatar-group.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_avatar-group.scss
@@ -22,7 +22,7 @@
   }
 
   &--details-label {
-    width: 90px;
+    width: 170px;
     margin-right: 10px;
   }
 


### PR DESCRIPTION
Certain languages produce lengthy words in the user profile page.
I altered --details-label to allow for 170px width, which appears
to accomodate the longest word I could locate.

A better answer long term would be to have flex items here that
fit themselves, but that is possibly included in project level work in
the near future.