### PR TITLE
Use external CSS files from .styles.scss source

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -1,3 +1,5 @@
+import wizardStylesURL from "../scss/form-wizard.styles.scss";
+
 /**
  * A custom element for displaying multi-step forms. Designed to be used with
  * child elements that inherit from `BaseFormStep`, or which implement a
@@ -44,57 +46,10 @@ export class FormWizard extends HTMLElement {
   }
 
   static get styles() {
-    let style = document.createElement("style");
-    style.textContent = `
-      :root,
-      :host {
-        --color-progress: var(--color-blue-06);
-      }
-      
-      :host {
-        display: flex;
-        flex-direction: column;
-        border-radius: 8px;
-        box-shadow: 0px 2px 6px rgba(58, 57, 68, 0.2);
-      }
-      
-      .form-wizard-content {
-        padding-inline: 32px;
-        padding-block-start: 24px;
-      }
-      
-      h2 {
-        margin: 0;
-        font-size: 1.5rem;
-        line-height: 1;
-        color: var(--color-heading);
-      }
-      
-      ul {
-        margin-inline-end: 48px;
-      }
-      
-      section,
-      ::slotted([slot="active"])  {
-        display: flex;
-        flex: 1;
-      }
-      
-      progress {
-        flex: 1;
-        max-height: 8px;
-        appearance: none;
-        border: none;
-        border-bottom-left-radius: 8px;
-        border-bottom-right-radius: 8px;
-      }
-      
-      progress::-moz-progress-bar,
-      progress::-webkit-progress-value {
-        background-color: var(--color-progress);
-      }
-    `;
-    return style;
+    let stylesheet = document.createElement("link");
+    stylesheet.rel = "stylesheet";
+    stylesheet.href = wizardStylesURL;
+    return stylesheet;
   }
 
   constructor() {

--- a/kitsune/sumo/static/sumo/scss/form-wizard.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard.styles.scss
@@ -1,0 +1,47 @@
+:root,
+:host {
+  --color-progress: var(--color-blue-06);
+}
+
+:host {
+  display: flex;
+  flex-direction: column;
+  border-radius: 8px;
+  box-shadow: 0px 2px 6px rgba(58, 57, 68, 0.2);
+}
+
+.form-wizard-content {
+  padding-inline: 32px;
+  padding-block-start: 24px;
+}
+
+h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--color-heading);
+}
+
+ul {
+  margin-inline-end: 48px;
+}
+
+section,
+::slotted([slot="active"]) {
+  display: flex;
+  flex: 1;
+}
+
+progress {
+  flex: 1;
+  max-height: 8px;
+  appearance: none;
+  border: none;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+progress::-moz-progress-bar,
+progress::-webkit-progress-value {
+  background-color: var(--color-progress);
+}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -51,7 +51,7 @@ module.exports = {
             preprocess: sveltePreprocess(),
             compilerOptions: {
               hydratable: true,
-            }
+            },
           },
         },
       },
@@ -64,12 +64,22 @@ module.exports = {
       },
       {
         test: /\.s?css$/,
+        exclude: /\.styles.scss$/,
         use: [
           MiniCssExtractPlugin.loader,
           "css-loader",
           "postcss-loader",
           "sass-loader",
         ],
+      },
+      {
+        test: /\.styles.scss$/,
+        exclude: /node_modules/,
+        type: "asset/resource",
+        use: ["sass-loader"],
+        generator: {
+          filename: "[name].[contenthash].css"
+        }
       },
       {
         test: /\.(svg|png|webp|gif|woff2?)$/,


### PR DESCRIPTION
This PR provides a potential solution for using external stylesheets in our wizard web components. The webpack config changes basically:

* takes `.scss` source code and translates it to CSS using `sass-loader`
* specifies `type: "asset/resource"` which will emit a separate file and export the URL of that generated file by default
* specifies that the naming structure for the file that gets emitted to ensure it's a `.css` file

Once we've generated the CSS file we can import the `.scss` source in our web component to get the URL of the built file, then create a link pointing to that URL.

This whole process doesn't seem to work if we run things through `MiniCssExtractPlugin.loader`, so I've given the file a `.styles.scss` extension so that we can specify different Webpack rules for CSS we want to load into web components. (This was inspired by [this article](https://dev.to/m4thieulavoie/how-i-managed-to-use-scss-inside-web-components-3lk9) - I'm open to other naming conventions.)

I'm not 100% sure this is going to work in production environments, but it's working well for me locally, so seems like a starting point at least.

--

As a little experiment to check that we could load Protocol styles, I copied the contents of `_protocol.scss` into `form-wizard.styles.scss` and added an import for the protocol button component. This was the result:

<img width="858" alt="Screenshot 2023-05-16 at 12 48 09 PM" src="https://github.com/mozilla/kitsune/assets/15138046/c30d954c-f8d1-4085-8413-ebbbc59dfd5a">
