### PR TITLE
switching devices -- add wiki "UI" hook for device-migration wizard

### DIFF
--- a/kitsune/sumo/parser.py
+++ b/kitsune/sumo/parser.py
@@ -306,9 +306,7 @@ class WikiParser(Parser):
         """
 
         for name in self.ui_components:
-            html = html.replace(
-                UI_COMPONENT_PLACEHOLDER % name, render_to_string(f"wikiparser/hook_{name}.html")
-            )
+            html = html.replace(UI_COMPONENT_PLACEHOLDER % name, generate_ui_component_embed(name))
 
         return html
 
@@ -445,6 +443,11 @@ def generate_video(v, params=[]):
 def generate_youtube_embed(video_id):
     """Takes a youtube video id and returns the embed markup."""
     return render_to_string("wikiparser/hook_youtube_embed.html", {"video_id": video_id})
+
+
+def generate_ui_component_embed(name):
+    """Takes a UI component name and returns the embed markup."""
+    return render_to_string(f"wikiparser/hook_{name}.html")
 
 
 def _get_video_url(video_file):

--- a/kitsune/sumo/parser.py
+++ b/kitsune/sumo/parser.py
@@ -215,7 +215,7 @@ class WikiParser(Parser):
         self.registerInternalLinkHook("Button", self._hook_button)
         self.registerInternalLinkHook("UI", self._hook_ui_component)
 
-        self.youtube_videos = []
+        self.youtube_videos = set()
         self.ui_components = set()
 
     def parse(
@@ -250,6 +250,10 @@ class WikiParser(Parser):
         :arg nofollow: should links have nofollow set?
         :arg youtube_embeds: should we replace the youtube placeholders
             with the iframes? This is kind of a hack so that subclasses
+            can skip embedding here and do it on their own at the end
+            of parsing.
+        :arg ui_component_embeds: should we replace the UI component
+            placeholders with their HTML? This exists so that subclasses
             can skip embedding here and do it on their own at the end
             of parsing.
         """
@@ -382,7 +386,7 @@ class WikiParser(Parser):
                 # The video id is in the v= query param
                 video_id = parse_qs(parsed_url.query)["v"][0]
 
-            self.youtube_videos.append(video_id)
+            self.youtube_videos.add(video_id)
 
             return YOUTUBE_PLACEHOLDER % video_id
 

--- a/kitsune/sumo/tests/test_parser.py
+++ b/kitsune/sumo/tests/test_parser.py
@@ -1,4 +1,5 @@
 from functools import partial
+from unittest.mock import patch
 
 from django.conf import settings
 from pyquery import PyQuery as pq
@@ -226,6 +227,23 @@ class TestWikiParser(TestCase):
         for url in urls:
             doc = pq(self.p.parse("[[V:%s]]" % url))
             assert doc("iframe")[0].attrib["src"].startswith("//www.youtube.com/embed/oHg5SJYRHA0")
+
+    def test_ui_component(self):
+        """Verify that the UI component hook works."""
+        dmw = '<input type="text" id="x" name="x">'
+        content_template = "<p>before</p>{}<p>after</p>"
+        with patch("kitsune.sumo.parser.generate_ui_component_embed", return_value=dmw):
+            result = self.p.parse(content_template.format("[[UI:device_migration_wizard]]"))
+            self.assertEqual(result, content_template.format(dmw))
+
+    def test_invalid_ui_component(self):
+        """Verify error message shown for invalid UI component requests."""
+        content_template = "<p>before</p>{}<p>after</p>"
+        result = self.p.parse(content_template.format("[[UI:undefined]]"))
+        self.assertEqual(
+            result,
+            content_template.format('The UI component "undefined" does not exist.'),
+        )
 
     def test_iframe_in_markup(self):
         """Verify iframe in wiki markup is escaped."""

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -88,9 +88,6 @@
     {% endif %}
     <article class="wiki-doc">
       {{ document_messages(document, redirected_from) }}
