### PR TITLE
Wizard step indicator

### DIFF
--- a/kitsune/sumo/static/sumo/js/device-migration-wizard.js
+++ b/kitsune/sumo/static/sumo/js/device-migration-wizard.js
@@ -3,6 +3,6 @@ import trackEvent from "sumo/js/analytics";
 import SwitchingDevicesWizardManager from "sumo/js/switching-devices-wizard-manager";
 import "sumo/js/form-wizard";
 
-$(document).ready(function() {
-  new SwitchingDevicesWizardManager(document.querySelector("#switching-devices-wizard"))
+$(document).ready(function () {
+  new SwitchingDevicesWizardManager(document.querySelector("#switching-devices-wizard"));
 });

--- a/kitsune/sumo/static/sumo/js/device-migration-wizard.js
+++ b/kitsune/sumo/static/sumo/js/device-migration-wizard.js
@@ -3,6 +3,6 @@ import trackEvent from "sumo/js/analytics";
 import SwitchingDevicesWizardManager from "sumo/js/switching-devices-wizard-manager";
 import "sumo/js/form-wizard";
 
-$(document).ready(function () {
-  new SwitchingDevicesWizardManager(document.querySelector("#switching-devices-wizard"));
+$(document).ready(function() {
+  new SwitchingDevicesWizardManager(document.querySelector("#switching-devices-wizard"))
 });

--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -2,12 +2,12 @@
  * A custom element for displaying multi-step forms.
  *
  * Uses a named slot and `#activeStep` state to determine which step of the form
- * should be shown. All child elements where the `name` attribute doesn't match
- * the `#activeStep` will not be assigned to the named slot.
+ * wizard should be shown. All child elements where the `name` attribute doesn't
+ * match the `#activeStep` will not be assigned to the named slot.
  *
  * Can be initialized with step data via the `steps` setter.
  *
- * wizard.steps = [
+ * wizard.steps = [ 
  *  { name: "first", status: "done", label: "foo" },
  *  { name: "second", status: "active", label: "bar" },
  *  { name: "third", status: "unavailable", label: "baz" },
@@ -107,21 +107,37 @@ export class FormWizard extends HTMLElement {
     this.#updateStepIndicator();
   }
 
+  get steps() {
+    return this.#steps;
+  }
+
   /**
-   * Changes the active step and updates the status of the
-   * previously active step to "done".
+   * Updates data for the step specified by name and/or changes the currently
+   * active step. Active step only changes when the step getting updated is
+   * currently "unavailable".
    *
-   * @param {string} name - Name of the active step.
-   * @param {FormWizardStep} data - Data about the active step.
+   * @param {string} name - Name of the step to be updated.
+   * @param {FormWizardStep} data - Data to update the step with.
    */
   setStep(name, data) {
+    let currentStatus = this.#steps.find((step) => step.name === name)?.status;
+    let isUnavailable = currentStatus === "unavailable";
     let nextSteps = this.#steps.map((step) => {
-      if (step.status === "active") {
+      if (step.status === "active" && isUnavailable) {
         return { ...step, status: "done" };
+      } else if (step.name === name && isUnavailable) {
+        return { ...step, ...data, status: "active" };
+      } else if (step.name === name) {
+        return { ...step, ...data };
       }
-      return step.name === name ? { ...step, ...data } : step;
+      return step;
     });
     this.steps = nextSteps;
+  }
+
+  // To be implemented as part of mozilla/sumo #1274.
+  disqualify(header, text) {
+    // NOOP
   }
 
   /**

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-tests.js
@@ -7,18 +7,18 @@ describe("form-wizard custom element", () => {
 
   beforeEach(() => {
     $("body").empty().html(`
-            <form-wizard>
-                <div name="first">
-                    <p>This is the first step.</p>
-                </div>
-                <div name="second">
-                    <p>This is the second step.</p>
-                </div>
-                <div name="third">
-                    <p>This is the third step.</p>
-                </div>
-            </form-wizard>
-        `);
+        <form-wizard>
+            <div name="first">
+                <p>This is the first step.</p>
+            </div>
+            <div name="second">
+                <p>This is the second step.</p>
+            </div>
+            <div name="third">
+                <p>This is the third step.</p>
+            </div>
+        </form-wizard>
+    `);
     wizard = document.querySelector("form-wizard");
     slot = wizard.shadowRoot.querySelector('slot[name="active"]');
   });
@@ -37,13 +37,19 @@ describe("form-wizard custom element", () => {
   });
 
   describe("step change behavior", () => {
+    let initialSteps = [
+      { name: "first", status: "active", label: "First label" },
+      { name: "second", status: "unavailable", label: "Second label" },
+      { name: "third", status: "unavailable", label: "Third label" },
+    ];
+
     // Reset the active step before each test in this block.
     beforeEach(() => {
-      wizard.activeStep = "first";
+      wizard.steps = initialSteps;
     });
 
     it("should show a different step when the active step changes", () => {
-      wizard.activeStep = "second";
+      wizard.setStep("second", { status: "active" });
       let assignedElements = slot.assignedElements();
       let activeStep = assignedElements[0];
       expect(assignedElements.length).to.equal(1);
@@ -63,6 +69,32 @@ describe("form-wizard custom element", () => {
 
       wizard.activeStep = "third";
       expect(progress.value).to.equal(100);
+    });
+
+    it("should show an indicator of how many steps are in the form", () => {
+      let indicator = wizard.shadowRoot.getElementById("step-indicator");
+      let steps = indicator.children;
+      expect(indicator).to.exist;
+      expect(steps.length).to.equal(initialSteps.length);
+      [...steps].forEach((step, i) => {
+        let subtitle = step.querySelector(".subtitle");
+        let title = step.querySelector(".title");
+        expect(step.getAttribute("status")).to.equal(initialSteps[i].status);
+        expect(subtitle.textContent).to.equal(`Step ${i + 1}`);
+        expect(title.textContent).to.equal(initialSteps[i].label);
+      });
+    });
+
+    it("should update the statuses of the steps when the active step changes", () => {
+      let indicator = wizard.shadowRoot.getElementById("step-indicator");
+      let steps = indicator.children;
+      expect(steps[0].getAttribute("status")).to.equal("active");
+      expect(steps[1].getAttribute("status")).to.equal("unavailable");
+
+      wizard.setStep("second", { status: "active" });
+
+      expect(steps[0].getAttribute("status")).to.equal("done");
+      expect(steps[1].getAttribute("status")).to.equal("active");
     });
   });
 });

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-tests.js
@@ -37,7 +37,7 @@ describe("form-wizard custom element", () => {
   });
 
   describe("step change behavior", () => {
-    let initialSteps = [
+    const INITIAL_STEPS = [
       { name: "first", status: "active", label: "First label" },
       { name: "second", status: "unavailable", label: "Second label" },
       { name: "third", status: "unavailable", label: "Third label" },
@@ -45,11 +45,11 @@ describe("form-wizard custom element", () => {
 
     // Reset the active step before each test in this block.
     beforeEach(() => {
-      wizard.steps = initialSteps;
+      wizard.steps = INITIAL_STEPS;
     });
 
     it("should show a different step when the active step changes", () => {
-      wizard.setStep("second", { status: "active" });
+      wizard.setStep("second", {});
       let assignedElements = slot.assignedElements();
       let activeStep = assignedElements[0];
       expect(assignedElements.length).to.equal(1);
@@ -75,13 +75,13 @@ describe("form-wizard custom element", () => {
       let indicator = wizard.shadowRoot.getElementById("step-indicator");
       let steps = indicator.children;
       expect(indicator).to.exist;
-      expect(steps.length).to.equal(initialSteps.length);
+      expect(steps.length).to.equal(INITIAL_STEPS.length);
       [...steps].forEach((step, i) => {
         let subtitle = step.querySelector(".subtitle");
         let title = step.querySelector(".title");
-        expect(step.getAttribute("status")).to.equal(initialSteps[i].status);
+        expect(step.getAttribute("status")).to.equal(INITIAL_STEPS[i].status);
         expect(subtitle.textContent).to.equal(`Step ${i + 1}`);
-        expect(title.textContent).to.equal(initialSteps[i].label);
+        expect(title.textContent).to.equal(INITIAL_STEPS[i].label);
       });
     });
 
@@ -91,10 +91,60 @@ describe("form-wizard custom element", () => {
       expect(steps[0].getAttribute("status")).to.equal("active");
       expect(steps[1].getAttribute("status")).to.equal("unavailable");
 
-      wizard.setStep("second", { status: "active" });
+      wizard.setStep("second", {});
 
       expect(steps[0].getAttribute("status")).to.equal("done");
       expect(steps[1].getAttribute("status")).to.equal("active");
+    });
+
+    describe("form wizard `setStep` method", () => {
+      it("should update 'unavailable' steps to 'active' update step data", () => {
+        const EXPECTED_STEPS = [
+          { name: "first", status: "done", label: "First label" },
+          {
+            name: "second",
+            status: "active",
+            label: "Second label",
+            foo: "bar",
+          },
+          { name: "third", status: "unavailable", label: "Third label" },
+        ];
+        expect(wizard.steps).to.deep.equal(INITIAL_STEPS);
+        wizard.setStep("second", { foo: "bar" });
+        expect(wizard.steps).to.deep.equal(EXPECTED_STEPS);
+      });
+
+      it("should update data for 'active' steps", () => {
+        const EXPECTED_STEPS = [
+          { name: "first", status: "active", label: "First label", foo: "bar" },
+          { name: "second", status: "unavailable", label: "Second label" },
+          { name: "third", status: "unavailable", label: "Third label" },
+        ];
+        expect(wizard.steps).to.deep.equal(INITIAL_STEPS);
+        wizard.setStep("first", { foo: "bar" });
+        expect(wizard.steps).to.deep.equal(EXPECTED_STEPS);
+      });
+
+      it("should update data for 'done' steps without changing the 'active' step", () => {
+        const TEST_STEPS = [
+          { name: "first", status: "done", label: "First label" },
+          { name: "second", status: "done", label: "Second label" },
+          { name: "third", status: "active", label: "Third label" },
+        ];
+        const EXPECTED_STEPS = [
+          { name: "first", status: "done", label: "First label" },
+          { name: "second", status: "done", label: "Second label" },
+          {
+            name: "third",
+            status: "active",
+            label: "Third label",
+            foo: "bar",
+          },
+        ];
+        wizard.steps = TEST_STEPS;
+        wizard.setStep("third", { foo: "bar" });
+        expect(wizard.steps).to.deep.equal(EXPECTED_STEPS);
+      });
     });
   });
 });

--- a/kitsune/wiki/jinja2/wikiparser/hook_device_migration_wizard.html
+++ b/kitsune/wiki/jinja2/wikiparser/hook_device_migration_wizard.html
@@ -1,11 +1,11 @@
 <form-wizard id="switching-devices-wizard" fxa-root="{{ settings.FXA_ROOT }}">
-    <div name="first">
-        <p>this is the first step</p>
-    </div>
-    <div name="second">
-        <p>this is the second step</p>
-    </div>
-    <div name="third">
-        <p>this is the third step</p>   
-    </div>
+  <div name="sign-into-fxa">
+    <p>This is where the sign in/sign up form will go.</p>
+  </div>
+  <div name="configure-sync">
+    <p>This is where the sync step will go.</p>
+  </div>
+  <div name="setup-new-device">
+    <p>This is where the link info will go.</p>
+  </div>
 </form-wizard>


### PR DESCRIPTION
This PR adds a super basic/un-styled implementation of the step indicator piece of the `<form-wizard>`. I was originally going to create this as a separate component, but since it's relatively simple and more or less needs the same data as the rest of the wizard it felt like keeping the two components in sync might be more trouble than it was worth.

We aren't yet initializing `step` data for the wizard, but for testing purposes something like this can be added to `device-migration-wizard.js` in order to make the step indicator visible:

```js
let wizard = document.querySelector("#switching-devices-wizard");
let steps = [
  {
    name: "sign-into-fxa",
    status: "done",
    label: "Create an account",
  },
  {
    name: "configure-sync",
    status: "active",
    label: "Sync your data",
  },
  {
    name: "setup-new-device",
    status: "unavailable",
    label: "Set up your new device",
  },
];
wizard.steps = steps;
```