### PR TITLE
SEO adjustments for KB forums and user-related links

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Part 2: Developer's Guide
    svelte
    browser_permissions
    zendesk
+   seo
    notes
 
 

--- a/docs/seo.rst
+++ b/docs/seo.rst
@@ -1,0 +1,60 @@
+===
+SEO
+===
+
+This document covers notes and policies related to SEO.
+
+Prefer ``meta`` tag if possible
+=============================
+
+If an entire page should not be indexed, and/or none of its links
+followed, prefer to use the ``<meta name="robots" ...>`` tag by specifying
+something like::
+
+    {% set meta = (('robots', 'noindex'),) %}
+
+or::
+
+    {% set meta = (('robots', 'noindex, nofollow'),) %}
+
+
+within the lowest-level Jinja2 templates of the inheritance chain that
+apply to only the desired pages.
+
+However, if you only want to discourage the crawling of specific links within
+a page, you'll have to add ``rel="nofollow"`` to each of those links within its
+template. For example::
+
+    <a rel="nofollow" href="...">...</a>
+
+
+Breadcrumbs
+===========
+
+If one or more of the breadcrumb links for a page should not be crawled, you
+can add an extra string to those breadcrumb tuples to specify the proper
+attribute to use, for example::
+
+    {% set crumbs = [((profile_url(user), 'rel="nofollow"'), user.username), (None, title)] %}
+
+or::
+
+    {% set crumbs = [(document.get_absolute_url(), document.title), ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss'))] %}
+
+KB Forums
+=========
+
+KB forums are user-generated content about KB articles. They are not
+official content, and therefore not meant to be searchable. All links to
+KB forums should be marked with ``rel="ugc nofollow"``.
+
+User Links
+==========
+
+User-related pages are also not meant to be indexed (searchable), and links
+to them should not be crawled, so the base user template
+(``kitsune/users/jinja2/users/base.html``) contains::
+
+    {% set meta = (('robots', 'noindex'),) %}
+
+and all user links on all pages should be marked with ``rel="nofollow"``.

--- a/kitsune/community/jinja2/community/index.html
+++ b/kitsune/community/jinja2/community/index.html
@@ -156,7 +156,7 @@
     {% for result in results %}
       <li>
         {% set tooltip = _('{user} - {num} contributions in last 90 days')|f(user=result['user']['display_name'], num=result['count']) %}
-        <a href="{{ url('users.profile', result['user']['id']) }}" title="{{ tooltip }}">
+        <a rel="ugc nofollow" href="{{ url('users.profile', result['user']['id']) }}" title="{{ tooltip }}">
           <img src="{{ result['user']['avatar'] }}" alt="{{ tooltip }}" />
         </a>
       </li>

--- a/kitsune/community/jinja2/community/index.html
+++ b/kitsune/community/jinja2/community/index.html
@@ -156,7 +156,7 @@
     {% for result in results %}
       <li>
         {% set tooltip = _('{user} - {num} contributions in last 90 days')|f(user=result['user']['display_name'], num=result['count']) %}
-        <a rel="ugc nofollow" href="{{ url('users.profile', result['user']['id']) }}" title="{{ tooltip }}">
+        <a rel="nofollow" href="{{ url('users.profile', result['user']['id']) }}" title="{{ tooltip }}">
           <img src="{{ result['user']['avatar'] }}" alt="{{ tooltip }}" />
         </a>
       </li>

--- a/kitsune/community/jinja2/community/search.html
+++ b/kitsune/community/jinja2/community/search.html
@@ -37,7 +37,7 @@
                   <h2 class="card--title">{{ result['name'] }}</h2>
                   <ul class="results-user-details">
                     <li>{{ result['username'] }}</li>
-                    <li><a rel="ugc nofollow" href="{{ url('users.profile', result['user_id']) }}">{{ _('View Profile') }}</a></li>
+                    <li><a rel="nofollow" href="{{ url('users.profile', result['user_id']) }}">{{ _('View Profile') }}</a></li>
                     <li><a href="{{ url('messages.new')|urlparams(to=result['username']) }}">{{ _('Private Message') }}</a></li>
                   </ul>
                 </div>

--- a/kitsune/community/jinja2/community/search.html
+++ b/kitsune/community/jinja2/community/search.html
@@ -37,7 +37,7 @@
                   <h2 class="card--title">{{ result['name'] }}</h2>
                   <ul class="results-user-details">
                     <li>{{ result['username'] }}</li>
-                    <li><a href="{{ url('users.profile', result['user_id']) }}">{{ _('View Profile') }}</a></li>
+                    <li><a rel="ugc nofollow" href="{{ url('users.profile', result['user_id']) }}">{{ _('View Profile') }}</a></li>
                     <li><a href="{{ url('messages.new')|urlparams(to=result['username']) }}">{{ _('Private Message') }}</a></li>
                   </ul>
                 </div>

--- a/kitsune/community/jinja2/community/top_contributors.html
+++ b/kitsune/community/jinja2/community/top_contributors.html
@@ -114,7 +114,7 @@
                 <ul class="results-user-details">
                   <li>{{ result['user']['username'] }}</li>
                   <li>{{ _('Contributions in last 90 days: {count}')|f(count=result['count']) }}</li>
-                  <li><a href="{{ url('users.profile', result['user']['id']) }}">{{ _('View Profile') }}</a></li>
+                  <li><a rel="ugc nofollow" href="{{ url('users.profile', result['user']['id']) }}">{{ _('View Profile') }}</a></li>
                   <li><a href="{{ url('messages.new')|urlparams(to=result['user']['username']) }}">{{ _('Private Message') }}</a></li>
                   {% if result['user']['days_since_last_activity'] is not undefined %}
                     <li>

--- a/kitsune/community/jinja2/community/top_contributors.html
+++ b/kitsune/community/jinja2/community/top_contributors.html
@@ -114,7 +114,7 @@
                 <ul class="results-user-details">
                   <li>{{ result['user']['username'] }}</li>
                   <li>{{ _('Contributions in last 90 days: {count}')|f(count=result['count']) }}</li>
-                  <li><a rel="ugc nofollow" href="{{ url('users.profile', result['user']['id']) }}">{{ _('View Profile') }}</a></li>
+                  <li><a rel="nofollow" href="{{ url('users.profile', result['user']['id']) }}">{{ _('View Profile') }}</a></li>
                   <li><a href="{{ url('messages.new')|urlparams(to=result['user']['username']) }}">{{ _('Private Message') }}</a></li>
                   {% if result['user']['days_since_last_activity'] is not undefined %}
                     <li>

--- a/kitsune/flagit/jinja2/flagit/includes/flagged_post.html
+++ b/kitsune/flagit/jinja2/flagit/includes/flagged_post.html
@@ -23,10 +23,10 @@
   <a class="sumo-button button-sm" href="{{ object.content_object.get_absolute_url() }}">View</a>
   {% if object.content_type.name == 'KB Forum Post' %}
     {% if user.has_perm('kbforums.change_post') %}
-      <a class="sumo-button button-sm edit" href="{{ url('wiki.discuss.edit_post', object.content_object.thread.document.slug, object.content_object.thread.id, object.content_object.id) }}">{{ _('Edit') }}</a>
+      <a class="sumo-button button-sm edit" rel="ugc nofollow" href="{{ url('wiki.discuss.edit_post', object.content_object.thread.document.slug, object.content_object.thread.id, object.content_object.id) }}">{{ _('Edit') }}</a>
     {% endif %}
     {% if user.has_perm('kbforums.delete_post') %}
-      <a class="sumo-button button-sm delete" href="{{ url('wiki.discuss.delete_post', object.content_object.thread.document.slug, object.content_object.thread.id, object.content_object.id) }}">{{ _('Delete') }}</a>
+      <a class="sumo-button button-sm delete" rel="ugc nofollow" href="{{ url('wiki.discuss.delete_post', object.content_object.thread.document.slug, object.content_object.thread.id, object.content_object.id) }}">{{ _('Delete') }}</a>
     {% endif %}
   {% endif %}
 </div>

--- a/kitsune/flagit/jinja2/flagit/includes/macros.html
+++ b/kitsune/flagit/jinja2/flagit/includes/macros.html
@@ -1,5 +1,5 @@
 {% macro date_by_user(date, user) -%}
   {% trans date=datetimeformat(date, format='longdatetime'), user=display_name(user), url=profile_url(user) %}
-    {{date}} by <a rel="ugc nofollow" href="{{url}}">{{user}}</a>
+    {{date}} by <a rel="nofollow" href="{{url}}">{{user}}</a>
   {% endtrans %}
 {%- endmacro %}

--- a/kitsune/flagit/jinja2/flagit/includes/macros.html
+++ b/kitsune/flagit/jinja2/flagit/includes/macros.html
@@ -1,5 +1,5 @@
 {% macro date_by_user(date, user) -%}
   {% trans date=datetimeformat(date, format='longdatetime'), user=display_name(user), url=profile_url(user) %}
-    {{date}} by <a href="{{url}}">{{user}}</a>
+    {{date}} by <a rel="ugc nofollow" href="{{url}}">{{user}}</a>
   {% endtrans %}
 {%- endmacro %}

--- a/kitsune/flagit/jinja2/flagit/queue.html
+++ b/kitsune/flagit/jinja2/flagit/queue.html
@@ -40,7 +40,7 @@
     {% endfor %}
 
     <div class="sumo-button-wrap">
-      <a class="sumo-button primary-button" href="{{ url('users.deactivation_log') }}">{{ _('View all deactivated users') }}</a>
+      <a class="sumo-button primary-button" rel="nofollow" href="{{ url('users.deactivation_log') }}">{{ _('View all deactivated users') }}</a>
     </div>
   </div>
 {% endblock %}

--- a/kitsune/forums/jinja2/forums/forums.html
+++ b/kitsune/forums/jinja2/forums/forums.html
@@ -35,7 +35,7 @@
               <a href="{{ forum.last_post.get_absolute_url() }}">
                 {{ datetimeformat(forum.last_post.created) }}
               </a><br />
-              {{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(forum.last_post.author), username=display_name(forum.last_post.author)) }}
+              {{ _('by <a class="username" rel="nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(forum.last_post.author), username=display_name(forum.last_post.author)) }}
               {% else %}
               {# Not localized because it's not worth localizers time. #}
               No posts.

--- a/kitsune/forums/jinja2/forums/forums.html
+++ b/kitsune/forums/jinja2/forums/forums.html
@@ -35,7 +35,7 @@
               <a href="{{ forum.last_post.get_absolute_url() }}">
                 {{ datetimeformat(forum.last_post.created) }}
               </a><br />
-              {{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(forum.last_post.author), username=display_name(forum.last_post.author)) }}
+              {{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(forum.last_post.author), username=display_name(forum.last_post.author)) }}
               {% else %}
               {# Not localized because it's not worth localizers time. #}
               No posts.

--- a/kitsune/forums/jinja2/forums/includes/forum_macros.html
+++ b/kitsune/forums/jinja2/forums/includes/forum_macros.html
@@ -19,7 +19,7 @@
   <td class="title"><a
       href="{{ url('forums.posts', forum_slug=_forum.slug, thread_id=thread.id)|urlparams(last=thread.last_post.id) }}">{{ thread.title }}</a>
   </td>
-  <td class="author"><a class="username" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a>
+  <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a>
   </td>
   <td class="replies">{{ thread.replies }}</td>
   {% if thread.last_post %}
@@ -27,7 +27,7 @@
     <a href="{{ thread.get_last_post_url() }}">
       {{ datetimeformat(thread.last_post.created) }}
     </a><br />
-    {{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.author), username=display_name(thread.last_post.author)) }}
+    {{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.author), username=display_name(thread.last_post.author)) }}
   </td>
   {% endif %}
 </tr>

--- a/kitsune/forums/jinja2/forums/includes/forum_macros.html
+++ b/kitsune/forums/jinja2/forums/includes/forum_macros.html
@@ -19,7 +19,7 @@
   <td class="title"><a
       href="{{ url('forums.posts', forum_slug=_forum.slug, thread_id=thread.id)|urlparams(last=thread.last_post.id) }}">{{ thread.title }}</a>
   </td>
-  <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a>
+  <td class="author"><a class="username" rel="nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a>
   </td>
   <td class="replies">{{ thread.replies }}</td>
   {% if thread.last_post %}
@@ -27,7 +27,7 @@
     <a href="{{ thread.get_last_post_url() }}">
       {{ datetimeformat(thread.last_post.created) }}
     </a><br />
