### PR TITLE
Fix announcment formatting#1198

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_notifications.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_notifications.scss
@@ -23,6 +23,7 @@
   @include p.bidi(((padding, p.$spacing-sm p.$spacing-2xl p.$spacing-sm p.$spacing-sm, p.$spacing-sm p.$spacing-sm p.$spacing-sm p.$spacing-2xl),));
   position: relative;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   min-width: 0;


### PR DESCRIPTION
- added flex-direction: column to stop muli-paragraph announcments becoming two columns

Should fix this: https://github.com/mozilla/sumo/issues/1198