### PR TITLE
adjust pipeline to handle svelte pre-render variations

### DIFF
--- a/.circleci/build.html
+++ b/.circleci/build.html
@@ -18,6 +18,7 @@
   <body>
     build completed!<br />
     hash: <span class="hash"></span><br />
+    image: mozilla/kitsune:stage-<span class="hash"></span>
     image: mozilla/kitsune:prod-<span class="hash"></span>
     <script>
       const GIT_COMMIT_SHORT = "replaceme";

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,19 @@ jobs:
                   { pattern: "^prod-.+$", value: << pipeline.git.branch >> }
           steps:
             - run:
+                name: Build stage image
+                command: ./bin/dc_ci.sh build --progress=plain stage
+            - run:
                 name: Build prod image
                 command: ./bin/dc_ci.sh build --progress=plain prod
             - run:
-                name: Push prod image
+                name: Push stage and prod images
                 command: |
                   echo "$DOCKER_PASSWORD" | docker login -u $DOCKER_USERNAME --password-stdin
                   source docker/bin/set_git_env_vars.sh
+                  docker image tag mozilla/kitsune:stage-${GIT_COMMIT_SHORT} mozilla/kitsune:stage-latest
+                  docker image push mozilla/kitsune:stage-${GIT_COMMIT_SHORT}
+                  docker image push mozilla/kitsune:stage-latest
                   docker image tag mozilla/kitsune:prod-${GIT_COMMIT_SHORT} mozilla/kitsune:prod-latest
                   docker image push mozilla/kitsune:prod-${GIT_COMMIT_SHORT}
                   docker image push mozilla/kitsune:prod-latest
@@ -67,11 +73,11 @@ jobs:
                   source docker/bin/set_git_env_vars.sh
                   ./docker/bin/upload-staticfiles.sh
             - run:
-                name: Echo prod image hash
+                name: Echo image hash for stage and prod
                 command: |
                   source docker/bin/set_git_env_vars.sh
                   sed s/replaceme/${GIT_COMMIT_SHORT}/ .circleci/build.html > /tmp/build-status.html
-                  echo -e 'build completed!\n'"hash: ${GIT_COMMIT_SHORT}\nimage: mozilla/kitsune:prod-${GIT_COMMIT_SHORT}"
+                  echo -e 'build completed!\n'"hash: ${GIT_COMMIT_SHORT}\nimage: mozilla/kitsune:stage-${GIT_COMMIT_SHORT}\nimage: mozilla/kitsune:prod-${GIT_COMMIT_SHORT}"
             - store_artifacts:
                 path: /tmp/build-status.html
                 destination: build-status.html

--- a/docker/bin/set_git_env_vars.sh
+++ b/docker/bin/set_git_env_vars.sh
@@ -20,6 +20,3 @@ if [[ -z "$GIT_BRANCH" ]]; then
 fi
 export BRANCH_NAME_SAFE="${BRANCH_NAME/\//-}"
 export BRANCH_AND_COMMIT="${BRANCH_NAME_SAFE}-${GIT_COMMIT}"
-# Docker Hub Stuff
-export DEPLOYMENT_DOCKER_REPO="mozilla/kitsune"
-export DEPLOYMENT_DOCKER_IMAGE="${DEPLOYMENT_DOCKER_REPO}:prod-${GIT_COMMIT_SHORT}"

--- a/docker/bin/upload-staticfiles.sh
+++ b/docker/bin/upload-staticfiles.sh
@@ -5,36 +5,44 @@ set -exo pipefail
 GIT_COMMIT=${GIT_COMMIT:-latest}
 GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT:-$GIT_COMMIT}
 CONTAINER_NAME="kitsune-static-${GIT_COMMIT}"
-IMAGE_NAME="mozilla/kitsune:prod-${GIT_COMMIT_SHORT}"
 TMP_DIR="s3-static"
 TMP_DIR_HASHED="s3-static-hashed"
 
-rm -rf "${TMP_DIR}"
-rm -rf "${TMP_DIR_HASHED}"
 
-# extract the static files
-docker create --name "${CONTAINER_NAME}" "${IMAGE_NAME}"
-docker cp "${CONTAINER_NAME}:/app/static" "${TMP_DIR}"
-docker rm -f "${CONTAINER_NAME}"
+function clean_tmp_dirs {
+    rm -rf "${TMP_DIR}"
+    rm -rf "${TMP_DIR_HASHED}"
+}
 
-# separate the hashed files into another directory
-mkdir "${TMP_DIR_HASHED}"
-find ${TMP_DIR} -maxdepth 1 -type f -regextype sed -regex ".*\.[0-9a-f]\{16\}\..*" -exec mv -t ${TMP_DIR_HASHED} {} +
+function build_and_upload {
+    # stage or prod
+    target=$1
 
-for BUCKET in stage prod; do
+    clean_tmp_dirs
+
+    # extract the static files
+    docker create --name "${CONTAINER_NAME}" "mozilla/kitsune:${target}-${GIT_COMMIT_SHORT}"
+    docker cp "${CONTAINER_NAME}:/app/static" "${TMP_DIR}"
+    docker rm -f "${CONTAINER_NAME}"
+
+    # separate the hashed files into another directory
+    mkdir "${TMP_DIR_HASHED}"
+    find ${TMP_DIR} -maxdepth 1 -type f -regextype sed -regex ".*\.[0-9a-f]\{16\}\..*" -exec mv -t ${TMP_DIR_HASHED} {} +
+
     # hashed filenames
     aws s3 sync \
         --only-show-errors \
         --acl public-read \
         --cache-control "max-age=315360000, public, immutable" \
-        "./${TMP_DIR_HASHED}" "s3://mozit-sumo-${BUCKET}-media/static/"
+        "./${TMP_DIR_HASHED}" "s3://mozit-sumo-${target}-media/static/"
     # non-hashed-filenames
     aws s3 sync \
         --only-show-errors \
         --acl public-read \
         --cache-control "max-age=21600, public" \
-        "./${TMP_DIR}" "s3://mozit-sumo-${BUCKET}-media/static/"
-done
+        "./${TMP_DIR}" "s3://mozit-sumo-${target}-media/static/"
+}
 
