### PR TITLE
filtering custom extractor that uses the js extractor for svelte files

### DIFF
--- a/babeljs.cfg
+++ b/babeljs.cfg
@@ -1,8 +1,9 @@
 [extractors]
-jinja2_custom = kitsune.lib.babel:extract_jinja 
+jinja2_custom = kitsune.lib.babel:extract_jinja
+svelte_custom = kitsune.lib.babel:extract_svelte
 
 [ignore: kitsune/**/static/**/js/*-all.js]
 [ignore: kitsune/**/static/**/js/*-min.js]
 [javascript: kitsune/**/static/**/js/*.js]
-[javascript: svelte/**/*.svelte]
+[svelte_custom: svelte/**/*.svelte]
 [jinja2_custom: kitsune/**/static/**/tpl/**.njk]


### PR DESCRIPTION
mozilla/sumo#1138

This PR is one option to resolve mozilla/sumo#1138. Also, it includes two options in itself, each with its own commit. I think the latest commit is the best of the two, but there is the first one as well.

# Summary
The PR creates a custom extractor for localizable strings within `.svelte` files. It simply filters-out some special Svelte tags -- like `{#if ...}`, `{/if}`, `{#each ...}`, `{/each }` and so on -- that are sometimes problematic for Babel's built-in JS extractor, and then calls that extractor. It's a hack, but it works, and for our current practical purposes works well. It should be noted that Babel's built-in JS extractor also handles JSX files, so it's actually quite good at navigating `.svelte` files with their mixture of HTML tags, component tags, and JavaScript. It just has trouble navigating some of the special Svelte tags.

It does mean, however, that we can't embed localizable strings in the JS expressions within Svelte tags, for example the localizable strings in the following wouldn't be found:
```svelte
{#each [gettext("yes"), gettext("no")] as text}
```
It also means that all Svelte tags like `{#if ...}`, that surround lines that include localizable strings, must be on their own line, with nothing else on that line, because all lines that start with special Svelte tags are filtered-out before the extraction is performed.