### PR TITLE
fix extraction of localizable strings from Picker.svelte

### DIFF
--- a/svelte/contribute/Picker.svelte
+++ b/svelte/contribute/Picker.svelte
@@ -9,41 +9,51 @@
     import storeImg from "./img/Play Store.svg";
 
     export let location;
+
+    let localized = {
+        "other-ways": gettext("Other ways to contribute"),
+        "pick-a-way": gettext("Pick a way to contribute"),
+        "forum-header": gettext("Answer questions in the support forum"),
+        "kb-header": gettext("Write help articles"),
+        "l10n-header": gettext("Localize support content"),
+        "social-header": gettext("Provide support on social channels"),
+        "store-header": gettext("Respond to mobile store reviews"),
+    };
 </script>
 
 <section class="mzp-l-content">
     <h2>
         {#if location}
-            {gettext("Other ways to contribute")}
+            {localized["other-ways"]}
         {:else}
-            {gettext("Pick a way to contribute")}
+            {localized["pick-a-way"]}
         {/if}
     </h2>
     <nav>
         <ul>
             {#if location?.pathname != "/forum"}
                 <Tile to="../forum" img={forumImg}>
-                    {gettext("Answer questions in the support forum")}
+                    {localized["forum-header"]}
                 </Tile>
             {/if}
             {#if location?.pathname != "/kb"}
                 <Tile to="../kb" img={kbImg}>
-                    {gettext("Write help articles")}
+                    {localized["kb-header"]}
                 </Tile>
             {/if}
             {#if location?.pathname != "/l10n"}
                 <Tile to="../l10n" img={l10nImg}>
-                    {gettext("Localize support content")}
+                    {localized["l10n-header"]}
                 </Tile>
             {/if}
             {#if location?.pathname != "/social"}
                 <Tile to="../social" img={socialImg}>
-                    {gettext("Provide support on social channels")}
+                    {localized["social-header"]}
                 </Tile>
             {/if}
             {#if location?.pathname != "/store"}
                 <Tile to="../store" img={storeImg}>
-                    {gettext("Respond to mobile store reviews")}
+                    {localized["store-header"]}
                 </Tile>
             {/if}
         </ul>


### PR DESCRIPTION
https://github.com/mozilla/sumo/issues/1138

# Intro
In my research into options for extracting `gettext` strings from `.svelte` files, I couldn't find any viable options. There's https://www.npmjs.com/package/svelte-i18n, which seems stable and widely used, but it's a different L10n approach from `gettext`. So I think we can continue to use the default JS extractor that ships with PyBabel for `.svelte` files, but with some additional rules/guidelines about where we can place `gettext` calls within a `.svelte` file, or as stated below in "Another option", we can place all of our `gettext` calls in a separate JS file that we import into the `.svelte` file.

# This PR
This is one way we could fix the extraction of localizable strings from `Picker.svelte`. The JavaScript extractor that we're using for `.svelte` files sometimes has trouble parsing logic blocks like `{#if ...`. Moving the `gettext` calls with their strings into the `<script>` block avoids these parsing issues.

Running `./manage.py extract` with these changes in place yielded the desired/expected results. The four missing strings appeared in the `djangojs.pot` file:

```
...
+#: svelte/contribute/Picker.svelte:17
+msgid "Write help articles"
+msgstr ""
+
+#: svelte/contribute/Picker.svelte:18
+msgid "Localize support content"
+msgstr ""
+
+#: svelte/contribute/Picker.svelte:19
+msgid "Provide support on social channels"
+msgstr ""
+
+#: svelte/contribute/Picker.svelte:20
+msgid "Respond to mobile store reviews"
+msgstr ""
+
...
```

# Another option
Another, even safer approach we might want to consider is moving all of our localizable strings into a JS file that we import into the `.svelte` file, so that we guarantee that we're using the extractor on a vanilla JS file rather a `.svelte` file with its special syntax.