### PR TITLE
use document for label on tabbed-menu link clicks

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -427,9 +427,9 @@
           <div class="topic-article--text">
             <h2 class="sumo-card-heading">
               <a {% if is_fallback %} href="{{ document['url']|replace('/'+ settings.WIKI_DEFAULT_LANGUAGE +'/', '/' + request.LANGUAGE_CODE + '/') }}" {% else %} href="{{ document['url'] }}" {% endif %}
-                data-event-category="device-migration-tabbed-menu" 
+                data-event-category="device-migration-tabbed-menu"
                 data-event-action="link-click"
-                data-event-label="{{ active_topic_slug }}">
+                data-event-label="{{ document['document_title'] }}">
                 {{ document['document_title'] }}
               </a>
             </h2>
@@ -444,18 +444,18 @@
   <nav class="tabs">
     <ul class="tabs--list subtopics">
       <li class="tabs--item">
-      <button class="tabs--link is-active" id="kb-tab-all" 
+      <button class="tabs--link is-active" id="kb-tab-all"
         data-event-category="device-migration-tabbed-menu"
-        data-event-action="tab-click" 
+        data-event-action="tab-click"
         data-event-label="view-all">
         <span>{{ _('View All') }}</span>
       </button>
       </li>
       {% for subtopic in subtopics %}
         <li class="tabs--item">
-          <button class="tabs--link" id="kb-subtopic-{{ subtopic.title }}" 
+          <button class="tabs--link" id="kb-subtopic-{{ subtopic.title }}"
              data-event-category="device-migration-tabbed-menu"
-             data-event-action="tab-click" 
+             data-event-action="tab-click"
              data-event-label="{{subtopic.slug}}">
             <span>{{ pgettext('DB: products.Topic.title', subtopic.title) }}</span>
           </button>


### PR DESCRIPTION
I was reviewing our GA calls, and noticed that for `link-click` actions within the `device-migration-tabbed-menu` category we're reporting the topic's slug as the label. These are clicks on document links within any of the tabs, so it seems better to report the document rather than the topic, so either the document's title or slug.