### PR TITLE
allow wiki syntax in announcements

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -95,7 +95,7 @@
 
   {% for announ in get_announcements() %}
       {% call announcement_bar(announ.id, 'warning') %}
-          {{ announ.content | safe }}
+          {{ announ.content | wiki_to_html }}
       {% endcall %}
   {% endfor %}
   {% if settings.READ_ONLY %}


### PR DESCRIPTION
https://github.com/mozilla/sumo/issues/112

### Before
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/3743693/199544585-f8481270-e97b-49aa-b953-1e1dd4bdc121.png">

### After
<img width="982" alt="image" src="https://user-images.githubusercontent.com/3743693/199544448-b3cdbecf-858f-49bf-a41b-58fc9a3c91f9.png">
