### PR TITLE
remove React dependency within JS tests

### DIFF
--- a/kitsune/sumo/static/sumo/js/tests/ajaxpreviewtests.js
+++ b/kitsune/sumo/static/sumo/js/tests/ajaxpreviewtests.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect} from 'chai';
 import sinon from 'sinon';
 
@@ -11,25 +10,23 @@ describe('ajax preview', () => {
 
       sinon.stub($, 'ajax').yieldsTo('success', '<p>The content to preview.</p>');
 
-      let sandbox = (
+      $('body').empty().html(`
         <div>
           <form action="" method="post">
-            <input type="hidden" name="csrfmiddlewaretoken" defaultValue="tokenvalue" />
-            <textarea id="id_content" name="content" defaultValue="The content to preview."/>
-            <input type="submit" id="preview" name="preview" defaultValue="Preview"
+            <input type="hidden" name="csrfmiddlewaretoken" value="tokenvalue">
+            <textarea id="id_content" name="content"></textarea>
+            <input type="submit" id="preview" name="preview" value="Preview"
               data-preview-url="/preview"
               data-preview-container-id="preview-container"
-              data-preview-content-id="id_content" />
+              data-preview-content-id="id_content">
           </form>
           <div id="preview-container"></div>
-        </div>
+        </div>`
       );
-      React.render(sandbox, window.document.body);
     });
 
     afterEach(() => {
       $.ajax.restore();
-      React.unmountComponentAtNode(window.document.body);
     });
 
     // This test is mainly about testing the test framework.
@@ -39,7 +36,7 @@ describe('ajax preview', () => {
 
     it('should fire "show-preview" event', done => {
       let ajaxPreview = new AjaxPreview($('#preview'));
-      $(ajaxPreview).bind('show-preview', (e, success, content) => {
+      $(ajaxPreview).on('show-preview', (e, success, content) => {
         expect(success).to.equal(true);
         expect(content).to.equal('<p>The content to preview.</p>');
         done();
@@ -49,7 +46,7 @@ describe('ajax preview', () => {
 
     it('should fire "done" event', done => {
       let ajaxPreview = new AjaxPreview($('#preview'));
-      $(ajaxPreview).bind('done', (e, success) => {
+      $(ajaxPreview).on('done', (e, success) => {
         expect(success).to.equal(true);
         done();
       });
@@ -58,7 +55,7 @@ describe('ajax preview', () => {
 
     it('should show the preview', done => {
       let ajaxPreview = new AjaxPreview($('#preview'));
-      $(ajaxPreview).bind('done', (e, success) => {
+      $(ajaxPreview).on('done', (e, success) => {
         expect($('#preview-container').html())
           .to.equal('<p>The content to preview.</p>');
         done();

--- a/kitsune/sumo/static/sumo/js/tests/ajaxvotetests.js
+++ b/kitsune/sumo/static/sumo/js/tests/ajaxvotetests.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect} from 'chai';
 import sinon from 'sinon';
 
@@ -8,19 +7,16 @@ describe('ajaxvote', () => {
   describe('helpful vote', () => {
     beforeEach(() => {
       sinon.stub($, 'ajax').yieldsTo('success', {message: 'Thanks for the vote!'});
-
-      let sandbox = (
-        <form className="vote" action="/vote" method="post">
-          <input type="submit" name="helpful" defaultValue="Yes" />
-          <input type="submit" name="not-helpful" defaultValue="No" />
-        </form>
+      $('body').empty().html(`
+        <form class="vote" action="/vote" method="post">
+          <input type="submit" name="helpful" value="Yes">
+          <input type="submit" name="not-helpful" value="No">
+        </form>`
       );
-      React.render(sandbox, document.body);
     });
 
     afterEach(() => {
       $.ajax.restore();
-      React.unmountComponentAtNode(document.body);
       $(document).off('vote');
     });
 

--- a/kitsune/sumo/static/sumo/js/tests/crashidtests.js
+++ b/kitsune/sumo/static/sumo/js/tests/crashidtests.js
@@ -1,16 +1,12 @@
 import {expect} from 'chai';
-import React from 'react';
 
 import { linkCrashIds } from "sumo/js/questions";
 
 describe('k', () => {
   describe('linkCrashIds', () => {
-    afterEach(() => {
-      React.unmountComponentAtNode(document.body);
-    });
 
     it('should link one crash ID', () => {
-      let sandbox = (
+      $('body').empty().html(`
         <section>
           <h1>Firefox keeps crashing</h1>
           <p>Firefox keeps crashing</p>
@@ -18,17 +14,15 @@ describe('k', () => {
             This is my crash ID:<br/>
             bp-6ec83338-f37e-4ee1-aef4-0e66c2120808
           </p>
-          <div className="stem"></div>
-        </section>
+          <div class="stem"></div>
+        </section>`
       );
-      React.render(sandbox, document.body);
-
       linkCrashIds($('body'));
       expect($('.crash-report').length).to.equal(1);
     });
 
     it('should link multiple crash IDs', function() {
-      let sandbox = (
+      $('body').empty().html(`
         <section>
           <h1>Firefox keeps crashing</h1>
           <p>Firefox keeps crashing</p>
@@ -40,37 +34,31 @@ describe('k', () => {
             bp-15a73687-dabf-4014-9c03-b97b3212071717.07.1211:27
             bp-f894adf7-9ff8-4f21-8564-da425212071111.07.1218:22
           </p>
-          <div className="stem"></div>
-        </section>
+          <div class="stem"></div>
+        </section>`
       );
-      React.render(sandbox, document.body);
-
       linkCrashIds($('body'));
       expect($('.crash-report').length).to.equal(5);
     });
 
     it("shouldn't link invalid crash IDs", function() {
-      let sandbox = (
+      $('body').empty().html(`
         <section>
           <p>The following will look like an invalid crash ID that hasn't been processed yet:</p>
           <p>765879E6-CFE7-43A7-BE93-B2F322E67649</p>
-        </section>
+        </section>`
       );
-      React.render(sandbox, document.body);
       linkCrashIds($('body'));
-
       expect($('.crash-report').length).to.equal(0);
     });
 
     it("shouldn't link crash IDs without 'bp-'", function() {
-      let sandbox = (
+      $('body').empty().html(`
         <section>
           <p>Now, crash IDs without 'bp-' at the beginning shouldn't get linked either</p>
           <p>6ec83338-f37e-4ee1-aef4-0e66c2120808</p>
-        </section>
+        </section>`
       );
-      React.render(sandbox, document.body);
-
       linkCrashIds($('body'));
       expect($('.crash-report').length).to.equal(0);
     });

--- a/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
@@ -1,5 +1,4 @@
 import {default as chai, expect} from 'chai';
-import React from 'react';
 import chaiLint from 'chai-lint';
 import sinon from 'sinon';
 
@@ -17,20 +16,18 @@ describe('instant search', () => {
       clock = sinon.useFakeTimers();
       cxhrMock = sinon.fake();
       sinon.replace(CachedXHR.prototype, "request", cxhrMock);
-      let content = (
+      $('body').empty().html(`
         <div>
-          <div id="main-content"/>
-          <form data-instant-search="form" action="" method="get" className="simple-search-form">
-            <input type="search" name="q" className="searchbox" id="search-q"/>
-            <button type="submit" title="{{ _('Search') }}" className="submit-button">Search</button>
+          <div id="main-content"></div>
+          <form data-instant-search="form" action="" method="get" class="simple-search-form">
+            <input type="search" name="q" class="searchbox" id="search-q">
+            <button type="submit" title="Search" class="submit-button">Search</button>
           </form>
-        </div>
+        </div>`
       );
-      React.render(content, document.body);
     });
 
     afterEach(() => {
-      React.unmountComponentAtNode(document.body);
       clock.restore();
       sinon.restore();
     });

--- a/kitsune/sumo/static/sumo/js/tests/kboxtests.js
+++ b/kitsune/sumo/static/sumo/js/tests/kboxtests.js
@@ -1,5 +1,4 @@
 import {default as chai, expect} from 'chai';
-import React from 'react';
 import chaiLint from 'chai-lint';
 
 import KBox from "sumo/js/kbox.js";
@@ -11,26 +10,21 @@ describe('kbox', () => {
     let $kbox, kbox;
 
     beforeEach(() => {
-      let sandbox = (
+      $('body').empty().html(`
         <div id="sandbox">
-          <div className="kbox"
+          <div class="kbox"
                data-title="ignored title"
                title="test kbox"
                data-target="#sandbox a.kbox-target"
                data-modal="true">
             <p>lorem ipsum dolor sit amet.</p>
           </div>
-          <a href="#" className="kbox-target">click me</a>
-        </div>
+          <a href="#" class="kbox-target">click me</a>
+        </div>`
       );
-      React.render(sandbox, document.body);
 
       $kbox = $('.kbox');
       kbox = new KBox($kbox);
-    });
-
-    afterEach(() => {
-      React.unmountComponentAtNode(document.body);
     });
 
     it('should open when the target is clicked', () => {

--- a/kitsune/sumo/static/sumo/js/tests/lazyloadtests.js
+++ b/kitsune/sumo/static/sumo/js/tests/lazyloadtests.js
@@ -1,13 +1,13 @@
 import {default as chai, expect} from 'chai';
-import React from 'react';
 import chaiLint from 'chai-lint';
 
 chai.use(chaiLint);
 
 describe('lazyload', () => {
   it('should load original image', () => {
-    let img = <img className="lazy" data-original-src="http://example.com/test.jpg"/>;
-    React.render(img, document.body);
+    $('body').empty().html(`
+      <img class="lazy" data-original-src="http://example.com/test.jpg">`
+    );
     let $img = $('img');
 
     $.fn.lazyload.loadOriginalImage($img);

--- a/kitsune/sumo/static/sumo/js/tests/showfortests.js
+++ b/kitsune/sumo/static/sumo/js/tests/showfortests.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {default as chai, expect} from 'chai';
 import chaiLint from 'chai-lint';
 import sinon from 'sinon';
@@ -32,29 +31,29 @@ describe('ShowFor', () => {
 
   beforeEach(() => {
     // Wow. That's a lot of data. Can we make this smaller?
-    let sandbox = (
+    $('body').empty().html(`
       <div>
-        <span className="for" data-for="fx24"></span>
-        <span className="for" data-for="fx24,win"></span>
-        <span className="for" data-for="=fx25"></span>
-        <span className="for" data-for="not m25"></span>
+        <span class="for" data-for="fx24"></span>
+        <span class="for" data-for="fx24,win"></span>
+        <span class="for" data-for="=fx25"></span>
+        <span class="for" data-for="not m25"></span>
 
-        <div className="product" data-product="firefox">
+        <div class="product" data-product="firefox">
           <h2>
-            <input type="checkbox" defaultChecked value="product:firefox"/>
+            <input type="checkbox" checked value="product:firefox">
             Firefox
           </h2>
-          <div className="selectbox-wrapper">
-            <select className="version" value="version:fx24">
+          <div class="selectbox-wrapper">
+            <select class="version" value="version:fx24">
               <option value="version:fx26" data-min="26.0" data-max="27.0">Version 26</option>
               <option value="version:fx25" data-min="25.0" data-max="26.0">Version 25</option>
-              <option value="version:fx24" data-min="24.0" data-max="25.0">Version 24</option>
+              <option value="version:fx24" data-min="24.0" data-max="25.0" selected>Version 24</option>
               <option value="version:fx23" data-min="23.0" data-max="24.0">Version 23</option>
               <option value="version:fx17" data-min="17.0" data-max="18.0">Version 17 (ESR)</option>
             </select>
           </div>
-          <div className="selectbox-wrapper">
-            <select className="platform">
+          <div class="selectbox-wrapper">
+            <select class="platform">
               <option value="platform:win8">Windows 8</option>
               <option value="platform:win7">Windows 7/Vista</option>
               <option value="platform:winxp">Windows XP</option>
@@ -64,59 +63,60 @@ describe('ShowFor', () => {
           </div>
         </div>
 
-        <div className="product" data-product="mobile">
+        <div class="product" data-product="mobile">
           <h2>
-            <input type="checkbox" defaultChecked value="product:mobile"/>
+            <input type="checkbox" checked value="product:mobile">
             Firefox for Android
           </h2>
-          <div className="selectbox-wrapper">
-            <select className="version" value="version:m24">
+          <div class="selectbox-wrapper">
+            <select class="version" value="version:m24">
               <option value="version:m26" data-min="26.0" data-max="27.0">Version 26</option>
               <option value="version:m25" data-min="25.0" data-max="26.0">Version 25</option>
-              <option value="version:m24" data-min="24.0" data-max="25.0">Version 24</option>
+              <option value="version:m24" data-min="24.0" data-max="25.0" selected>Version 24</option>
               <option value="version:m23" data-min="23.0" data-max="24.0">Version 23</option>
             </select>
           </div>
         </div>
 
-        <script type="application/json" className="showfor-data" dangerouslySetInnerHTML={{__html: JSON.stringify({
-          platforms: {
-            firefox: [
-              {title: 'Linux', slug: 'linux', visible: true},
-              {title: 'Mac', slug: 'mac', visible: true},
-              {title: 'Windows XP', slug: 'winxp', visible: true},
-              {title: 'Windows 7', slug: 'win7', visible: true},
-              {title: 'Windows 8', slug: 'win8', visible: true},
-              {title: 'Windows 10', slug: 'win10', visible: true},
+        <script type="application/json" class="showfor-data">
+          {
+            "platforms": {
+              "firefox": [
+                {"title": "Linux", "slug": "linux", "visible": true},
+                {"title": "Mac", "slug": "mac", "visible": true},
+                {"title": "Windows XP", "slug": "winxp", "visible": true},
+                {"title": "Windows 7", "slug": "win7", "visible": true},
+                {"title": "Windows 8", "slug": "win8", "visible": true},
+                {"title": "Windows 10", "slug": "win10", "visible": true}
+              ],
+              "mobile": [{"slug": "android"}],
+              "firefox-os": [{"slug": "web"}]
+            },
+            "products": [
+              {"slug": "firefox", "title": "Firefox", "platforms": ["linux", "mac", "winxp", "win7", "win8"]},
+              {"slug": "mobile", "title": "Firefox for Android", "platforms": ["android"]},
+              {"slug": "firefox-os", "title": "Firefox OS", "platforms": ["web"]}
             ],
-            mobile: [{slug: 'android'}],
-            'firefox-os': [{slug: 'web'}],
-          },
-          products: [
-            {slug: 'firefox', title: 'Firefox', platforms: ['linux', 'mac', 'winxp', 'win7', 'win8']},
-            {slug: 'mobile', title: 'Firefox for Android', platforms: ['android']},
-            {slug: 'firefox-os', title: 'Firefox OS', platforms: ['web']},
-          ],
-          'versions': {
-            firefox: [
-              {product: 'firefox', name: 'Version 26', default: false, min_version: 26.0, max_version: 27.0, slug: 'fx26'},
-              {product: 'firefox', name: 'Version 25', default: false, min_version: 25.0, max_version: 26.0, slug: 'fx25'},
-              {product: 'firefox', name: 'Version 24', default: true, min_version: 24.0, max_version: 25.0, slug: 'fx24'},
-              {product: 'firefox', name: 'Version 23', default: false, min_version: 23.0, max_version: 24.0, slug: 'fx23'},
-              {product: 'firefox', name: 'Version 17 (ESR)', default: false, min_version: 17.0, max_version: 18.0, slug: 'fx17'},
-            ],
-            mobile: [
-              {product: 'mobile', name: 'Version 26', default: false, min_version: 26.0, max_version: 27.0, slug: 'm26'},
-              {product: 'mobile', name: 'Version 25', default: false, min_version: 25.0, max_version: 26.0, slug: 'm25'},
-              {product: 'mobile', name: 'Version 24', default: true, min_version: 24.0, max_version: 25.0, slug: 'm24'},
-              {product: 'mobile', name: 'Version 23', default: false, min_version: 23.0, max_version: 24.0, slug: 'm23'},
-            ],
+            "versions": {
+              "firefox": [
+                {"product": "firefox", "name": "Version 26", "default": false, "min_version": 26.0, "max_version": 27.0, "slug": "fx26"},
+                {"product": "firefox", "name": "Version 25", "default": false, "min_version": 25.0, "max_version": 26.0, "slug": "fx25"},
+                {"product": "firefox", "name": "Version 24", "default": true, "min_version": 24.0, "max_version": 25.0, "slug": "fx24"},
+                {"product": "firefox", "name": "Version 23", "default": false, "min_version": 23.0, "max_version": 24.0, "slug": "fx23"},
+                {"product": "firefox", "name": "Version 17 (ESR)", "default": false, "min_version": 17.0, "max_version": 18.0, "slug": "fx17"}
+              ],
+              "mobile": [
+                {"product": "mobile", "name": "Version 26", "default": false, "min_version": 26.0, "max_version": 27.0, "slug": "m26"},
+                {"product": "mobile", "name": "Version 25", "default": false, "min_version": 25.0, "max_version": 26.0, "slug": "m25"},
+                {"product": "mobile", "name": "Version 24", "default": true, "min_version": 24.0, "max_version": 25.0, "slug": "m24"},
+                {"product": "mobile", "name": "Version 23", "default": false, "min_version": 23.0, "max_version": 24.0, "slug": "m23"}
+              ]
+            }
           }
-        })}}/>
-      </div>
+        </script>
+      </div>`
     );
 
-    React.render(sandbox, document.body);
     showFor = showForNoInit($('body'));
 
     sinon.stub(navigator, "userAgent").get(() =>
@@ -275,6 +275,7 @@ describe('ShowFor', () => {
       showFor.loadData();
       await showFor.updateUI();
       showFor.updateState();
+      showFor.initShowFuncs();
     });
 
     it('should show and hide elements correctly', () => {

--- a/kitsune/sumo/static/sumo/js/tests/tagsfiltertests.js
+++ b/kitsune/sumo/static/sumo/js/tests/tagsfiltertests.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect} from 'chai';
 
 import TagsFilter from "sumo/js/tags.filter";
@@ -6,34 +5,33 @@ import TagsFilter from "sumo/js/tags.filter";
 describe('k', () => {
   describe('TagsFilter', () => {
     beforeEach(() => {
-      let sandbox = (
+      $('body').empty().html(`
         <div>
-          <section className="tag-filter">
+          <section class="tag-filter">
             <form method="get" action="">
               <input type="text"
                      name="tagged"
-                     className="text tags-autocomplete"
-                     defaultValue="Go"
-                     data-vocabulary={JSON.stringify({
-                       'Name 1': 'slug-1',
-                       'Name 2': 'slug-2',
-                       'Name 3': 'slug-3',
-                     })}/>
-              <input type="submit" defaultValue="Go" />
+                     class="text tags-autocomplete"
+                     value="Go"
+                     data-vocabulary="{
+                       &quot;Name 1&quot;: &quot;slug-1&quot;,
+                       &quot;Name 2&quot;: &quot;slug-2&quot;,
+                       &quot;Name 3&quot;: &quot;slug-3&quot;
+                     }">
+              <input type="submit" value="Go">
             </form>
           </section>
-        </div>
+        </div>`
       );
-      React.render(sandbox, window.document.body);
 
       TagsFilter.init($('body'));
       // Don't let forms submit
-      $('form').submit((e) => e.preventDefault());
+      $('form').on("submit", (e) => e.preventDefault());
     });
 
     function check(input, output) {
       $('form').find('input[type="text"]').val(input);
-      $('form').submit();
+      $('form').trigger("submit");
       expect($('form').find('input[name="tagged"]').val()).to.equal(output);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
       },
       "devDependencies": {
         "@babel/core": "^7.16.7",
-        "@babel/plugin-transform-react-jsx": "^7.16.7",
         "@babel/plugin-transform-runtime": "^7.16.7",
         "@babel/preset-env": "^7.16.7",
         "@mozilla-protocol/core": "10.0.1",
@@ -57,7 +56,6 @@
         "postcss": "^8.4.5",
         "postcss-custom-properties": "^12.0.2",
         "postcss-loader": "^6.2.1",
-        "react": "^0.13.3",
         "sass": "^1.45.2",
         "sass-loader": "^12.4.0",
         "sinon": "12.0.1",
@@ -863,21 +861,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
-      "integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
@@ -1341,25 +1324,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.7.tgz",
-      "integrity": "sha512-8D16ye66fxiE8m890w0BpPpngG9o9OVBBy0gH2E+2AR7qMR2ZpTYJEqLxAsoroenMId0p/wMW+Blc0meDgu0Ag==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-jsx": "^7.16.7",
-        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2456,15 +2420,6 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -2629,15 +2584,6 @@
         "node": "*"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2788,15 +2734,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/base62": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
-      "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3874,51 +3811,6 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
-    "node_modules/commoner": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-      "dev": true,
-      "dependencies": {
-        "commander": "^2.5.0",
-        "detective": "^4.3.1",
-        "glob": "^5.0.15",
-        "graceful-fs": "^4.1.2",
-        "iconv-lite": "^0.4.5",
-        "mkdirp": "^0.5.0",
-        "private": "^0.1.6",
-        "q": "^1.1.2",
-        "recast": "^0.11.17"
-      },
-      "bin": {
-        "commonize": "bin/commonize"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/commoner/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
-    },
-    "node_modules/commoner/node_modules/glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/compression-webpack-plugin": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz",
@@ -4921,12 +4813,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4958,28 +4844,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/detective": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^5.2.1",
-        "defined": "^1.0.0"
-      }
-    },
-    "node_modules/detective/node_modules/acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/dev-ip": {
@@ -5386,19 +5250,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/envify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
-      "integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
-      "dev": true,
-      "dependencies": {
-        "jstransform": "^11.0.3",
-        "through": "~2.3.4"
-      },
-      "bin": {
-        "envify": "bin/envify"
       }
     },
     "node_modules/envinfo": {
@@ -5996,19 +5847,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/esprima-fb": {
-      "version": "15001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/esquery": {
@@ -8152,46 +7990,6 @@
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jstransform": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-      "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-      "dev": true,
-      "dependencies": {
-        "base62": "^1.1.0",
-        "commoner": "^0.10.1",
-        "esprima-fb": "^15001.1.0-dev-harmony-fb",
-        "object-assign": "^2.0.0",
-        "source-map": "^0.4.2"
-      },
-      "bin": {
-        "jstransform": "bin/jstransform"
-      },
-      "engines": {
-        "node": ">=0.8.8"
-      }
-    },
-    "node_modules/jstransform/node_modules/object-assign": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-      "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jstransform/node_modules/source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "dev": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/junk": {
@@ -10601,15 +10399,6 @@
         "renderkid": "^3.0.0"
       }
     },
-    "node_modules/private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -10660,16 +10449,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {
@@ -10761,18 +10540,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/react": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.13.3.tgz",
-      "integrity": "sha512-f9bivPvgNqGmcxjSuKCkY27YVKi1RlDm4TlPUNjLDH7lN6gnMQp9lJ9PpTVbo9kNEBr2BIZLz1kI/RFh9Cq2Kg==",
-      "dev": true,
-      "dependencies": {
-        "envify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/read-pkg": {
@@ -10962,34 +10729,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/recast": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-      "dev": true,
-      "dependencies": {
-        "ast-types": "0.9.6",
-        "esprima": "~3.1.0",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/recast/node_modules/esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/rechoir": {
@@ -14789,15 +14528,6 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
-      "integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
-      }
-    },
     "@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
@@ -15099,19 +14829,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.16.7"
-      }
-    },
-    "@babel/plugin-transform-react-jsx": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.7.tgz",
-      "integrity": "sha512-8D16ye66fxiE8m890w0BpPpngG9o9OVBBy0gH2E+2AR7qMR2ZpTYJEqLxAsoroenMId0p/wMW+Blc0meDgu0Ag==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-jsx": "^7.16.7",
-        "@babel/types": "^7.16.7"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -16014,12 +15731,6 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -16133,12 +15844,6 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "ast-types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
-      "dev": true
-    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -16250,12 +15955,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "base62": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
-      "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA==",
       "dev": true
     },
     "base64-js": {
@@ -17120,44 +16819,6 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
-    "commoner": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-      "dev": true,
-      "requires": {
-        "commander": "^2.5.0",
-        "detective": "^4.3.1",
-        "glob": "^5.0.15",
-        "graceful-fs": "^4.1.2",
-        "iconv-lite": "^0.4.5",
-        "mkdirp": "^0.5.0",
-        "private": "^0.1.6",
-        "q": "^1.1.2",
-        "recast": "^0.11.17"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
     "compression-webpack-plugin": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz",
@@ -17914,12 +17575,6 @@
         "object-keys": "^1.0.12"
       }
     },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -17943,24 +17598,6 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
-    },
-    "detective": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-      "dev": true,
-      "requires": {
-        "acorn": "^5.2.1",
-        "defined": "^1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
-          "dev": true
-        }
-      }
     },
     "dev-ip": {
       "version": "1.0.1",
@@ -18265,16 +17902,6 @@
           "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
           "dev": true
         }
-      }
-    },
-    "envify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
-      "integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
-      "dev": true,
-      "requires": {
-        "jstransform": "^11.0.3",
-        "through": "~2.3.4"
       }
     },
     "envinfo": {
@@ -18731,12 +18358,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
-    },
-    "esprima-fb": {
-      "version": "15001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=",
       "dev": true
     },
     "esquery": {
@@ -20322,36 +19943,6 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "jstransform": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-      "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-      "dev": true,
-      "requires": {
-        "base62": "^1.1.0",
-        "commoner": "^0.10.1",
-        "esprima-fb": "^15001.1.0-dev-harmony-fb",
-        "object-assign": "^2.0.0",
-        "source-map": "^0.4.2"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
       }
     },
     "junk": {
@@ -22084,12 +21675,6 @@
         "renderkid": "^3.0.0"
       }
     },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -22134,12 +21719,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
@@ -22199,15 +21778,6 @@
         "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "react": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.13.3.tgz",
-      "integrity": "sha512-f9bivPvgNqGmcxjSuKCkY27YVKi1RlDm4TlPUNjLDH7lN6gnMQp9lJ9PpTVbo9kNEBr2BIZLz1kI/RFh9Cq2Kg==",
-      "dev": true,
-      "requires": {
-        "envify": "^3.0.0"
       }
     },
     "read-pkg": {
@@ -22349,26 +21919,6 @@
       "devOptional": true,
       "requires": {
         "picomatch": "^2.2.1"
-      }
-    },
-    "recast": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.9.6",
-        "esprima": "~3.1.0",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        }
       }
     },
     "rechoir": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.7",
-    "@babel/plugin-transform-react-jsx": "^7.16.7",
     "@babel/plugin-transform-runtime": "^7.16.7",
     "@babel/preset-env": "^7.16.7",
     "@mozilla-protocol/core": "10.0.1",
@@ -84,7 +83,6 @@
     "postcss": "^8.4.5",
     "postcss-custom-properties": "^12.0.2",
     "postcss-loader": "^6.2.1",
-    "react": "^0.13.3",
     "sass": "^1.45.2",
     "sass-loader": "^12.4.0",
     "sinon": "12.0.1",

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -17,7 +17,6 @@ module.exports = merge(common, {
           loader: "babel-loader",
           options: {
             presets: ["@babel/preset-env"],
-            plugins: ["@babel/plugin-transform-react-jsx"],
           },
         },
       },


### PR DESCRIPTION
mozilla/sumo#1185

This PR removes the dependency on React within the JS tests. React was used only within our tests, and only for the convenience of using JSX to create HTML for each test. Whatever purpose it served originally, no longer exists, and it has become a unnecessary complication that's best removed. With this PR, it is replaced with simple JQuery (`$("body").empty().html(...)`).

Some notes:
- This PR only changes the way the HTML is created for the tests. Nothing else has been changed, except for the case of the `showAndHide` tests (see note below).
- The `showAndHide` tests are the only exception. I had to add `showFor.initShowFuncs();` to its `beforeEach()` set-up function. To understand why, you first have to understand a misleading, subtle issue in the React-based `kitsune/sumo/static/sumo/js/tests/showfortests.js`. In the React-based version, the same DOM elements are re-used for every test case, because the HTML created for each test case is **never** unmounted. This means that any DOM changes (like changing a data attribute of an element) persist from test to test, and suddenly the order of the tests can make a difference. The only reason why the `showAndHide` tests worked in the React-based version is because the `initShowFuncs` tests were run just prior, and the DOM changes they introduced with `showFor.initShowFuncs();` persisted into the run of the `showAndHide` tests, which depended on them. In my new version of `kitsune/sumo/static/sumo/js/tests/showfortests.js`, the DOM is created fresh for each test (because of the `$('body').empty()`), so `showFor.initShowFuncs();` has to be explicitly called before the `showAndHide` tests (which is what happens in real usage anyway, because `initShowFuncs()` is called in the `showFor` constructor, which is bypassed in the tests).
- One of the primary tasks, when creating this PR, was translating React's JSX into plain, vanilla HTML. So, for example, attributes like `className` and `defaultValue` become `class` and `value`, and `<input ... />` becomes `<input ... >`.
- Removing `react` from our dev dependencies also meant that we could remove `@babel/plugin-transform-react-jsx` as well.