### PR TITLE
Use slug instead of title in id

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -453,10 +453,10 @@
       </li>
       {% for subtopic in subtopics %}
         <li class="tabs--item">
-          <button class="tabs--link" id="kb-subtopic-{{ subtopic.title }}"
+          <button class="tabs--link" id="kb-subtopic-{{ subtopic.slug }}"
              data-event-category="device-migration-tabbed-menu"
              data-event-action="tab-click"
-             data-event-label="{{subtopic.slug}}">
+             data-event-label="{{ subtopic.slug }}">
             <span>{{ pgettext('DB: products.Topic.title', subtopic.title) }}</span>
           </button>
         </li>


### PR DESCRIPTION
If we introduce a subtopic with spaces, the JS part will break.