### PR TITLE
use interpolate to make error message translatable

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -51,7 +51,12 @@ export class FormWizard extends HTMLElement {
             </div>
 
             <div class="disqualification" reason="uitour-broken">
-              <div class="disqualification-message">${gettext("The setup assistant is currently unavailable for your version of Firefox. However, you can still perform a manual backup of your data by following the steps outlined in")} <a href="/kb/profile-manager-create-remote-switch-firefox-profiles">${gettext("this article.")}</a></div>
+              <div class="disqualification-message">
+                ${interpolate(
+                  gettext("The setup assistant is currently unavailable for your version of Firefox. However, you can still perform a manual backup of your data by following the steps outlined in %s"),
+                  [`<a href="/kb/profile-manager-create-remote-switch-firefox-profiles">${gettext("this article.")}</a>`]
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -53,8 +53,8 @@ export class FormWizard extends HTMLElement {
             <div class="disqualification" reason="uitour-broken">
               <div class="disqualification-message">
                 ${interpolate(
-                  gettext("The setup assistant is currently unavailable for your version of Firefox. However, you can still perform a manual backup of your data by following the steps outlined in %s"),
-                  [`<a href="/kb/profile-manager-create-remote-switch-firefox-profiles">${gettext("this article.")}</a>`]
+                  gettext("The setup assistant is currently unavailable for your version of Firefox. However, you can still perform a manual backup of your data by following the steps outlined in <a href='%s'>this article.</a>"),
+                  ["/kb/profile-manager-create-remote-switch-firefox-profiles"]
                 )}
               </div>
             </div>


### PR DESCRIPTION
Attempting to address the points raised in [this comment](https://github.com/mozilla/kitsune/pull/5499/files#r1204155619).