### PR TITLE
remove fuzzy matching

### DIFF
--- a/kitsune/sumo/management/commands/merge.py
+++ b/kitsune/sumo/management/commands/merge.py
@@ -52,6 +52,7 @@ class Command(BaseCommand):
                     "--update",
                     "--width=200",
                     "--backup=off",
+                    "--no-fuzzy-matching",
                     domain_po,
                     domain_pot,
                 )


### PR DESCRIPTION
mozilla-l10n/sumo-l10n#75

While working on https://github.com/mozilla/kitsune/pull/5540 I noticed that after [all of the work to remove `puente`](https://github.com/mozilla/kitsune/pull/5207), we can easily remove fuzzy matching.

Once this is merged, we should enable the new `Pre-Translation` feature in SUMO's Pontoon settings:
<img width="1077" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/2c26d714-dfa1-4f58-9b8e-0a082583aa80">
