### PR TITLE
Have alternative links from switching devices manager pass redirect_immediately=true.

### DIFF
--- a/kitsune/sumo/static/sumo/js/device-migration-wizard.js
+++ b/kitsune/sumo/static/sumo/js/device-migration-wizard.js
@@ -33,7 +33,7 @@ class SignInStep extends BaseFormStep {
             <input name="utm_source" value="" type="hidden"/>
             <input name="utm_medium" value="" type="hidden"/>
             <input name="entrypoint" value="" type="hidden"/>
-            <input name="redirect_immediately" value="true" type="hidden"/>
+            <input name="redirect_immediately" value="" type="hidden"/>
             <input name="redirect_to" value="" type="hidden"/>
 
             <label for="email">${gettext("Email")}</label>
@@ -93,6 +93,7 @@ class SignInStep extends BaseFormStep {
       "utm_medium",
       "entrypoint",
       "redirect_to",
+      "redirect_immediately",
     ];
 
     for (let fieldName of STATE_FIELDS) {

--- a/kitsune/sumo/static/sumo/js/switching-devices-wizard-manager.js
+++ b/kitsune/sumo/static/sumo/js/switching-devices-wizard-manager.js
@@ -100,6 +100,7 @@ export default class SwitchingDevicesWizardManager {
           flow_begin_time: state.flow_begin_time,
           context: state.context,
           redirect_to: window.location.href,
+          redirect_immediately: true,
         }
 
         let linkParams = new URLSearchParams();

--- a/kitsune/sumo/static/sumo/js/tests/switching-devices-wizard-manager-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/switching-devices-wizard-manager-tests.js
@@ -357,7 +357,7 @@ describe("k", () => {
       expect(payload).to.deep.equal({
         fxaRoot: FAKE_FXA_ROOT,
         email: "",
-        linkHref: `${FAKE_FXA_ROOT}?utm_source=support.mozilla.org&utm_campaign=migration&utm_medium=mozilla-websites&entrypoint=fx-new-device-sync&flow_id=${FAKE_FXA_FLOW_ID}&flow_begin_time=${FAKE_FXA_FLOW_BEGIN_TIME}&context=fx_desktop_v3&redirect_to=https%3A%2F%2Fexample.com%2F%23search`,
+        linkHref: `${FAKE_FXA_ROOT}?utm_source=support.mozilla.org&utm_campaign=migration&utm_medium=mozilla-websites&entrypoint=fx-new-device-sync&flow_id=${FAKE_FXA_FLOW_ID}&flow_begin_time=${FAKE_FXA_FLOW_BEGIN_TIME}&context=fx_desktop_v3&redirect_to=https%3A%2F%2Fexample.com%2F%23search&redirect_immediately=true`,
 
         utm_source: "support.mozilla.org",
         utm_campaign: "migration",
@@ -369,6 +369,7 @@ describe("k", () => {
         flow_begin_time: FAKE_FXA_FLOW_BEGIN_TIME,
         context: "fx_desktop_v3",
         redirect_to: window.location.href,
+        redirect_immediately: true,
       });
     });
 
@@ -413,7 +414,8 @@ describe("k", () => {
         fxaRoot: FAKE_FXA_ROOT,
         email: "test@example.com",
         redirect_to: window.location.href,
-        linkHref: `${FAKE_FXA_ROOT}?utm_source=support.mozilla.org&utm_campaign=migration&utm_medium=mozilla-websites&entrypoint=fx-new-device-sync&entrypoint_experiment=experiment&entrypoint_variation=variation&flow_id=${FAKE_FXA_FLOW_ID}&flow_begin_time=${FAKE_FXA_FLOW_BEGIN_TIME}&context=fx_desktop_v3&redirect_to=https%3A%2F%2Fexample.com%2F%23search`
+        redirect_immediately: true,
+        linkHref: `${FAKE_FXA_ROOT}?utm_source=support.mozilla.org&utm_campaign=migration&utm_medium=mozilla-websites&entrypoint=fx-new-device-sync&entrypoint_experiment=experiment&entrypoint_variation=variation&flow_id=${FAKE_FXA_FLOW_ID}&flow_begin_time=${FAKE_FXA_FLOW_BEGIN_TIME}&context=fx_desktop_v3&redirect_to=https%3A%2F%2Fexample.com%2F%23search&redirect_immediately=true`
       };
       expect(step.enter(TEST_STATE)).to.deep.equal(EXPECTED_PAYLOAD);
     });


### PR DESCRIPTION
This was also being hardcoded into the <form>, but for consistency sake, is now read and set from the state object sent from the SwitchingDevicesWizardManager.