### PR TITLE
JSON.stringify WebChannelMessageToChrome event detail

### DIFF
--- a/kitsune/sumo/static/sumo/js/remote.js
+++ b/kitsune/sumo/static/sumo/js/remote.js
@@ -35,12 +35,12 @@ export default class RemoteTroubleshooting {
     // Create the remote-troubleshooting event requesting data and
     // kick it off.
     const request = new window.CustomEvent("WebChannelMessageToChrome", {
-      detail: {
+      detail: JSON.stringify({
         id: "remote-troubleshooting",
         message: {
           command: "request",
         },
-      },
+      }),
     });
     window.dispatchEvent(request);
 


### PR DESCRIPTION
mozilla/sumo#1095

When sending the `WebChannelMessageToChrome` event to Firefox, SUMO is currently allowed to send an object for the event's `detail` since its on a special allowed list, but all other domains must send a JSON string. Firefox would like to remove the allowed list altogether, so they're asking SUMO to `JSON.stringify` our event's `detail` object so they can take a step closer by removing us. This PR does that.

I spent a good chunk of time trying to [test this locally](https://github.com/mozilla/kitsune/blob/main/docs/browser_permissions.md#testing-locally), and I'm close, but still not there yet.
