### PR TITLE
Issue 1335 - Content scrolling

### DIFF
--- a/kitsune/sumo/static/sumo/js/document.js
+++ b/kitsune/sumo/static/sumo/js/document.js
@@ -10,13 +10,36 @@ import ShowFor from "sumo/js/showfor";
 new ShowFor();
 
 addReferrerAndQueryToVoteForm();
+determineLazyLoad();
+
 new AjaxVote(".document-vote form", {
   positionMessage: false,
   replaceFormWithMessage: true,
   removeForm: true,
 });
 
-$("img.lazy").lazyload();
+$(window).on("load", function() {
+    // Wait for all content (including images) to load
+    var hash = window.location.hash;
+    window.location.hash = ""; // Clear the hash initially
+    setTimeout(function() {
+        window.location.hash = hash; // Restore the hash after all images are loaded
+    }, 0);
+  }
+);
+
+// For this singular document, we are going to load
+// all images without lazy loading 
+// TODO: We need a fix for the whole KB that won't
+// break the lazy loading.
+function determineLazyLoad() {
+  if(window.location.href.indexOf("relay-integration") > -1) {
+    $("img.lazy").loadnow(); // Load all images
+  }
+  else {
+    $("img.lazy").lazyload();
+  }
+};
 
 function addReferrerAndQueryToVoteForm() {
   // Add the source/referrer and query terms to the helpful vote form
@@ -26,20 +49,4 @@ function addReferrerAndQueryToVoteForm() {
   $(".document-vote form")
     .append($('<input type="hidden" name="referrer"/>').attr("value", referrer))
     .append($('<input type="hidden" name="query"/>').attr("value", query));
-}
-
-// For this singular document, we are going to load
-// all images and then scroll to the anchor.
-// TODO: We need a fix for the whole KB that won't
-// break the lazy loading.
-$(window).on("load", function() {
-  if(window.location.href.indexOf("relay-integration") > -1) { 
-    $("img.lazy").loadnow(); // Load all images
-    // Wait for all content (including images) to load
-    var hash = window.location.hash;
-    window.location.hash = ""; // Clear the hash initially
-    setTimeout(function() {
-        window.location.hash = hash; // Restore the hash after all images are loaded
-    }, 0);
-  }
-});
+};


### PR DESCRIPTION
Avoid the chance of a race condition
* Decouple url test from the scroll to hash function
* Remove lazyload actions from the window.load section

I was never able to replicate the issues here: https://github.com/mozilla/sumo/issues/1335 but I was able to determine that it didn't make sense to handle the lazyload decision AFTER the page fully loads - that seemed like a mistake. 
