### PR TITLE
Typo correction

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -1222,5 +1222,5 @@ GRAPHENE = {
 # Contributor Groups
 LEGACY_CONTRIBUTOR_GROUPS = [
     "Contributors",
-    "Registered as Contributors",
+    "Registered as contributor",
 ]


### PR DESCRIPTION
Responding to an issue in Slack - some contributors were being miscounted/left off [the top-contributors page](https://support.mozilla.org/en-US/community/top-contributors/questions).  @escattone caught a typo in `settings.LEGACY_CONTRIBUTOR_GROUPS` that should correct the issue.