### PR TITLE
Add BaseFormStep and sketch in the migration wizard form steps

### DIFF
--- a/kitsune/sumo/static/sumo/js/device-migration-wizard.js
+++ b/kitsune/sumo/static/sumo/js/device-migration-wizard.js
@@ -1,7 +1,71 @@
 import trackEvent from "sumo/js/analytics";
 import SwitchingDevicesWizardManager from "sumo/js/switching-devices-wizard-manager";
-import "sumo/js/form-wizard";
+import { BaseFormStep } from "sumo/js/form-wizard";
 
-$(document).ready(function() {
-  new SwitchingDevicesWizardManager(document.querySelector("#switching-devices-wizard"))
+class SignInStep extends BaseFormStep {
+  get template() {
+    return `
+      <template>
+        <div>
+          <p>This is where the sign in/sign up form will go.</p>
+          <p id="email"></p>
+        </div>
+      </template>
+    `;
+  }
+
+  render() {
+    if (this.state.email) {
+      let emailEl = this.shadowRoot.getElementById("email");
+      emailEl.textContent = this.state.email;
+    }
+  }
+}
+customElements.define("sign-in-step", SignInStep);
+
+class ConfigureStep extends BaseFormStep {
+  get template() {
+    return `
+      <template>
+        <div>
+          <p>This is where the sync step will go.</p>
+          <p id="sync-status"></p>
+        </div>
+      </template>
+    `;
+  }
+
+  render(prevState, state) {
+    if (this.state.syncEnabled !== prevState.syncEnabled) {
+      let statusEl = this.shadowRoot.getElementById("sync-status");
+      statusEl.textContent = this.state.syncEnabled
+        ? "Syncing: ON"
+        : "Syncing: OFF";
+    }
+  }
+}
+customElements.define("configure-step", ConfigureStep);
+``;
+
+class SetupDeviceStep extends BaseFormStep {
+  get template() {
+    return `
+      <template>
+        <div>
+          <p>This is where the link info will go.</p>
+        </div>
+      </template>
+    `;
+  }
+
+  render() {
+    // NOOP
+  }
+}
+customElements.define("setup-device-step", SetupDeviceStep);
+
+$(document).ready(function () {
+  new SwitchingDevicesWizardManager(
+    document.querySelector("#switching-devices-wizard")
+  );
 });

--- a/kitsune/wiki/jinja2/wikiparser/hook_device_migration_wizard.html
+++ b/kitsune/wiki/jinja2/wikiparser/hook_device_migration_wizard.html
@@ -1,11 +1,5 @@
 <form-wizard id="switching-devices-wizard" fxa-root="{{ settings.FXA_ROOT }}">
-  <div name="sign-into-fxa">
-    <p>This is where the sign in/sign up form will go.</p>
-  </div>
-  <div name="configure-sync">
-    <p>This is where the sync step will go.</p>
-  </div>
-  <div name="setup-new-device">
-    <p>This is where the link info will go.</p>
-  </div>
+  <sign-in-step name="sign-into-fxa"></sign-in-step>
+  <configure-step name="configure-sync"></configure-step>
+  <setup-device-step name="setup-new-device"></setup-device-step>
 </form-wizard>


### PR DESCRIPTION
This PR adds a `BaseFormStep` element that is intended to be used in tandem with `FormWizard` to create and update custom form steps.

I'll file follow up tickets for filling in the specific markup/logic we need for the three form steps. For now I've just implemented something super basic so we can see that they're working.