### PR TITLE
Add l10n process to bootstrap script

### DIFF
--- a/bin/run-bootstrap.sh
+++ b/bin/run-bootstrap.sh
@@ -2,8 +2,12 @@
 
 set -ex
 
+# Install and setup localization
+./scripts/l10n-fetch-lint-compile.sh
+
 # Collect the JavaScript catalog files.
 python manage.py compilejsi18n
+
 # Install Node dependencies, run the weback build, and pre-render the svelte templates.
 npm run development && npm run webpack:build && npm run webpack:build:pre-render
 # Run the DB migrations.


### PR DESCRIPTION
Unit tests now depend on a functional locale folder (see [this pull request](https://github.com/mozilla/kitsune/pull/5362 )). Rather than modify documentation for local development, we can add the step to `run-bootstrap.sh` so the process can be part of the make automation.
