### PR TITLE
add missing import of protocol/css/base/elements/common

### DIFF
--- a/kitsune/sumo/static/sumo/scss/_protocol.scss
+++ b/kitsune/sumo/static/sumo/scss/_protocol.scss
@@ -21,13 +21,14 @@ $image-path: 'protocol/img' !default;
 
 // Base elements - general HTML elements
 @import 'protocol/css/base/elements/reset';
+@import 'protocol/css/base/elements/common';
+@import 'protocol/css/base/elements/containers';
 @import 'protocol/css/base/elements/details';
 @import 'protocol/css/base/elements/document';
 // @import 'protocol/css/base/elements/forms';
 @import 'protocol/css/base/elements/links';
 @import 'protocol/css/base/elements/lists';
 @import 'protocol/css/base/elements/quotes';
-@import 'protocol/css/base/elements/containers';
 @import 'protocol/css/base/elements/tables';
 @import 'protocol/css/base/elements/titles';
 


### PR DESCRIPTION
mozilla/sumo#1236

# Notes
I discovered that we don't use `@import 'protocol/css/base/elements';`, but instead manually import items under `protocol/css/base/elements/` line by line (because we exclude `protocol/css/base/elements/forms`), so we missed importing the new `protocol/css/base/elements/common` which contains, among other things, the CSS for the bottom margin that we were missing.