### PR TITLE
Prevent keyboard interaction when the wizard is disabled

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -186,7 +186,7 @@ export class FormWizard extends HTMLElement {
     }
 
     let root = this.shadowRoot.querySelector(".form-wizard-root");
-    root.toggleAttribute("disqualified", true);
+    root.toggleAttribute("inert", true);
   }
 
   /**

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-tests.js
@@ -200,7 +200,7 @@ describe("form-wizard custom element", () => {
       wizard.disqualify("need-fx-desktop");
 
       let root = wizard.shadowRoot.querySelector(".form-wizard-root");
-      expect(root.hasAttribute("disqualified")).to.be.true;
+      expect(root.hasAttribute("inert")).to.be.true;
 
       let needFxDesktop = wizard.shadowRoot.querySelector(
         ".disqualification[reason='need-fx-desktop']"

--- a/kitsune/sumo/static/sumo/scss/form-wizard.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard.styles.scss
@@ -18,7 +18,7 @@
 
 :host([disqualified-mobile]) .form-wizard-content,
 :host([disqualified-mobile]) #progress,
-.form-wizard-root:not([disqualified]) > .form-wizard-disqualified {
+.form-wizard-root:not([inert]) > .form-wizard-disqualified {
   display: none;
 }
 


### PR DESCRIPTION
Emil identified an issue where it was still possible to navigate into the form steps even when the wizard was "disqualified." Digging into this a bit it seemed like a good opportunity to take the [relatively new](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert#browser_compatibility) `inert` attribute for a spin, since it prevents focus events on an element and all of its descendants.

If this feels heavy handed/we have any concerns about this approach I'm happy to try something else.