### PR TITLE
add flake8-annotations to catch (some) type hint issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,8 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
+        additional_dependencies:
+        - flake8-annotations
   -   repo: https://github.com/pre-commit/mirrors-prettier
       rev: v2.6.2
       hooks:


### PR DESCRIPTION
https://pypi.org/project/flake8-annotations/

I added this plugin to flake8 for us to discuss - it enforces type annotation during pre-commit, but we might want to discuss some details. It could be frustrating to be forced to retrofit large pieces of existing codebase during a quick fix vs. as a project/planned effort.

Give it a test drive and let me know - I'd rather a check on only new code, but haven't landed on a way to do that yet.