### PR TITLE
add mypy type-checking to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,22 @@ repos:
           - prettier@2.7.1
           - prettier-plugin-svelte@2.7.0
         files: "^svelte/"
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.0.1
+    hooks:
+      - id: mypy
+        # Add to the "additional_dependencies" list below any poetry
+        # dependencies or their stub packages that provide type hints.
+        additional_dependencies:
+          - boto3-stubs==1.26.71
+          - types-redis==4.5.1
+          - types-requests==2.28.11.12
+          - types-bleach==6.0.0.0
+          - types-python-dateutil==2.8.19.7
+          - types-simplejson==3.18.0.0
+          - types-PyMySQL==1.0.19.3
+        files: "^kitsune/"
+        exclude: "/migrations/"
 
   # - repo: https://github.com/pre-commit/mirrors-eslint
   #   rev: v8.1.0

--- a/docs/architecture/decisions/0001-record-architecture-decisions.md
+++ b/docs/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,4 +1,4 @@
-# 1. Record architecture decisions
+# 1 - Record architecture decisions
 
 Date: 2019-01-10
 

--- a/docs/architecture/decisions/0002-es-l10n-content.md
+++ b/docs/architecture/decisions/0002-es-l10n-content.md
@@ -1,4 +1,4 @@
-# 2. Storing localized content in Search
+# 2 - Storing localized content in Search
 
 Date: 2020-10-27
 

--- a/docs/architecture/decisions/0003-es-aaq-documents.md
+++ b/docs/architecture/decisions/0003-es-aaq-documents.md
@@ -1,4 +1,4 @@
-# 3. AAQ structure in Search
+# 3 - AAQ structure in Search
 
 Date: 2020-10-27
 

