### PR TITLE
use relative urls to avoid SUMO_URL consequences

### DIFF
--- a/svelte/contribute/Contribute.svelte
+++ b/svelte/contribute/Contribute.svelte
@@ -5,11 +5,7 @@
     import Linkable from "./Linkable.svelte";
     import { gettext } from "../lib/utils";
     import { createClient, setContextClient } from "@urql/svelte";
-    import {
-        SUMO_URL,
-        GRAPHQL_ENDPOINT,
-        TEACHABLE_URL,
-    } from "../lib/constants";
+    import { GRAPHQL_ENDPOINT } from "../lib/constants";
     import { queryStore, gql, getContextClient } from "@urql/svelte";
 
     // this is a little verbose, but dynamic imports aren't SSRed
@@ -64,16 +60,14 @@
                     [
                         Linkable,
                         {
-                            link:
-                                SUMO_URL +
-                                "/kb/mozilla-support-rules-guidelines",
+                            link: "/kb/mozilla-support-rules-guidelines",
                             text: gettext("Learn the basic guidelines"),
                         },
                     ],
                     [
                         Linkable,
                         {
-                            link: SUMO_URL + "/questions",
+                            link: "/questions",
                             text: gettext("Find support questions to answer"),
                         },
                     ],
@@ -81,7 +75,7 @@
                     [
                         Linkable,
                         {
-                            link: SUMO_URL + "/kb/how-contribute-support-forum",
+                            link: "/kb/how-contribute-support-forum",
                             text: gettext(
                                 "Learn more about forum contribution"
                             ),
@@ -121,16 +115,14 @@
                     [
                         Linkable,
                         {
-                            link:
-                                SUMO_URL +
-                                "/kb/mozilla-support-rules-guidelines",
+                            link: "/kb/mozilla-support-rules-guidelines",
                             text: gettext("Learn the basic guidelines"),
                         },
                     ],
                     [
                         Linkable,
                         {
-                            link: SUMO_URL + "/contributors/kb-overview",
+                            link: "/contributors/kb-overview",
                             text: gettext(
                                 "Explore the Knowledge Base Dashboard"
                             ),
@@ -148,8 +140,7 @@
                     [
                         Linkable,
                         {
-                            link:
-                                SUMO_URL + "/kb/how-contribute-knowledge-base",
+                            link: "/kb/how-contribute-knowledge-base",
                             text: gettext("Learn moore about KB contribution"),
                         },
                     ],
@@ -181,16 +172,14 @@
                     [
                         Linkable,
                         {
-                            link:
-                                SUMO_URL +
-                                "/kb/mozilla-support-rules-guidelines",
+                            link: "/kb/mozilla-support-rules-guidelines",
                             text: gettext("Learn the basic guidelines"),
                         },
                     ],
                     [
                         Linkable,
                         {
-                            link: SUMO_URL + "/kb/locales",
+                            link: "/kb/locales",
                             text: gettext(
                                 "Check if your locale is available and go to your localization dashboard"
                             ),
@@ -206,9 +195,7 @@
                     [
                         Linkable,
                         {
-                            link:
-                                SUMO_URL +
-                                "/kb/how-contribute-article-localization",
+                            link: "/kb/how-contribute-article-localization",
                             text: gettext(
                                 "Learn more about localization contribution"
                             ),
@@ -244,7 +231,7 @@
                     [
                         Linkable,
                         {
-                            link: SUMO_URL + "/kb/social-support-guidelines",
+                            link: "/kb/social-support-guidelines",
                             text: gettext("Learn the basic guidelines"),
                         },
                     ],
@@ -267,8 +254,7 @@
                     [
                         Linkable,
                         {
-                            link:
-                                SUMO_URL + "/kb/how-contribute-social-support",
+                            link: "/kb/how-contribute-social-support",
                             text: gettext(
                                 "Learn more about social support contribution"
                             ),
@@ -304,7 +290,7 @@
                     [
                         Linkable,
                         {
-                            link: SUMO_URL + "/kb/get-started-mobile-support",
+                            link: "/kb/get-started-mobile-support",
                             text: gettext("Learn the basic guidelines"),
                         },
                     ],
@@ -325,9 +311,7 @@
                     [
                         Linkable,
                         {
-                            link:
-                                SUMO_URL +
-                                "/kb/how-contribute-mobile-support-start-here",
+                            link: "/kb/how-contribute-mobile-support-start-here",
                             text: gettext(
                                 "Learn more about mobile store support contribution"
                             ),

--- a/svelte/contribute/Contribute.svelte
+++ b/svelte/contribute/Contribute.svelte
@@ -141,7 +141,7 @@
                         Linkable,
                         {
                             link: "/kb/how-contribute-knowledge-base",
-                            text: gettext("Learn moore about KB contribution"),
+                            text: gettext("Learn more about KB contribution"),
                         },
                     ],
                 ],

--- a/svelte/contribute/Steps.svelte
+++ b/svelte/contribute/Steps.svelte
@@ -2,7 +2,7 @@
     import { queryStore, gql, getContextClient } from "@urql/svelte";
     import Linkable from "./Linkable.svelte";
     import { gettext } from "../lib/utils";
-    import { SUMO_URL, TEACHABLE_URL } from "../lib/constants";
+    import { TEACHABLE_URL } from "../lib/constants";
 
     export let steps = [];
     export let fact = {};
@@ -20,10 +20,10 @@
         `,
     });
     let contributionArea = location?.pathname.split("/").pop();
-    let signUp = new URL(
-        SUMO_URL + "/fxa/authenticate?next=/contribute/" + contributionArea
-    );
-    signUp.searchParams.append("contributor", contributionArea);
+    let signUp = `/fxa/authenticate?${new URLSearchParams({
+        next: "/contribute/" + contributionArea,
+        contributor: contributionArea,
+    }).toString()}`;
 </script>
 
 <section class="mzp-l-content">

--- a/svelte/lib/constants.js
+++ b/svelte/lib/constants.js
@@ -1,7 +1,4 @@
-export const SUMO_URL =
-  process.env["SUMO_URL"] || "https://support.mozilla.org";
 export const TEACHABLE_URL =
   process.env["TEACHABLE_URL"] ||
   "https://mozilla.teachable.com/p/cpg-training-contributors";
-export const GRAPHQL_ENDPOINT =
-  process.env["GRAPHQL_ENDPOINT"] || SUMO_URL + "/graphql";
+export const GRAPHQL_ENDPOINT = process.env["GRAPHQL_ENDPOINT"] || "/graphql";


### PR DESCRIPTION
By using relative URLs, we guarantee that we use the same origin that the page was loaded from and we avoid:
- building separate Docker images for each target environment (e.g., stage, prod) -- at least for now, since we don't yet have any other settings that vary between the target environments
- the need to provide the extra code and configuration required to set `SUMO_URL` for each target environment, including local development -- for example, like parts of https://github.com/mozilla/kitsune/pull/5274