### PR TITLE
regex-based custom extractor for svelte files

### DIFF
--- a/babeljs.cfg
+++ b/babeljs.cfg
@@ -1,8 +1,9 @@
 [extractors]
-jinja2_custom = kitsune.lib.babel:extract_jinja 
+jinja2_custom = kitsune.lib.babel:extract_jinja
+svelte_custom = kitsune.lib.babel:extract_svelte
 
 [ignore: kitsune/**/static/**/js/*-all.js]
 [ignore: kitsune/**/static/**/js/*-min.js]
 [javascript: kitsune/**/static/**/js/*.js]
-[javascript: svelte/**/*.svelte]
+[svelte_custom: svelte/**/*.svelte]
 [jinja2_custom: kitsune/**/static/**/tpl/**.njk]


### PR DESCRIPTION
mozilla/sumo#1138

# Summary
The strength of this approach is that it cuts through all of the Svelte parsing issues and directly extracts localizable strings. For example, it means we could even embed localizable strings in the JS expressions within Svelte tags and they'd be found without any problem, for example the following strings would be extracted without any problem:
```svelte
{#each [gettext("yes"), gettext("no")] as text}
...
{/each}
```
It means we can use the complete syntax of Svelte files without any effect on our ability to extract localizable strings. For example, unlike https://github.com/mozilla/kitsune/pull/5302, we would not have to ensure that when we use Svelte's special tags they are always on their own line without anything else on that line.

There are two limitations with this approach:
- `gettext` calls within comments will be extracted. Because we're not parsing the language, we can't tell that the `gettext` call is within a comment. This is not really a problem however, because we probably never do that anyway, and even if we did, it's not a problem -- other than bloat -- to add a localizable string to the message catalog that is never used.
- It can't handle localization comments related to a string.

One more thing. For now this only works for `_`, `N_`, `gettext`, and `ugettext`, but it wouldn't be difficult to add support for multi-argument calls like `ngettext` or `pgettext` if needed in the future.

# Testing
I've tested this against the latest locale data, and it works great. It finds the four currently-missing strings from `Picker.svelte` while keeping everything else the same:
```sh
kitsune/locale % git diff
diff --git a/templates/LC_MESSAGES/django.pot b/templates/LC_MESSAGES/django.pot
index e977a8474..6b61bf43e 100644
--- a/templates/LC_MESSAGES/django.pot
+++ b/templates/LC_MESSAGES/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kitsune 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-02 01:44-0700\n"
+"POT-Creation-Date: 2022-11-17 08:58-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
diff --git a/templates/LC_MESSAGES/djangojs.pot b/templates/LC_MESSAGES/djangojs.pot
index f56ad9996..2657445e5 100644
--- a/templates/LC_MESSAGES/djangojs.pot
+++ b/templates/LC_MESSAGES/djangojs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kitsune 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-02 01:44-0700\n"
+"POT-Creation-Date: 2022-11-17 08:59-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -909,6 +909,22 @@ msgstr ""
 msgid "Pick a way to contribute"
 msgstr ""

+#: svelte/contribute/Picker.svelte:31
+msgid "Write help articles"
+msgstr ""
+
+#: svelte/contribute/Picker.svelte:36
+msgid "Localize support content"
+msgstr ""
+
+#: svelte/contribute/Picker.svelte:41
+msgid "Provide support on social channels"
+msgstr ""
+
+#: svelte/contribute/Picker.svelte:46
+msgid "Respond to mobile store reviews"
+msgstr ""
+
 #: svelte/contribute/Steps.svelte:30
 msgid "How you can contribute"
 msgstr ""
```