--- a/docs/architecture/decisions/0004-type-checking.md
+++ b/docs/architecture/decisions/0004-type-checking.md
@@ -1,0 +1,57 @@
+# 4 - Type Hints and Checking
+
+Date: 2023-02-15
+
+## Status
+
+Pending
+
+## Context
+
+With support for [type hints](https://docs.python.org/3/library/typing.html)
+and [static type-checking tools](https://mypy-lang.org/) solidly entrenched in
+the Python eco-system, we'd like to take advantage of both within Kitsune. The
+goal is to support
+[gradual typing](https://peps.python.org/pep-0483/#summary-of-gradual-typing),
+to support the addition of type-hints only where they're helpful, where their
+addition adds more value than their burden.
+
+Type hints can be helpful to quickly understand the types of values expected by
+functions and methods, as well as the types of their results, easing the burden
+of using those functions/methods for the first time. It encourages modularity,
+since one doesn't have to dig into the details of the underlying code to discover
+what's expected. Once in place, they also enable the use of static type-checking
+tools, which can flag basic interface errors, for example, when you're passing a
+`str` into a function that expects an `int`.
+
+Type hints can sometimes be an undue burden as well. In some cases determining
+the correct type can be difficult, time-consuming, and the outcome unintuitive.
+In those cases, it's probably better to skip them.
+
+In the end, it's important to remember that type hints and static type-checking
+are never a substitute for testing. Writing good tests for your code is essential
+whether you add type hints or not.
+
+## Decision
+
+We recommend that all pull requests that modify/create Python functions and/or
+methods, add a type hint for each of the function/method arguments as well as the
+result. There's a judgement call here though. If it's an "undue burden", skip it.
+If not, do it.
+
+Also, we will run a static type-checking tool, either prior to commits, or during
+CI, or both.
+
+## Consequences
+
+There are two primary consequences.
+
+- An easier, less error-prone coding experience when working with unfamiliar Python
+  functions/methods.
+
+- We reap the benefits of using a static type-checking tool. For example, the
+  detection, prior to run time, of interface errors, where the types passed into
+  functions/methods or the results returned are not what's expected.
+
+There is the potential for this to have a negative consequence as well. It could slow
+us down. It could cost more than its worth. So, it's important to keep in mind the tradeoff. Type hints should only be added where they're helpful.

--- a/docs/conventions.rst
+++ b/docs/conventions.rst
@@ -15,6 +15,13 @@ bootcamp guide
 
 It is recommended that you :ref:`install pre-commit<hacking_howto:Install linting tools>`.
 
+Type hints
+----------
+When creating and/or modifying Python functions/methods, we add `type hints
+<https://docs.python.org/3/library/typing.html>`_ to their arguments and result,
+but only when it makes sense. See
+:doc:`our Architectural Decision Record<architecture/decisions/0004-type-checking>`
+for more details.
 
 Git conventions
 ===============

--- a/kitsune/announcements/admin.py
+++ b/kitsune/announcements/admin.py
@@ -19,7 +19,7 @@ class AnnouncementAdmin(admin.ModelAdmin):
             return "Yes (always)"
         return ""
 
-    is_visible.short_description = "Visible?"
+    is_visible.short_description = "Visible?"  # type: ignore
 
     def save_model(self, request, obj, form, change):
         if not obj.pk:

--- a/kitsune/announcements/models.py
+++ b/kitsune/announcements/models.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from datetime import datetime
 from typing import Self
 
@@ -64,7 +65,7 @@ class Announcement(ModelBase):
         return cls._visible_query(group=None, locale=None)
 
     @classmethod
-    def get_for_groups(cls, group_ids: list[int] | QuerySet) -> QuerySet[Self]:
+    def get_for_groups(cls, group_ids: Iterable[int]) -> QuerySet[Self]:
         """Returns visible announcements for a given group id."""
         return cls._visible_query(group__id__in=group_ids)
 

--- a/kitsune/dashboards/admin.py
+++ b/kitsune/dashboards/admin.py
@@ -11,7 +11,7 @@ class WikiMetricAdmin(admin.ModelAdmin):
     def locale_code(self, obj):
         return obj.locale
 
-    locale_code.short_description = "Locale Code"
+    locale_code.short_description = "Locale Code"  # type: ignore
 
 
 admin.site.register(WikiMetric, WikiMetricAdmin)

--- a/kitsune/dashboards/readouts.py
+++ b/kitsune/dashboards/readouts.py
@@ -486,7 +486,7 @@ class Readout(object):
     column3_label = _lazy("Visits in last 30 days")
     column4_label = _lazy("Status")
     modes = [(MOST_VIEWED, _lazy("Most Viewed")), (MOST_RECENT, _lazy("Most Recent"))]
-    default_mode = MOST_VIEWED
+    default_mode: int | None = MOST_VIEWED
 
     def __init__(self, request, locale=None, mode=None, product=None):
         """Take request so the template can use contextual macros that need it.
@@ -1216,13 +1216,13 @@ class CannedResponsesReadout(Readout):
 
 # L10n Dashboard tables that have their own whole-page views:
 L10N_READOUTS = OrderedDict(
-    (t.slug, t)
+    (t.slug, t)  # type: ignore
     for t in [MostVisitedTranslationsReadout, TemplateTranslationsReadout, UnreviewedReadout]
 )
 
 # Contributors ones:
 CONTRIBUTOR_READOUTS = OrderedDict(
-    (t.slug, t)
+    (t.slug, t)  # type: ignore
     for t in [
         MostVisitedDefaultLanguageReadout,
         TemplateReadout,
@@ -1240,7 +1240,7 @@ READOUTS = L10N_READOUTS.copy()
 READOUTS.update(CONTRIBUTOR_READOUTS)
 
 GROUP_L10N_READOUTS = OrderedDict(
-    (t.slug, t) for t in [MostVisitedTranslationsReadout, UnreviewedReadout]
+    (t.slug, t) for t in [MostVisitedTranslationsReadout, UnreviewedReadout]  # type: ignore
 )
 # English group locale is the same as l10n dashboard.
 GROUP_CONTRIBUTOR_READOUTS = CONTRIBUTOR_READOUTS

--- a/kitsune/gallery/api.py
+++ b/kitsune/gallery/api.py
@@ -17,7 +17,7 @@ class ImageShortSerializer(serializers.ModelSerializer):
 
     class Meta(object):
         model = Image
-        fields = ("id", "title", "url", "locale", "width", "height")
+        fields: tuple[str, ...] = ("id", "title", "url", "locale", "width", "height")
 
 
 class ImageDetailSerializer(ImageShortSerializer):

--- a/kitsune/kbadge/admin.py
+++ b/kitsune/kbadge/admin.py
@@ -20,7 +20,7 @@ def show_image(obj):
     )
 
 
-show_image.short_description = "Image"
+show_image.short_description = "Image"  # type: ignore
 
 
 def build_related_link(self, model_name, name_single, name_plural, qs):
@@ -41,7 +41,7 @@ def related_awards_link(self):
     return mark_safe(build_related_link(self, "award", "award", "awards", self.award_set))
 
 
-related_awards_link.short_description = "Awards"
+related_awards_link.short_description = "Awards"  # type: ignore
 
 
 class BadgeAdmin(admin.ModelAdmin):
@@ -80,7 +80,7 @@ def badge_link(self):
     return mark_safe('<a href="%s">%s</a>' % (url, self.badge))
 
 
-badge_link.short_description = "Badge"
+badge_link.short_description = "Badge"  # type: ignore
 
 
 class AwardAdmin(admin.ModelAdmin):
@@ -110,7 +110,7 @@ def award_link(self):
     return mark_safe('<a href="%s">%s</a>' % (url, self.award))
 
 
-award_link.short_description = "award"
+award_link.short_description = "award"  # type: ignore
 
 
 for x in (

--- a/kitsune/kbadge/models.py
+++ b/kitsune/kbadge/models.py
@@ -138,10 +138,6 @@ class BadgeException(Exception):
     """General Badger model exception"""
 
 
-class BadgeException(BadgeException):
-    """Badge model exception"""
-
-
 class BadgeAwardNotAllowedException(BadgeException):
     """Attempt to award a badge not allowed."""
 

--- a/kitsune/log_settings.py
+++ b/kitsune/log_settings.py
@@ -1,5 +1,6 @@
 import logging
 import logging.config
+import logging.handlers
 
 from django.conf import settings
 

--- a/kitsune/products/admin.py
+++ b/kitsune/products/admin.py
@@ -15,7 +15,7 @@ class TopicAdmin(admin.ModelAdmin):
     def parent(obj):
         return obj.parent
 
-    parent.short_description = "Parent"
+    parent.short_description = "Parent"  # type: ignore
 
     list_display = ("product", "title", "slug", parent, "display_order", "visible", "in_aaq")
     list_display_links = ("title", "slug")

--- a/kitsune/search/documents.py
+++ b/kitsune/search/documents.py
@@ -20,8 +20,10 @@ connections.add_connection(config.DEFAULT_ES_CONNECTION, es_client())
 
 
 class WikiDocument(SumoDocument):
-    updated = field.Date()
+    # Wiki Documents should be merged/updated.
+    update_document = True
 
+    updated = field.Date()
     product_ids = field.Keyword(multi=True)
     topic_ids = field.Keyword(multi=True)
     category = field.Keyword()
@@ -37,12 +39,6 @@ class WikiDocument(SumoDocument):
 
     class Index:
         pass
-
-    @classmethod
-    @property
-    def update_document(cls):
-        """Wiki Documents should be merged/updated."""
-        return True
 
     @classmethod
     def prepare(cls, instance):

--- a/kitsune/search/models.py
+++ b/kitsune/search/models.py
@@ -53,7 +53,7 @@ class SearchMappingType(object):
 
     """
 
-    list_keys = []
+    list_keys: list[str] = []
     seconds_ago_filter = None
 
     @classmethod

--- a/kitsune/search/search.py
+++ b/kitsune/search/search.py
@@ -323,7 +323,7 @@ class CompoundSearch(SumoSearch):
     _children: list[SumoSearch] = dfield(default_factory=list, init=False)
     _parse_query: bool = True
 
-    @property
+    @property  # type: ignore
     def parse_query(self):
         return self._parse_query
 

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -472,7 +472,7 @@ TEMPLATES = [
 ]
 
 
-MIDDLEWARE = (
+MIDDLEWARE: tuple[str, ...] = (
     "kitsune.sumo.middleware.HostnameMiddleware",
     "allow_cidr.middleware.AllowCIDRMiddleware",
     "kitsune.sumo.middleware.FilterByUserAgentMiddleware",
@@ -539,7 +539,7 @@ WATCHMAN_CHECKS = (
 )
 
 # Auth
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS: tuple[str, ...] = (
     # This backend is used for the /admin interface
     "kitsune.users.auth.SumoOIDCAuthBackend",
     "kitsune.users.auth.FXAAuthBackend",
@@ -630,7 +630,7 @@ ROOT_URLCONF = "%s.urls" % PROJECT_MODULE
 
 # TODO: Figure out why changing the order of apps (for example, moving
 # taggit higher in the list) breaks tests.
-INSTALLED_APPS = (
+INSTALLED_APPS: tuple[str, ...] = (
     "django.contrib.contenttypes",
     "django.contrib.auth",
     "django.contrib.sessions",
@@ -983,26 +983,26 @@ ATOMIC_REQUESTS = config("ATOMIC_REQUESTS", default=True, cast=bool)
 
 # CORS Setup
 CORS_ALLOW_ALL_ORIGINS = True
-CORS_URLS_REGEX = [
-    r"^/api/1/gallery/.*$",
-    r"^/api/1/kb/.*$",
-    r"^/api/1/products/.*",
-    r"^/api/1/users/get_token$",
-    r"^/api/1/users/test_auth$",
-    r"^/api/2/answer/.*$",
-    r"^/api/2/pushnotification/.*$",
-    r"^/api/2/notification/.*$",
-    r"^/api/2/question/.*$",
-    r"^/api/2/realtime/.*$",
-    r"^/api/2/search/.*$",
-    r"^/api/2/user/.*$",
-    r"^/graphql/.*$",
-]
-# Now combine all those regexes with one big "or".
-CORS_URLS_REGEX = re.compile("|".join("({0})".format(r) for r in CORS_URLS_REGEX))
-
-# XXX Fix this when Bug 1059545 is fixed
-CC_IGNORE_USERS = []
+CORS_URLS_REGEX = re.compile(
+    "|".join(
+        "({0})".format(r)
+        for r in [
+            r"^/api/1/gallery/.*$",
+            r"^/api/1/kb/.*$",
+            r"^/api/1/products/.*",
+            r"^/api/1/users/get_token$",
+            r"^/api/1/users/test_auth$",
+            r"^/api/2/answer/.*$",
+            r"^/api/2/pushnotification/.*$",
+            r"^/api/2/notification/.*$",
+            r"^/api/2/question/.*$",
+            r"^/api/2/realtime/.*$",
+            r"^/api/2/search/.*$",
+            r"^/api/2/user/.*$",
+            r"^/graphql/.*$",
+        ]
+    )
+)
 
 ACTSTREAM_SETTINGS = {
     "USE_JSONFIELD": True,
@@ -1150,7 +1150,7 @@ CSP_INCLUDE_NONCE_IN = ["script-src"]
 
 CSP_DEFAULT_SRC = ("'none'",)
 
-CSP_SCRIPT_SRC = (
+CSP_SCRIPT_SRC: tuple[str, ...] = (
     "'self'",
     "https://*.mozilla.org",
     "https://*.itsre-sumo.mozilla.net",
@@ -1192,7 +1192,7 @@ CSP_FONT_SRC = (
     "https://*.webservices.mozgcp.net",
 )
 
-CSP_STYLE_SRC = (
+CSP_STYLE_SRC: tuple[str, ...] = (
     "'self'",
     "https://*.itsre-sumo.mozilla.net",
     "https://*.webservices.mozgcp.net",

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models.signals import pre_delete
@@ -21,8 +22,11 @@ from kitsune.journal.models import Record
 from kitsune.lib.tlds import VALID_TLDS
 from kitsune.sumo import paginator
 
+
 POTENTIAL_LINK_REGEX = re.compile(r"[^\s/]+\.([^\s/.]{2,})")
 POTENTIAL_IP_REGEX = re.compile(r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}")
+
+User: models.Model = get_user_model()
 
 
 def paginate(request, queryset, per_page=20, paginator_cls=paginator.Paginator, **kwargs):
@@ -388,7 +392,7 @@ def webpack_static(source_path):
         return url
 
 
-def is_trusted_user(user: object) -> bool:
+def is_trusted_user(user: User) -> bool:
     """Given a user ID, checks for group membership.
 
     If a user belongs to one of the trusted groups as defined in the project

--- a/kitsune/tidings/events.py
+++ b/kitsune/tidings/events.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
+from django.db import models
 from django.db.models import Q
 
 from kitsune.tidings.models import EmailUser, Watch, WatchFilter, multi_raw
@@ -97,11 +98,11 @@ class Event(object):
     """
 
     # event_type = 'hamster modified'  # key for the event_type column
-    content_type = None  # or, for example, Hamster
+    content_type: models.Model | None = None  # or, for example, Hamster
 
     #: Possible filter keys, for validation only. For example:
     #: ``set(['color', 'flavor'])``
-    filters = set()
+    filters: set[str] = set()
 
     def fire(self, exclude=None, delay=True):
         """

--- a/kitsune/tidings/models.py
+++ b/kitsune/tidings/models.py
@@ -7,7 +7,7 @@ from django.db import connections, models, router
 
 from .utils import import_from_setting, reverse
 
-ModelBase = import_from_setting("TIDINGS_MODEL_BASE", models.Model)
+ModelBase: models.Model = import_from_setting("TIDINGS_MODEL_BASE", models.Model)
 
 
 def multi_raw(query, params, models, model_to_fields):

--- a/kitsune/upload/storage.py
+++ b/kitsune/upload/storage.py
@@ -4,19 +4,18 @@ import os
 import time
 
 from django.conf import settings
-from django.core.files.storage import FileSystemStorage
+from django.core.files.storage import FileSystemStorage, Storage
 
 from storages.backends.gcloud import GoogleCloudStorage
 from storages.backends.s3boto3 import S3Boto3Storage
+
+DjangoStorage: Storage = FileSystemStorage
 
 if settings.GS_BUCKET_NAME:
     DjangoStorage = GoogleCloudStorage
 
 elif settings.AWS_ACCESS_KEY_ID:
     DjangoStorage = S3Boto3Storage
-
-else:
-    DjangoStorage = FileSystemStorage
 
 
 class RenameFileStorage(DjangoStorage):

--- a/kitsune/users/admin.py
+++ b/kitsune/users/admin.py
@@ -94,7 +94,7 @@ class ProfileAdmin(admin.ModelAdmin):
         else:
             return obj.user.username
 
-    full_user.short_description = "User"
+    full_user.short_description = "User"  # type: ignore
 
     def save_model(self, request, obj, form, change):
         delete_avatar = form.cleaned_data.pop("delete_avatar", False)

--- a/kitsune/users/api.py
+++ b/kitsune/users/api.py
@@ -251,8 +251,8 @@ class ProfileViewSet(
         DjangoFilterBackend,
         filters.OrderingFilter,
     ]
-    filterset_fields = []
-    ordering_fields = []
+    filterset_fields: list[str] = []
+    ordering_fields: list[str] = []
     # Default, if not overwritten
     ordering = ("-user__date_joined",)
 

--- a/kitsune/users/models.py
+++ b/kitsune/users/models.py
@@ -300,7 +300,7 @@ class RegistrationProfile(models.Model):
         """
         return True
 
-    activation_key_expired.boolean = True
+    activation_key_expired.boolean = True  # type: ignore
 
 
 class EmailChange(models.Model):

--- a/kitsune/users/monkeypatch.py
+++ b/kitsune/users/monkeypatch.py
@@ -10,7 +10,7 @@ def _activate_users(admin, request, qs):
     admin.message_user(request, msg)
 
 
-_activate_users.short_description = "Activate selected users"
+_activate_users.short_description = "Activate selected users"  # type: ignore
 
 
 def _deactivate_users(admin, request, qs):
@@ -19,7 +19,7 @@ def _deactivate_users(admin, request, qs):
     admin.message_user(request, msg)
 
 
-_deactivate_users.short_description = "Deactivate selected users"
+_deactivate_users.short_description = "Deactivate selected users"  # type: ignore
 
 
 def patch_user_admin():

--- a/kitsune/users/widgets.py
+++ b/kitsune/users/widgets.py
@@ -22,7 +22,7 @@ class MonthYearWidget(Widget):
 
     @classmethod
     def id_for_label(cls, id_):
-        return "%s_month" % id_
+        return f"{id_}_month"
 
     def __init__(self, attrs=None, years=None, required=True):
         # years is an optional list/tuple of years to use in the "year" select box.

--- a/kitsune/users/widgets.py
+++ b/kitsune/users/widgets.py
@@ -20,6 +20,10 @@ class MonthYearWidget(Widget):
     month_field = "%s_month"
     year_field = "%s_year"
 
+    @classmethod
+    def id_for_label(cls, id_):
+        return "%s_month" % id_
+
     def __init__(self, attrs=None, years=None, required=True):
         # years is an optional list/tuple of years to use in the "year" select box.
         self.attrs = attrs or {}
@@ -65,11 +69,6 @@ class MonthYearWidget(Widget):
         output.append(select_html)
 
         return mark_safe("\n".join(output))
-
-    def id_for_label(self, id_):
-        return "%s_month" % id_
-
-    id_for_label = classmethod(id_for_label)
 
     def value_from_datadict(self, data, files, name):
         y = data.get(self.year_field % name)

--- a/kitsune/wiki/admin.py
+++ b/kitsune/wiki/admin.py
@@ -56,14 +56,14 @@ class DocumentAdmin(admin.ModelAdmin):
         self._set_archival(queryset, True)
         self._show_archival_message(request, queryset, "obsolete")
 
-    archive.short_description = "Mark as obsolete"
+    archive.short_description = "Mark as obsolete"  # type: ignore
 
     def unarchive(self, request, queryset):
         """Mark several documents as not obsolete."""
         self._set_archival(queryset, False)
         self._show_archival_message(request, queryset, "no longer obsolete")
 
-    unarchive.short_description = "Mark as not obsolete"
+    unarchive.short_description = "Mark as not obsolete"  # type: ignore
 
     def allow_discussion(self, request, queryset):
         """Allow discussion on several documents."""

--- a/kitsune/wiki/managers.py
+++ b/kitsune/wiki/managers.py
@@ -10,7 +10,7 @@ class VisibilityManager(models.Manager):
     # For managers of models related to documents, provide the name of the model attribute
     # that provides the related document. For example, for the manager of revisions, this
     # should be "document".
-    document_relation = None
+    document_relation: str | None = None
 
     def get_creator_condition(self, user):
         """

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -990,7 +990,7 @@ class Revision(ModelBase, AbstractRevision):
             return None
 
 
-class DraftRevision(ModelBase, AbstractRevision):
+class DraftRevision(ModelBase, AbstractRevision):  # type: ignore
     based_on = models.ForeignKey(Revision, on_delete=models.CASCADE)
     content = models.TextField(blank=True)
     locale = LocaleField(blank=False, db_index=True)

--- a/kitsune/wiki/widgets.py
+++ b/kitsune/wiki/widgets.py
@@ -1,13 +1,10 @@
+from collections.abc import Iterable
+
 from django import forms
 from django.template.loader import render_to_string
 
 from kitsune.products.models import Topic
 from kitsune.wiki.models import Document
-
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 
 
 class ProductTopicsAndSubtopicsWidget(forms.widgets.SelectMultiple):


### PR DESCRIPTION
mozilla/sumo#1120

This PR adds type checking via `mypy` to our `pre-commit` flow, which is also run as part of the linting step of the CI flow.

## Notes and Comments
- The default option passed to the `mypy` `pre-commit` hook is `--ignore-missing-imports`.
- I limited type-checking to all of the Python files under the`kitsune` folder (excluding the Django database migration files). Do we also want to run this on our Python scripts under the `scripts` folder? It didn't seem worth it, but maybe I'm wrong about that.
- The bulk of the changes in this PR are simply to get `mypy` passing on all of our Python files. There's a reason for that. When running `mypy` in `pre-commit`, it'll be called with any Python files that have changed, but it also checks each of their imported files as well. This can be turned-off (for example, one way is to use `--follow-imports=silent`) but `mypy` strongly recommends using the default setting. Since so many extra files get pulled into the type-checking, in the end it only makes sense to start by getting `mypy` to run on all of our Python files.
- The `additional_dependencies` (type-hint stubs) I added in the `.pre-commit-config.yaml` file for the `mypy` hook were the ones recommended by `mypy` itself when it was run on our Python files. I tried adding `django-stubs` as well, but it's not yet approved for `mypy` version `1.0.0` or greater. I think that would be good to add in the future when possible.
- Since we're not yet enabling the `--check-untyped-defs` option of `mypy`, some type errors won't be detected as you might expect. For example, although we provide type hints for the [Announcement.get_for_groups method](https://github.com/mozilla/kitsune/blob/f26ad9a75f27717f5a3facba9130a0ce14c9f2bc/kitsune/announcements/models.py#L67), if we were to make a mistake of using `Announcement.get_for_groups(23)` instead of [what we have currently](https://github.com/mozilla/kitsune/blob/f26ad9a75f27717f5a3facba9130a0ce14c9f2bc/kitsune/announcements/templatetags/jinja_helpers.py#L10), that type error won't be detected because it won't be checked. It's not checked because the `get_announcements()` function definition doesn't have any type hints. If we want to turn on `--check-untyped-defs`, we'd have to fix another 143 errors.
- I'm not convinced this work is worth the effort. I'm not a fan of typing. I think the extra time and effort is much better spent on improving tests. I'm willing to give it a try though.
- I added an ADR to the docs for type checking. Even though I'm not a fan, I still tried to explain the benefits and why we're using it as best I could.