-rm -rf "${TMP_DIR}"
-rm -rf "${TMP_DIR_HASHED}"
+build_and_upload stage
+build_and_upload prod
+clean_tmp_dirs

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -16,4 +16,14 @@ services:
       target: prod
       args:
         - GIT_SHA
+        - SUMO_URL=https://support.mozilla.org
     image: mozilla/kitsune:prod-${GIT_COMMIT_SHORT:-latest}
+
+  stage:
+    build:
+      context: .
+      target: prod
+      args:
+        - GIT_SHA
+        - SUMO_URL=https://support.allizom.org
+    image: mozilla/kitsune:stage-${GIT_COMMIT_SHORT:-latest}

--- a/k8s/commander.sh
+++ b/k8s/commander.sh
@@ -23,16 +23,16 @@ function deploy {
 		echo "Secrets will *NOT* be applied"
 	fi
 
-	invoke -f "regions/${REGION}/${REGION_ENV}.yaml" deployments.create-celery --apply --tag "prod-${COMMIT_HASH}"
+	invoke -f "regions/${REGION}/${REGION_ENV}.yaml" deployments.create-celery --apply --tag "${REGION_ENV}-${COMMIT_HASH}"
 	invoke -f "regions/${REGION}/${REGION_ENV}.yaml" rollouts.status-celery
-	invoke -f "regions/${REGION}/${REGION_ENV}.yaml" deployments.create-cron --apply --tag "prod-${COMMIT_HASH}"
+	invoke -f "regions/${REGION}/${REGION_ENV}.yaml" deployments.create-cron --apply --tag "${REGION_ENV}-${COMMIT_HASH}"
 	invoke -f "regions/${REGION}/${REGION_ENV}.yaml" rollouts.status-cron
-	invoke -f "regions/${REGION}/${REGION_ENV}.yaml" deployments.create-web --apply --tag "prod-${COMMIT_HASH}"
+	invoke -f "regions/${REGION}/${REGION_ENV}.yaml" deployments.create-web --apply --tag "${REGION_ENV}-${COMMIT_HASH}"
 	invoke -f "regions/${REGION}/${REGION_ENV}.yaml" rollouts.status-web
 
 	post-deploy "$@"
 
-	echo ":tada: Successfully deployed <${DOCKER_HUB}|prod-${COMMIT_HASH}> to <https://${REGION_ENV}-${REGION}.sumo.mozit.cloud/|SUMO-${REGION_ENV} in ${REGION}>"
+	echo ":tada: Successfully deployed <${DOCKER_HUB}|${REGION_ENV}-${COMMIT_HASH}> to <https://${REGION_ENV}-${REGION}.sumo.mozit.cloud/|SUMO-${REGION_ENV} in ${REGION}>"
 	printf "${GREEN}OK${NC}\n"
 }
 

--- a/k8s/regions/frankfurt/dev.yaml
+++ b/k8s/regions/frankfurt/dev.yaml
@@ -7,7 +7,7 @@ kubernetes:
     secrets_name: "sumo-secrets-dev"
     image:
         repo: "mozilla/kitsune"
-        tag: "prod-latest"
+        tag: "dev-latest"
         pull_policy: "Always"
     # default values
     limits:

--- a/k8s/regions/frankfurt/stage.yaml
+++ b/k8s/regions/frankfurt/stage.yaml
@@ -7,7 +7,7 @@ kubernetes:
     secrets_name: "sumo-secrets-stage"
     image:
         repo: "mozilla/kitsune"
-        tag: "prod-latest"
+        tag: "stage-latest"
         pull_policy: "Always"
     # default values
     limits:

--- a/k8s/regions/oregon/stage.yaml
+++ b/k8s/regions/oregon/stage.yaml
@@ -7,7 +7,7 @@ kubernetes:
     secrets_name: "sumo-secrets-stage"
     image:
         repo: "mozilla/kitsune"
-        tag: "prod-latest"
+        tag: "stage-latest"
         pull_policy: "Always"
     # default values
     limits:


### PR DESCRIPTION
This PR adjusts the Circle-CI pipeline and the k8s deployment script to build and deploy separate Docker images into the stage and prod environments. With the dependency of the `svelte` pre-rendering on the value of `SUMO_URL`, some of the pre-rendered JS, CSS, and HTML files can vary depending on the value of `SUMO_URL`, which will vary depending on the target environment. That means we can no longer deploy or upload static assets from a single Docker image into the stage and prod (and dev) environments. We must build, deploy, and upload static assets from an image specifically built for each target environment. 