### PR TITLE
replace FXA_ROOT with FXA_SET_ISSUER

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -601,7 +601,6 @@ else:
         FXA_SUBSCRIPTIONS = config(
             "FXA_SUBSCRIPTIONS", default="https://accounts.firefox.com/subscriptions"
         )
-        FXA_ROOT = config("FXA_ROOT", default="https://accounts.firefox.com")
         FXA_SET_ISSUER = config("FXA_SET_ISSUER", default="https://accounts.firefox.com")
         FXA_VERIFY_URL = config(
             "FXA_VERIFY_URL", default="https://oauth.accounts.firefox.com/v1/verify"

--- a/kitsune/wiki/jinja2/wikiparser/hook_device_migration_wizard.html
+++ b/kitsune/wiki/jinja2/wikiparser/hook_device_migration_wizard.html
@@ -1,4 +1,4 @@
-<form-wizard id="switching-devices-wizard" fxa-root="{{ settings.FXA_ROOT }}">
+<form-wizard id="switching-devices-wizard" fxa-root="{{ settings.FXA_SET_ISSUER }}">
   <sign-in-step name="sign-into-fxa"></sign-in-step>
   <configure-step name="configure-sync"></configure-step>
   <setup-device-step name="setup-new-device"></setup-device-step>


### PR DESCRIPTION
mozilla/sumo#1327

Replaces `FXA_ROOT` with `FXA_SET_ISSUER`.

**NOTE:** Once this is merged, create a PR in the `webservices-infra` repo that removes the `FXA_ROOT` values in the Helm chart for SUMO.