### PR TITLE
initial set-up for the firefox device migration project

### DIFF
--- a/kitsune/sumo/static/sumo/js/document.switching-devices.js
+++ b/kitsune/sumo/static/sumo/js/document.switching-devices.js
@@ -1,0 +1,4 @@
+import UITour from "./libs/uitour";
+import trackEvent from "sumo/js/analytics";
+
+// TODO: Add JavaScript for the Firefox device migration UI here.

--- a/kitsune/sumo/static/sumo/scss/_switching-devices.scss
+++ b/kitsune/sumo/static/sumo/scss/_switching-devices.scss
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// TODO: Add styles needed for the Firefox device migration UI here.

--- a/kitsune/sumo/static/sumo/scss/screen.scss
+++ b/kitsune/sumo/static/sumo/scss/screen.scss
@@ -7,5 +7,7 @@
 
 @use 'examples/examples'; // styleguide-only comment files
 
+@use './switching-devices';
+
 @import "../../../../../node_modules/codemirror/lib/codemirror";
 @import "../../../../../node_modules/codemirror/addon/hint/show-hint";

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -8,6 +8,10 @@
 {% set classes = 'document' %}
 {% set canonical_url = canonicalize(model_url=document.get_absolute_url()) %}
 {% set scripts = ('document',) %}
+{% set is_switching_devices_doc = 'switching-devices' in (document.slug, document.parent.slug) %}
+{% if is_switching_devices_doc %}
+  {% set scripts = scripts + ('document.switching-devices',) %}
+{% endif %}
 {% set extra_body_attrs = {'data-document-id': document.id, 'data-default-slug': document.parent.slug if document.parent else document.slug} %}
 
 {% block title %}

--- a/webpack/entrypoints.js
+++ b/webpack/entrypoints.js
@@ -33,6 +33,9 @@ const entrypoints = {
     "sumo/js/document.js",
     "sumo/js/wiki.metrics.js",
   ],
+  "document.switching-devices": [
+    "sumo/js/document.switching-devices.js",
+  ],
   revision: [
     "sumo/js/revision.js",
   ],


### PR DESCRIPTION
This PR provides an initial take on a structure for the HTML, CSS, and JavaScript pieces needed for the Firefox Device Migration project. Of course, none of this is set in stone, so recommendations are welcome.
- The HTML for the UI elements (the wizard and the tabbed panel of "Links for manual transfer") will live within the [`switching-devices` KB article](https://support.mozilla.org/en-US/kb/switching-devices). The HTML within KB articles is "cleaned" (some HTML elements are removed, like the `<input>` element), so we may have to either add elements to the allowed list, try another approach that allows us to keep the UI elements in the KB article (create a special macro or hook?), or abandon the idea of having the UI elements in the KB article. For translation purposes, it'd be more convenient to keep the UI elements within the article.
- The JavaScript for the UI elements will live in `kitsune/sumo/static/sumo/js/document.switching-devices.js`, which already imports the `UITour` object and SUMO's `trackEvent` function for GA.
- The styles for the UI elements will live in `kitsune/sumo/static/sumo/scss/_switching-devices.scss`.

# Notes
- The JavaScript (`kitsune/sumo/static/sumo/js/document.switching-devices.js`) is only loaded when the [`switching-devices` KB article](https://support.mozilla.org/en-US/kb/switching-devices) KB article is loaded. It's not loaded for any other SUMO page.
- The styles (`kitsune/sumo/static/sumo/scss/_switching-devices.scss`) are loaded for every SUMO page, which is [the current approach used for all of SUMO's styles](https://kitsune.readthedocs.io/en/latest/frontend.html#loading-css). We could adjust this such that they're loaded only when the `switching-devices` KB article is loaded, but this is the approach for now.

# Local Development/Testing
- For information on configuring Firefox to accept `localhost:8000` as an accepted origin for `UITour`, see https://bedrock.readthedocs.io/en/latest/uitour.html#local-development
- @akatsoulas or @escattone can provide the FxA settings needed for local development (place them within your `.env` file) .
