### PR TITLE
switching devices UI wizard lives outside kb article

### DIFF
--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -89,6 +89,9 @@
     {% endif %}
     <article class="wiki-doc">
       {{ document_messages(document, redirected_from) }}
+      {% if is_switching_devices_doc %}
+        {% include "wiki/includes/switching-devices.html" %}
+      {% endif %}
       {{ document_content(document, fallback_reason, request, settings, document_css_class, any_localizable_revision, full_locale_name) }}
 
       {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
@@ -111,7 +114,9 @@
       {% include "landings/includes/volunteer-callout.html" %}
     </section>
 
-    {% if document.related_documents.count() %}
+    {% if is_switching_devices_doc %}
+      {# TODO: Add HTML for tabbed panel here. #}
+    {% elif document.related_documents.count() %}
     {% set docs = document.related_documents.all() %}
     <section id="related-documents" class="sumo-page-section wiki-related-documents">
       <div class="text-center">

--- a/kitsune/wiki/jinja2/wiki/includes/switching-devices.html
+++ b/kitsune/wiki/jinja2/wiki/includes/switching-devices.html
@@ -1,0 +1,1 @@
+{# TODO: Add HTML for the Firefox device migration UI wizard, and more if desired, here. #}


### PR DESCRIPTION
This PR adjusts the `switching-devices` branch.

- The HTML for the UI wizard will live in its own file (`kitsune/wiki/jinja2/wiki/includes/switching-devices.html`) outside of the `/en-US/kb/switching-devices` KB article.
- It adds a spot in the `document.html` Jinja template for the tabbed panel HTML.
- The `/en-US/kb/switching-devices` KB article (and its translations) may contain any content intended to exist between the UI wizard and the tabbed panel, or it may remain empty if that content is instead placed directly in the `document.html` Jinja template.
- This assumes that all of the text for the UI wizard abd tabbed panel is localized via Pontoon.