### PR TITLE
Add progress indicator to form-wizard

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -8,13 +8,34 @@
  */
 export class FormWizard extends HTMLElement {
   #activeStep = null;
+  #progressIndicator = null;
+
+  static get markup() {
+    return `
+      <template>
+        <div>
+          <h2>Wizard header</h2>
+          <section>
+            <slot name="active"></slot>
+          </section>
+          <footer>
+            <progress max="100" value="0"></progress>
+          </footer>
+        </div>
+      </template>
+    `;
+  }
 
   constructor() {
     super();
     let shadow = this.attachShadow({ mode: "open" });
-    let activeSlot = document.createElement("slot");
-    activeSlot.setAttribute("name", "active");
-    shadow.appendChild(activeSlot);
+
+    let parser = new DOMParser();
+    let doc = parser.parseFromString(FormWizard.markup, "text/html");
+    let template = doc.querySelector("template");
+    shadow.appendChild(template.content.cloneNode(true));
+
+    this.#progressIndicator = shadow.querySelector("progress");
   }
 
   connectedCallback() {
@@ -34,6 +55,24 @@ export class FormWizard extends HTMLElement {
   set activeStep(name) {
     this.#activeStep = name;
     this.#setActiveStepAttributes();
+    this.#updateFormProgress();
+  }
+
+  get #steps() {
+    return [...this.children].map((child) => child.getAttribute("name"));
+  }
+
+  /**
+   * Update the value of the progress element to show form completion.
+   * Defaults to 10% for the first step.
+   */
+  #updateFormProgress() {
+    if (this.#steps?.length) {
+      let activeStepIndex = this.#steps.indexOf(this.activeStep);
+      let progress =
+        Math.ceil((activeStepIndex / (this.#steps.length - 1)) * 100) || 10;
+      this.#progressIndicator.value = progress;
+    }
   }
 
   /**

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-tests.js
@@ -14,6 +14,9 @@ describe("form-wizard custom element", () => {
                 <div name="second">
                     <p>This is the second step.</p>
                 </div>
+                <div name="third">
+                    <p>This is the third step.</p>
+                </div>
             </form-wizard>
         `);
     wizard = document.querySelector("form-wizard");
@@ -33,12 +36,33 @@ describe("form-wizard custom element", () => {
     expect(activeStep.textContent.trim()).to.equal("This is the first step.");
   });
 
-  it("should show a different step when the active step changes", () => {
-    wizard.activeStep = "second";
-    let assignedElements = slot.assignedElements();
-    let activeStep = assignedElements[0];
-    expect(assignedElements.length).to.equal(1);
-    expect(activeStep.getAttribute("name")).to.equal("second");
-    expect(activeStep.textContent.trim()).to.equal("This is the second step.");
+  describe("step change behavior", () => {
+    // Reset the active step before each test in this block.
+    beforeEach(() => {
+      wizard.activeStep = "first";
+    });
+
+    it("should show a different step when the active step changes", () => {
+      wizard.activeStep = "second";
+      let assignedElements = slot.assignedElements();
+      let activeStep = assignedElements[0];
+      expect(assignedElements.length).to.equal(1);
+      expect(activeStep.getAttribute("name")).to.equal("second");
+      expect(activeStep.textContent.trim()).to.equal(
+        "This is the second step."
+      );
+    });
+
+    it("should show a progress bar that updates when the active step changes", () => {
+      let progress = wizard.shadowRoot.querySelector("progress");
+      expect(progress).to.exist;
+      expect(progress.value).to.equal(10);
+
+      wizard.activeStep = "second";
+      expect(progress.value).to.equal(50);
+
+      wizard.activeStep = "third";
+      expect(progress.value).to.equal(100);
+    });
   });
 });

--- a/webpack/mocha-require.js
+++ b/webpack/mocha-require.js
@@ -14,6 +14,7 @@ global.history = dom.window.history;
 global.Element = dom.window.Element;
 global.HTMLElement = dom.window.HTMLElement;
 global.customElements = dom.window.customElements;
+global.DOMParser = dom.window.DOMParser;
 global.matchMedia = () => ({
   matches : false,
   addListener : () =>{},


### PR DESCRIPTION
This PR expands on the `<form-wizard>` by sketching in more of the markup and adding a `progress` element as well as a header with some placeholder text. The simple math for the steps is my best guess at percentages based on looking at the [Figma file](https://www.figma.com/file/qe9yX8x51jjbt6DJYgayg2/Device-Migration?type=design&node-id=3362-37818&t=BwQS1p021XyAQlAA-0).

Some beautiful screenshots:

<img width="214" alt="Screenshot 2023-05-08 at 6 12 17 PM" src="https://user-images.githubusercontent.com/15138046/236951306-085d77bc-238c-4ee1-915b-86c11b63515a.png">

<img width="203" alt="Screenshot 2023-05-08 at 6 22 15 PM" src="https://user-images.githubusercontent.com/15138046/236951318-ee48cfc2-3d3a-4c5d-b451-6f82ff13a217.png">
