### PR TITLE
Implement the setup device form step

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard-setup-device-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-setup-device-step.js
@@ -7,9 +7,10 @@ export class SetupDeviceStep extends BaseFormStep {
     return `
       <template>
         <div>
-          <h3>${gettext("Congratulatory headline they’ve done all they need to do on THIS device")}</h3>
+          <h3>${gettext("You’re all set on this device!")}</h3>
           <ul>
-            <li>${gettext("Let user know this is the point in the flow they will need to access their new device - if they don’t have it yet, that’s okay but.. (give next step - come back here when __ , do ___ until")}</li>
+            <li>${gettext("To continue with the download and sync process on your new device, click the copy-paste button and save the link in a place that you will remember, such as a note-taking app or send it to your email. When you're on your new device, simply paste the download link into the default browser of your new device to download Firefox and we'll be there to assist you with the next steps.")}</li>
+            <li>${gettext("You can save the link to this article in a convenient location, and we'll be here to help you pick up where you left off whenever you're ready.")}</li>
           </ul>
           <div class="download-link-wrapper">
             <a id="download-link" href="https://mzl.la/newdevice" target="_blank">https://mzl.la/newdevice</a>
@@ -20,10 +21,6 @@ export class SetupDeviceStep extends BaseFormStep {
               <aside id="copy-message" class="tooltip tooltip-right">${gettext("Copy to clipboard")}</aside>
             </div>
           </div>
-          <ul>
-            <li>${gettext("if they do have their device here’s how they can get it")}</li>
-            <li>${gettext("Try to let user know where the link goes so they don’t have to click it to understand it’s an app download - maybe in language, maybe we can do this visually?")}</li>
-          </ul>
         </div>
       </template>
     `;
@@ -54,10 +51,6 @@ export class SetupDeviceStep extends BaseFormStep {
   copyLink() {
     let downloadLink = this.shadowRoot.getElementById("download-link");
     navigator.clipboard.writeText(downloadLink.href);
-  }
-
-  render() {
-    // NOOP
   }
 }
 customElements.define("setup-device-step", SetupDeviceStep);

--- a/kitsune/sumo/static/sumo/js/form-wizard-setup-device-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-setup-device-step.js
@@ -1,19 +1,63 @@
 import { BaseFormStep } from "sumo/js/form-wizard";
+import setupDeviceStepStyles from "../scss/form-wizard-setup-device-step.styles.scss";
+import copyIconUrl from "protocol/img/icons/copy.svg"
 
 export class SetupDeviceStep extends BaseFormStep {
   get template() {
     return `
       <template>
         <div>
-          <p>This is where the link info will go.</p>
+          <h3>${gettext("Congratulatory headline they’ve done all they need to do on THIS device")}</h3>
+          <ul>
+            <li>${gettext("Let user know this is the point in the flow they will need to access their new device - if they don’t have it yet, that’s okay but.. (give next step - come back here when __ , do ___ until")}</li>
+          </ul>
+          <div class="download-link-wrapper">
+            <a id="download-link" href="https://mzl.la/newdevice" target="_blank">https://mzl.la/newdevice</a>
+            <div class="tooltip-container">
+              <button id="copy-button" aria-label=${gettext("Copy to clipboard")}>
+                <img src=${copyIconUrl} aria-hidden="true"></img>
+              </button>
+              <aside id="copy-message" class="tooltip tooltip-right">${gettext("Copy to clipboard")}</aside>
+            </div>
+          </div>
+          <ul>
+            <li>${gettext("if they do have their device here’s how they can get it")}</li>
+            <li>${gettext("Try to let user know where the link goes so they don’t have to click it to understand it’s an app download - maybe in language, maybe we can do this visually?")}</li>
+          </ul>
         </div>
       </template>
     `;
+  }
+
+  get styles() {
+    let linkEl = document.createElement("link");
+    linkEl.rel = "stylesheet";
+    linkEl.href = setupDeviceStepStyles;
+    return linkEl;
+  }
+
+  constructor() {
+    super();
+    this.copyLink = this.copyLink.bind(this);
+  }
+
+  connectedCallback() {
+    let copyButton = this.shadowRoot.getElementById("copy-button");
+    copyButton.addEventListener("click", this.copyLink);
+  }
+
+  disconnectedCallback() {
+    let copyButton = this.shadowRoot.getElementById("copy-button");
+    copyButton.removeEventListener("click", this.copyLink);
+  }
+
+  copyLink() {
+    let downloadLink = this.shadowRoot.getElementById("download-link");
+    navigator.clipboard.writeText(downloadLink.href);
   }
 
   render() {
     // NOOP
   }
 }
-
 customElements.define("setup-device-step", SetupDeviceStep);

--- a/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
@@ -37,7 +37,7 @@ export class SignInStep extends BaseFormStep {
 
             <label for="email">${gettext("Email")}</label>
             <div class="tooltip-container">
-              <aside id="email-error" class="error-tooltip hidden">${gettext("Valid email required")}</aside>
+              <aside id="email-error" class="tooltip tooltip-error tooltip-top">${gettext("Valid email required")}</aside>
               <input id="email" name="email" type="email" required="true" placeholder="${gettext("Enter your email")}"/>
             </div>
 
@@ -88,19 +88,19 @@ export class SignInStep extends BaseFormStep {
     switch (event.type) {
       case "blur": {
         if (!this.#emailEl.validity.valid) {
-          this.#emailErrorEl.classList.remove("hidden");
+          this.#emailErrorEl.classList.add("visible");
         }
         break;
       }
       case "input": {
         if (this.#emailEl.value?.trim()) {
-          this.#emailErrorEl.classList.add("hidden");
+          this.#emailErrorEl.classList.remove("visible");
         }
         break;
       }
       case "submit": {
         if (!this.#emailEl.validity.valid) {
-          this.#emailErrorEl.classList.remove("hidden");
+          this.#emailErrorEl.classList.add("visible");
           event.preventDefault();
         }
         break;

--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -289,12 +289,15 @@ export class BaseFormStep extends HTMLElement {
    * Method that gets run whenever the element's state changes. Can be used to
    * specify how the DOM should update in response to state changes. `prevState`
    * and `nextState` are provided for making comparisons.
+   * 
+   * This must be implemented in the subclass if the form step needs to respond
+   * to state updates.
    *
-   * @param {object} prevState The element's state before the most recent
-   *  update.
+   * @param {object} prevState
+   *  The element's state before the most recent update.
    * @param {object} nextState The element's current state.
    */
   render(prevState, nextState) {
-    throw new Error("render must be implemented.");
+    // NOOP
   }
 }

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-setup-device-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-setup-device-tests.js
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import { SetupDeviceStep } from "sumo/js/form-wizard-setup-device-step";
+
+describe("setup-device-step custom element", () => {
+  const DOWNLOAD_LINK = "https://mzl.la/newdevice"
+  let step;
+
+  beforeEach(() => {
+    step = new SetupDeviceStep();
+    $("body").empty().append(step);
+  });
+
+  it("should render a setup-device-step custom element", () => {
+    expect(step).to.exist;
+    expect(step).to.be.an.instanceof(SetupDeviceStep);
+  });
+
+  it("should display a link to download Firefox on a new device", () => {
+    let downloadLink = step.shadowRoot.getElementById("download-link");
+    expect(downloadLink).to.exist;
+    expect(downloadLink.textContent).to.equal(DOWNLOAD_LINK);
+    expect(downloadLink.href).to.equal(DOWNLOAD_LINK);
+  });
+
+  it("should contain a button that allows for copying the download link", () => {
+    let writeTextSpy = sinon.spy();
+    // The clipboard property is not provided by JSDom.
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: writeTextSpy,
+      },
+    });
+
+    let copyButton = step.shadowRoot.getElementById("copy-button");
+    expect(copyButton).to.exist;
+    copyButton.click();
+    expect(writeTextSpy.calledOnceWith(DOWNLOAD_LINK)).to.be.true;
+  })
+});

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
@@ -260,24 +260,24 @@ describe("sign-in-step custom element", () => {
     });
 
     it("should display an error message if an email address is not supplied", () => {
-      expect([...emailErrorMessage.classList]).to.include("hidden");
+      expect([...emailErrorMessage.classList]).to.not.include("visible");
 
       emailField.value = "";
       submitBtn.click();
 
       expect(emailField.validity.valid).to.be.false;
-      expect([...emailErrorMessage.classList]).to.not.include("hidden");
+      expect([...emailErrorMessage.classList]).to.include("visible");
       expect(emailErrorMessage.textContent).to.equal("Valid email required");
     });
 
     it("should display an error message if an incomplete email address is supplied", () => {
-      expect([...emailErrorMessage.classList]).to.include("hidden");
+      expect([...emailErrorMessage.classList]).to.not.include("visible");
 
       emailField.value = "this-is-not-an-email-address";
       submitBtn.click();
 
       expect(emailField.validity.valid).to.be.false;
-      expect([...emailErrorMessage.classList]).to.not.include("hidden");
+      expect([...emailErrorMessage.classList]).to.include("visible");
       expect(emailErrorMessage.textContent).to.equal("Valid email required");
     });
 
@@ -299,7 +299,7 @@ describe("sign-in-step custom element", () => {
       await preventSubmitListener;
 
       expect(emailField.validity.valid).to.be.true;
-      expect([...emailErrorMessage.classList]).to.include("hidden");
+      expect([...emailErrorMessage.classList]).to.not.include("visible");
     });
   });
 });

