### PR TITLE
centralize locale fallback and add to what-links-here

### DIFF
--- a/kitsune/wiki/utils.py
+++ b/kitsune/wiki/utils.py
@@ -178,14 +178,12 @@ def get_featured_articles(product=None, locale=settings.WIKI_DEFAULT_LANGUAGE):
     return random.sample(documents, 4)
 
 
-def get_visible_document_or_404(user, **kwargs):
+def get_visible_document_or_404(
+    user, look_for_translation_via_parent=False, return_parent_if_no_translation=False, **kwargs
+):
     """
     Get the document specified by the keyword arguments and visible to the given user, or 404.
     """
-
-    look_for_translation_via_parent = kwargs.pop("look_for_translation_via_parent", False)
-    return_parent_if_no_translation = kwargs.pop("return_parent_if_no_translation", False)
-
     try:
         return Document.objects.get_visible(user, **kwargs)
     except Document.DoesNotExist:


### PR DESCRIPTION
mozilla/sumo#477

This PR arose out of reviewing #4805, and is an alternative approach. That PR is well-written, and I like that it centralized the handling of locale-related fallbacks (e.g., used for redirecting URL's like`/de/<english-slug/` to `/de/<slug-of-german-translation/`), but I felt that its combination of middleware and a view decorator to mark exceptions made the wiki views more difficult to understand. I also felt that the locale-related fallback didn't make sense for most of the wiki endpoints.

This PR also centralizes the fallback code, but takes a more narrow approach in that it only changes the behavior of the `wiki.what_links_here` endpoint.