### PR TITLE
hide dynamically added iframes that receive async upload responses

### DIFF
--- a/kitsune/sumo/static/sumo/js/libs/jquery.ajaxupload.js
+++ b/kitsune/sumo/static/sumo/js/libs/jquery.ajaxupload.js
@@ -111,7 +111,7 @@ jQuery.fn.ajaxSubmitInput = function (options) {
         $form = '<form class="upload-input" action="' +
                 options.url + '" target="' + iframeName +
                 '" method="post" enctype="multipart/form-data"/>',
-        $iframe = $('<iframe name="' + iframeName +
+        $iframe = $('<iframe hidden name="' + iframeName +
                    '" style="position:absolute;top:-9999px;" />')
                    //'" style="position:fixed;top:0px;width:500px;height:350px" />')
                     .appendTo('body'),


### PR DESCRIPTION
mozilla/sumo#1100

# Notes
- The `sumo/js/libs/jquery.ajaxupload.js` file is used for the asynchronous uploading of images when creating/answering questions as well as adding images to the gallery. It only comes into play if the user is logged in.
- It's part of an unusual design that combines HTML forms with AJAX. It dynamically appends an `iframe` that captures the response (typically JSON) from the `form` POST (via the `target` attribute on the `form`) so the current page remains rather than being replaced with the POST response.
- The whole way we do this should be re-written in a simpler way using Svelte, but that's for a later time. For now, the `iframe` should be hidden from the user, which this PR does.