### PR TITLE
fix user profile serialization of timezone

### DIFF
--- a/kitsune/search/documents.py
+++ b/kitsune/search/documents.py
@@ -353,7 +353,7 @@ class ProfileDocument(SumoDocument):
             return InnerDoc(url=avatar)
 
     def prepare_timezone(self, instance):
-        return instance.timezone if instance.timezone else None
+        return str(instance.timezone) if instance.timezone else None
 
     def prepare_product_ids(self, instance):
         return [product.id for product in instance.products.all()]

--- a/kitsune/users/tests/__init__.py
+++ b/kitsune/users/tests/__init__.py
@@ -1,3 +1,5 @@
+from zoneinfo import ZoneInfo
+
 import factory
 from django.contrib.auth.models import Group, Permission, User
 from django.contrib.contenttypes.models import ContentType
@@ -47,7 +49,7 @@ class ProfileFactory(factory.django.DjangoModelFactory):
     name = FuzzyUnicode()
     bio = FuzzyUnicode()
     website = "http://support.example.com"
-    timezone = None
+    timezone = ZoneInfo("US/Pacific")
     country = "US"
     city = "Portland"
     locale = "en-US"


### PR DESCRIPTION
mozilla/sumo#1186

This PR fixes a bug introduced by https://github.com/mozilla/kitsune/pull/5382, which occurs when indexing user profiles.
- The `timezone` attribute of a profile, which is either `None` or an instance of `zoneinfo.ZoneInfo`, wasn't converted to a string in the latter case when "preparing" the profile for serialization and indexing.
- I also added a `zoneinfo.ZoneInfo` value to the `timezone` attribute of `ProfileFactory` so that this case is now included in the tests.