### PR TITLE
fix extraction from javascript files

### DIFF
--- a/babeljs.cfg
+++ b/babeljs.cfg
@@ -2,8 +2,5 @@
 jinja2_custom = kitsune.lib.babel:extract_jinja
 svelte_custom = kitsune.lib.babel:extract_svelte
 
-[ignore: kitsune/**/static/**/js/*-all.js]
-[ignore: kitsune/**/static/**/js/*-min.js]
-[javascript: kitsune/**/static/**/js/*.js]
 [svelte_custom: svelte/**/*.svelte]
 [jinja2_custom: kitsune/**/static/**/tpl/**.njk]

--- a/kitsune/sumo/management/commands/extract.py
+++ b/kitsune/sumo/management/commands/extract.py
@@ -1,6 +1,7 @@
+import glob
 import subprocess
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from babel.messages.frontend import CommandLineInterface
 
 
@@ -37,7 +38,7 @@ class Command(BaseCommand):
                 ".",
             ]
         )
-        # First run the Babel-based extraction on the JS-based Svelte and Nunjucks files.
+        # First run the Babel-based extraction on the Svelte and Nunjucks files.
         CommandLineInterface().run(
             [
                 "pybabel",
@@ -62,29 +63,36 @@ class Command(BaseCommand):
             ]
         )
         # Finally run the extraction on the JS files themselves. This will add to the
-        # djangojs.pot file created by the previous command due to the "--join-existing"
-        # option.
-        subprocess.run(
-            " ".join(
-                [
-                    "xgettext",
-                    "--join-existing",
-                    "--sort-by-file",
-                    "--copyright-holder=Mozilla",
-                    "--package-name=kitsune",
-                    "--package-version=1.0",
-                    "--msgid-bugs-address='https://github.com/mozilla-l10n/sumo-l10n/issues'",
-                    "--output=locale/templates/LC_MESSAGES/djangojs.pot",
-                    "--width=80",
-                    "--add-comments='L10n,L10n:'",
-                    "--keyword='_lazy'",
-                    "--keyword='pgettext_lazy:1c,2'",
-                    "--from-code=utf-8",
-                    "kitsune/**/static/**/js/*.js",
-                ]
-            ),
-            shell=True,
-            check=True,
-        )
+        # existing djangojs.pot file created by the previous command (because we're
+        # using the "--join-existing" option).
+        # NOTE: This loop is for reporting purposes only. The "--verbose" option of
+        #       "xgettext" doesn't seem to work.
+        for fname in glob.glob("kitsune/**/static/**/js/*.js"):
+            self.stdout.write(f"extracting messages from {fname}")
+            try:
+                subprocess.run(
+                    [
+                        "xgettext",
+                        "--join-existing",
+                        "--sort-by-file",
+                        "--copyright-holder=Mozilla",
+                        "--package-name=kitsune",
+                        "--package-version=1.0",
+                        "--msgid-bugs-address=https://github.com/mozilla-l10n/sumo-l10n/issues",
+                        "--output=locale/templates/LC_MESSAGES/djangojs.pot",
+                        "--width=80",
+                        "--add-comments=L10n,L10n:",
+                        "--keyword=_lazy",
+                        "--keyword=pgettext_lazy:1c,2",
+                        "--from-code=utf-8",
+                        fname,
+                    ],
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    check=True,
+                )
+            except subprocess.CalledProcessError as err:
+                raise CommandError(err.output)
 
         self.stdout.write(self.style.SUCCESS("extraction complete"))

--- a/kitsune/sumo/management/commands/extract.py
+++ b/kitsune/sumo/management/commands/extract.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from django.core.management.base import BaseCommand
 from babel.messages.frontend import CommandLineInterface
 
@@ -35,6 +37,7 @@ class Command(BaseCommand):
                 ".",
             ]
         )
+        # First run the Babel-based extraction on the JS-based Svelte and Nunjucks files.
         CommandLineInterface().run(
             [
                 "pybabel",
@@ -57,6 +60,31 @@ class Command(BaseCommand):
                 "--copyright-holder=Mozilla",
                 ".",
             ]
+        )
+        # Finally run the extraction on the JS files themselves. This will add to the
+        # djangojs.pot file created by the previous command due to the "--join-existing"
+        # option.
+        subprocess.run(
+            " ".join(
+                [
+                    "xgettext",
+                    "--join-existing",
+                    "--sort-by-file",
+                    "--copyright-holder=Mozilla",
+                    "--package-name=kitsune",
+                    "--package-version=1.0",
+                    "--msgid-bugs-address='https://github.com/mozilla-l10n/sumo-l10n/issues'",
+                    "--output=locale/templates/LC_MESSAGES/djangojs.pot",
+                    "--width=80",
+                    "--add-comments='L10n,L10n:'",
+                    "--keyword='_lazy'",
+                    "--keyword='pgettext_lazy:1c,2'",
+                    "--from-code=utf-8",
+                    "kitsune/**/static/**/js/*.js",
+                ]
+            ),
+            shell=True,
+            check=True,
         )
 
         self.stdout.write(self.style.SUCCESS("extraction complete"))


### PR DESCRIPTION
mozilla/sumo#1313

This works really well! I've run `./manage.py extract` against our current files, and the changes shown by `git diff locale/templates/LC_MESSAGES/djangojs.pot` fall into the following categories:
- Header comments that can't be controlled with `xgettext` options ✅  (**NOTE:** I added a third commit that updates these header comments)
    ```
    -# Translations template for kitsune.
    -# Copyright (C) 2023 Mozilla
    -# This file is distributed under the same license as the kitsune project.
    -# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
    +# SOME DESCRIPTIVE TITLE.
    +# Copyright (C) YEAR Mozilla
    +# This file is distributed under the same license as the kitsune package.
    +# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
    ```
- Strings that weren't extracted before but should have been 🎉 
    ```
    +#: kitsune/sumo/static/sumo/js/forums.js:25
    +#: kitsune/sumo/static/sumo/js/markup.js:1058
    +#: kitsune/sumo/static/sumo/js/questions.js:314
    +msgid "said"
    +msgstr ""
    ```
- New strings that would not have been found before 🎉 
    ```
    +#: kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js:19
    +msgid "Sign in to your account"
    +msgstr ""
    ```
- `python-format` being replaced by `javascript-format` ✅❓ 
    ```
    -#, python-format
    +#, javascript-format
    ```
-  Line-wrap-related changes ✅ 
    ```
    -msgid "WARNING! Are you sure you want to deactivate this user? This cannot be undone!"
    +msgid ""
    +"WARNING! Are you sure you want to deactivate this user? This cannot be undone!"
    ```
- More accurate line number changes 🎉 
    ```
    -#: svelte/contribute/Contribute.svelte:156
    +#: svelte/contribute/Contribute.svelte:155
    ```

So we only need to decide what we think about `python-format` comments for JS files sometimes being replaced with `javascript-format` comments. The [`javascript-format`](https://www.gnu.org/software/gettext/manual/html_node/javascript_002dformat.html) aligns nicely with old-style Python formatting except when using named items like `%(name)s`, so the `python-format` comments are probably only a factor for strings that contain those. Still, I'm hoping that translators won't be confused by whatever the comment says, and will simply understand that `%(name)s` and `%s` are both things one doesn't change in the translation.

## Output:

```shell
% dc exec web ./manage.py extract
extracting messages from kitsune/__init__.py
...
extracting messages from kitsune/wiki/templatetags/jinja_helpers.py
writing PO template file to locale/templates/LC_MESSAGES/django.pot
extracting messages from kitsune/sumo/static/sumo/tpl/macros.njk
...
extracting messages from kitsune/sumo/static/sumo/tpl/wiki-search-results.njk
extracting messages from svelte/contribute/Area.svelte
...
extracting messages from svelte/contribute/Tile.svelte
writing PO template file to locale/templates/LC_MESSAGES/djangojs.pot
extracting messages from kitsune/community/static/community/js/community.js
extracting messages from kitsune/community/static/community/js/select.js
extracting messages from kitsune/kpi/static/kpi/js/kpi.browserify.js
extracting messages from kitsune/sumo/static/sumo/js/aaq.js
extracting messages from kitsune/sumo/static/sumo/js/ajaxpreview.js
extracting messages from kitsune/sumo/static/sumo/js/ajaxvote.js
extracting messages from kitsune/sumo/static/sumo/js/analytics.js
extracting messages from kitsune/sumo/static/sumo/js/browserdetect.js
extracting messages from kitsune/sumo/static/sumo/js/cached_xhr.js
extracting messages from kitsune/sumo/static/sumo/js/codemirror.sumo-hint.js
extracting messages from kitsune/sumo/static/sumo/js/codemirror.sumo-mode.js
extracting messages from kitsune/sumo/static/sumo/js/compare_versions.js
extracting messages from kitsune/sumo/static/sumo/js/dashboards.js
extracting messages from kitsune/sumo/static/sumo/js/device-migration-wizard.js
extracting messages from kitsune/sumo/static/sumo/js/diff.js
extracting messages from kitsune/sumo/static/sumo/js/document.js
extracting messages from kitsune/sumo/static/sumo/js/editable.js
extracting messages from kitsune/sumo/static/sumo/js/form-wizard-configure-step.js
extracting messages from kitsune/sumo/static/sumo/js/form-wizard-setup-device-step.js
extracting messages from kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
extracting messages from kitsune/sumo/static/sumo/js/form-wizard.js
extracting messages from kitsune/sumo/static/sumo/js/forums.js
extracting messages from kitsune/sumo/static/sumo/js/gallery.js
extracting messages from kitsune/sumo/static/sumo/js/geoip-locale.js
extracting messages from kitsune/sumo/static/sumo/js/groups.js
extracting messages from kitsune/sumo/static/sumo/js/gtm-snippet.js
extracting messages from kitsune/sumo/static/sumo/js/historycharts.js
extracting messages from kitsune/sumo/static/sumo/js/i18n.js
extracting messages from kitsune/sumo/static/sumo/js/instant_search.js
extracting messages from kitsune/sumo/static/sumo/js/kbox.js
extracting messages from kitsune/sumo/static/sumo/js/location.js
extracting messages from kitsune/sumo/static/sumo/js/main.js
extracting messages from kitsune/sumo/static/sumo/js/markup.js
extracting messages from kitsune/sumo/static/sumo/js/messages.js
extracting messages from kitsune/sumo/static/sumo/js/nunjucks.js
extracting messages from kitsune/sumo/static/sumo/js/products.js
extracting messages from kitsune/sumo/static/sumo/js/profile-avatars.js
extracting messages from kitsune/sumo/static/sumo/js/protocol-details-init.js
extracting messages from kitsune/sumo/static/sumo/js/protocol-language-switcher-init.js
extracting messages from kitsune/sumo/static/sumo/js/protocol-modal-init.js
extracting messages from kitsune/sumo/static/sumo/js/protocol-nav.js
extracting messages from kitsune/sumo/static/sumo/js/protocol-notification-init.js
extracting messages from kitsune/sumo/static/sumo/js/protocol.js
extracting messages from kitsune/sumo/static/sumo/js/questions.js
extracting messages from kitsune/sumo/static/sumo/js/questions.metrics-dashboard.js
extracting messages from kitsune/sumo/static/sumo/js/questions.metrics.js
extracting messages from kitsune/sumo/static/sumo/js/remote.js
extracting messages from kitsune/sumo/static/sumo/js/reportabuse.js
extracting messages from kitsune/sumo/static/sumo/js/responsive-nav-toggle.js
extracting messages from kitsune/sumo/static/sumo/js/revision.js
extracting messages from kitsune/sumo/static/sumo/js/rickshaw_utils.js
extracting messages from kitsune/sumo/static/sumo/js/search.js
extracting messages from kitsune/sumo/static/sumo/js/search_utils.js
extracting messages from kitsune/sumo/static/sumo/js/show-fx-download.js
extracting messages from kitsune/sumo/static/sumo/js/showfor.js
extracting messages from kitsune/sumo/static/sumo/js/sumo-close-this.js
extracting messages from kitsune/sumo/static/sumo/js/sumo-tabs.js
extracting messages from kitsune/sumo/static/sumo/js/switching-devices-wizard-manager.js
extracting messages from kitsune/sumo/static/sumo/js/tags.filter.js
extracting messages from kitsune/sumo/static/sumo/js/tags.js
extracting messages from kitsune/sumo/static/sumo/js/ui.js
extracting messages from kitsune/sumo/static/sumo/js/upload-dialog.js
extracting messages from kitsune/sumo/static/sumo/js/upload.js
extracting messages from kitsune/sumo/static/sumo/js/users.autocomplete.js
extracting messages from kitsune/sumo/static/sumo/js/users.js
extracting messages from kitsune/sumo/static/sumo/js/wiki.dashboard.js
extracting messages from kitsune/sumo/static/sumo/js/wiki.editor.js
extracting messages from kitsune/sumo/static/sumo/js/wiki.js
extracting messages from kitsune/sumo/static/sumo/js/wiki.metrics.js
extracting messages from kitsune/sumo/static/sumo/js/wiki_search.js
extraction complete
```