-    {{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.author), username=display_name(thread.last_post.author)) }}
+    {{ _('by <a class="username" rel="nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.author), username=display_name(thread.last_post.author)) }}
   </td>
   {% endif %}
 </tr>

--- a/kitsune/forums/jinja2/forums/includes/post.html
+++ b/kitsune/forums/jinja2/forums/includes/post.html
@@ -4,13 +4,13 @@
 <section class="avatar-row">
   <div class="avatar-details user-meta">
     <div class="avatar">
-      <a rel="ugc nofollow" href="{{ profile_url(post.author) }}">
+      <a rel="nofollow" href="{{ profile_url(post.author) }}">
         <img src="{{ profile_avatar(post.author) }}" height="45" width="45" alt="{{ display_name(post.author) }}" />
       </a>
     </div>
     <div class="user">
       <div class="asked-by">
-        <a class="author-name" rel="ugc nofollow" href="{{ profile_url(post.author) }}">
+        <a class="author-name" rel="nofollow" href="{{ profile_url(post.author) }}">
           <span class="display-name">{{ display_name(post.author) }}</span>
           {# L10n: {0} is the number of posts. #}
           <span

--- a/kitsune/forums/jinja2/forums/includes/post.html
+++ b/kitsune/forums/jinja2/forums/includes/post.html
@@ -4,13 +4,13 @@
 <section class="avatar-row">
   <div class="avatar-details user-meta">
     <div class="avatar">
-      <a href="{{ profile_url(post.author) }}">
+      <a rel="ugc nofollow" href="{{ profile_url(post.author) }}">
         <img src="{{ profile_avatar(post.author) }}" height="45" width="45" alt="{{ display_name(post.author) }}" />
       </a>
     </div>
     <div class="user">
       <div class="asked-by">
-        <a class="author-name" href="{{ profile_url(post.author) }}">
+        <a class="author-name" rel="ugc nofollow" href="{{ profile_url(post.author) }}">
           <span class="display-name">{{ display_name(post.author) }}</span>
           {# L10n: {0} is the number of posts. #}
           <span

--- a/kitsune/gallery/jinja2/gallery/media.html
+++ b/kitsune/gallery/jinja2/gallery/media.html
@@ -58,7 +58,7 @@
         </ul>
         <ul id="media-meta" class="topic-article--meta-list">
           <li class="creator">
-              {{ _('by <a href="{profile_url}">{user}</a>')|fe
+              {{ _('by <a rel="ugc nofollow" href="{profile_url}">{user}</a>')|fe
                       (profile_url=profile_url(media.creator),
                       user=display_name(media.creator)) }}
           </li>

--- a/kitsune/gallery/jinja2/gallery/media.html
+++ b/kitsune/gallery/jinja2/gallery/media.html
@@ -58,7 +58,7 @@
         </ul>
         <ul id="media-meta" class="topic-article--meta-list">
           <li class="creator">
-              {{ _('by <a rel="ugc nofollow" href="{profile_url}">{user}</a>')|fe
+              {{ _('by <a rel="nofollow" href="{profile_url}">{user}</a>')|fe
                       (profile_url=profile_url(media.creator),
                       user=display_name(media.creator)) }}
           </li>

--- a/kitsune/groups/jinja2/groups/profile.html
+++ b/kitsune/groups/jinja2/groups/profile.html
@@ -100,12 +100,12 @@
 
 {% macro user_row(user) -%}
   <div class="avatar">
-    <a href="{{ profile_url(user) }}">
+    <a rel="ugc nofollow" href="{{ profile_url(user) }}">
       <img src="{{ profile_avatar(user) }}" alt="" />
     </a>
   </div>
   <div class="info">
-    <a href="{{ profile_url(user) }}">{{ display_name(user) }}</a>
+    <a rel="ugc nofollow" href="{{ profile_url(user) }}">{{ display_name(user) }}</a>
     {{ private_message(user) }}
   </div>
 {%- endmacro %}

--- a/kitsune/groups/jinja2/groups/profile.html
+++ b/kitsune/groups/jinja2/groups/profile.html
@@ -100,12 +100,12 @@
 
 {% macro user_row(user) -%}
   <div class="avatar">
-    <a rel="ugc nofollow" href="{{ profile_url(user) }}">
+    <a rel="nofollow" href="{{ profile_url(user) }}">
       <img src="{{ profile_avatar(user) }}" alt="" />
     </a>
   </div>
   <div class="info">
-    <a rel="ugc nofollow" href="{{ profile_url(user) }}">{{ display_name(user) }}</a>
+    <a rel="nofollow" href="{{ profile_url(user) }}">{{ display_name(user) }}</a>
     {{ private_message(user) }}
   </div>
 {%- endmacro %}

--- a/kitsune/kbadge/jinja2/badger/award_detail.html
+++ b/kitsune/kbadge/jinja2/badger/award_detail.html
@@ -23,7 +23,7 @@
 
     {% if badge.creator %}
       <dt>{{ _('Creator:') }}</dt>
-      <dd><a rel="ugc nofollow" href="{{ profile_url(badge.creator) }}">{{ badge.creator }}</a></dd>
+      <dd><a rel="nofollow" href="{{ profile_url(badge.creator) }}">{{ badge.creator }}</a></dd>
     {% endif %}
 
     <dt>{{ _('Created:') }}</dt>
@@ -39,7 +39,7 @@
   <dl class="badge-details">
     <dt>{{ _('Awarded to:') }}</dt>
     <dd class="awarded_to">
-      <a rel="ugc nofollow" href="{{ profile_url(award.user) }}">
+      <a rel="nofollow" href="{{ profile_url(award.user) }}">
         <img src="{{ profile_avatar(award.user) }}" alt="" title="{{ display_name(award.user) }}">
         <br>{{ award.user }}
       </a>
@@ -53,7 +53,7 @@
     {% if award.creator %}
       <dt>{{ _('Awarded by:') }}</dt>
       <dd>
-        <a rel="ugc nofollow" href="{{ profile_url(award.creator) }}">
+        <a rel="nofollow" href="{{ profile_url(award.creator) }}">
           <img src="{{ profile_avatar(award.creator) }}" alt="" title="{{ award.creator }}">
           {{ award.creator }}
         </a>

--- a/kitsune/kbadge/jinja2/badger/award_detail.html
+++ b/kitsune/kbadge/jinja2/badger/award_detail.html
@@ -23,7 +23,7 @@
 
     {% if badge.creator %}
       <dt>{{ _('Creator:') }}</dt>
-      <dd><a href="{{ profile_url(badge.creator) }}">{{ badge.creator }}</a></dd>
+      <dd><a rel="ugc nofollow" href="{{ profile_url(badge.creator) }}">{{ badge.creator }}</a></dd>
     {% endif %}
 
     <dt>{{ _('Created:') }}</dt>
@@ -39,7 +39,7 @@
   <dl class="badge-details">
     <dt>{{ _('Awarded to:') }}</dt>
     <dd class="awarded_to">
-      <a href="{{ profile_url(award.user) }}">
+      <a rel="ugc nofollow" href="{{ profile_url(award.user) }}">
         <img src="{{ profile_avatar(award.user) }}" alt="" title="{{ display_name(award.user) }}">
         <br>{{ award.user }}
       </a>
@@ -53,7 +53,7 @@
     {% if award.creator %}
       <dt>{{ _('Awarded by:') }}</dt>
       <dd>
-        <a href="{{ profile_url(award.creator) }}">
+        <a rel="ugc nofollow" href="{{ profile_url(award.creator) }}">
           <img src="{{ profile_avatar(award.creator) }}" alt="" title="{{ award.creator }}">
           {{ award.creator }}
         </a>

--- a/kitsune/kbadge/jinja2/badger/badge_detail.html
+++ b/kitsune/kbadge/jinja2/badger/badge_detail.html
@@ -22,7 +22,7 @@
 
     {% if badge.creator %}
       <dt>{{ _('Creator:') }}</dt>
-      <dd><a rel="ugc nofollow" href="{{ profile_url(badge.creator) }}">{{ display_name(badge.creator) }}</a></dd>
+      <dd><a rel="nofollow" href="{{ profile_url(badge.creator) }}">{{ display_name(badge.creator) }}</a></dd>
     {% endif %}
 
     <dt>{{ _('Created:') }}</dt>

--- a/kitsune/kbadge/jinja2/badger/badge_detail.html
+++ b/kitsune/kbadge/jinja2/badger/badge_detail.html
@@ -22,7 +22,7 @@
 
     {% if badge.creator %}
       <dt>{{ _('Creator:') }}</dt>
-      <dd><a href="{{ profile_url(badge.creator) }}">{{ display_name(badge.creator) }}</a></dd>
+      <dd><a rel="ugc nofollow" href="{{ profile_url(badge.creator) }}">{{ display_name(badge.creator) }}</a></dd>
     {% endif %}
 
     <dt>{{ _('Created:') }}</dt>

--- a/kitsune/kbforums/jinja2/kbforums/base.html
+++ b/kitsune/kbforums/jinja2/kbforums/base.html
@@ -4,7 +4,8 @@
 {% if not scripts %}
   {% set scripts = ('forums',) %}
 {% endif %}
-{% set meta = (('robots', 'noindex'),) %}
+{% set meta = (('robots', 'noindex, nofollow'),) %}
+
 
 {% block side_top %}
   {% block side_top_top %}{% endblock %}

--- a/kitsune/kbforums/jinja2/kbforums/base.html
+++ b/kitsune/kbforums/jinja2/kbforums/base.html
@@ -4,8 +4,7 @@
 {% if not scripts %}
   {% set scripts = ('forums',) %}
 {% endif %}
-{% set meta = (('robots', 'noindex, nofollow'),) %}
-
+{% set meta = (('robots', 'noindex'),) %}
 
 {% block side_top %}
   {% block side_top_top %}{% endblock %}

--- a/kitsune/kbforums/jinja2/kbforums/confirm_post_delete.html
+++ b/kitsune/kbforums/jinja2/kbforums/confirm_post_delete.html
@@ -26,7 +26,7 @@
         {{ _('You are about to permanently delete this post. <strong>This cannot be undone!</strong> Are you sure you want to continue?')|safe }}
       </p>
       <input type="submit" value="{{ _('Delete') }}" />
-      <a href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
+      <a rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
     </form>
   </div>
 </article>

--- a/kitsune/kbforums/jinja2/kbforums/confirm_post_delete.html
+++ b/kitsune/kbforums/jinja2/kbforums/confirm_post_delete.html
@@ -3,8 +3,8 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('Delete Post | {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
-                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc"'), thread.title),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss')),
+                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc nofollow"'), thread.title),
                  (None, _('Delete Post'))] %}
 
 {% block content %}
@@ -26,7 +26,7 @@
         {{ _('You are about to permanently delete this post. <strong>This cannot be undone!</strong> Are you sure you want to continue?')|safe }}
       </p>
       <input type="submit" value="{{ _('Delete') }}" />
-      <a rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
+      <a rel="ugc nofollow" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
     </form>
   </div>
 </article>

--- a/kitsune/kbforums/jinja2/kbforums/confirm_post_delete.html
+++ b/kitsune/kbforums/jinja2/kbforums/confirm_post_delete.html
@@ -3,8 +3,8 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('Delete Post | {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 (url('wiki.discuss.threads', document.slug), _('Discuss')),
-                 (url('wiki.discuss.posts', document.slug, thread.id), thread.title),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
+                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc"'), thread.title),
                  (None, _('Delete Post'))] %}
 
 {% block content %}

--- a/kitsune/kbforums/jinja2/kbforums/confirm_thread_delete.html
+++ b/kitsune/kbforums/jinja2/kbforums/confirm_thread_delete.html
@@ -3,8 +3,8 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('Delete Thread | {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
-                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc"'), thread.title),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss')),
+                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc nofollow"'), thread.title),
                  (None, _('Delete Thread'))] %}
 
 {% block content %}
@@ -28,7 +28,7 @@
         {{ _('You are about to permanently delete this thread. <strong>This cannot be undone!</strong> Are you sure you want to continue?')|safe }}
       </p>
       <input type="submit" value="{{ _('Delete') }}" />
-      <a rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
+      <a rel="ugc nofollow" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
     </form>
   </div>
 </article>

--- a/kitsune/kbforums/jinja2/kbforums/confirm_thread_delete.html
+++ b/kitsune/kbforums/jinja2/kbforums/confirm_thread_delete.html
@@ -28,7 +28,7 @@
         {{ _('You are about to permanently delete this thread. <strong>This cannot be undone!</strong> Are you sure you want to continue?')|safe }}
       </p>
       <input type="submit" value="{{ _('Delete') }}" />
-      <a href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
+      <a rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
     </form>
   </div>
 </article>

--- a/kitsune/kbforums/jinja2/kbforums/confirm_thread_delete.html
+++ b/kitsune/kbforums/jinja2/kbforums/confirm_thread_delete.html
@@ -3,8 +3,8 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('Delete Thread | {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 (url('wiki.discuss.threads', document.slug), _('Discuss')),
-                 (url('wiki.discuss.posts', document.slug, thread.id), thread.title),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
+                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc"'), thread.title),
                  (None, _('Delete Thread'))] %}
 
 {% block content %}

--- a/kitsune/kbforums/jinja2/kbforums/discussions.html
+++ b/kitsune/kbforums/jinja2/kbforums/discussions.html
@@ -32,9 +32,9 @@
                 <th class="watch">{{ _('Watch') }}</th>
               {% endif %}
               <th class="title">{{ _('Title') }}</th>
-              <th class="author{% if sort == 3 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
-              <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
-              <th class="last-post{% if sort == 5 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
+              <th class="author{% if sort == 3 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
+              <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
+              <th class="last-post{% if sort == 5 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
             </tr>
           </thead>
           <tbody class="threads">
@@ -79,17 +79,17 @@
                            thread_title=thread.title,
                            document_discussion_url=url('wiki.discuss.threads',thread.document.slug),
                            document=thread.document %}
-                    <a rel="ugc" href="{{ thread_url }}">{{ thread_title }}</a><br>
-                    in <a rel="ugc" href="{{ document_discussion_url }}">{{ document }}</a>
+                    <a rel="ugc nofollow" href="{{ thread_url }}">{{ thread_title }}</a><br>
+                    in <a rel="ugc nofollow" href="{{ document_discussion_url }}">{{ document }}</a>
                   {% endtrans %}
                 </td>
-                <td class="author"><a class="username" rel="ugc" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+                <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
                 <td class="replies">{{ thread.replies }}</td>
                 <td class="last-post">
-                  <a rel="ugc" href="{{ thread.last_post.get_absolute_url() }}">
+                  <a rel="ugc nofollow" href="{{ thread.last_post.get_absolute_url() }}">
                     {{ datetimeformat(thread.last_post.created) }}
                   </a><br/>
-                  {{ _('by <a class="username" rel="ugc" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
+                  {{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
                 </td>
               </tr>
             {% endfor %}

--- a/kitsune/kbforums/jinja2/kbforums/discussions.html
+++ b/kitsune/kbforums/jinja2/kbforums/discussions.html
@@ -83,13 +83,13 @@
                     in <a rel="ugc nofollow" href="{{ document_discussion_url }}">{{ document }}</a>
                   {% endtrans %}
                 </td>
-                <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+                <td class="author"><a class="username" rel="nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
                 <td class="replies">{{ thread.replies }}</td>
                 <td class="last-post">
                   <a rel="ugc nofollow" href="{{ thread.last_post.get_absolute_url() }}">
                     {{ datetimeformat(thread.last_post.created) }}
                   </a><br/>
-                  {{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
+                  {{ _('by <a class="username" rel="nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
                 </td>
               </tr>
             {% endfor %}

--- a/kitsune/kbforums/jinja2/kbforums/discussions.html
+++ b/kitsune/kbforums/jinja2/kbforums/discussions.html
@@ -32,9 +32,9 @@
                 <th class="watch">{{ _('Watch') }}</th>
               {% endif %}
               <th class="title">{{ _('Title') }}</th>
-              <th class="author{% if sort == 3 %} sort{% endif %}"><a href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
-              <th class="replies{% if sort == 4 %} sort{% endif %}"><a href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
-              <th class="last-post{% if sort == 5 %} sort{% endif %}"><a href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
+              <th class="author{% if sort == 3 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
+              <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
+              <th class="last-post{% if sort == 5 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
             </tr>
           </thead>
           <tbody class="threads">
@@ -79,17 +79,17 @@
                            thread_title=thread.title,
                            document_discussion_url=url('wiki.discuss.threads',thread.document.slug),
                            document=thread.document %}
-                    <a href="{{ thread_url }}">{{ thread_title }}</a><br>
-                    in <a href="{{ document_discussion_url }}">{{ document }}</a>
+                    <a rel="ugc" href="{{ thread_url }}">{{ thread_title }}</a><br>
+                    in <a rel="ugc" href="{{ document_discussion_url }}">{{ document }}</a>
                   {% endtrans %}
                 </td>
-                <td class="author"><a class="username" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+                <td class="author"><a class="username" rel="ugc" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
                 <td class="replies">{{ thread.replies }}</td>
                 <td class="last-post">
-                  <a href="{{ thread.last_post.get_absolute_url() }}">
+                  <a rel="ugc" href="{{ thread.last_post.get_absolute_url() }}">
                     {{ datetimeformat(thread.last_post.created) }}
                   </a><br/>
-                  {{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
+                  {{ _('by <a class="username" rel="ugc" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
                 </td>
               </tr>
             {% endfor %}

--- a/kitsune/kbforums/jinja2/kbforums/discussions.html
+++ b/kitsune/kbforums/jinja2/kbforums/discussions.html
@@ -83,13 +83,13 @@
                     in <a rel="ugc nofollow" href="{{ document_discussion_url }}">{{ document }}</a>
                   {% endtrans %}
                 </td>
-                <td class="author"><a class="username" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+                <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
                 <td class="replies">{{ thread.replies }}</td>
                 <td class="last-post">
                   <a rel="ugc nofollow" href="{{ thread.last_post.get_absolute_url() }}">
                     {{ datetimeformat(thread.last_post.created) }}
                   </a><br/>
-                  {{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
+                  {{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
                 </td>
               </tr>
             {% endfor %}

--- a/kitsune/kbforums/jinja2/kbforums/discussions.html
+++ b/kitsune/kbforums/jinja2/kbforums/discussions.html
@@ -83,13 +83,13 @@
                     in <a rel="ugc nofollow" href="{{ document_discussion_url }}">{{ document }}</a>
                   {% endtrans %}
                 </td>
-                <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+                <td class="author"><a class="username" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
                 <td class="replies">{{ thread.replies }}</td>
                 <td class="last-post">
                   <a rel="ugc nofollow" href="{{ thread.last_post.get_absolute_url() }}">
                     {{ datetimeformat(thread.last_post.created) }}
                   </a><br/>
-                  {{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
+                  {{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}
                 </td>
               </tr>
             {% endfor %}

--- a/kitsune/kbforums/jinja2/kbforums/edit_post.html
+++ b/kitsune/kbforums/jinja2/kbforums/edit_post.html
@@ -5,8 +5,8 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('Edit a post | {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 (url('wiki.discuss.threads', document.slug), _('Discuss')),
-                 (url('wiki.discuss.posts', document.slug, thread.id), thread.title),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
+                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc"'), thread.title),
                  (None, _('Edit a post'))] %}
 {% set scripts = ('forums',) %}
 

--- a/kitsune/kbforums/jinja2/kbforums/edit_post.html
+++ b/kitsune/kbforums/jinja2/kbforums/edit_post.html
@@ -33,7 +33,7 @@
             data-preview-container-id="post-preview"
             data-preview-content-id="id_content">{{ _('Preview') }}
         </button>
-        <a class="sumo-button push-left" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
+        <a class="sumo-button push-left" rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
       </div>
     </form>
 

--- a/kitsune/kbforums/jinja2/kbforums/edit_post.html
+++ b/kitsune/kbforums/jinja2/kbforums/edit_post.html
@@ -5,8 +5,8 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('Edit a post | {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
-                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc"'), thread.title),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss')),
+                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc nofollow"'), thread.title),
                  (None, _('Edit a post'))] %}
 {% set scripts = ('forums',) %}
 
@@ -33,7 +33,7 @@
             data-preview-container-id="post-preview"
             data-preview-content-id="id_content">{{ _('Preview') }}
         </button>
-        <a class="sumo-button push-left" rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
+        <a class="sumo-button push-left" rel="ugc nofollow" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
       </div>
     </form>
 

--- a/kitsune/kbforums/jinja2/kbforums/edit_thread.html
+++ b/kitsune/kbforums/jinja2/kbforums/edit_thread.html
@@ -4,8 +4,8 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('Edit thread {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
-                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc"'), thread.title),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss')),
+                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc nofollow"'), thread.title),
                  (None, _('Edit thread'))] %}
 
 {% block content %}
@@ -24,7 +24,7 @@
 
       <div class="form-widget submit">
         <button type="submit" class="btn btn-submit big">{{ _('Update thread') }}</button>
-        <a class="btn" rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
+        <a class="btn" rel="ugc nofollow" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
       </div>
     </form>
   </article>

--- a/kitsune/kbforums/jinja2/kbforums/edit_thread.html
+++ b/kitsune/kbforums/jinja2/kbforums/edit_thread.html
@@ -4,8 +4,8 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('Edit thread {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 (url('wiki.discuss.threads', document.slug), _('Discuss')),
-                 (url('wiki.discuss.posts', document.slug, thread.id), thread.title),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
+                 ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc"'), thread.title),
                  (None, _('Edit thread'))] %}
 
 {% block content %}

--- a/kitsune/kbforums/jinja2/kbforums/edit_thread.html
+++ b/kitsune/kbforums/jinja2/kbforums/edit_thread.html
@@ -24,7 +24,7 @@
 
       <div class="form-widget submit">
         <button type="submit" class="btn btn-submit big">{{ _('Update thread') }}</button>
-        <a class="btn" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
+        <a class="btn" rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ _('Cancel') }}</a>
       </div>
     </form>
   </article>

--- a/kitsune/kbforums/jinja2/kbforums/includes/macros.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/macros.html
@@ -22,7 +22,7 @@
                url=url('wiki.discuss.threads', document.parent.slug, locale='en-US') %}
         This forum is a discussion about improving the localization of the
         "{{ title }}" article. If you want to improve the article content,
-        go to the <a rel="ugc" href="{{ url }}">English article discussion</a>.
+        go to the <a rel="ugc nofollow" href="{{ url }}">English article discussion</a>.
       {% endtrans %}
     </p>
   {% endif %}

--- a/kitsune/kbforums/jinja2/kbforums/includes/macros.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/macros.html
@@ -12,7 +12,7 @@
       {% else %}
         {% trans title=document.title, register_url=url('users.fxa_authentication_init') %}
           This forum is a discussion about improving the "{{ title }}" article. If
-          you'd like to participate, please <a href="{{ register_url }}">register</a>.
+          you'd like to participate, please <a rel="nofollow" href="{{ register_url }}">register</a>.
         {% endtrans %}
       {% endif %}
     </p>

--- a/kitsune/kbforums/jinja2/kbforums/includes/macros.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/macros.html
@@ -22,7 +22,7 @@
                url=url('wiki.discuss.threads', document.parent.slug, locale='en-US') %}
         This forum is a discussion about improving the localization of the
         "{{ title }}" article. If you want to improve the article content,
-        go to the <a href="{{ url }}">English article discussion</a>.
+        go to the <a rel="ugc" href="{{ url }}">English article discussion</a>.
       {% endtrans %}
     </p>
   {% endif %}

--- a/kitsune/kbforums/jinja2/kbforums/includes/post.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/post.html
@@ -5,13 +5,13 @@
 <section class="avatar-row">
   <div class="avatar-details user-meta">
     <div class="avatar">
-      <a rel="ugc nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
+      <a rel="nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
         <img src="{{ profile_avatar(post.creator) }}" height="45" width="45" alt=""/>
       </a>
     </div>
     <div class="user">
       <div class="asked-by">
-        <a class="author-name" rel="ugc nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
+        <a class="author-name" rel="nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
           <span class="display-name">{{ display_name(post.creator) }}</span>
           {# L10n: {0} is the number of posts. #}
           {% with count = post.creator.post_set.count() %}

--- a/kitsune/kbforums/jinja2/kbforums/includes/post.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/post.html
@@ -5,13 +5,13 @@
 <section class="avatar-row">
   <div class="avatar-details user-meta">
     <div class="avatar">
-      <a href="{{ profile_url(post.creator, request.user == post.creator) }}">
+      <a rel="ugc" href="{{ profile_url(post.creator, request.user == post.creator) }}">
         <img src="{{ profile_avatar(post.creator) }}" height="45" width="45" alt=""/>
       </a>
     </div>
     <div class="user">
       <div class="asked-by">
-        <a class="author-name" href="{{ profile_url(post.creator, request.user == post.creator) }}">
+        <a class="author-name" rel="ugc" href="{{ profile_url(post.creator, request.user == post.creator) }}">
           <span class="display-name">{{ display_name(post.creator) }}</span>
           {# L10n: {0} is the number of posts. #}
           {% with count = post.creator.post_set.count() %}
@@ -33,21 +33,21 @@
         <li class="mzp-c-menu-list-item clear-button-styles">{{ private_message(post.creator) }}</li>
       {% endif %}
       {% if post.id and (perms.kbforums.change_post or (post.creator == request.user and not thread.is_locked)) %}
-        <li class="mzp-c-menu-list-item"><a href="{{ url('wiki.discuss.edit_post', document.slug, thread.id, post.id) }}">{{ _('Edit this post') }}</a></li>
+        <li class="mzp-c-menu-list-item"><a rel="ugc" href="{{ url('wiki.discuss.edit_post', document.slug, thread.id, post.id) }}">{{ _('Edit this post') }}</a></li>
       {% endif %}
 
       {% if post.id and perms.kbforums.delete_post %}
-        <li class="mzp-c-menu-list-item"><a href="{{ url('wiki.discuss.delete_post', document.slug, thread.id, post.id) }}">{{ _('Delete this post') }}</a></li>
+        <li class="mzp-c-menu-list-item"><a rel="ugc" href="{{ url('wiki.discuss.delete_post', document.slug, thread.id, post.id) }}">{{ _('Delete this post') }}</a></li>
       {% endif %}
 
       {% if post.id and user.is_authenticated and not thread.is_locked %}
         <li class="mzp-c-menu-list-item post-action">
-          <a class="reply" data-post="{{ post.id }}" href="#thread-reply">{{ _('Quote') }}</a>
+          <a class="reply" data-post="{{ post.id }}" rel="ugc" href="#thread-reply">{{ _('Quote') }}</a>
         </li>
       {% endif %}
 
     <li class="mzp-c-menu-list-item post-action">
-    <a href="#post-{{ post.id }}">{{ _('Link to this post') }}</a>
+    <a rel="ugc" href="#post-{{ post.id }}">{{ _('Link to this post') }}</a>
     </li>
     {% if user.is_authenticated and document and document.slug and post.id %}
     <li class="mzp-c-menu-list-item post-action">

--- a/kitsune/kbforums/jinja2/kbforums/includes/post.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/post.html
@@ -5,13 +5,13 @@
 <section class="avatar-row">
   <div class="avatar-details user-meta">
     <div class="avatar">
-      <a rel="ugc nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
+      <a href="{{ profile_url(post.creator, request.user == post.creator) }}">
         <img src="{{ profile_avatar(post.creator) }}" height="45" width="45" alt=""/>
       </a>
     </div>
     <div class="user">
       <div class="asked-by">
-        <a class="author-name" rel="ugc nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
+        <a class="author-name" href="{{ profile_url(post.creator, request.user == post.creator) }}">
           <span class="display-name">{{ display_name(post.creator) }}</span>
           {# L10n: {0} is the number of posts. #}
           {% with count = post.creator.post_set.count() %}

--- a/kitsune/kbforums/jinja2/kbforums/includes/post.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/post.html
@@ -5,13 +5,13 @@
 <section class="avatar-row">
   <div class="avatar-details user-meta">
     <div class="avatar">
-      <a rel="ugc" href="{{ profile_url(post.creator, request.user == post.creator) }}">
+      <a rel="ugc nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
         <img src="{{ profile_avatar(post.creator) }}" height="45" width="45" alt=""/>
       </a>
     </div>
     <div class="user">
       <div class="asked-by">
-        <a class="author-name" rel="ugc" href="{{ profile_url(post.creator, request.user == post.creator) }}">
+        <a class="author-name" rel="ugc nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
           <span class="display-name">{{ display_name(post.creator) }}</span>
           {# L10n: {0} is the number of posts. #}
           {% with count = post.creator.post_set.count() %}
@@ -33,21 +33,21 @@
         <li class="mzp-c-menu-list-item clear-button-styles">{{ private_message(post.creator) }}</li>
       {% endif %}
       {% if post.id and (perms.kbforums.change_post or (post.creator == request.user and not thread.is_locked)) %}
-        <li class="mzp-c-menu-list-item"><a rel="ugc" href="{{ url('wiki.discuss.edit_post', document.slug, thread.id, post.id) }}">{{ _('Edit this post') }}</a></li>
+        <li class="mzp-c-menu-list-item"><a rel="ugc nofollow" href="{{ url('wiki.discuss.edit_post', document.slug, thread.id, post.id) }}">{{ _('Edit this post') }}</a></li>
       {% endif %}
 
       {% if post.id and perms.kbforums.delete_post %}
-        <li class="mzp-c-menu-list-item"><a rel="ugc" href="{{ url('wiki.discuss.delete_post', document.slug, thread.id, post.id) }}">{{ _('Delete this post') }}</a></li>
+        <li class="mzp-c-menu-list-item"><a rel="ugc nofollow" href="{{ url('wiki.discuss.delete_post', document.slug, thread.id, post.id) }}">{{ _('Delete this post') }}</a></li>
       {% endif %}
 
       {% if post.id and user.is_authenticated and not thread.is_locked %}
         <li class="mzp-c-menu-list-item post-action">
-          <a class="reply" data-post="{{ post.id }}" rel="ugc" href="#thread-reply">{{ _('Quote') }}</a>
+          <a class="reply" data-post="{{ post.id }}" rel="ugc nofollow" href="#thread-reply">{{ _('Quote') }}</a>
         </li>
       {% endif %}
 
     <li class="mzp-c-menu-list-item post-action">
-    <a rel="ugc" href="#post-{{ post.id }}">{{ _('Link to this post') }}</a>
+    <a rel="ugc nofollow" href="#post-{{ post.id }}">{{ _('Link to this post') }}</a>
     </li>
     {% if user.is_authenticated and document and document.slug and post.id %}
     <li class="mzp-c-menu-list-item post-action">

--- a/kitsune/kbforums/jinja2/kbforums/includes/post.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/post.html
@@ -5,13 +5,13 @@
 <section class="avatar-row">
   <div class="avatar-details user-meta">
     <div class="avatar">
-      <a href="{{ profile_url(post.creator, request.user == post.creator) }}">
+      <a rel="ugc nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
         <img src="{{ profile_avatar(post.creator) }}" height="45" width="45" alt=""/>
       </a>
     </div>
     <div class="user">
       <div class="asked-by">
-        <a class="author-name" href="{{ profile_url(post.creator, request.user == post.creator) }}">
+        <a class="author-name" rel="ugc nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
           <span class="display-name">{{ display_name(post.creator) }}</span>
           {# L10n: {0} is the number of posts. #}
           {% with count = post.creator.post_set.count() %}

--- a/kitsune/kbforums/jinja2/kbforums/new_thread.html
+++ b/kitsune/kbforums/jinja2/kbforums/new_thread.html
@@ -45,7 +45,7 @@
             data-preview-container-id="post-preview"
             data-preview-content-id="id_content">{{ _('Preview') }}
         </button>
-        <a class="sumo-button push-right" href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Cancel') }}</a>
+        <a class="sumo-button push-right" rel="ugc" href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Cancel') }}</a>
       </div>
 
       <div id="post-preview">

--- a/kitsune/kbforums/jinja2/kbforums/new_thread.html
+++ b/kitsune/kbforums/jinja2/kbforums/new_thread.html
@@ -5,7 +5,7 @@
 {# L10n: {d} is the name of the document. #}
 {% set title = _('Create a new thread | {d} | Knowledge Base')|f(d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 (url('wiki.discuss.threads', document.slug), _('Discuss')),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
                  (None, _('Create a new thread'))] %}
 {% set scripts = ('forums',) %}
 

--- a/kitsune/kbforums/jinja2/kbforums/new_thread.html
+++ b/kitsune/kbforums/jinja2/kbforums/new_thread.html
@@ -5,7 +5,7 @@
 {# L10n: {d} is the name of the document. #}
 {% set title = _('Create a new thread | {d} | Knowledge Base')|f(d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss')),
                  (None, _('Create a new thread'))] %}
 {% set scripts = ('forums',) %}
 
@@ -45,7 +45,7 @@
             data-preview-container-id="post-preview"
             data-preview-content-id="id_content">{{ _('Preview') }}
         </button>
-        <a class="sumo-button push-right" rel="ugc" href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Cancel') }}</a>
+        <a class="sumo-button push-right" rel="ugc nofollow" href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Cancel') }}</a>
       </div>
 
       <div id="post-preview">

--- a/kitsune/kbforums/jinja2/kbforums/posts.html
+++ b/kitsune/kbforums/jinja2/kbforums/posts.html
@@ -5,7 +5,7 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('{t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 (url('wiki.discuss.threads', document.slug), _('Discuss')),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
                  (None, thread.title)] %}
 {% set scripts = ('forums',) %}
 

--- a/kitsune/kbforums/jinja2/kbforums/posts.html
+++ b/kitsune/kbforums/jinja2/kbforums/posts.html
@@ -12,10 +12,10 @@
 {% block side_top_top %}
   <ul id="thread-actions" class="sidebar-nav">
     {% if perms.kbforums.change_thread or (thread.creator == request.user and not thread.is_locked) %}
-      <li><a href="{{ url('wiki.discuss.edit_thread', document.slug, thread.id) }}">{{ _('Edit this thread') }}</a></li>
+      <li><a rel="ugc" href="{{ url('wiki.discuss.edit_thread', document.slug, thread.id) }}">{{ _('Edit this thread') }}</a></li>
     {% endif %}
     {% if perms.kbforums.delete_thread %}
-      <li><a href="{{ url('wiki.discuss.delete_thread', document.slug, thread.id) }}">{{ _('Delete this thread') }}</a></li>
+      <li><a rel="ugc" href="{{ url('wiki.discuss.delete_thread', document.slug, thread.id) }}">{{ _('Delete this thread') }}</a></li>
     {% endif %}
     {% if perms.kbforums.lock_thread %}
       <li>

--- a/kitsune/kbforums/jinja2/kbforums/posts.html
+++ b/kitsune/kbforums/jinja2/kbforums/posts.html
@@ -5,17 +5,17 @@
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
 {% set title = _('{t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
-                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc"'), _('Discuss')),
+                 ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss')),
                  (None, thread.title)] %}
 {% set scripts = ('forums',) %}
 
 {% block side_top_top %}
   <ul id="thread-actions" class="sidebar-nav">
     {% if perms.kbforums.change_thread or (thread.creator == request.user and not thread.is_locked) %}
-      <li><a rel="ugc" href="{{ url('wiki.discuss.edit_thread', document.slug, thread.id) }}">{{ _('Edit this thread') }}</a></li>
+      <li><a rel="ugc nofollow" href="{{ url('wiki.discuss.edit_thread', document.slug, thread.id) }}">{{ _('Edit this thread') }}</a></li>
     {% endif %}
     {% if perms.kbforums.delete_thread %}
-      <li><a rel="ugc" href="{{ url('wiki.discuss.delete_thread', document.slug, thread.id) }}">{{ _('Delete this thread') }}</a></li>
+      <li><a rel="ugc nofollow" href="{{ url('wiki.discuss.delete_thread', document.slug, thread.id) }}">{{ _('Delete this thread') }}</a></li>
     {% endif %}
     {% if perms.kbforums.lock_thread %}
       <li>

--- a/kitsune/kbforums/jinja2/kbforums/threads.html
+++ b/kitsune/kbforums/jinja2/kbforums/threads.html
@@ -48,13 +48,13 @@
               {% endif %}
             </td>
             <td class="title"><a rel="ugc nofollow" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ thread.title }}</a></td>
-            <td class="author"><a class="username" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+            <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
             <td class="replies">{{ thread.replies }}</td>
             <td class="last-post">
               <a rel="ugc nofollow" href="{{ thread.last_post.get_absolute_url() }}">
                 {{ datetimeformat(thread.last_post.created) }}
               </a><br/>
-              <span class="text-body-xs ">{{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
+              <span class="text-body-xs ">{{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
             </td>
           </tr>
         {% endfor %}

--- a/kitsune/kbforums/jinja2/kbforums/threads.html
+++ b/kitsune/kbforums/jinja2/kbforums/threads.html
@@ -48,13 +48,13 @@
               {% endif %}
             </td>
             <td class="title"><a rel="ugc nofollow" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ thread.title }}</a></td>
-            <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+            <td class="author"><a class="username" rel="nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
             <td class="replies">{{ thread.replies }}</td>
             <td class="last-post">
               <a rel="ugc nofollow" href="{{ thread.last_post.get_absolute_url() }}">
                 {{ datetimeformat(thread.last_post.created) }}
               </a><br/>
-              <span class="text-body-xs ">{{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
+              <span class="text-body-xs ">{{ _('by <a class="username" rel="nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
             </td>
           </tr>
         {% endfor %}

--- a/kitsune/kbforums/jinja2/kbforums/threads.html
+++ b/kitsune/kbforums/jinja2/kbforums/threads.html
@@ -10,7 +10,7 @@
     <article id="threads" class="content-box sumo-page-section">
       <h1 class="sumo-page-heading">{{ _('{d} Discussion')|f(d=document.title) }}</h1>
       <div class="sumo-button-wrap forum-actions">
-        <a id="new-thread" class="sumo-button button-primary" href="{{ url('wiki.discuss.new_thread', document_slug=document.slug) }}">{{ _('Post a new thread') }}</a>
+        <a id="new-thread" class="sumo-button button-primary" rel="ugc" href="{{ url('wiki.discuss.new_thread', document_slug=document.slug) }}">{{ _('Post a new thread') }}</a>
 
         {% if user.is_authenticated %}
           <form action="{{ url('wiki.discuss.watch_forum', document.slug) }}" method="post">
@@ -31,11 +31,11 @@
       <div class="table-scroll">
       <table class="{% if not desc_toggle %}desc{% endif %}">
         <tr>
-          <th class="type"><a href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Type') }}</a></th>
+          <th class="type"><a rel="ugc" href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Type') }}</a></th>
           <th class="title">{{ _('Title') }}</th>
-          <th class="author{% if sort == 3 %} sort{% endif %}"><a href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
-          <th class="replies{% if sort == 4 %} sort{% endif %}"><a href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
-          <th class="last-post{% if sort == 5 %} sort{% endif %}"><a href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
+          <th class="author{% if sort == 3 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
+          <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
+          <th class="last-post{% if sort == 5 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
         </tr>
         {% for thread in threads.object_list %}
           <tr class="threads">
@@ -47,14 +47,14 @@
                 <img src="{{ webpack_static('sumo/img/blank.png') }}" alt="{{ pgettext('thread_type', 'Sticky') }}" title="{{ pgettext('thread_type', 'Sticky') }}" class="icon-sticky" />
               {% endif %}
             </td>
-            <td class="title"><a href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ thread.title }}</a></td>
-            <td class="author"><a class="username" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+            <td class="title"><a rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ thread.title }}</a></td>
+            <td class="author"><a class="username" rel="ugc" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
             <td class="replies">{{ thread.replies }}</td>
             <td class="last-post">
-              <a href="{{ thread.last_post.get_absolute_url() }}">
+              <a rel="ugc" href="{{ thread.last_post.get_absolute_url() }}">
                 {{ datetimeformat(thread.last_post.created) }}
               </a><br/>
-              <span class="text-body-xs ">{{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
+              <span class="text-body-xs ">{{ _('by <a class="username" rel="ugc" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
             </td>
           </tr>
         {% endfor %}

--- a/kitsune/kbforums/jinja2/kbforums/threads.html
+++ b/kitsune/kbforums/jinja2/kbforums/threads.html
@@ -48,13 +48,13 @@
               {% endif %}
             </td>
             <td class="title"><a rel="ugc nofollow" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ thread.title }}</a></td>
-            <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+            <td class="author"><a class="username" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
             <td class="replies">{{ thread.replies }}</td>
             <td class="last-post">
               <a rel="ugc nofollow" href="{{ thread.last_post.get_absolute_url() }}">
                 {{ datetimeformat(thread.last_post.created) }}
               </a><br/>
-              <span class="text-body-xs ">{{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
+              <span class="text-body-xs ">{{ _('by <a class="username" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
             </td>
           </tr>
         {% endfor %}

--- a/kitsune/kbforums/jinja2/kbforums/threads.html
+++ b/kitsune/kbforums/jinja2/kbforums/threads.html
@@ -10,7 +10,7 @@
     <article id="threads" class="content-box sumo-page-section">
       <h1 class="sumo-page-heading">{{ _('{d} Discussion')|f(d=document.title) }}</h1>
       <div class="sumo-button-wrap forum-actions">
-        <a id="new-thread" class="sumo-button button-primary" rel="ugc" href="{{ url('wiki.discuss.new_thread', document_slug=document.slug) }}">{{ _('Post a new thread') }}</a>
+        <a id="new-thread" class="sumo-button button-primary" rel="ugc nofollow" href="{{ url('wiki.discuss.new_thread', document_slug=document.slug) }}">{{ _('Post a new thread') }}</a>
 
         {% if user.is_authenticated %}
           <form action="{{ url('wiki.discuss.watch_forum', document.slug) }}" method="post">
@@ -31,11 +31,11 @@
       <div class="table-scroll">
       <table class="{% if not desc_toggle %}desc{% endif %}">
         <tr>
-          <th class="type"><a rel="ugc" href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Type') }}</a></th>
+          <th class="type"><a rel="ugc nofollow" href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Type') }}</a></th>
           <th class="title">{{ _('Title') }}</th>
-          <th class="author{% if sort == 3 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
-          <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
-          <th class="last-post{% if sort == 5 %} sort{% endif %}"><a rel="ugc" href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
+          <th class="author{% if sort == 3 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
+          <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
+          <th class="last-post{% if sort == 5 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
         </tr>
         {% for thread in threads.object_list %}
           <tr class="threads">
@@ -47,14 +47,14 @@
                 <img src="{{ webpack_static('sumo/img/blank.png') }}" alt="{{ pgettext('thread_type', 'Sticky') }}" title="{{ pgettext('thread_type', 'Sticky') }}" class="icon-sticky" />
               {% endif %}
             </td>
-            <td class="title"><a rel="ugc" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ thread.title }}</a></td>
-            <td class="author"><a class="username" rel="ugc" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
+            <td class="title"><a rel="ugc nofollow" href="{{ url('wiki.discuss.posts', document.slug, thread.id) }}">{{ thread.title }}</a></td>
+            <td class="author"><a class="username" rel="ugc nofollow" href="{{ profile_url(thread.creator) }}">{{ display_name(thread.creator) }}</a></td>
             <td class="replies">{{ thread.replies }}</td>
             <td class="last-post">
-              <a rel="ugc" href="{{ thread.last_post.get_absolute_url() }}">
+              <a rel="ugc nofollow" href="{{ thread.last_post.get_absolute_url() }}">
                 {{ datetimeformat(thread.last_post.created) }}
               </a><br/>
-              <span class="text-body-xs ">{{ _('by <a class="username" rel="ugc" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
+              <span class="text-body-xs ">{{ _('by <a class="username" rel="ugc nofollow" href="{profile_url}">{username}</a>')|fe(profile_url=profile_url(thread.last_post.creator), username=display_name(thread.last_post.creator)) }}</span>
             </td>
           </tr>
         {% endfor %}

--- a/kitsune/kbforums/tests/test_templates.py
+++ b/kitsune/kbforums/tests/test_templates.py
@@ -426,12 +426,12 @@ class SEOTemplateTests(KBForumTestCase):
         resp = get(self.client, "wiki.discuss.threads", args=[thread.document.slug])
         self.assertEqual(resp.status_code, 200)
         doc = pq(resp.content)
-        # All links to KB forums pages should have rel="ugc".
+        # All links to KB forums pages should have rel="ugc nofollow".
         self.assertEqual(
-            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+            len(doc('a[href*="/discuss/"][rel="ugc nofollow"]')), len(doc('a[href*="/discuss/"]'))
         )
-        # All KB pages should not be indexed and their links should not be followed.
-        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+        # All KB pages should not be indexed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex")
 
     def test_posts(self):
         """Test the posts view for SEO characteristics."""
@@ -441,12 +441,12 @@ class SEOTemplateTests(KBForumTestCase):
         resp = get(self.client, "wiki.discuss.posts", args=[thread.document.slug, thread.pk])
         self.assertEqual(resp.status_code, 200)
         doc = pq(resp.content)
-        # All links to KB forums pages should have rel="ugc".
+        # All links to KB forums pages should have rel="ugc nofollow".
         self.assertEqual(
-            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+            len(doc('a[href*="/discuss/"][rel="ugc nofollow"]')), len(doc('a[href*="/discuss/"]'))
         )
-        # All KB pages should not be indexed and their links should not be followed.
-        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+        # All KB pages should not be indexed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex")
 
     def test_new_thread(self):
         """Test the new thread view for SEO characteristics.."""
@@ -456,12 +456,12 @@ class SEOTemplateTests(KBForumTestCase):
         resp = get(self.client, "wiki.discuss.new_thread", args=[doc.slug])
         self.assertEqual(resp.status_code, 200)
         doc = pq(resp.content)
-        # All links to KB forums pages should have rel="ugc".
+        # All links to KB forums pages should have rel="ugc nofollow".
         self.assertEqual(
-            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+            len(doc('a[href*="/discuss/"][rel="ugc nofollow"]')), len(doc('a[href*="/discuss/"]'))
         )
-        # All KB pages should not be indexed and their links should not be followed.
-        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+        # All KB pages should not be indexed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex")
 
     def test_edit_thread(self):
         """Test the edit thread view for SEO characteristics."""
@@ -473,12 +473,12 @@ class SEOTemplateTests(KBForumTestCase):
         resp = get(self.client, "wiki.discuss.edit_thread", args=[thread.document.slug, thread.pk])
         self.assertEqual(resp.status_code, 200)
         doc = pq(resp.content)
-        # All links to KB forums pages should have rel="ugc".
+        # All links to KB forums pages should have rel="ugc nofollow".
         self.assertEqual(
-            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+            len(doc('a[href*="/discuss/"][rel="ugc nofollow"]')), len(doc('a[href*="/discuss/"]'))
         )
-        # All KB pages should not be indexed and their links should not be followed.
-        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+        # All KB pages should not be indexed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex")
 
     def test_delete_thread(self):
         """Test the delete thread view for SEO characteristics."""
@@ -492,12 +492,12 @@ class SEOTemplateTests(KBForumTestCase):
         )
         self.assertEqual(resp.status_code, 200)
         doc = pq(resp.content)
-        # All links to KB forums pages should have rel="ugc".
+        # All links to KB forums pages should have rel="ugc nofollow".
         self.assertEqual(
-            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+            len(doc('a[href*="/discuss/"][rel="ugc nofollow"]')), len(doc('a[href*="/discuss/"]'))
         )
-        # All KB pages should not be indexed and their links should not be followed.
-        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+        # All KB pages should not be indexed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex")
 
     def test_edit_post(self):
         """Test the edit post view for SEO characteristics."""
@@ -512,12 +512,12 @@ class SEOTemplateTests(KBForumTestCase):
         )
         self.assertEqual(resp.status_code, 200)
         doc = pq(resp.content)
-        # All links to KB forums pages should have rel="ugc".
+        # All links to KB forums pages should have rel="ugc nofollow".
         self.assertEqual(
-            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+            len(doc('a[href*="/discuss/"][rel="ugc nofollow"]')), len(doc('a[href*="/discuss/"]'))
         )
-        # All KB pages should not be indexed and their links should not be followed.
-        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+        # All KB pages should not be indexed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex")
 
     def test_delete_post(self):
         """Test the delete post view for SEO characteristics."""
@@ -533,9 +533,9 @@ class SEOTemplateTests(KBForumTestCase):
         )
         self.assertEqual(resp.status_code, 200)
         doc = pq(resp.content)
-        # All links to KB forums pages should have rel="ugc".
+        # All links to KB forums pages should have rel="ugc nofollow".
         self.assertEqual(
-            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+            len(doc('a[href*="/discuss/"][rel="ugc nofollow"]')), len(doc('a[href*="/discuss/"]'))
         )
-        # All KB pages should not be indexed and their links should not be followed.
-        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+        # All KB pages should not be indexed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex")

--- a/kitsune/kbforums/tests/test_templates.py
+++ b/kitsune/kbforums/tests/test_templates.py
@@ -415,3 +415,86 @@ class TestRatelimiting(KBForumTestCase):
 
         # We should only have 4 posts (each thread and reply creates a post).
         self.assertEqual(4, Post.objects.count())
+
+
+class SEOTemplateTests(KBForumTestCase):
+    def test_posts(self):
+        """Test the posts view for SEO characteristics."""
+        user = UserFactory()
+        thread = ThreadFactory()
+        thread.new_post(creator=user, content="yada yada")
+        resp = get(self.client, "wiki.discuss.posts", args=[thread.document.slug, thread.pk])
+        self.assertEqual(resp.status_code, 200)
+        doc = pq(resp.content)
+        # All links to KB forums pages should have rel="ugc".
+        self.assertEqual(
+            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+        )
+        # All KB pages should not be indexed and their links should not be followed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+
+    def test_threads(self):
+        """Test the threads view for SEO characteristics."""
+        user = UserFactory()
+        thread = ThreadFactory()
+        thread.new_post(creator=user, content="yada yada")
+        resp = get(self.client, "wiki.discuss.threads", args=[thread.document.slug])
+        self.assertEqual(resp.status_code, 200)
+        doc = pq(resp.content)
+        # All links to KB forums pages should have rel="ugc".
+        self.assertEqual(
+            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+        )
+        # All KB pages should not be indexed and their links should not be followed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+
+    def test_new_thread(self):
+        """Test the new thread view for SEO characteristics.."""
+        user = UserFactory()
+        self.client.login(username=user.username, password="testpass")
+        doc = ApprovedRevisionFactory().document
+        resp = get(self.client, "wiki.discuss.new_thread", args=[doc.slug])
+        self.assertEqual(resp.status_code, 200)
+        doc = pq(resp.content)
+        # All links to KB forums pages should have rel="ugc".
+        self.assertEqual(
+            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+        )
+        # All KB pages should not be indexed and their links should not be followed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+
+    def test_edit_thread(self):
+        """Test the edit thread view for SEO characteristics."""
+        user = UserFactory()
+        add_permission(user, Thread, "change_thread")
+        thread = ThreadFactory()
+        thread.new_post(creator=user, content="yada yada")
+        self.client.login(username=user.username, password="testpass")
+        resp = get(self.client, "wiki.discuss.edit_thread", args=[thread.document.slug, thread.pk])
+        self.assertEqual(resp.status_code, 200)
+        doc = pq(resp.content)
+        # All links to KB forums pages should have rel="ugc".
+        self.assertEqual(
+            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+        )
+        # All KB pages should not be indexed and their links should not be followed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")
+
+    def test_delete_thread(self):
+        """Test the delete thread view for SEO characteristics."""
+        user = UserFactory()
+        add_permission(user, Thread, "delete_thread")
+        thread = ThreadFactory()
+        thread.new_post(creator=user, content="yada yada")
+        self.client.login(username=user.username, password="testpass")
+        resp = get(
+            self.client, "wiki.discuss.delete_thread", args=[thread.document.slug, thread.pk]
+        )
+        self.assertEqual(resp.status_code, 200)
+        doc = pq(resp.content)
+        # All links to KB forums pages should have rel="ugc".
+        self.assertEqual(
+            len(doc('a[href*="/discuss/"][rel="ugc"]')), len(doc('a[href*="/discuss/"]'))
+        )
+        # All KB pages should not be indexed and their links should not be followed.
+        self.assertEqual(doc('meta[name="robots"]').attr("content"), "noindex, nofollow")

--- a/kitsune/landings/jinja2/landings/includes/register_contributor.html
+++ b/kitsune/landings/jinja2/landings/includes/register_contributor.html
@@ -24,7 +24,7 @@
         <button id="sign-up-contributor" class="sumo-button primary-button button-lg" data-event-category="Sign Me Up Click" data-event-action="Logged In">{{ _('Sign me up') }} &raquo;</button>
       </form>
     {% else %}
-      <a id="sign-up-contributor" class="sumo-button primary-button" href="{{ url('users.fxa_authentication_init') }}?next={{ next_url }}&is_contributor=True" data-event-category="Sign Me Up Click" data-event-action="Logged In">
+      <a id="sign-up-contributor" class="sumo-button primary-button" rel="nofollow" href="{{ url('users.fxa_authentication_init') }}?next={{ next_url }}&is_contributor=True" data-event-category="Sign Me Up Click" data-event-action="Logged In">
         {{ _('Sign me up') }} &raquo;
       </a>
     {% endif %}

--- a/kitsune/messages/jinja2/messages/includes/macros.html
+++ b/kitsune/messages/jinja2/messages/includes/macros.html
@@ -2,7 +2,7 @@
 
 {% macro avatar_link(user=None) -%}
   {% if user %}
-    <a href="{{ profile_url(user) }}">
+    <a rel="ugc nofollow" href="{{ profile_url(user) }}">
       <img src="{{ profile_avatar(user) }}" height="48" width="48" alt="{{ display_name(user) }}" />
     </a>
   {% else %}
@@ -12,7 +12,7 @@
 
 {% macro name_link(user=None, name=None) -%}
   {% if user -%}
-    <a href="{{ profile_url(user) }}">{% if name %}{{ name }}{% else %}{{ display_name(user) }}{% endif %}</a>
+    <a rel="ugc nofollow" href="{{ profile_url(user) }}">{% if name %}{{ name }}{% else %}{{ display_name(user) }}{% endif %}</a>
   {%- else -%}
     {{ name if name else _('System') }}
   {%- endif %}

--- a/kitsune/messages/jinja2/messages/includes/macros.html
+++ b/kitsune/messages/jinja2/messages/includes/macros.html
@@ -2,7 +2,7 @@
 
 {% macro avatar_link(user=None) -%}
   {% if user %}
-    <a rel="ugc nofollow" href="{{ profile_url(user) }}">
+    <a rel="nofollow" href="{{ profile_url(user) }}">
       <img src="{{ profile_avatar(user) }}" height="48" width="48" alt="{{ display_name(user) }}" />
     </a>
   {% else %}
@@ -12,7 +12,7 @@
 
 {% macro name_link(user=None, name=None) -%}
   {% if user -%}
-    <a rel="ugc nofollow" href="{{ profile_url(user) }}">{% if name %}{{ name }}{% else %}{{ display_name(user) }}{% endif %}</a>
+    <a rel="nofollow" href="{{ profile_url(user) }}">{% if name %}{{ name }}{% else %}{{ display_name(user) }}{% endif %}</a>
   {%- else -%}
     {{ name if name else _('System') }}
   {%- endif %}

--- a/kitsune/questions/jinja2/questions/includes/answer.html
+++ b/kitsune/questions/jinja2/questions/includes/answer.html
@@ -7,13 +7,13 @@
   <section class="avatar-row">
     <div class="avatar-details user-meta">
       <div class="avatar">
-        <a href="{{ profile_url(answer.creator) }}">
+        <a rel="ugc nofollow" href="{{ profile_url(answer.creator) }}">
           <img src="{{ profile_avatar(answer.creator) }}" height="48" width="48" alt="{{ display_name(answer.creator) }}"/>
         </a>
       </div>
       <div class="user">
         <div class="asked-by">
-          <a class="author-name" href="{{ profile_url(answer.creator) }}">
+          <a class="author-name" rel="ugc nofollow" href="{{ profile_url(answer.creator) }}">
             <span class="display-name">{{ display_name(answer.creator) }}</span>
             {{ titles(answer.creator) }}
             {% if answer.id and answer.creator == question.creator %}<span class="user-title">{{_('Question owner')}}</span>{% endif %}

--- a/kitsune/questions/jinja2/questions/includes/answer.html
+++ b/kitsune/questions/jinja2/questions/includes/answer.html
@@ -7,13 +7,13 @@
   <section class="avatar-row">
     <div class="avatar-details user-meta">
       <div class="avatar">
-        <a rel="ugc nofollow" href="{{ profile_url(answer.creator) }}">
+        <a rel="nofollow" href="{{ profile_url(answer.creator) }}">
           <img src="{{ profile_avatar(answer.creator) }}" height="48" width="48" alt="{{ display_name(answer.creator) }}"/>
         </a>
       </div>
       <div class="user">
         <div class="asked-by">
-          <a class="author-name" rel="ugc nofollow" href="{{ profile_url(answer.creator) }}">
+          <a class="author-name" rel="nofollow" href="{{ profile_url(answer.creator) }}">
             <span class="display-name">{{ display_name(answer.creator) }}</span>
             {{ titles(answer.creator) }}
             {% if answer.id and answer.creator == question.creator %}<span class="user-title">{{_('Question owner')}}</span>{% endif %}

--- a/kitsune/questions/jinja2/questions/question_details.html
+++ b/kitsune/questions/jinja2/questions/question_details.html
@@ -137,13 +137,13 @@
       <section class="avatar-row">
         <div class="avatar-details user-meta">
           <div class="avatar">
-            <a rel="ugc nofollow" href="{{ profile_url(question.creator, request.user == question.creator) }}">
+            <a rel="nofollow" href="{{ profile_url(question.creator, request.user == question.creator) }}">
               <img src="{{ profile_avatar(question.creator) }}" height="48" width="48" alt="{{ display_name(question.creator) }}"/>
             </a>
           </div>
           <div class="user">
             <div class="asked-by">
-              <a class="author-name" rel="ugc nofollow" href="{{ profile_url(question.creator, request.user == question.creator) }}">
+              <a class="author-name" rel="nofollow" href="{{ profile_url(question.creator, request.user == question.creator) }}">
                 <span class="display-name">{{ display_name(question.creator) }}</span>
               </a>
             </div>
@@ -283,7 +283,7 @@
             </div>
           {% endif %}
           <p>
-            {{ _('You must <a href="{login_url}">log in to your account</a> to reply to posts. Please <a href="{ask_url}">start a new question</a>, if you do not have an account yet.')|fe(login_url=url('users.auth'), ask_url=ask_url) }}
+            {{ _('You must <a rel="nofollow" href="{login_url}">log in to your account</a> to reply to posts. Please <a href="{ask_url}">start a new question</a>, if you do not have an account yet.')|fe(login_url=url('users.auth'), ask_url=ask_url) }}
           </p>
         </div>
       {% endif %}

--- a/kitsune/questions/jinja2/questions/question_details.html
+++ b/kitsune/questions/jinja2/questions/question_details.html
@@ -137,13 +137,13 @@
       <section class="avatar-row">
         <div class="avatar-details user-meta">
           <div class="avatar">
-            <a href="{{ profile_url(question.creator, request.user == question.creator) }}">
+            <a rel="ugc nofollow" href="{{ profile_url(question.creator, request.user == question.creator) }}">
               <img src="{{ profile_avatar(question.creator) }}" height="48" width="48" alt="{{ display_name(question.creator) }}"/>
             </a>
           </div>
           <div class="user">
             <div class="asked-by">
-              <a class="author-name" href="{{ profile_url(question.creator, request.user == question.creator) }}">
+              <a class="author-name" rel="ugc nofollow" href="{{ profile_url(question.creator, request.user == question.creator) }}">
                 <span class="display-name">{{ display_name(question.creator) }}</span>
               </a>
             </div>

--- a/kitsune/questions/jinja2/questions/question_list.html
+++ b/kitsune/questions/jinja2/questions/question_list.html
@@ -241,16 +241,16 @@
 
                   <div class="forum--user-meta">
                     <p class="user-meta-asked-by">
-                      {{ _('Asked by <strong><a rel="ugc nofollow" href="{user_url}">{username}</a></strong> {when}')|fe(user_url=profile_url(question.creator), username=display_name(question.creator), when=question.created|timesince) }}
+                      {{ _('Asked by <strong><a rel="nofollow" href="{user_url}">{username}</a></strong> {when}')|fe(user_url=profile_url(question.creator), username=display_name(question.creator), when=question.created|timesince) }}
                     </p>
                     {% if question.solution %}
                       <p class="user-meta-answered-by">
-                        {{ _('Answered by <strong><a rel="ugc nofollow" href="{user_url}">{username}</a></strong> {when}')|fe(user_url=profile_url(question.solution.creator), username=display_name(question.solution.creator), when=question.solution.created|timesince) }}
+                        {{ _('Answered by <strong><a rel="nofollow" href="{user_url}">{username}</a></strong> {when}')|fe(user_url=profile_url(question.solution.creator), username=display_name(question.solution.creator), when=question.solution.created|timesince) }}
                       </p>
                     {% else %}
                       {% if question.last_answer %}
                         <p class="user-meta-answered-by">
-                          {{ _('<a href="{reply_url}">Last reply</a> by <strong><a rel="ugc nofollow" href="{user_url}">{username}</a></strong> {when}')|fe(reply_url=question.last_answer.get_absolute_url(), user_url=profile_url(question.last_answer.creator), username=display_name(question.last_answer.creator), when=question.last_answer.created|timesince) }}
+                          {{ _('<a href="{reply_url}">Last reply</a> by <strong><a rel="nofollow" href="{user_url}">{username}</a></strong> {when}')|fe(reply_url=question.last_answer.get_absolute_url(), user_url=profile_url(question.last_answer.creator), username=display_name(question.last_answer.creator), when=question.last_answer.created|timesince) }}
                         </p>
                       {% endif %}
                     {% endif %}

--- a/kitsune/questions/jinja2/questions/question_list.html
+++ b/kitsune/questions/jinja2/questions/question_list.html
@@ -241,16 +241,16 @@
 
                   <div class="forum--user-meta">
                     <p class="user-meta-asked-by">
-                      {{ _('Asked by <strong><a href="{user_url}">{username}</a></strong> {when}')|fe(user_url=profile_url(question.creator), username=display_name(question.creator), when=question.created|timesince) }}
+                      {{ _('Asked by <strong><a rel="ugc nofollow" href="{user_url}">{username}</a></strong> {when}')|fe(user_url=profile_url(question.creator), username=display_name(question.creator), when=question.created|timesince) }}
                     </p>
                     {% if question.solution %}
                       <p class="user-meta-answered-by">
-                        {{ _('Answered by <strong><a href="{user_url}">{username}</a></strong> {when}')|fe(user_url=profile_url(question.solution.creator), username=display_name(question.solution.creator), when=question.solution.created|timesince) }}
+                        {{ _('Answered by <strong><a rel="ugc nofollow" href="{user_url}">{username}</a></strong> {when}')|fe(user_url=profile_url(question.solution.creator), username=display_name(question.solution.creator), when=question.solution.created|timesince) }}
                       </p>
                     {% else %}
                       {% if question.last_answer %}
                         <p class="user-meta-answered-by">
-                          {{ _('<a href="{reply_url}">Last reply</a> by <strong><a href="{user_url}">{username}</a></strong> {when}')|fe(reply_url=question.last_answer.get_absolute_url(), user_url=profile_url(question.last_answer.creator), username=display_name(question.last_answer.creator), when=question.last_answer.created|timesince) }}
+                          {{ _('<a href="{reply_url}">Last reply</a> by <strong><a rel="ugc nofollow" href="{user_url}">{username}</a></strong> {when}')|fe(reply_url=question.last_answer.get_absolute_url(), user_url=profile_url(question.last_answer.creator), username=display_name(question.last_answer.creator), when=question.last_answer.created|timesince) }}
                         </p>
                       {% endif %}
                     {% endif %}

--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -254,7 +254,7 @@
         <section class="mzp-c-footer-col">
           <h5 class="mzp-c-footer-heading">{{ _('Firefox Accounts') }}</h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('users.auth') }}">{{ _('Sign In/Up') }}</a></li>
+            <li><a rel="nofollow" href="{{ url('users.auth') }}">{{ _('Sign In/Up') }}</a></li>
             <li><a href="https://www.mozilla.org/en-US/firefox/accounts/">{{ _('Benefits') }}</a></li>
             <li class="mzp-c-footer-heading"><br><a href="https://fpn.firefox.com/">{{ _('Firefox Private Network') }}</a></li>
           </ul>

--- a/kitsune/sumo/jinja2/email/base.html
+++ b/kitsune/sumo/jinja2/email/base.html
@@ -244,7 +244,7 @@
             <td>
               {% block prefooter %}{% endblock %}
               {% block footer %}
-                <a class="email-prefs" href="{{ url('users.edit_settings') }}">{{ _('Change your email preferences') }}</a>
+                <a class="email-prefs" rel="ugc nofollow" href="{{ url('users.edit_settings') }}">{{ _('Change your email preferences') }}</a>
                 {% if watch %}
                   <div class="watch-link"><a href="{{ watch.unsubscribe_url() }}">{{ _('Unsubscribe from these emails') }}</a></div>
                 {% endif %}

--- a/kitsune/sumo/jinja2/email/base.html
+++ b/kitsune/sumo/jinja2/email/base.html
@@ -244,7 +244,7 @@
             <td>
               {% block prefooter %}{% endblock %}
               {% block footer %}
-                <a class="email-prefs" rel="ugc nofollow" href="{{ url('users.edit_settings') }}">{{ _('Change your email preferences') }}</a>
+                <a class="email-prefs" rel="nofollow" href="{{ url('users.edit_settings') }}">{{ _('Change your email preferences') }}</a>
                 {% if watch %}
                   <div class="watch-link"><a href="{{ watch.unsubscribe_url() }}">{{ _('Unsubscribe from these emails') }}</a></div>
                 {% endif %}

--- a/kitsune/sumo/jinja2/handlers/403.html
+++ b/kitsune/sumo/jinja2/handlers/403.html
@@ -9,7 +9,7 @@
 
       {% if not user.is_authenticated %}
         <p>
-          {{ _('Please try to log in / sign up first with') }} <a href="{{ url('users.fxa_authentication_init') }}">{{ _('Firefox Accounts') }}</a>.
+          {{ _('Please try to log in / sign up first with') }} <a rel="nofollow" href="{{ url('users.fxa_authentication_init') }}">{{ _('Firefox Accounts') }}</a>.
         </p>
       {% endif %}
     </div>

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -211,7 +211,7 @@
           aria-controls="mzp-c-menu-panel-profile">{{ _('Close Firefox menu') }}</button>
         <div class="sumo-nav--dropdown-thirds">
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
-            <a class="mzp-c-menu-item-link" href="{{ profile_url(user) }}">
+            <a class="mzp-c-menu-item-link" rel="ugc nofollow" href="{{ profile_url(user) }}">
               <svg class="mzp-c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                 <g transform="translate(5 3)" stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd">
                   <path d="M0 18c1-4 3.333-6 7-6s6 2 7 6" stroke-linecap="round" />
@@ -224,14 +224,14 @@
               </p>
             </a>
             <ul class="mzp-c-menu-item-list sumo-nav--sublist">
-              <li><a href="{{ url('users.edit_my_profile') }}">{{ _('Edit Profile') }}</a></li>
-              <li><a href="{{ url('users.questions', user.username) }}">{{ _('My Questions') }}</a></li>
+              <li><a rel="ugc nofollow" href="{{ url('users.edit_my_profile') }}">{{ _('Edit Profile') }}</a></li>
+              <li><a rel="ugc nofollow" href="{{ url('users.questions', user.username) }}">{{ _('My Questions') }}</a></li>
             </ul>
           </section>
         </div>
         <div class="sumo-nav--dropdown-thirds">
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
-            <a class="mzp-c-menu-item-link" href="{{ url('users.edit_settings') }}">
+            <a class="mzp-c-menu-item-link" rel="ugc nofollow" href="{{ url('users.edit_settings') }}">
               <svg class="mzp-c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                 <g transform="translate(1 1)" stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd"
                   stroke-linecap="round" stroke-linejoin="round">

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -200,7 +200,7 @@
 <li
   class="mzp-c-menu-category {% if user.is_authenticated %}mzp-has-drop-down mzp-js-expandable{% else %}logged-out-button-row{% endif %} {% if hide_locale_switcher %}sumo-nav--item-right{% endif %}">
   {% if user.is_authenticated %}
-  <a class="mzp-c-menu-title sumo-nav--link has-avatar hide-on-mobile" href="{{ url('users.auth') }}">
+  <a class="mzp-c-menu-title sumo-nav--link has-avatar hide-on-mobile" rel="nofollow" href="{{ url('users.auth') }}">
     <span class="sumo-nav--username">{{ display_name(user) }}</span>
     <img class="avatar" src="{{ profile_avatar(user) }}" alt="Avatar for Username">
   </a>
@@ -211,7 +211,7 @@
           aria-controls="mzp-c-menu-panel-profile">{{ _('Close Firefox menu') }}</button>
         <div class="sumo-nav--dropdown-thirds">
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
-            <a class="mzp-c-menu-item-link" rel="ugc nofollow" href="{{ profile_url(user) }}">
+            <a class="mzp-c-menu-item-link" rel="nofollow" href="{{ profile_url(user) }}">
               <svg class="mzp-c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                 <g transform="translate(5 3)" stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd">
                   <path d="M0 18c1-4 3.333-6 7-6s6 2 7 6" stroke-linecap="round" />
@@ -224,14 +224,14 @@
               </p>
             </a>
             <ul class="mzp-c-menu-item-list sumo-nav--sublist">
-              <li><a rel="ugc nofollow" href="{{ url('users.edit_my_profile') }}">{{ _('Edit Profile') }}</a></li>
-              <li><a rel="ugc nofollow" href="{{ url('users.questions', user.username) }}">{{ _('My Questions') }}</a></li>
+              <li><a rel="nofollow" href="{{ url('users.edit_my_profile') }}">{{ _('Edit Profile') }}</a></li>
+              <li><a rel="nofollow" href="{{ url('users.questions', user.username) }}">{{ _('My Questions') }}</a></li>
             </ul>
           </section>
         </div>
         <div class="sumo-nav--dropdown-thirds">
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
-            <a class="mzp-c-menu-item-link" rel="ugc nofollow" href="{{ url('users.edit_settings') }}">
+            <a class="mzp-c-menu-item-link" rel="nofollow" href="{{ url('users.edit_settings') }}">
               <svg class="mzp-c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                 <g transform="translate(1 1)" stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd"
                   stroke-linecap="round" stroke-linejoin="round">
@@ -277,7 +277,7 @@
     </div>
   </div>
   {% elif not request.path == url('users.auth') %}
-  <a href="{{ url('users.auth') }}" class="sumo-button secondary-button button-lg" data-event-category="navigation"
+  <a rel="nofollow" href="{{ url('users.auth') }}" class="sumo-button secondary-button button-lg" data-event-category="navigation"
     data-event-action="main navigation" data-event-label="Sign In">{{ _('Sign In/Up') }}</a>
   {% endif %}
 </li>

--- a/kitsune/sumo/jinja2/layout/breadcrumbs.html
+++ b/kitsune/sumo/jinja2/layout/breadcrumbs.html
@@ -3,7 +3,12 @@
   <ol id="breadcrumbs" class="breadcrumbs--list">
   {% for target, label in breadcrumbs %}
     {% if target %}
-      <li><a href="{{ target }}">{{ label|truncate(length=30) }}</a></li>
+      {% if target is string %}
+        <li><a href="{{ target }}">{{ label|truncate(length=30) }}</a></li>
+      {% else %}
+        {% set target, extra = target %}
+        <li><a {{ extra|safe }} href="{{ target }}">{{ label|truncate(length=30) }}</a></li>
+      {% endif %}
     {% else %}
       <li>{{ label|truncate(length=40) }}</li>
     {% endif %}

--- a/kitsune/sumo/jinja2/sumo/robots.html
+++ b/kitsune/sumo/jinja2/sumo/robots.html
@@ -6,10 +6,12 @@ Disallow: /{{ l }}/forums
 Disallow: /{{ l }}/users
 Disallow: /{{ l }}/user
 Disallow: /{{ l }}/search
+Disallow: /{{ l }}/kb/*/discuss
 {% endfor %}
 {% for l in settings.NON_SUPPORTED_LOCALES.keys() %}
 Disallow: /{{ l }}/forums
 Disallow: /{{ l }}/users
 Disallow: /{{ l }}/user
 Disallow: /{{ l }}/search
+Disallow: /{{ l }}/kb/*/discuss
 {% endfor %}

--- a/kitsune/users/jinja2/users/auth.html
+++ b/kitsune/users/jinja2/users/auth.html
@@ -53,7 +53,7 @@
 
                 <div class="center-on-mobile">
                   <p class="login-button-wrap">
-                    <a href="{{ url('users.fxa_authentication_init') }}?next={{ next_url }}" class="sumo-button primary-button button-lg">{{ _('Continue with Firefox Accounts') }}</a>
+                    <a rel="nofollow" href="{{ url('users.fxa_authentication_init') }}?next={{ next_url }}" class="sumo-button primary-button button-lg">{{ _('Continue with Firefox Accounts') }}</a>
                   </p>
 
                   <p class="help-text">

--- a/kitsune/users/jinja2/users/base.html
+++ b/kitsune/users/jinja2/users/base.html
@@ -23,7 +23,7 @@
       <nav class="sidebar-nav">
         <span class="details-heading">{{ display_name(profile.user) }}</span>
         <ul id="user-nav" class="sidebar-nav--list">
-          <li class="sidebar-nav--item"><a rel="ugc nofollow" href="{{ profile_url(profile.user) }}" class="sidebar-nav--link selected">{{ display_name(profile.user) }}</a></li>
+          <li class="sidebar-nav--item"><a rel="nofollow" href="{{ profile_url(profile.user) }}" class="sidebar-nav--link selected">{{ display_name(profile.user) }}</a></li>
         </ul>
       </nav>
     {% endif %}

--- a/kitsune/users/jinja2/users/base.html
+++ b/kitsune/users/jinja2/users/base.html
@@ -3,6 +3,7 @@
 {% set scripts = ('users',) %}
 {% set classes = "profile" %}
 {% set is_owner = profile and profile.user == request.user %}
+{% set meta = (('robots', 'noindex'),) %}
 
 {% block breadcrumbs %}
 {% endblock %}
@@ -22,7 +23,7 @@
       <nav class="sidebar-nav">
         <span class="details-heading">{{ display_name(profile.user) }}</span>
         <ul id="user-nav" class="sidebar-nav--list">
-          <li class="sidebar-nav--item"><a href="{{ profile_url(profile.user) }}" class="sidebar-nav--link selected">{{ display_name(profile.user) }}</a></li>
+          <li class="sidebar-nav--item"><a rel="ugc nofollow" href="{{ profile_url(profile.user) }}" class="sidebar-nav--link selected">{{ display_name(profile.user) }}</a></li>
         </ul>
       </nav>
     {% endif %}

--- a/kitsune/users/jinja2/users/close_account.html
+++ b/kitsune/users/jinja2/users/close_account.html
@@ -2,6 +2,7 @@
 
 {% set title = 'Your account was closed' %}
 {% set crumbs = [(None, title)] %}
+{% set meta = (('robots', 'noindex'),) %}
 
 {% block content %}
   <article>

--- a/kitsune/users/jinja2/users/confirm_avatar_delete.html
+++ b/kitsune/users/jinja2/users/confirm_avatar_delete.html
@@ -20,7 +20,7 @@
           {% endtrans %}
         </p>
         <div class="form-actions">
-          <a href="{{ url('users.edit_my_profile') }}">{{ _('Cancel') }}</a>
+          <a rel="ugc nofollow" href="{{ url('users.edit_my_profile') }}">{{ _('Cancel') }}</a>
           <input type="submit" class="btn" value="{{ _('Delete avatar') }}" />
         </div>
       </form>

--- a/kitsune/users/jinja2/users/confirm_avatar_delete.html
+++ b/kitsune/users/jinja2/users/confirm_avatar_delete.html
@@ -20,7 +20,7 @@
           {% endtrans %}
         </p>
         <div class="form-actions">
-          <a rel="ugc nofollow" href="{{ url('users.edit_my_profile') }}">{{ _('Cancel') }}</a>
+          <a rel="nofollow" href="{{ url('users.edit_my_profile') }}">{{ _('Cancel') }}</a>
           <input type="submit" class="btn" value="{{ _('Delete avatar') }}" />
         </div>
       </form>

--- a/kitsune/users/jinja2/users/deactivation_log.html
+++ b/kitsune/users/jinja2/users/deactivation_log.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% set title = _('Deactivation Log') %}
+{% set meta = (('robots', 'noindex'),) %}
 
 
 {% block content %}
@@ -17,9 +18,9 @@
       {% for deactivation in deactivations %}
         <tr>
           <td>{{ deactivation.date }}</td>
-          <td><a href="{{ profile_url(deactivation.user) }}">
+          <td><a rel="ugc nofollow" href="{{ profile_url(deactivation.user) }}">
               {{ display_name(deactivation.user) }}</a></td>
-          <td><a href="{{ profile_url(deactivation.moderator) }}">
+          <td><a rel="ugc nofollow" href="{{ profile_url(deactivation.moderator) }}">
               {{ display_name(deactivation.moderator) }}</a></td>
         </tr>
       {% endfor %}

--- a/kitsune/users/jinja2/users/deactivation_log.html
+++ b/kitsune/users/jinja2/users/deactivation_log.html
@@ -18,9 +18,9 @@
       {% for deactivation in deactivations %}
         <tr>
           <td>{{ deactivation.date }}</td>
-          <td><a rel="ugc nofollow" href="{{ profile_url(deactivation.user) }}">
+          <td><a rel="nofollow" href="{{ profile_url(deactivation.user) }}">
               {{ display_name(deactivation.user) }}</a></td>
-          <td><a rel="ugc nofollow" href="{{ profile_url(deactivation.moderator) }}">
+          <td><a rel="nofollow" href="{{ profile_url(deactivation.moderator) }}">
               {{ display_name(deactivation.moderator) }}</a></td>
         </tr>
       {% endfor %}

--- a/kitsune/users/jinja2/users/edit_avatar.html
+++ b/kitsune/users/jinja2/users/edit_avatar.html
@@ -1,7 +1,7 @@
 {% extends "users/base.html" %}
 {% set title = _('Change Avatar') %}
 {% set classes = 'profile' %}
-{% set crumbs = [((profile_url(user), 'rel="ugc nofollow"'), user.username),
+{% set crumbs = [((profile_url(user), 'rel="nofollow"'), user.username),
                  (None, title)] %}
 
 {% block content %}

--- a/kitsune/users/jinja2/users/edit_avatar.html
+++ b/kitsune/users/jinja2/users/edit_avatar.html
@@ -1,7 +1,7 @@
 {% extends "users/base.html" %}
 {% set title = _('Change Avatar') %}
 {% set classes = 'profile' %}
-{% set crumbs = [(profile_url(user), user.username),
+{% set crumbs = [((profile_url(user), 'rel="ugc nofollow"'), user.username),
                  (None, title)] %}
 
 {% block content %}

--- a/kitsune/users/jinja2/users/edit_profile.html
+++ b/kitsune/users/jinja2/users/edit_profile.html
@@ -5,7 +5,7 @@
 {% set classes = 'profile' %}
 {% set active = 'edit-profile' %}
 {% if not user_form.errors %}
- {% set crumbs = [((profile_url(user=profile.user), 'rel="ugc nofollow"'), profile.user.username), (None, title)] %}
+ {% set crumbs = [((profile_url(user=profile.user), 'rel="nofollow"'), profile.user.username), (None, title)] %}
 {% endif %}
 
 {% block above_main %}

--- a/kitsune/users/jinja2/users/edit_profile.html
+++ b/kitsune/users/jinja2/users/edit_profile.html
@@ -5,7 +5,7 @@
 {% set classes = 'profile' %}
 {% set active = 'edit-profile' %}
 {% if not user_form.errors %}
- {% set crumbs = [(profile_url(user=profile.user), profile.user.username), (None, title)] %}
+ {% set crumbs = [((profile_url(user=profile.user), 'rel="ugc nofollow"'), profile.user.username), (None, title)] %}
 {% endif %}
 
 {% block above_main %}

--- a/kitsune/users/jinja2/users/includes/macros.html
+++ b/kitsune/users/jinja2/users/includes/macros.html
@@ -3,14 +3,14 @@
   <nav class="sidebar-nav">
     <span class="details-heading">My Profile</span>
     <ul id="user-nav" class="sidebar-nav--list">
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('my-profile') }} href="{{ profile_url(user) }}">{{ _('My profile') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-profile') }} href="{{ url('users.edit_my_profile') }}">{{ _('Edit my profile') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-settings') }} href="{{ url('users.edit_settings') }}">{{ _('Edit settings') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-contributions') }} href="{{ url('users.edit_contribution_area') }}">{{ _('Edit contribution areas') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-watches') }} href="{{ url('users.edit_watch_list') }}">{{ _('Manage watch list') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('user-questions') }} href="{{ url('users.questions', user.username) }}">{{ _('My questions') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('my-profile') }} rel="ugc nofollow" href="{{ profile_url(user) }}">{{ _('My profile') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-profile') }} rel="ugc nofollow" href="{{ url('users.edit_my_profile') }}">{{ _('Edit my profile') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-settings') }} rel="ugc nofollow" href="{{ url('users.edit_settings') }}">{{ _('Edit settings') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-contributions') }} rel="ugc nofollow" href="{{ url('users.edit_contribution_area') }}">{{ _('Edit contribution areas') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-watches') }} rel="ugc nofollow" href="{{ url('users.edit_watch_list') }}">{{ _('Manage watch list') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('user-questions') }} rel="ugc nofollow" href="{{ url('users.questions', user.username) }}">{{ _('My questions') }}</a></li>
       {% if user.profile.is_subscriber %}
-        <li class="sidebar-nav--item"><a {{ selected|class_selected('user-subscriptions') }} href="{{ url('users.subscriptions', user.username) }}">{{ _('My subscriptions') }}</a></li>
+        <li class="sidebar-nav--item"><a {{ selected|class_selected('user-subscriptions') }} rel="ugc nofollow" href="{{ url('users.subscriptions', user.username) }}">{{ _('My subscriptions') }}</a></li>
       {% endif %}
     </ul>
   </nav>

--- a/kitsune/users/jinja2/users/includes/macros.html
+++ b/kitsune/users/jinja2/users/includes/macros.html
@@ -3,14 +3,14 @@
   <nav class="sidebar-nav">
     <span class="details-heading">My Profile</span>
     <ul id="user-nav" class="sidebar-nav--list">
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('my-profile') }} rel="ugc nofollow" href="{{ profile_url(user) }}">{{ _('My profile') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-profile') }} rel="ugc nofollow" href="{{ url('users.edit_my_profile') }}">{{ _('Edit my profile') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-settings') }} rel="ugc nofollow" href="{{ url('users.edit_settings') }}">{{ _('Edit settings') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-contributions') }} rel="ugc nofollow" href="{{ url('users.edit_contribution_area') }}">{{ _('Edit contribution areas') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-watches') }} rel="ugc nofollow" href="{{ url('users.edit_watch_list') }}">{{ _('Manage watch list') }}</a></li>
-      <li class="sidebar-nav--item"><a {{ selected|class_selected('user-questions') }} rel="ugc nofollow" href="{{ url('users.questions', user.username) }}">{{ _('My questions') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('my-profile') }} rel="nofollow" href="{{ profile_url(user) }}">{{ _('My profile') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-profile') }} rel="nofollow" href="{{ url('users.edit_my_profile') }}">{{ _('Edit my profile') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-settings') }} rel="nofollow" href="{{ url('users.edit_settings') }}">{{ _('Edit settings') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-contributions') }} rel="nofollow" href="{{ url('users.edit_contribution_area') }}">{{ _('Edit contribution areas') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('edit-watches') }} rel="nofollow" href="{{ url('users.edit_watch_list') }}">{{ _('Manage watch list') }}</a></li>
+      <li class="sidebar-nav--item"><a {{ selected|class_selected('user-questions') }} rel="nofollow" href="{{ url('users.questions', user.username) }}">{{ _('My questions') }}</a></li>
       {% if user.profile.is_subscriber %}
-        <li class="sidebar-nav--item"><a {{ selected|class_selected('user-subscriptions') }} rel="ugc nofollow" href="{{ url('users.subscriptions', user.username) }}">{{ _('My subscriptions') }}</a></li>
+        <li class="sidebar-nav--item"><a {{ selected|class_selected('user-subscriptions') }} rel="nofollow" href="{{ url('users.subscriptions', user.username) }}">{{ _('My subscriptions') }}</a></li>
       {% endif %}
     </ul>
   </nav>

--- a/kitsune/users/jinja2/users/profile.html
+++ b/kitsune/users/jinja2/users/profile.html
@@ -30,7 +30,7 @@
         {% if request.user.is_authenticated and request.user != profile.user %}
           {% if user.has_perm('users.change_profile') %}
             <div id="admin-actions">
-              <a class="edit" rel="ugc nofollow" href="{{ url('users.edit_profile', profile.user.username) }}">
+              <a class="edit" rel="nofollow" href="{{ url('users.edit_profile', profile.user.username) }}">
                 {{ _('Edit user profile') }}
               </a>
            </div>
@@ -44,7 +44,7 @@
         </h2>
         <p>
           {% if is_owner %}
-            {% trans a_open='<a href="'|safe + url("users.edit_my_profile") + '">'|safe, a_close='</a>'|safe %}
+            {% trans a_open='<a rel="nofollow" href="'|safe + url("users.edit_my_profile") + '">'|safe, a_close='</a>'|safe %}
               Your privacy is important to us. Your username is always visible to the public -
               if you would like to edit your username, {{ a_open }} click here. {{ a_close }}
             {% endtrans %}
@@ -142,14 +142,14 @@
             {% endif %}
             {% if num_questions %}
               <li>
-                <a rel="ugc nofollow" href="{{ url('users.questions', profile.user.username) }}">
+                <a rel="nofollow" href="{{ url('users.questions', profile.user.username) }}">
                   {{ ngettext('{0} question', '{0} questions', num_questions)|f(num_questions) }}
                 </a>
               </li>
             {% endif %}
             {% if num_answers %}
               <li>
-                <a rel="ugc nofollow" href="{{ url('users.answers', profile.user.username) }}">
+                <a rel="nofollow" href="{{ url('users.answers', profile.user.username) }}">
                   {{ ngettext('{0} answer', '{0} answers', num_answers)|f(num_answers) }}
                 </a>
               </li>
@@ -161,7 +161,7 @@
             {% endif %}
             {% if num_documents %}
               <li>
-                <a rel="ugc nofollow" href="{{ url('users.documents', profile.user.username) }}">
+                <a rel="nofollow" href="{{ url('users.documents', profile.user.username) }}">
                   {{ ngettext('{0} document', '{0} documents', num_documents)|f(num_documents) }}
                 </a>
               </li>

--- a/kitsune/users/jinja2/users/profile.html
+++ b/kitsune/users/jinja2/users/profile.html
@@ -30,7 +30,7 @@
         {% if request.user.is_authenticated and request.user != profile.user %}
           {% if user.has_perm('users.change_profile') %}
             <div id="admin-actions">
-              <a class="edit" href="{{ url('users.edit_profile', profile.user.username) }}">
+              <a class="edit" rel="ugc nofollow" href="{{ url('users.edit_profile', profile.user.username) }}">
                 {{ _('Edit user profile') }}
               </a>
            </div>
@@ -142,14 +142,14 @@
             {% endif %}
             {% if num_questions %}
               <li>
-                <a href="{{ url('users.questions', profile.user.username) }}">
+                <a rel="ugc nofollow" href="{{ url('users.questions', profile.user.username) }}">
                   {{ ngettext('{0} question', '{0} questions', num_questions)|f(num_questions) }}
                 </a>
               </li>
             {% endif %}
             {% if num_answers %}
               <li>
-                <a href="{{ url('users.answers', profile.user.username) }}">
+                <a rel="ugc nofollow" href="{{ url('users.answers', profile.user.username) }}">
                   {{ ngettext('{0} answer', '{0} answers', num_answers)|f(num_answers) }}
                 </a>
               </li>
@@ -161,7 +161,7 @@
             {% endif %}
             {% if num_documents %}
               <li>
-                <a href="{{ url('users.documents', profile.user.username) }}">
+                <a rel="ugc nofollow" href="{{ url('users.documents', profile.user.username) }}">
                   {{ ngettext('{0} document', '{0} documents', num_documents)|f(num_documents) }}
                 </a>
               </li>

--- a/kitsune/users/templatetags/jinja_helpers.py
+++ b/kitsune/users/templatetags/jinja_helpers.py
@@ -60,7 +60,7 @@ def unicode_to_html(text):
 @library.global_function
 def user_list(users):
     """Turn a list of users into a list of links to their profiles."""
-    link = '<a class="user secondary-color" href="%s">%s</a>'
+    link = '<a class="user secondary-color" rel="ugc nofollow" href="%s">%s</a>'
     result_list = ", ".join(
         [link % (escape(profile_url(u)), escape(display_name(u))) for u in users]
     )

--- a/kitsune/users/templatetags/jinja_helpers.py
+++ b/kitsune/users/templatetags/jinja_helpers.py
@@ -60,7 +60,7 @@ def unicode_to_html(text):
 @library.global_function
 def user_list(users):
     """Turn a list of users into a list of links to their profiles."""
-    link = '<a class="user secondary-color" rel="ugc nofollow" href="%s">%s</a>'
+    link = '<a class="user secondary-color" rel="nofollow" href="%s">%s</a>'
     result_list = ", ".join(
         [link % (escape(profile_url(u)), escape(display_name(u))) for u in users]
     )

--- a/kitsune/wiki/jinja2/wiki/history.html
+++ b/kitsune/wiki/jinja2/wiki/history.html
@@ -53,7 +53,7 @@
         <ul class="avatar-wrap">
           {% for u in document.contributors.all() %}
             <li class="avatar-wrap--item">
-                <a class="avatar" href="{{ profile_url(u) }}">
+                <a class="avatar" rel="ugc nofollow" href="{{ profile_url(u) }}">
                   <img src="{{ profile_avatar(u) }}" alt="" />
                   <span class="avatar-wrap--info">{{ display_name(u) }}</span>
                 </a>

--- a/kitsune/wiki/jinja2/wiki/history.html
+++ b/kitsune/wiki/jinja2/wiki/history.html
@@ -53,7 +53,7 @@
         <ul class="avatar-wrap">
           {% for u in document.contributors.all() %}
             <li class="avatar-wrap--item">
-                <a class="avatar" rel="ugc nofollow" href="{{ profile_url(u) }}">
+                <a class="avatar" rel="nofollow" href="{{ profile_url(u) }}">
                   <img src="{{ profile_avatar(u) }}" alt="" />
                   <span class="avatar-wrap--info">{{ display_name(u) }}</span>
                 </a>

--- a/kitsune/wiki/jinja2/wiki/includes/revision_list.html
+++ b/kitsune/wiki/jinja2/wiki/includes/revision_list.html
@@ -84,7 +84,7 @@
            {% endif %}
          </td>
          <td class="creator">
-           <a rel="ugc nofollow" href="{{ profile_url(rev.creator) }}">
+           <a rel="nofollow" href="{{ profile_url(rev.creator) }}">
              {{ display_name(rev.creator) }}
            </a>
          </td>

--- a/kitsune/wiki/jinja2/wiki/includes/revision_list.html
+++ b/kitsune/wiki/jinja2/wiki/includes/revision_list.html
@@ -84,7 +84,7 @@
            {% endif %}
          </td>
          <td class="creator">
-           <a href="{{ profile_url(rev.creator) }}">
+           <a rel="ugc nofollow" href="{{ profile_url(rev.creator) }}">
              {{ display_name(rev.creator) }}
            </a>
          </td>

--- a/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
+++ b/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
@@ -20,7 +20,7 @@
           {% endif %}
           {% if document and document.allow_discussion %}
             <li {{ active|class_selected('discussion') }}>
-              <a href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Discussion') }}</a>
+              <a rel="ugc nofollow" href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Discussion') }}</a>
             </li>
           {% endif %}
           {% if document and not document.is_archived and (document.allows(user, 'create_revision') or document.allows(user, 'edit')) and fallback_reason != "fallback_locale" %}

--- a/kitsune/wiki/jinja2/wiki/locale_details.html
+++ b/kitsune/wiki/jinja2/wiki/locale_details.html
@@ -116,13 +116,13 @@
 {% macro user_row(user) -%}
 <div class="avatar-details user-meta">
   <div class="avatar">
-    <a href="{{ profile_url(user) }}">
+    <a rel="ugc nofollow" href="{{ profile_url(user) }}">
       <img src="{{ profile_avatar(user) }}" alt="" />
     </a>
   </div>
   <div class="user">
     <div class="asked-by">
-      <a class="author-name" href="{{ profile_url(user) }}">
+      <a class="author-name" rel="ugc nofollow" href="{{ profile_url(user) }}">
         <span class="display-name">{{ display_name(user) }}</span>
       </a>
     </div>

--- a/kitsune/wiki/jinja2/wiki/locale_details.html
+++ b/kitsune/wiki/jinja2/wiki/locale_details.html
@@ -116,13 +116,13 @@
 {% macro user_row(user) -%}
 <div class="avatar-details user-meta">
   <div class="avatar">
-    <a rel="ugc nofollow" href="{{ profile_url(user) }}">
+    <a rel="nofollow" href="{{ profile_url(user) }}">
       <img src="{{ profile_avatar(user) }}" alt="" />
     </a>
   </div>
   <div class="user">
     <div class="asked-by">
-      <a class="author-name" rel="ugc nofollow" href="{{ profile_url(user) }}">
+      <a class="author-name" rel="nofollow" href="{{ profile_url(user) }}">
         <span class="display-name">{{ display_name(user) }}</span>
       </a>
     </div>

--- a/kitsune/wiki/jinja2/wiki/revision.html
+++ b/kitsune/wiki/jinja2/wiki/revision.html
@@ -26,7 +26,7 @@
             </li>
             <li>
               <strong>{{ _('Creator:') }}</strong>
-              <span><a href="{{ profile_url(revision.creator) }}">{{ display_name(revision.creator) }}</a></span>
+              <span><a rel="ugc nofollow" href="{{ profile_url(revision.creator) }}">{{ display_name(revision.creator) }}</a></span>
             </li>
             <li>
               <strong>{{ _('Comment:') }}</strong>

--- a/kitsune/wiki/jinja2/wiki/revision.html
+++ b/kitsune/wiki/jinja2/wiki/revision.html
@@ -26,7 +26,7 @@
             </li>
             <li>
               <strong>{{ _('Creator:') }}</strong>
-              <span><a rel="ugc nofollow" href="{{ profile_url(revision.creator) }}">{{ display_name(revision.creator) }}</a></span>
+              <span><a rel="nofollow" href="{{ profile_url(revision.creator) }}">{{ display_name(revision.creator) }}</a></span>
             </li>
             <li>
               <strong>{{ _('Comment:') }}</strong>

--- a/kitsune/wiki/jinja2/wiki/translate.html
+++ b/kitsune/wiki/jinja2/wiki/translate.html
@@ -22,7 +22,7 @@
           </li>
         {% endif %}
 
-        {% if draft_revision %}  
+        {% if draft_revision %}
           <li class="mzp-c-notification-bar mzp-t-info info">
             <button class="mzp-c-notification-bar-button" type="button"></button>
             <div>
@@ -127,7 +127,7 @@
               {% for rev in recent_approved_revs %}
                 <li>
                   <a href="{{ url('wiki.revision', parent.slug, rev.id, locale=parent.locale) }}" rel="nofollow, noindex">{{ datetimeformat(rev.created, format='date') }}</a>:
-                  [<a href="{{ profile_url(rev.creator) }}">{{ display_name(rev.creator) }}</a>]
+                  [<a rel="ugc nofollow" href="{{ profile_url(rev.creator) }}">{{ display_name(rev.creator) }}</a>]
                   {{ rev.comment }}
                 </li>
               {% endfor %}

--- a/kitsune/wiki/jinja2/wiki/translate.html
+++ b/kitsune/wiki/jinja2/wiki/translate.html
@@ -127,7 +127,7 @@
               {% for rev in recent_approved_revs %}
                 <li>
                   <a href="{{ url('wiki.revision', parent.slug, rev.id, locale=parent.locale) }}" rel="nofollow, noindex">{{ datetimeformat(rev.created, format='date') }}</a>:
-                  [<a rel="ugc nofollow" href="{{ profile_url(rev.creator) }}">{{ display_name(rev.creator) }}</a>]
+                  [<a rel="nofollow" href="{{ profile_url(rev.creator) }}">{{ display_name(rev.creator) }}</a>]
                   {{ rev.comment }}
                 </li>
               {% endfor %}


### PR DESCRIPTION
mozilla/sumo#1131

This PR does the following:
- adds `rel="nofollow"` to all user links (NOTE: I didn't consider user links as "content" so I didn't use `ugc`)
- disallows crawling of the KB forums, which are user-generated discussions of KB articles, via `robots.txt`
- adds `rel="ugc nofollow"` to all KB forum links
- adds tests
- adds a doc for notes and policies related to SEO