### PR TITLE
remove celery-flower from local docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - kibana
       - redis
       - celery
-      - celery-flower
       - mailcatcher
     ports:
       - "8000:8000"
@@ -71,21 +70,6 @@ services:
     depends_on:
       - mariadb
       - redis
-
-  celery-flower:
-    build:
-      context: .
-      target: base
-    command: celery -A kitsune flower -l info --address=0.0.0.0 --port=5555
-    env_file: .env
-    volumes:
-      - ./:/app:delegated
-    user: ${UID:-kitsune}
-    depends_on:
-      - mariadb
-      - redis
-    ports:
-      - "5555:5555"
 
   mailcatcher:
     image: schickling/mailcatcher


### PR DESCRIPTION
Remove `celery-flower` from local Docker configuration. It currently fails, and I don't see it as useful enough to fix.