### PR TITLE
restore bottom margins for h1 and h2

### DIFF
--- a/kitsune/sumo/static/sumo/scss/base/_typography.scss
+++ b/kitsune/sumo/static/sumo/scss/base/_typography.scss
@@ -82,9 +82,17 @@ h1,
   @include c.text-display-xxl;
 }
 
+h1 {
+  margin-bottom: .25em;
+}
+
 h2,
 .text-display-xl {
   @include c.text-display-xl;
+}
+
+h2 {
+  margin-bottom: .45em;
 }
 
 h3,


### PR DESCRIPTION
mozilla/sumo#1239

# Notes
The bottom margins for `h1` and `h2` simply changed somewhere along the line from version 10 to 16 of `@mozilla-protocol/core`. This PR restores the original bottom margins for `h1` and `h2`.