-      {% if is_switching_devices_doc %}
-        {% include "wiki/includes/switching-devices.html" %}
-      {% endif %}
       {{ document_content(document, fallback_reason, request, settings, document_css_class, any_localizable_revision, full_locale_name) }}
 
       {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}

--- a/kitsune/wiki/jinja2/wiki/includes/switching-devices.html
+++ b/kitsune/wiki/jinja2/wiki/includes/switching-devices.html
@@ -1,1 +1,0 @@
-{# TODO: Add HTML for the Firefox device migration UI wizard, and more if desired, here. #}

--- a/kitsune/wiki/jinja2/wikiparser/hook_device_migration_wizard.html
+++ b/kitsune/wiki/jinja2/wikiparser/hook_device_migration_wizard.html
@@ -1,0 +1,1 @@
+{# TODO: Add HTML for the Firefox device migration UI wizard here. #}

--- a/kitsune/wiki/parser.py
+++ b/kitsune/wiki/parser.py
@@ -412,7 +412,9 @@ class WikiParser(sumo_parser.WikiParser):
         text = parse_simple_syntax(text)
 
         # Run the formatter:
-        html = super(WikiParser, self).parse(text, youtube_embeds=False, **kwargs)
+        html = super(WikiParser, self).parse(
+            text, youtube_embeds=False, ui_component_embeds=False, **kwargs
+        )
 
         # Put the fors back in (as XML-ish <for> tags this time):
         html = ForParser.unstrip_fors(html, data)
@@ -426,6 +428,7 @@ class WikiParser(sumo_parser.WikiParser):
         html = for_parser.serialize(**kwargs)
 
         html = self.add_youtube_embeds(html)
+        html = self.add_ui_component_embeds(html)
 
         return html
 

--- a/kitsune/wiki/tests/test_parser.py
+++ b/kitsune/wiki/tests/test_parser.py
@@ -1,4 +1,5 @@
 import re
+from unittest.mock import patch
 
 from django.conf import settings
 from django.test.utils import override_settings
@@ -996,3 +997,26 @@ class TestLazyWikiImageTags(TestCase):
         self.assertEqual("test.jpg", img.attr("alt"))
         self.assertEqual(self.img.file.url, img.attr("data-original-src"))
         self.assertRegex(img.attr("src"), r"placeholder\.[0-9a-z]+\.gif")
+
+
+class TestWikiUIComponent(TestCase):
+    """Test the UI Component hook."""
+
+    def test_ui_component(self):
+        """Verify that the UI component hook works."""
+        parser = WikiParser()
+        dmw = '<input type="text" id="x" name="x">'
+        content_template = "<p>before</p>{}<p>after</p>"
+        with patch("kitsune.sumo.parser.generate_ui_component_embed", return_value=dmw):
+            result = parser.parse(content_template.format("[[UI:device_migration_wizard]]"))
+            self.assertEqual(result, content_template.format(dmw))
+
+    def test_invalid_ui_component(self):
+        """Verify error message shown for invalid UI component requests."""
+        parser = WikiParser()
+        content_template = "<p>before</p>{}<p>after</p>"
+        result = parser.parse(content_template.format("[[UI:undefined]]"))
+        self.assertEqual(
+            result,
+            content_template.format('The UI component "undefined" does not exist.'),
+        )


### PR DESCRIPTION
https://github.com/mozilla/sumo/issues/1247

This PR adds a new Wiki "hook" called `UI`, which can be used to pull predefined UI components into any KB article. The predefined UI components are not restricted in any way, so for example normally-disallowed HTML elements will not be escaped. This PR also adds a placeholder file (`kitsune/wiki/jinja2/wikiparser/hook_device_migration_wizard.html`) for a predefined UI component called `device_migration_wizard`, which can be included into any KB article using the already familiar Wiki syntax of:

```wiki
[[UI:device_migration_wizard]]
```

## Testing
I've tested this code locally, and it works great. I've also added unit tests.
