### PR TITLE
Upgrade mozilla protocol package

### DIFF
--- a/kitsune/sumo/static/sumo/js/protocol-compat.js
+++ b/kitsune/sumo/static/sumo/js/protocol-compat.js
@@ -1,2 +1,0 @@
-// Necessary until we upgrade protocol to include this fix: https://github.com/mozilla/protocol/issues/687
-window.Mzp = {};

--- a/kitsune/sumo/static/sumo/js/protocol.js
+++ b/kitsune/sumo/static/sumo/js/protocol.js
@@ -1,4 +1,3 @@
-import "./protocol-compat";
 import "protocol/js/protocol-base";
 import "protocol/js/protocol-utils";
 import "protocol/js/protocol-supports";

--- a/kitsune/sumo/static/sumo/scss/_protocol.scss
+++ b/kitsune/sumo/static/sumo/scss/_protocol.scss
@@ -27,9 +27,9 @@ $image-path: 'protocol/img' !default;
 @import 'protocol/css/base/elements/links';
 @import 'protocol/css/base/elements/lists';
 @import 'protocol/css/base/elements/quotes';
-@import 'protocol/css/base/elements/sections';
+@import 'protocol/css/base/elements/containers';
 @import 'protocol/css/base/elements/tables';
-@import 'protocol/css/base/elements/typography';
+@import 'protocol/css/base/elements/titles';
 
 // Base includes - animations
 @import 'protocol/css/base/includes';
@@ -49,13 +49,13 @@ $image-path: 'protocol/img' !default;
 @import 'protocol/css/components/call-out';
 @import 'protocol/css/components/emphasis-box';
 @import 'protocol/css/components/feature-card';
-@import 'protocol/css/components/hero';
+@import 'protocol/css/components/split';
 @import 'protocol/css/components/inline-list';
 @import 'protocol/css/components/modal';
 @import 'protocol/css/components/menu-list';
 @import 'protocol/css/components/newsletter-form';
 @import 'protocol/css/components/notification-bar';
-@import 'protocol/css/components/picto-card';
+@import 'protocol/css/components/picto';
 @import 'protocol/css/components/sidebar-menu';
 @import 'protocol/css/components/zap';
 @import 'protocol/css/templates/card-layout';

--- a/kitsune/sumo/static/sumo/scss/base/forms/_buttons.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_buttons.scss
@@ -81,7 +81,7 @@
   &.button-sm {
     padding: 0 p.$spacing-md;
     height: p.$spacing-lg;
-    border-radius: 2px;
+    border-radius: p.$border-radius-xs;
 
   }
 

--- a/kitsune/sumo/static/sumo/scss/base/forms/_radios-checkboxes.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_radios-checkboxes.scss
@@ -36,7 +36,7 @@
       width: 20px;
       height: 20px;
       border: 2px solid var(--field-border-color-default);
-      border-radius: 2px;
+      border-radius: p.$border-radius-xs;
       background-color: var(--color-white);
       vertical-align: middle;
       content: "";

--- a/kitsune/sumo/static/sumo/scss/base/forms/_simple-search-form.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_simple-search-form.scss
@@ -44,7 +44,7 @@
   width: p.$spacing-xl;
   height: p.$spacing-xl;
   border: none;
-  border-radius: p.$spacing-xs;
+  border-radius: p.$border-radius-sm;
   background-image: url('protocol/img/icons/search.svg');
   background-color: transparent;
   background-position: center center;

