### PR TITLE
remove patch no longer needed for django-activity-stream

### DIFF
--- a/kitsune/questions/apps.py
+++ b/kitsune/questions/apps.py
@@ -1,16 +1,6 @@
 from django.apps import AppConfig
 
 
-def is_installed(model_class):
-    """
-    This is a fix for django-activity-stream 1.4.0 that
-    should fix an issue. Evidently django-activity-stream
-    will have a release just for 4.1 at some point...
-    https://github.com/justquick/django-activity-stream/issues/515
-    """
-    return model_class._meta.app_config is not None
-
-
 class QuestionsConfig(AppConfig):
     name = "kitsune.questions"
     default_auto_field = "django.db.models.AutoField"
@@ -19,11 +9,6 @@ class QuestionsConfig(AppConfig):
         import actstream.registry
 
         from kitsune.questions.badges import register_signals
-
-        """
-        Drop the following line once that release happens
-        """
-        actstream.registry.is_installed = is_installed
 
         Question = self.get_model("Question")
         actstream.registry.register(Question)


### PR DESCRIPTION
mozilla/sumo#1143

This PR removes a patch that is no longer needed now that [version `1.4.2` of `django-activity-stream`](https://github.com/justquick/django-activity-stream/blob/890d13fd23d5c165a9f28841bd8df9b92f6ad662/actstream/registry.py#L55) has been released and incorporated into our codebase.