### PR TITLE
restrict attributes in messages

### DIFF
--- a/kitsune/messages/models.py
+++ b/kitsune/messages/models.py
@@ -6,6 +6,30 @@ from django.db import models
 from kitsune.sumo.models import ModelBase
 
 
+ALLOWED_MESSAGE_ATTRIBUTES = {
+    "a": ["href", "title", "rel", "data-mozilla-ui-reset", "data-mozilla-ui-preferences"],
+    "div": ["id", "data-for", "title", "data-target", "data-modal"],
+    "h1": ["id"],
+    "h2": ["id"],
+    "h3": ["id"],
+    "h4": ["id"],
+    "h5": ["id"],
+    "h6": ["id"],
+    "span": ["data-for"],
+    "img": ["src", "data-original-src", "alt", "title", "height", "width"],
+    "video": [
+        "height",
+        "width",
+        "controls",
+        "data-fallback",
+        "poster",
+        "data-width",
+        "data-height",
+    ],
+    "source": ["src", "type"],
+}
+
+
 class InboxMessage(ModelBase):
     """A message in a user's private message inbox."""
 
@@ -26,7 +50,7 @@ class InboxMessage(ModelBase):
     def content_parsed(self):
         from kitsune.sumo.templatetags.jinja_helpers import wiki_to_html
 
-        return wiki_to_html(self.message)
+        return wiki_to_html(self.message, attributes=ALLOWED_MESSAGE_ATTRIBUTES)
 
     class Meta:
         db_table = "messages_inboxmessage"
@@ -46,7 +70,7 @@ class OutboxMessage(ModelBase):
     def content_parsed(self):
         from kitsune.sumo.templatetags.jinja_helpers import wiki_to_html
 
-        return wiki_to_html(self.message)
+        return wiki_to_html(self.message, attributes=ALLOWED_MESSAGE_ATTRIBUTES)
 
     class Meta:
         db_table = "messages_outboxmessage"

--- a/kitsune/messages/tests/test_templates.py
+++ b/kitsune/messages/tests/test_templates.py
@@ -80,3 +80,15 @@ class MessagePreviewTests(TestCase):
         self.assertEqual(200, response.status_code)
         doc = pq(response.content)
         self.assertEqual("Test Content", doc("div.message h1").text())
+
+    def test_preview_with_disallowed_attribute(self):
+        """Test removal of disallowed attributes."""
+        response = self.client.post(
+            reverse("messages.preview_async", locale="en-US"),
+            {"content": '[https://attacker.com <img src="login.png" class="mzp-c-modal">]'},
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+        doc = pq(response.content)
+        self.assertIsNone(doc("img").attr("class"))
+        self.assertEqual(doc('a[href="https://attacker.com"]').attr("rel"), "nofollow")

--- a/kitsune/sumo/parser.py
+++ b/kitsune/sumo/parser.py
@@ -46,10 +46,17 @@ VIDEO_PARAMS = ["height", "width", "modal", "title", "placeholder"]
 YOUTUBE_PLACEHOLDER = "YOUTUBE_EMBED_PLACEHOLDER_%s"
 
 
-def wiki_to_html(wiki_markup, locale=settings.WIKI_DEFAULT_LANGUAGE, nofollow=True, tags=None):
+def wiki_to_html(
+    wiki_markup, locale=settings.WIKI_DEFAULT_LANGUAGE, nofollow=True, tags=None, attributes=None
+):
     """Wiki Markup -> HTML"""
     return WikiParser().parse(
-        wiki_markup, show_toc=False, locale=locale, nofollow=nofollow, tags=tags
+        wiki_markup,
+        show_toc=False,
+        locale=locale,
+        nofollow=nofollow,
+        tags=tags,
+        attributes=attributes,
     )
 
 

--- a/kitsune/sumo/templatetags/jinja_helpers.py
+++ b/kitsune/sumo/templatetags/jinja_helpers.py
@@ -113,11 +113,17 @@ def urlparams(url_, hash=None, query_dict=None, **query):
 
 
 @library.filter
-def wiki_to_html(wiki_markup, locale=settings.WIKI_DEFAULT_LANGUAGE, nofollow=True):
+def wiki_to_html(
+    wiki_markup, locale=settings.WIKI_DEFAULT_LANGUAGE, nofollow=True, tags=None, attributes=None
+):
     """Wiki Markup -> HTML Markup object"""
     if not wiki_markup:
         return ""
-    return Markup(parser.wiki_to_html(wiki_markup, locale=locale, nofollow=nofollow))
+    return Markup(
+        parser.wiki_to_html(
+            wiki_markup, locale=locale, nofollow=nofollow, tags=tags, attributes=attributes
+        )
+    )
 
 
 @library.filter


### PR DESCRIPTION
This is a gentler alternative to #5410. It resolves the issue without breaking any of the wiki syntax that users may have become used to within messages.

Either choose #5410 or this PR, but not both.