### PR TITLE
tweak sumo data migration to use Permission.objects.get_or_create

### DIFF
--- a/kitsune/sumo/migrations/0001_squashed_0002_initial_data.py
+++ b/kitsune/sumo/migrations/0001_squashed_0002_initial_data.py
@@ -12,14 +12,14 @@ def create_ratelimit_bypass_perm(apps, schema_editor):
 
     # Then we create a permission attached to that content type.
     Permission = apps.get_model("auth", "Permission")
-    perm = Permission.objects.create(
+    Permission.objects.get_or_create(
         name="Bypass Ratelimits", content_type=global_permission_ct, codename="bypass_ratelimit"
     )
 
 
 def remove_ratelimit_bypass_perm(apps, schema_editor):
     Permission = apps.get_model("auth", "Permission")
-    perm = Permission.objects.filter(codename="bypass_ratelimit").delete()
+    Permission.objects.filter(codename="bypass_ratelimit").delete()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This PR tweaks the `kitsune/sumo/migrations/0001_squashed_0002_initial_data.py` migration to call `Permission.objects.get_or_create` instead of `Permission.objects.create`, so that if the permission already exists, we won't raise an exception.

For some unknown reason, when I run `./manage.py migrate --database postgres` on a fresh PostgreSQL instance (which I've tried multiple times to double-check that I wasn't doing something wrong), the `sumo.bypass_ratelimit` permission already exists when the `create_ratelimit_bypass_perm()` function is called, so I get the exception shown below.
```python
...
  File "/app/kitsune/sumo/migrations/0001_squashed_0002_initial_data.py", line 15, in create_ratelimit_bypass_perm
    perm = Permission.objects.create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/models/query.py", line 671, in create
    obj.save(force_insert=True, using=self.db)
  File "/venv/lib/python3.11/site-packages/django/db/models/base.py", line 812, in save
    self.save_base(
  File "/venv/lib/python3.11/site-packages/django/db/models/base.py", line 863, in save_base
    updated = self._save_table(
              ^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/models/base.py", line 1006, in _save_table
    results = self._do_insert(
              ^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/models/base.py", line 1047, in _do_insert
    return manager._insert(
           ^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/models/query.py", line 1791, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1660, in execute_sql
    cursor.execute(sql, params)
  File "/venv/lib/python3.11/site-packages/django/db/backends/utils.py", line 102, in execute
    return super().execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/venv/lib/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/venv/lib/python3.11/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/db/backends/mysql/base.py", line 75, in execute
    return self.cursor.execute(query, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
             ^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "/venv/lib/python3.11/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "/venv/lib/python3.11/site-packages/pymysql/connections.py", line 1163, in read
    self._read_result_packet(first_packet)
  File "/venv/lib/python3.11/site-packages/pymysql/connections.py", line 1236, in _read_result_packet
    self._read_rowdata_packet()
  File "/venv/lib/python3.11/site-packages/pymysql/connections.py", line 1270, in _read_rowdata_packet
    packet = self.connection._read_packet()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/venv/lib/python3.11/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/venv/lib/python3.11/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
django.db.utils.IntegrityError: (1062, "Duplicate entry '122-bypass_ratelimit' for key 'content_type_id'")
```

