### PR TITLE
switching devices -- fix 1260

### DIFF
--- a/kitsune/sumo/parser.py
+++ b/kitsune/sumo/parser.py
@@ -43,8 +43,8 @@ IMAGE_PARAM_VALUES = {
     "valign": ("baseline", "sub", "super", "top", "text-top", "middle", "bottom", "text-bottom"),
 }
 VIDEO_PARAMS = ["height", "width", "modal", "title", "placeholder"]
-YOUTUBE_PLACEHOLDER = "YOUTUBE_EMBED_PLACEHOLDER_%s"
-UI_COMPONENT_PLACEHOLDER = "UI_COMPONENT_EMBED_PLACEHOLDER_%s"
+YOUTUBE_PLACEHOLDER = "<p>YOUTUBE_EMBED_PLACEHOLDER_%s</p>"
+UI_COMPONENT_PLACEHOLDER = "<p>UI_COMPONENT_EMBED_PLACEHOLDER_%s</p>"
 ALLOWED_UI_COMPONENTS = frozenset(["device_migration_wizard"])
 
 

--- a/kitsune/sumo/tests/test_parser.py
+++ b/kitsune/sumo/tests/test_parser.py
@@ -219,14 +219,19 @@ class TestWikiParser(TestCase):
         """Verify youtube embeds."""
         urls = [
             "http://www.youtube.com/watch?v=oHg5SJYRHA0",
-            "https://youtube.com/watch?v=oHg5SJYRHA0"
-            "http://youtu.be/oHg5SJYRHA0"
+            "https://youtube.com/watch?v=oHg5SJYRHA0",
+            "http://youtu.be/oHg5SJYRHA0",
             "https://youtu.be/oHg5SJYRHA0",
         ]
 
         for url in urls:
-            doc = pq(self.p.parse("[[V:%s]]" % url))
-            assert doc("iframe")[0].attrib["src"].startswith("//www.youtube.com/embed/oHg5SJYRHA0")
+            with self.subTest(url):
+                doc = pq(self.p.parse("[[V:%s]]" % url))
+                assert (
+                    doc("iframe")[0]
+                    .attrib["src"]
+                    .startswith("//www.youtube.com/embed/oHg5SJYRHA0")
+                )
 
     def test_ui_component(self):
         """Verify that the UI component hook works."""

--- a/kitsune/wiki/tests/test_parser.py
+++ b/kitsune/wiki/tests/test_parser.py
@@ -539,15 +539,20 @@ class TestWikiVideo(TestCase):
         """Verify youtube embeds."""
         urls = [
             "http://www.youtube.com/watch?v=oHg5SJYRHA0",
-            "https://youtube.com/watch?v=oHg5SJYRHA0"
-            "http://youtu.be/oHg5SJYRHA0"
+            "https://youtube.com/watch?v=oHg5SJYRHA0",
+            "http://youtu.be/oHg5SJYRHA0",
             "https://youtu.be/oHg5SJYRHA0",
         ]
         parser = WikiParser()
 
         for url in urls:
-            doc = pq(parser.parse("[[V:%s]]" % url))
-            assert doc("iframe")[0].attrib["src"].startswith("//www.youtube.com/embed/oHg5SJYRHA0")
+            with self.subTest(url):
+                doc = pq(parser.parse("[[V:%s]]" % url))
+                assert (
+                    doc("iframe")[0]
+                    .attrib["src"]
+                    .startswith("//www.youtube.com/embed/oHg5SJYRHA0")
+                )
 
 
 class ForWikiTests(TestCase):


### PR DESCRIPTION
mozilla/sumo#1260

Thanks to @hannajones and @smithellis for identifying that the `<form-wizard>` custom HTML element breaks when it's wrapped in a `<p>` tag. This PR ensures that neither of our special "embedded" hooks, `UI` and `Video`, are wrapped in a `<p>` tag by the underlying `py-wikimarkup` parser.

Our special "embedded" Wiki syntax hooks, `[[UI:...]` and `[[Video:...]]`, work by injecting some placeholder text when encountered by the parser, and then after the parser has completed (after it's done "bleaching" the HTML, or in other words, escaping/removing disallowed elements), we make a final pass and replace all of the placeholders with their respective HTML chunks. Since our placeholder text was just text, the underlying `py-wikimarkup` parser wrapped that text in a `<p>` tag. This PR changes the placeholders to be `<p>` tags themselves, so the underlying `py-wikimarkup` parser has no need to wrap them, and since the placeholders are replaced in the final pass, the final result is no longer wrapped in a `<p>` tag.

# Note on the test changes
I discovered that the YouTube video tests had a bug in their list of test URLs (missing commas), so I fixed those and also added a `self.subTest()` context manager so all of the cases will run even if one fails.