### PR TITLE
Prevent tooltip from hiding input label

### DIFF
--- a/kitsune/sumo/static/sumo/scss/form-wizard-sign-in-step.styles.scss
+++ b/kitsune/sumo/static/sumo/scss/form-wizard-sign-in-step.styles.scss
@@ -61,6 +61,7 @@ button.for-sign-up {
   width: max-content;
   visibility: hidden;
   top: -34px;
+  z-index: -1;
 }
 
 .tooltip::before {
@@ -78,6 +79,10 @@ button.for-sign-up {
 
 .visible {
   visibility: visible;
+}
+
+.tooltip.visible {
+  z-index: 0;
 }
 
 .tooltip.visible + input:invalid,


### PR DESCRIPTION
Full disclosure I was testing this out by editing the CSS sources in the browser on my Windows machine since I don't have the kitsune repo set up locally there.