### PR TITLE
sync black version in pre-commit with poetry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         files: "^kitsune/"


### PR DESCRIPTION
While working on setting-up `mypy` within `pre-commit`, I discovered this little adjustment.