--- a/kitsune/sumo/static/sumo/scss/form-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-step.styles.scss
@@ -19,10 +19,6 @@
   color: var(--color-text-form-step);
 }
 
-.visible {
-  visibility: visible;
-}
-
 .tooltip-container {
   position: relative;
   display: flex;
@@ -75,4 +71,8 @@
 
 .tooltip-error::before {
   background-color: p.$color-red-60;
+}
+
+.visible {
+  visibility: visible;
 }

--- a/kitsune/sumo/static/sumo/scss/form-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-step.styles.scss
@@ -19,41 +19,60 @@
   color: var(--color-text-form-step);
 }
 
-.hidden {
-  visibility: hidden;
-}
-
-.error-tooltip:not(.hidden) + input:invalid,
-input:not(:focus):not(:placeholder-shown):invalid {
-  border: 2px solid p.$color-red-60;
-}
-
-.error-tooltip:not(.hidden) + input:focus:invalid {
-  box-shadow: 0 0 0 2px rgba(226, 40, 80, 0.5);
+.visible {
+  visibility: visible;
 }
 
 .tooltip-container {
   position: relative;
+  display: flex;
+  align-items: center;
 }
 
-.error-tooltip {
-  background-color: p.$color-red-60;
+.tooltip {
   border-radius: 4px;
-  color: var(--color-white);
   padding: 8px;
   position: absolute;
+  background-color: var(--color-light-gray-02);
+  width: max-content;
+  visibility: hidden;
+}
+
+.tooltip-top {
   top: -34px;
 }
 
-.error-tooltip::before {
+.tooltip-top::before {
+  bottom: -6px;
+  left: 12px;
+}
+
+.tooltip-right {
+  left: 34px;
+}
+
+.tooltip-right::before {
+  left: -6px;
+  bottom: 0;
+  top: 10px;
+}
+
+.tooltip-error {
   background-color: p.$color-red-60;
-  bottom: -8px;
+  color: var(--color-white);
+}
+
+.tooltip::before {
+  background-color: var(--color-light-gray-02);
   content: "";
-  height: 16px;
+  height: 12px;
   position: absolute;
   text-indent: -999px;
   transform: rotate(45deg);
   white-space: nowrap;
-  width: 16px;
-  margin-inline-start: 6px;
+  width: 12px;
+}
+
+.tooltip-error::before {
+  background-color: p.$color-red-60;
 }

--- a/kitsune/sumo/static/sumo/scss/form-wizard-setup-device-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard-setup-device-step.styles.scss
@@ -1,17 +1,17 @@
 h3 {
   font-size: 1rem;
   line-height: 1.5;
-  margin-block-end: 26px;
 }
 
-ul {
-  margin-block-end: 0;
+h3,
+ul,
+li {
+  margin-block-end: 16px;
 }
 
 .download-link-wrapper {
   display: flex;
   align-items: center;
-  margin-block: 16px;
 }
 
 #download-link {
@@ -25,6 +25,7 @@ ul {
   background-color: transparent;
   border: none;
   padding: 0;
+  cursor: pointer;
 }
 
 #copy-button > img {

--- a/kitsune/sumo/static/sumo/scss/form-wizard-setup-device-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard-setup-device-step.styles.scss
@@ -1,0 +1,37 @@
+h3 {
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-block-end: 26px;
+}
+
+ul {
+  margin-block-end: 0;
+}
+
+.download-link-wrapper {
+  display: flex;
+  align-items: center;
+  margin-block: 16px;
+}
+
+#download-link {
+  margin-inline-end: 8px;
+  font-size: 1.375rem;
+}
+
+#copy-button {
+  display: flex;
+  appearance: none;
+  background-color: transparent;
+  border: none;
+  padding: 0;
+}
+
+#copy-button > img {
+  height: 16px;
+}
+
+#copy-button:focus-visible + .tooltip,
+#copy-button:hover + .tooltip {
+  visibility: visible;
+}

