### PR TITLE
Progress bar enhancements

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -225,6 +225,11 @@ export class FormWizard extends HTMLElement {
       let progress =
         Math.ceil((activeStepIndex / (this.#steps.length - 1)) * 100) || 10;
       this.#progressIndicator.value = progress;
+      this.#progressIndicator.setAttribute(
+        "aria-label",
+        gettext(`Step ${activeStepIndex + 1} of 3`)
+      );
+      this.#progressIndicator.style.setProperty("--progress", progress + "%");
     }
   }
 
@@ -317,7 +322,7 @@ export class BaseFormStep extends HTMLElement {
    * Method that gets run whenever the element's state changes. Can be used to
    * specify how the DOM should update in response to state changes. `prevState`
    * and `nextState` are provided for making comparisons.
-   * 
+   *
    * This must be implemented in the subclass if the form step needs to respond
    * to state updates.
    *

--- a/kitsune/sumo/static/sumo/scss/form-wizard.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard.styles.scss
@@ -94,6 +94,15 @@ progress::-webkit-progress-value {
   background-color: var(--color-progress);
 }
 
+progress::-moz-progress-bar {
+  transition: padding-bottom 0.6s;
+  padding-left: 8px;
+  height: 0;
+  padding-bottom: var(--progress);
+  transform-origin: 0 0;
+  transform: rotate(-90deg) translateX(-8px);
+}
+
 p {
   margin: 0;
   color: var(--color-dark-gray-10);


### PR DESCRIPTION
Found kind of a weird/nifty way of animating progress elements via transforming width/animating padding here: https://codepen.io/snookca/pen/KRdRzZ

Actually seemed nicer than replacing the progress element with a div or something.

Also added an aria-label to the progress element - @escattone is it alright to do string interpolation for `gettext`/translation purposes? Let me know if there's something else I should be doing.