### PR TITLE
remove obsolete messages from po files

### DIFF
--- a/kitsune/sumo/management/commands/merge.py
+++ b/kitsune/sumo/management/commands/merge.py
@@ -32,7 +32,11 @@ class Command(BaseCommand):
                 continue
 
             if Path(f"locale/{locale}").is_dir():
-                sub_cmd = "update"
+                command = [
+                    "pybabel",
+                    "update",
+                    "--ignore-obsolete",
+                ]
             elif not is_supported_for_init(locale):
                 # NOTE: Babel only supports initializing locales included in the CLDR.
                 self.stdout.write(
@@ -40,16 +44,20 @@ class Command(BaseCommand):
                 )
                 continue
             else:
-                sub_cmd = "init"
+                command = ["pybabel", "init"]
 
-            CommandLineInterface().run(
-                [
-                    "pybabel",
-                    sub_cmd,
+            command.extend(
+                (
                     "-d",
                     "locale/",
                     "-l",
                     locale,
+                )
+            )
+
+            CommandLineInterface().run(
+                command
+                + [
                     "-D",
                     "django",
                     "-i",
@@ -57,13 +65,8 @@ class Command(BaseCommand):
                 ]
             )
             CommandLineInterface().run(
-                [
-                    "pybabel",
-                    sub_cmd,
-                    "-d",
-                    "locale/",
-                    "-l",
-                    locale,
+                command
+                + [
                     "-D",
                     "djangojs",
                     "-i",

--- a/kitsune/sumo/management/commands/merge.py
+++ b/kitsune/sumo/management/commands/merge.py
@@ -36,6 +36,7 @@ class Command(BaseCommand):
                     "pybabel",
                     "update",
                     "--ignore-obsolete",
+                    "--no-fuzzy-matching",
                 ]
             elif not is_supported_for_init(locale):
                 # NOTE: Babel only supports initializing locales included in the CLDR.


### PR DESCRIPTION
https://github.com/mozilla/sumo/issues/1135

This is a companion PR for https://github.com/mozilla-l10n/sumo-l10n/pull/107.

This PR changes the `./manage.py merge` command so that it excludes obsolete messages from the updated PO files.

[Obsolete messages](https://www.gnu.org/software/gettext/manual/html_node/Obsolete-Entries.html) are no-longer used messages in PO files which are commented-out with `#~` and only exist for the convenience of being able to resurrect their translation if needed again sometime in the future. We should **not** be including obsolete messages in the PO files, since we have all of the message history in `git`, but also because they can and do trigger fatal duplicate message errors during compilation, since the `msgfmt` command treats them the same as active messages.

This PR also disables fuzzy matching when updating (merging) the PO files (via `--no-fuzzy-matching`). We shouldn't be using fuzzy matching. The translators in [our Pontoon community](https://pontoon.mozilla.org/projects/sumo/) will do a much better job than any fuzzy guesses at translations that the merge command attempts when adding new strings.


