### PR TITLE
include templates in kb_overview_rows

### DIFF
--- a/kitsune/dashboards/readouts.py
+++ b/kitsune/dashboards/readouts.py
@@ -199,9 +199,7 @@ def kb_overview_rows(mode=None, max=None, locale=None, product=None, category=No
     if mode is None:
         mode = LAST_30_DAYS
 
-    docs = Document.objects.filter(
-        locale=settings.WIKI_DEFAULT_LANGUAGE, is_archived=False, is_template=False
-    )
+    docs = Document.objects.filter(locale=settings.WIKI_DEFAULT_LANGUAGE, is_archived=False)
 
     docs = docs.exclude(html__startswith=REDIRECT_HTML)
 


### PR DESCRIPTION
mozilla/sumo#1232

# Notes
It looks like templates have been excluded from the following pages since [October 15, 2014](https://github.com/mozilla/kitsune/commit/a5715c27d3a9f12b779981761f4f6f565b644459):

- `/<locale>/contributors`
- `/<locale>/contributors/kb-overview`
- `/<locale>/contributors/overview-rows`

We allow filtering by category for the first two endpoints, but the `Templates` category never worked because they were always excluded.