### PR TITLE
Implement email input validation and styling

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
@@ -118,12 +118,11 @@ export class SignInStep extends BaseFormStep {
     let root = this.shadowRoot.querySelector("#sign-in-step-root");
 
     if (this.state.email) {
-      let emailEl = this.shadowRoot.querySelector("#email");
       // If the user somehow has managed to type something into the email
       // field before we were able to get the email address, let's not
       // overwrite what the user had typed in.
-      if (!emailEl.value) {
-        emailEl.value = this.state.email;
+      if (!this.#emailEl.value) {
+        this.#emailEl.value = this.state.email;
       }
       root.setAttribute("mode", "sign-in");
     } else {

--- a/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
@@ -37,7 +37,7 @@ export class SignInStep extends BaseFormStep {
 
             <label for="email">${gettext("Email")}</label>
             <div class="tooltip-container">
-              <aside id="email-error" class="error-tooltip hidden"></aside>
+              <aside id="email-error" class="error-tooltip hidden">${gettext("Valid email required")}</aside>
               <input id="email" name="email" type="email" required="true" placeholder="${gettext("Enter your email")}"/>
             </div>
 
@@ -88,30 +88,24 @@ export class SignInStep extends BaseFormStep {
     switch (event.type) {
       case "blur": {
         if (!this.#emailEl.validity.valid) {
-          this.handleShowError();
+          this.#emailErrorEl.classList.remove("hidden");
         }
         break;
       }
       case "input": {
         if (this.#emailEl.value?.trim()) {
           this.#emailErrorEl.classList.add("hidden");
-          this.#emailErrorEl.textContent = "";
         }
         break;
       }
       case "submit": {
         if (!this.#emailEl.validity.valid) {
-          this.handleShowError();
+          this.#emailErrorEl.classList.remove("hidden");
           event.preventDefault();
         }
         break;
       }
     }
-  }
-
-  handleShowError() {
-    this.#emailErrorEl.textContent = gettext("Valid email required");
-    this.#emailErrorEl.classList.remove("hidden");
   }
 
   render() {

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
@@ -245,4 +245,57 @@ describe("sign-in-step custom element", () => {
       expect(link.href).to.equal("https://expected-url.com/")
     }
   });
+
+  describe("form valdiation", () => {
+    let form;
+    let submitBtn;
+    let emailField;
+    let emailErrorMessage;
+
+    beforeEach(() => {
+      form = step.shadowRoot.querySelector("form");
+      submitBtn = form.querySelector("button[type=submit]");
+      emailField = form.querySelector("input[name=email]");
+      emailErrorMessage = form.querySelector("#email-error");
+    });
+
+    it("should display an error message if an email address is not supplied", () => {
+      expect([...emailErrorMessage.classList]).to.include("hidden");
+
+      emailField.value = "";
+      submitBtn.click();
+
+      expect(emailField.validity.valid).to.be.false;
+      expect([...emailErrorMessage.classList]).to.not.include("hidden");
+      expect(emailErrorMessage.textContent).to.equal("Valid email required");
+    });
+
+    it("should display an error message if an incomplete email address is supplied", () => {
+      expect([...emailErrorMessage.classList]).to.include("hidden");
+
+      emailField.value = "this-is-not-an-email-address";
+      submitBtn.click();
+
+      expect(emailField.validity.valid).to.be.false;
+      expect([...emailErrorMessage.classList]).to.not.include("hidden");
+      expect(emailErrorMessage.textContent).to.equal("Valid email required");
+    });
+
+    it("should submit the form when a valid email address is supplied", () => {
+      // Prevent the form from actually submitting.
+      form.addEventListener(
+        "submit",
+        (e) => {
+          e.preventDefault();
+        },
+        { once: true }
+      );
+
+      emailField.value = "email@email.com";
+      submitBtn.click();
+
+      expect(emailField.validity.valid).to.be.true;
+      expect([...emailErrorMessage.classList]).to.include("hidden");
+    });
+  });
 });

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
@@ -281,18 +281,22 @@ describe("sign-in-step custom element", () => {
       expect(emailErrorMessage.textContent).to.equal("Valid email required");
     });
 
-    it("should submit the form when a valid email address is supplied", () => {
+    it("should submit the form when a valid email address is supplied", async () => {
       // Prevent the form from actually submitting.
-      form.addEventListener(
-        "submit",
-        (e) => {
-          e.preventDefault();
-        },
-        { once: true }
-      );
+      let preventSubmitListener = new Promise((resolve) => {
+        form.addEventListener(
+          "submit",
+          (e) => {
+            e.preventDefault();
+            resolve();
+          },
+          { once: true }
+        );
+      });
 
       emailField.value = "email@email.com";
       submitBtn.click();
+      await preventSubmitListener;
 
       expect(emailField.validity.valid).to.be.true;
       expect([...emailErrorMessage.classList]).to.include("hidden");

--- a/kitsune/sumo/static/sumo/scss/form-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-step.styles.scss
@@ -1,3 +1,5 @@
+@use "@mozilla-protocol/core/protocol/css/includes/lib" as p;
+
 // Base elements - general HTML elements
 @import "protocol/css/base/elements/reset";
 @import "protocol/css/base/elements/common";
@@ -15,4 +17,43 @@
   font-size: 0.875rem;
   line-height: 1.14;
   color: var(--color-text-form-step);
+}
+
+.hidden {
+  visibility: hidden;
+}
+
+.error-tooltip:not(.hidden) + input:invalid,
+input:not(:focus):not(:placeholder-shown):invalid {
+  border: 2px solid p.$color-red-60;
+}
+
+.error-tooltip:not(.hidden) + input:focus:invalid {
+  box-shadow: 0 0 0 2px rgba(226, 40, 80, 0.5);
+}
+
+.tooltip-container {
+  position: relative;
+}
+
+.error-tooltip {
+  background-color: p.$color-red-60;
+  border-radius: 4px;
+  color: var(--color-white);
+  padding: 8px;
+  position: absolute;
+  top: -34px;
+}
+
+.error-tooltip::before {
+  background-color: p.$color-red-60;
+  bottom: -8px;
+  content: ".";
+  height: 16px;
+  position: absolute;
+  text-indent: -999px;
+  transform: rotate(45deg);
+  white-space: nowrap;
+  width: 16px;
+  margin-inline-start: 6px;
 }

--- a/kitsune/sumo/static/sumo/scss/form-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-step.styles.scss
@@ -48,7 +48,7 @@ input:not(:focus):not(:placeholder-shown):invalid {
 .error-tooltip::before {
   background-color: p.$color-red-60;
   bottom: -8px;
-  content: ".";
+  content: "";
   height: 16px;
   position: absolute;
   text-indent: -999px;

--- a/kitsune/sumo/static/sumo/scss/form-wizard-configure-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard-configure-step.styles.scss
@@ -1,3 +1,5 @@
+@use "@mozilla-protocol/core/protocol/css/includes/lib" as p;
+
 .configure-step-wrapper {
   display: flex;
   flex-direction: column;
@@ -32,12 +34,7 @@
   padding: 4px 16px;
   margin-inline-start: 12px;
   text-transform: uppercase;
-
-  /**
-   * TODO: the spec calls for this to be #E22850, but that's not part of
-   * the colour swatches available to us.
-   */
-  background-color: var(--color-error);
+  background-color: p.$color-red-60;
 }
 
 #sync-status[sync-enabled] {


### PR DESCRIPTION
This PR adds a custom error message tooltip to the email input in the sign in step. The styling is largely taken from the FxA sign in form, which I believe was the inspiration for the mockups.

<img width="884" alt="Screenshot 2023-05-18 at 10 42 47 AM" src="https://github.com/mozilla/kitsune/assets/15138046/bb1741e0-d92c-4134-9769-4e911041956f">
