### PR TITLE
add migration to remove ghost fields from badge tables

### DIFF
--- a/kitsune/kbadge/migrations/0005_drop_ghost_columns.py
+++ b/kitsune/kbadge/migrations/0005_drop_ghost_columns.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+from django.db.utils import OperationalError
+
+
+def drop_ghost_columns(apps, schema_editor):
+    with schema_editor.connection.cursor() as cursor:
+        for table_name, column_name in [
+            ("badger_award", "claim_code"),
+            ("badger_badge", "nominations_accepted"),
+            ("badger_badge", "nominations_autoapproved"),
+        ]:
+            try:
+                cursor.execute(f"ALTER TABLE {table_name} DROP COLUMN {column_name}")
+            except OperationalError:
+                # This should only happen if the column doesn't exist.
+                pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("kbadge", "0004_auto_20200629_0826"),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_ghost_columns, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
mozilla/sumo#1170

Our badge tables (`badger_award` and `badger_badge`) were originally created by a package called `django-badger` that SUMO used. About 4-5 years ago, that package was removed from SUMO, and replaced with a copy of some of the original `django-badger` code. When that was done, some fields were excluded in the `Award` and `Badge` models, but still remained in the tables of the database. Those fields do not allow null values and have no default, so every time a badge or award creation is attempted, it fails because one or more of the ghost fields are never given a value. This PR removes those fields from the DB, but since the `Award` and `Badge` models knows nothing about them, the normal `migrations.RemoveField` approach won't work. We have to run SQL directly. I'd like to run something like `ALTER TABLE badger_award DROP COLUMN IF EXISTS claim_code`, but MySQL doesn't support `IF EXISTS` for that statement (MariaDB and Postgres do), so this PR silently swallows the `OperationalError` exception that occurs if the column doesn't exist.

Another approach, which may be preferable to this migration, is to simply run `ALTER TABLE badger_award DROP COLUMN claim_code` (and similar for the other ghost fields as well) manually on our stage and production databases, and be done with it.