### PR TITLE
add missing unsupported firefox locale codes

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -275,11 +275,15 @@ NON_SUPPORTED_LOCALES = {
     "pa-IN": None,
     "rm": None,
     "rw": None,
+    "sc": "it",
+    "sco": None,
     "sah": None,
     "son": None,
     "su": None,
     "sv-SE": "sv",
+    "szl": "pl",
     "tl": None,
+    "trs": "es",
     "uz": None,
 }
 


### PR DESCRIPTION
mozilla/sumo#1231

# Notes
Firefox supports locales that SUMO does not, and since these locales are substituted into SUMO "in-product" links, SUMO should handle them gracefully with a fallback locale. This PR adds fallbacks for four (4) Firefox locale codes that SUMO was not yet handling properly:
- `sc`
- `sco`
- `szl`
- `trs`