--- a/kitsune/sumo/static/sumo/scss/components/_rickshaw.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_rickshaw.scss
@@ -1,3 +1,5 @@
+@use 'protocol/css/includes/lib' as p;
+
 .rickshaw_graph .detail {
   pointer-events: none;
   position: absolute;
@@ -19,7 +21,7 @@
 }
 .rickshaw_graph .detail .x_label {
   font-family: Arial, sans-serif;
-  border-radius: 3px;
+  border-radius: p.$border-radius-sm;
   padding: 6px;
   opacity: 0.5;
   border: 1px solid #e0e0e0;
@@ -31,7 +33,7 @@
 .rickshaw_graph .detail .item {
   position: absolute;
   z-index: 2;
-  border-radius: 3px;
+  border-radius: p.$border-radius-sm;
   padding: 0.25em;
   font-size: 12px;
   font-family: Arial, sans-serif;
@@ -59,7 +61,7 @@
   height: 4px;
   margin-left: -4px;
   margin-top: -3px;
-  border-radius: 5px;
+  border-radius: p.$border-radius-sm;
   position: absolute;
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.6);
   background: white;
@@ -115,7 +117,7 @@
   width: 6px;
   margin-left: -2px;
   top: -3px;
-  border-radius: 5px;
+  border-radius: p.$border-radius-sm;
   background-color: rgba(0, 0, 0, 0.25);
 }
 .rickshaw_graph .annotation_line {
@@ -150,7 +152,7 @@
   opacity: 0.9;
   padding: 5px 5px;
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
-  border-radius: 3px;
+  border-radius: p.$border-radius-sm;
   position: relative;
   z-index: 20;
   font-size: 12px;
@@ -252,7 +254,7 @@
   background: #404040;
   display: inline-block;
   padding: 12px 5px;
-  border-radius: 2px;
+  border-radius: p.$border-radius-xs;
   position: relative;
 }
 .rickshaw_legend:hover {
@@ -271,7 +273,7 @@
 .rickshaw_legend .line .swatch {
   display: inline-block;
   margin-right: 3px;
-  border-radius: 2px;
+  border-radius: p.$border-radius-xs;
 }
 .rickshaw_legend .label {
   margin: 0;
@@ -312,9 +314,9 @@
 }
 .rickshaw_legend li:hover {
   background: rgba(255, 255, 255, 0.08);
-  border-radius: 3px;
+  border-radius: p.$border-radius-sm;
 }
 .rickshaw_legend li:active {
   background: rgba(255, 255, 255, 0.2);
-  border-radius: 3px;
+  border-radius: p.$border-radius-sm;
 }

--- a/kitsune/sumo/static/sumo/scss/components/_rickshaw.sumo.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_rickshaw.sumo.scss
@@ -1,3 +1,5 @@
+@use 'protocol/css/includes/lib' as p;
+
 .rickshaw {
   position: relative;
 }
@@ -54,7 +56,7 @@
 
 .controls {
   > div {
-    border-radius: 2px;
+    border-radius: p.$border-radius-xs;
     background: #444;
     color: #fff;
     margin-bottom: 10px;
@@ -75,7 +77,7 @@
         // These next two styles emulate jQuery's UI, since they style
         // the [type=text] elements.
         box-shadow: 0px 0px 0px 1px rgb(239, 239, 239);
-        border-radius: 5px;
+        border-radius: p.$border-radius-sm;
         width: 110px;
       }
 
@@ -208,7 +210,7 @@
 
   ul {
     background: rgba(255, 255, 255, 0.8);
-    border-radius:  5px;
+    border-radius:  p.$border-radius-sm;
     border: 1px solid black;
     margin: 0 10px;
     padding: 5px;
@@ -231,7 +233,7 @@
 
   .dot {
     background: rgba(255, 255, 255, 0.5);
-    border-radius: 8px;
+    border-radius: p.$border-radius-md;
     border: 2px solid #000;
     display: inline-block;
     height: 6px;

--- a/kitsune/sumo/static/sumo/scss/components/_wiki.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_wiki.scss
@@ -1097,7 +1097,7 @@ article {
 /* Ace syntax custom CSS */
 #editor {
   border: 2px solid #F7F7F7;
-  border-radius: 5px;
+  border-radius: p.$border-radius-sm;
   bottom: 0;
   left: 0;
   position: absolute;

--- a/kitsune/sumo/static/sumo/scss/config/_grid.scss
+++ b/kitsune/sumo/static/sumo/scss/config/_grid.scss
@@ -1,5 +1,6 @@
 @use '@mozilla-protocol/core/protocol/css/includes/lib' as p;
 @use './variables' as c;
+@use 'sass:math';
 
 
 // Grid
@@ -52,9 +53,9 @@ $max-container-width: 1312px !default;
   margin-right: auto;
   margin-left: auto;
   padding-top: 0;
-  padding-right: $gutter-width / 2;
+  padding-right: math.div($gutter-width, 2);
   padding-bottom: 0;
-  padding-left: $gutter-width / 2;
+  padding-left: math.div($gutter-width, 2);
   width: 100%;
   max-width: $max-container-width;
 
@@ -67,8 +68,8 @@ $max-container-width: 1312px !default;
 @mixin grid-row() {
   display: flex;
   flex-wrap: wrap;
-  margin-right: $gutter-width / -2;
-  margin-left: $gutter-width / -2;
+  margin-right: math.div($gutter-width, -2);
+  margin-left: math.div($gutter-width, -2);
 }
 
 @function col-width($column: 4, $of-columns: 4) {
@@ -76,9 +77,9 @@ $max-container-width: 1312px !default;
   @if $column == $of-columns {
     $result: 100%;
   } @else if $column == 1 {
-    $result: calc(#{100% / $of-columns} - #{$gutter-width});
+    $result: calc(#{math.div(100%, $of-columns)} - #{$gutter-width});
   } @else {
-    $result: calc(((#{100% / $of-columns} - #{$gutter-width}) * #{$column}) + #{$gutter-width * ($column - 1)});
+    $result: calc(((#{math.div(100%, $of-columns)} - #{$gutter-width}) * #{$column}) + #{$gutter-width * ($column - 1)});
   }
 
   @return $result;
@@ -91,8 +92,8 @@ $max-container-width: 1312px !default;
     width: calc(100% - #{$gutter-width});
   }
 
-  margin-right: $gutter-width / 2;
-  margin-left: $gutter-width / 2;
+  margin-right: math.div($gutter-width, 2);
+  margin-left: math.div($gutter-width, 2);
 }
 
 // overrides protocol/css/base/elements/_sections.scss

--- a/kitsune/sumo/static/sumo/scss/config/_project-theme.scss
+++ b/kitsune/sumo/static/sumo/scss/config/_project-theme.scss
@@ -42,7 +42,7 @@
   --code-font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
 
   --global-margin: 1rem;
-  --global-radius: #{p.$spacing-xs};
+  --global-radius: #{p.$border-radius-sm};
 
   // form fields
   --focus-shadow: 0 0 0 #{p.$spacing-xs} rgba(0, 96, 223, 0.3), 0 0 0 2px rgb(0, 138, 234);

--- a/kitsune/sumo/static/sumo/scss/layout/_containers.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_containers.scss
@@ -1,5 +1,6 @@
 @use 'protocol/css/includes/lib' as p;
 @use '../config' as c;
+@use 'sass:math';
 
 // Containers
 //
@@ -19,8 +20,8 @@
   }
 
   & & {
-    padding-right: c.$gutter-width /2;
-    padding-left: c.$gutter-width /2;
+    padding-right: math.div(c.$gutter-width, 2);
+    padding-left: math.div(c.$gutter-width, 2);
   }
 }
 

--- a/kitsune/sumo/static/sumo/scss/layout/_document.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_document.scss
@@ -261,7 +261,7 @@
     align-items: center;
     border: 2px solid var(--color-marketing-gray-03);
     padding: 0 p.$spacing-md;
-    border-radius: 2px;
+    border-radius: p.$border-radius-xs;
     font-family: var(--heading-alt-font-family);
     @include p.font-size(14px);
     font-weight:700;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/core": "^7.20.12",
         "@babel/plugin-transform-runtime": "^7.19.6",
         "@babel/preset-env": "^7.20.2",
-        "@mozilla-protocol/core": "10.0.1",
+        "@mozilla-protocol/core": "16.1.0",
         "@types/underscore": "^1.11.4",
         "autoprefixer": "^10.4.13",
         "babel-loader": "^9.1.2",
@@ -1958,9 +1958,9 @@
       }
     },
     "node_modules/@mozilla-protocol/core": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-10.0.1.tgz",
-      "integrity": "sha512-sUvdRyaWhCsLl4o7kDj6hIH83YNcDbIGsrLjaUdST/1frVv+Clg0CbBW6R+b3fsRhMLHFoAXXhA2I6U88yOHNg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-16.1.0.tgz",
+      "integrity": "sha512-M9Omsb8/J+yT42nESsZk3ENPB8TVOpGjjGOK364ufDK6bT5cUhazxvIVF1EGOi46rLsv7QBH9POku01kd+Xb7Q==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/core": "^7.20.12",
     "@babel/plugin-transform-runtime": "^7.19.6",
     "@babel/preset-env": "^7.20.2",
-    "@mozilla-protocol/core": "10.0.1",
+    "@mozilla-protocol/core": "16.1.0",
     "@types/underscore": "^1.11.4",
     "autoprefixer": "^10.4.13",
     "babel-loader": "^9.1.2",

--- a/styleguide/kss-template/kss-assets/scss/layout/_kss-content.scss
+++ b/styleguide/kss-template/kss-assets/scss/layout/_kss-content.scss
@@ -1,3 +1,4 @@
+@use 'protocol/css/includes/lib' as p;
 
 // ------------------------------------------------------------------------------
 // Content-area components
@@ -385,7 +386,7 @@ a:hover {
     font-weight: normal;
     font-size: 12px;
     border: 1px solid #eee;
-    border-radius: 2px;
+    border-radius: p.$border-radius-xs;
     text-align: center;
     margin-bottom: 4px;
     cursor: copy;

--- a/svelte/contribute/Steps.svelte
+++ b/svelte/contribute/Steps.svelte
@@ -89,7 +89,7 @@
     li {
         background: var(--tile-bg);
         box-shadow: var(--tile-shadow);
-        border-radius: 4px;
+        border-radius: p.$border-radius-sm;
 
         font-family: var(--base-font-family);
         font-weight: 600;
@@ -129,7 +129,7 @@
 
     .fact {
         background: var(--fact-bg);
-        border-radius: 4px;
+        border-radius: p.$border-radius-sm;
         text-align: center;
         display: flex;
         flex-direction: column;

--- a/svelte/contribute/Tile.svelte
+++ b/svelte/contribute/Tile.svelte
@@ -13,11 +13,13 @@
 </Link>
 
 <style lang="scss">
+    @use "@mozilla-protocol/core/protocol/css/includes/lib" as p;
+
     li {
         height: 100%;
         background-color: var(--tile-bg);
         box-shadow: var(--tile-shadow);
-        border-radius: 4px;
+        border-radius: p.$border-radius-sm;
 
         display: flex;
         align-items: center;


### PR DESCRIPTION
mozilla/sumo#1182

# Notes
This PR upgrades our `@mozilla-protocol` npm package to the latest version (`16.1.0`). It includes some minor changes to our existing Sass/CSS, but avoids the much more significant effort of replacing chunks of SUMO's existing Sass/CSS with similar `@mozilla-protocol` offerings -- like the [typography mixins](https://github.com/mozilla/kitsune/blob/main/kitsune/sumo/static/sumo/scss/config/_typography-mixins.scss) -- since that quickly starts to involve more system-level issues, which felt like something better done as part of a UI refresh later down the road.

Although not essential to this PR, I also used Sass' `math.div` in several places where we were using the deprecated `/` operator. This eliminated all of the remaining Sass compilation warnings.

```
kitsune@6da4efe48b28:~$ npm run webpack:build

> webpack:build
> npx webpack build --config webpack.dev.js

assets by status 6.03 MiB [cached] 438 assets
assets by path . 3.29 MiB
  assets by path *.js 2.9 MiB
    assets by chunk 1.93 MiB (id hint: vendors) 8 assets
    + 32 assets
  assets by path entrypoints/*.html 10.7 KiB
    asset entrypoints/wiki.html 1.46 KiB [compared for emit]
    asset entrypoints/questions.html 919 bytes [compared for emit]
    asset entrypoints/community.metrics.html 735 bytes [compared for emit]
    + 22 assets
  assets by path *.css 353 KiB
    asset screen.css 343 KiB [compared for emit] (name: screen) 1 related asset
    asset contribute.css 10.9 KiB [compared for emit] (name: contribute) 1 related asset
  asset source-to-asset.json 30.5 KiB [emitted] [compared for emit]
cached modules 2.85 MiB (javascript) 2.48 MiB (asset) 355 KiB (css/mini-extract) 4.7 KiB (runtime) [cached] 396 modules
./svelte/lib/constants.js 196 bytes [built] [code generated]
webpack 5.76.0 compiled successfully in 2942 ms
```

As far as I know, the only explicit, visible changes I made were the ones where I adjusted some `border-radius` values of `3px` and `5px` to their closest `@mozilla-protocol` token value (`$border-radius-sm`, which is `4px`) in order to standardize a bit more on the `@mozilla-protocol` tokens. Of course, the changes introduced by the `@mozilla-protocol` package upgrade itself may cause visible changes to the UI as well.
