### PR TITLE
always use english slug for short links

### DIFF
--- a/kitsune/wiki/tasks.py
+++ b/kitsune/wiki/tasks.py
@@ -180,8 +180,13 @@ def add_short_links(doc_ids):
     docs = Document.objects.filter(id__in=doc_ids)
     try:
         for doc in docs:
-            # Use django's reverse so the locale isn't included.
-            endpoint = django_reverse("wiki.document", args=[doc.slug])
+            # Use Django's reverse so the locale isn't included.
+            # Since we're not including the locale in the URL, we
+            # should always use the English slug. That ensures that
+            # we'll find and redirect to the translation based on the
+            # locale of the user using the short link.
+            slug = doc.parent.slug if doc.parent else doc.slug
+            endpoint = django_reverse("wiki.document", args=[slug])
             doc.update(share_link=generate_short_url(base_url % endpoint))
     except HTTPError:
         # The next run of the `generate_missing_share_links` cron job will


### PR DESCRIPTION
mozilla/sumo#1082

I wanted to create this draft PR in order to capture my thoughts while the issue and code were fresh in my mind.

When we generate a short link for a document, we do not include the locale, because we want to use the preferred locale of the user that clicks the link. That only works if we use the English slug for a document, so that we find and redirect to the proper translation if the requesting user's preferred locale is not English. Currently, this is not a problem when we generate short links from the periodic task that runs every 6 hours, since that periodic task only generates short links for English documents. However, it is a problem when we create a short link for a new translation. This PR ensures that we always use the English slug when creating a short link.