### PR TITLE
flake8 move to github in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         files: "^kitsune/"
         exclude: "^.*/migrations/.*$|kitsune/sumo/db_strings.py"
         language_version: python3.10
-  - repo: https://gitlab.com/pycqa/flake8.git
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
@@ -27,6 +27,7 @@ repos:
           -   prettier@2.6.2
           -   prettier-plugin-svelte@2.7.0
           files: "^svelte/"
+          
   # - repo: https://github.com/pre-commit/mirrors-eslint
   #   rev: v8.1.0
   #   hooks:


### PR DESCRIPTION
Builds are breaking now in CI because flake8 moved from gitlab to github ; updating out pre-commit to handle the shift.