### PR TITLE
create current_user graphql query

### DIFF
--- a/kitsune/graphql/query.py
+++ b/kitsune/graphql/query.py
@@ -1,17 +1,14 @@
 import graphene
 
-from kitsune.graphql.schema import ContributorType
-from kitsune.users.models import ContributionAreas
+from kitsune.graphql.schema import CurrentUserType
 
 
 class Query(graphene.ObjectType):
-    is_contributor = graphene.Field(ContributorType)
+    current_user = graphene.Field(CurrentUserType)
 
-    def resolve_is_contributor(root, info):
-        """Return the current user if they are a contributor."""
-        # by default we reject non logged in users
+    def resolve_current_user(root, info):
+        """Return the current user."""
         user = info.context.user
-
-        if user.is_authenticated and user.groups.filter(name__in=ContributionAreas.get_groups()):
+        if user.is_authenticated:
             return user
         return None

--- a/kitsune/graphql/schema.py
+++ b/kitsune/graphql/schema.py
@@ -1,11 +1,25 @@
 from django.contrib.auth.models import User
+import graphene
 from graphene_django import DjangoObjectType
 
+from kitsune.users.models import ContributionAreas
 
-class ContributorType(DjangoObjectType):
+
+class CurrentUserType(DjangoObjectType):
     class Meta:
         model = User
         fields = (
             "id",
+            "email",
             "username",
+        )
+
+    is_contributor = graphene.Boolean()
+
+    def resolve_is_contributor(self, info):
+        """Return whether the current user is a contributor."""
+        user = info.context.user
+        return (
+            user.is_authenticated
+            and user.groups.filter(name__in=ContributionAreas.get_groups()).exists()
         )

--- a/svelte/contribute/Contribute.svelte
+++ b/svelte/contribute/Contribute.svelte
@@ -36,13 +36,12 @@
         url: GRAPHQL_ENDPOINT,
     });
     setContextClient(gqlClient);
-    const isContributor = queryStore({
+    const contributorQ = queryStore({
         client: getContextClient(),
         query: gql`
             query getContributorStatus {
-                isContributor {
-                    id
-                    username
+                currentUser {
+                    isContributor
                 }
             }
         `,

--- a/svelte/contribute/Steps.svelte
+++ b/svelte/contribute/Steps.svelte
@@ -8,13 +8,12 @@
     export let fact = {};
     export let location = "";
 
-    const isContributor = queryStore({
+    const contributorQ = queryStore({
         client: getContextClient(),
         query: gql`
             query getContributorStatus {
-                isContributor {
-                    id
-                    username
+                currentUser {
+                    isContributor
                 }
             }
         `,
@@ -32,7 +31,7 @@
     <div class="wrapper">
         <ol>
             <li>
-                {#if !$isContributor.data?.isContributor?.id}
+                {#if !$contributorQ.data?.currentUser?.isContributor}
                     <Linkable link={signUp}>
                         {gettext("Sign up as a volunteer")}
                     </Linkable>


### PR DESCRIPTION
mozilla/sumo#1266

This PR modifies our current `/graphql` endpoint to provide a `currentUser` query that will return information about the current user. For example, POSTing the following graphQL query:
```graphql
{
  currentUser {
    id,
    username,
    email, 
    isContributor
  }
}
```
might return the following JSON:
```json
{
  "data": {
    "currentUser": {
      "id": "1",
      "username": "kitsune",
      "email": "kitsune@mozilla.com",
      "isContributor": true
    }
  }
}
```

This query supports both the svelte-based community stuff as well as the needs of the device-migration UI wizard.

So the device-migration UI wizard could make the following graphQL query:
```graphql
{
  currentUser {
    email
  }
}
```
and see something like the following if the user was logged into SUMO:
```json
{
  "data": {
    "currentUser": {
      "email": "kitsune@mozilla.com"
    }
  }
}
```
or the following if the user was not logged into SUMO:
```json
{
  "data": {
    "currentUser": null
  }
}
```

The existing graphQL queries used within Svelte have been modified (and successfully tested locally) to make the follow query:
```graphql
{
  currentUser {
    isContributor
  }
}
```
