### PR TITLE
Add common form step styles, bring protocol elements into steps

### DIFF
--- a/kitsune/sumo/static/sumo/js/device-migration-wizard.js
+++ b/kitsune/sumo/static/sumo/js/device-migration-wizard.js
@@ -17,10 +17,10 @@ class SignInStep extends BaseFormStep {
             ${gettext("Body provide short value of the account other than the bookmarks/password/history line, what else could they get out of it that would be good to know here?")}
           </p>
 
-          <p class="for-sign-up">
+          <p class="for-sign-up form-title">
             <strong>${gettext("Create an account")}</strong>
           </p>
-          <p class="for-sign-in">
+          <p class="for-sign-in form-title">
             <strong>${gettext("Sign in to your account")}</strong>
           </p>
 
@@ -39,14 +39,14 @@ class SignInStep extends BaseFormStep {
             <label for="email">${gettext("Email")}</label>
             <input id="email" name="email" type="email" required="true" placeholder="${gettext("Enter your email")}"/>
 
-            <button class="for-sign-up" type="submit" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="signup-button">${gettext("Sign up")}</button>
-            <button class="for-sign-in" type="submit" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="sign-in-button">${gettext("Sign in")}</button>
+            <button class="for-sign-up mzp-c-button mzp-t-product" type="submit" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="signup-button">${gettext("Sign up")}</button>
+            <button class="for-sign-in mzp-c-button mzp-t-product" type="submit" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="sign-in-button">${gettext("Sign in")}</button>
           </form>
 
-          <p class="for-sign-up">
+          <p class="for-sign-up form-footer">
             ${gettext("Already have an account?")} <a class='alternative-link' href='#' data-event-category="device-migration-wizard" data-event-action="click" data-event-label="sign-in-link">${gettext("Sign in")}</a>
           </p>
-          <p class="for-sign-in">
+          <p class="for-sign-in form-footer">
             ${gettext("Don’t have an account?")} <a class='alternative-link' href='#' data-event-category="device-migration-wizard" data-event-action="click" data-event-label="signup-link">${gettext("Sign up")}</a>
           </p>
 
@@ -117,7 +117,7 @@ class ConfigureStep extends BaseFormStep {
   get template() {
     return `
       <template>
-        <div>
+        <div class="configure-step-wrapper">
           <p id="header">
             <img class="icon" src="${infoImageURL}" aria-hidden="true"></img>
             <span>${gettext("You are now logged in to Firefox Accounts")}</span>
@@ -134,9 +134,9 @@ class ConfigureStep extends BaseFormStep {
             <li>${gettext("set expectations we sync all data across all devices - can’t pick and choose")}</li>
           </ul>
           <p id="buttons">
-            <button id="turn-on-sync" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="turn-on-sync">${gettext("Turn on sync")}</button>
-            <button id="change-sync-prefs" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="change-sync-prefs">${gettext("Change what you are syncing")}</button>
-            <button id="next" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="configuration-next">${gettext("Next")}</button>
+            <button id="turn-on-sync" class="mzp-c-button mzp-t-product" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="turn-on-sync">${gettext("Turn on sync")}</button>
+            <button id="change-sync-prefs" class="mzp-c-button" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="change-sync-prefs">${gettext("Change what you are syncing")}</button>
+            <button id="next" class="mzp-c-button mzp-t-product" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="configuration-next">${gettext("Next")}</button>
           </p>
         </div>
       </template>

--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -1,4 +1,5 @@
 import wizardStylesURL from "../scss/form-wizard.styles.scss";
+import formStepStylesURL from "../scss/form-step.styles.scss";
 
 /**
  * A custom element for displaying multi-step forms. Designed to be used with
@@ -235,6 +236,17 @@ export class BaseFormStep extends HTMLElement {
   }
 
   /**
+   * Provides styles that are common to all form steps, mainly selected Protocol
+   * styles and components.
+   */
+  get defaultStyles() {
+    let stylesheet = document.createElement("link");
+    stylesheet.rel = "stylesheet";
+    stylesheet.href = formStepStylesURL;
+    return stylesheet;
+  }
+
+  /**
    * Provides a <link> element to be injected into the shadow DOM at construction
    * time. Subclasses that need custom styles should override this.
    */
@@ -249,7 +261,11 @@ export class BaseFormStep extends HTMLElement {
     let parser = new DOMParser();
     let doc = parser.parseFromString(this.template, "text/html");
     let template = doc.querySelector("template");
-    this.shadowRoot.append(this.styles, template.content.cloneNode(true));
+    this.shadowRoot.append(
+      this.defaultStyles,
+      this.styles,
+      template.content.cloneNode(true)
+    );
 
     this.render({}, this.#state);
   }

--- a/kitsune/sumo/static/sumo/scss/form-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-step.styles.scss
@@ -1,0 +1,18 @@
+// Base elements - general HTML elements
+@import "protocol/css/base/elements/reset";
+@import "protocol/css/base/elements/common";
+@import "protocol/css/base/elements/forms";
+
+// Components from protocol-extra.scss
+@import "protocol/css/components/button";
+
+@import "./base/typography";
+
+:root,
+:host {
+  --color-text-form-step: var(--color-dark-gray-10);
+
+  font-size: 0.875rem;
+  line-height: 1.14;
+  color: var(--color-text-form-step);
+}

--- a/kitsune/sumo/static/sumo/scss/form-wizard-configuration-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard-configuration-step.styles.scss
@@ -1,3 +1,8 @@
+.configure-step-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
 #header,
 #sync-status-container {
   display: flex;
@@ -7,6 +12,7 @@
 #header {
   padding-block-end: 12px;
   border-bottom: 1px solid var(--color-light-gray-03);
+  font-size: 0.8125rem;
 }
 
 .icon {
@@ -23,7 +29,7 @@
   font-weight: 700;
   color: var(--color-white);
   border-radius: 34px;
-  padding: 2px 16px;
+  padding: 4px 16px;
   margin-inline-start: 12px;
   text-transform: uppercase;
 
@@ -41,6 +47,9 @@
 #buttons {
   display: flex;
   flex-direction: column;
+  margin-block-end: 0;
+  flex: 1;
+  justify-content: space-between;
 }
 
 #buttons > button {
@@ -54,4 +63,15 @@
 
 #next {
   align-self: end;
+  margin-block: 8px 16px;
+}
+
+#change-sync-prefs {
+  background-color: var(--color-light-gray-03);
+  border-color: var(--color-light-gray-03);
+  color: var(--color-text-form-step);
+}
+
+#instructions {
+  margin-block-end: 30px;
 }

--- a/kitsune/sumo/static/sumo/scss/form-wizard-sign-in-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard-sign-in-step.styles.scss
@@ -6,4 +6,44 @@
 .key-icon {
   width: 16px;
   height: 8px;
+  margin-inline-end: 11px;
+}
+
+label,
+input[name="email"] {
+  font-size: 0.8125rem;
+}
+
+label {
+  font-weight: normal;
+}
+
+input[name="email"] {
+  width: 325px;
+  margin-block-end: 16px;
+}
+
+button.for-sign-in,
+button.for-sign-up {
+  display: block;
+  margin-block-end: 8px;
+}
+
+.form-title {
+  margin-block-end: 8px;
+}
+
+.form-footer {
+  margin-block-end: 26px;
+  font-size: 0.8125rem;
+}
+
+.warning {
+  display: flex;
+  align-items: center;
+  background-color: rgba(255, 234, 128, 0.4);
+  padding-inline: 16px;
+  padding-block: 8px;
+  border-radius: 8px;
+  font-size: 0.75rem;
 }


### PR DESCRIPTION
This PR provides a way to pull Protocol styles/other common styles into all of our form steps via `BaseFormStep`. It also adds some styling/polish to the existing form steps. Here's how things are looking now:

<img width="897" alt="Screenshot 2023-05-17 at 11 02 13 AM" src="https://github.com/mozilla/kitsune/assets/15138046/7278130a-c636-405c-9520-2439683d0849">

<img width="888" alt="Screenshot 2023-05-17 at 11 02 00 AM" src="https://github.com/mozilla/kitsune/assets/15138046/d4a5ccb7-15be-4ddb-9f25-d60afb9f81af">
