### PR TITLE
Added contributors section to README with profile pictures

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ By participating in this project, you're agreeing to uphold the [Mozilla Communi
 ## Contribute
 
 See our [contribution guide](https://kitsune.readthedocs.io/en/latest/contributors.html), or dive into [setting up your development environment](https://kitsune.readthedocs.io/en/latest/hacking_howto.html).
+
+## Thanks to all the contributors ❤️
+<a href = "https://github.com/mozilla/kitsune/contributors">
+  <img src = "https://contrib.rocks/image?repo=mozilla/kitsune"/>
+</a>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By participating in this project, you're agreeing to uphold the [Mozilla Communi
 
 See our [contribution guide](https://kitsune.readthedocs.io/en/latest/contributors.html), or dive into [setting up your development environment](https://kitsune.readthedocs.io/en/latest/hacking_howto.html).
 
-## Thanks to all the contributors ❤️
+## Thanks to all of our contributors ❤️
 <a href = "https://github.com/mozilla/kitsune/contributors">
   <img src = "https://contrib.rocks/image?repo=mozilla/kitsune"/>
 </a>


### PR DESCRIPTION
This commit adds a new section to the README file that displays a list of all the contributors to the project, along with their profile pictures. The section is styled in a visually appealing way and also provides a way for users to quickly navigate to the profile of each contributor