--- a/kitsune/sumo/static/sumo/scss/form-wizard-sign-in-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard-sign-in-step.styles.scss
@@ -1,3 +1,5 @@
+@use "@mozilla-protocol/core/protocol/css/includes/lib" as p;
+
 #sign-in-step-root[mode="sign-in"] .for-sign-up,
 #sign-in-step-root[mode="sign-up"] .for-sign-in {
   display: none;
@@ -46,4 +48,13 @@ button.for-sign-up {
   padding-block: 8px;
   border-radius: 8px;
   font-size: 0.75rem;
+}
+
+.tooltip-error.visible + input:invalid,
+input:not(:focus):not(:placeholder-shown):invalid {
+  border: 2px solid p.$color-red-60;
+}
+
+.tooltip-error.visible + input:focus:invalid {
+  box-shadow: 0 0 0 2px rgba(226, 40, 80, 0.5);
 }


### PR DESCRIPTION
This PR adds the third and final setup device form step. There are a handful of design things I think will need to be followed up on, specifically:

* there's no feedback when the user clicks on the "copy link" button
* the contrast between the tooltip and the white background probably isn't accessible

Those still need design input, so this seems alright as a first pass.

<img width="887" alt="Screenshot 2023-05-18 at 3 22 03 PM" src="https://github.com/mozilla/kitsune/assets/15138046/6d5e3da1-4240-47ca-96e4-430ba3b8dd57">
