### PR TITLE
5566 doc edit usability

### DIFF
--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -2,7 +2,6 @@ import spinnerImg from "sumo/img/spinner.gif";
 import "sumo/js/libs/jquery.cookie";
 import "sumo/js/libs/jquery.lazyload";
 import KBox from "sumo/js/kbox";
-import "sumo/js/libs/django/prepopulate";
 import CodeMirror from "codemirror";
 import "codemirror/addon/mode/simple";
 import "codemirror/addon/hint/show-hint";
@@ -25,7 +24,6 @@ import ShowFor from "sumo/js/showfor";
 
     $('select.enable-if-js').prop("disabled", false);
 
-    initPrepopulatedSlugs();
     initDetailsTags();
 
     if ($body.is('.review')) { // Review pages
@@ -38,7 +36,7 @@ import ShowFor from "sumo/js/showfor";
       $('#actions input').prop("disabled", false);
     }
 
-    if ($body.is('.edit, .new, .translate')) { // Document form page
+    if ($body.is('.edit_doc, .edit, .new, .translate')) { // Document form page
       // Submit form
       $('#id_comment').on('keypress', function(e) {
         if (e.which === 13) {
@@ -51,16 +49,19 @@ import ShowFor from "sumo/js/showfor";
       initArticlePreview();
       initPreviewDiff();
       initTitleAndSlugCheck();
-      initPreValidation();
       initNeedsChange();
-      initSummaryCount();
       initFormLock();
-      initCodeMirrorEditor();
 
       $('img.lazy').loadnow();
 
       // We can enable the buttons now.
       $('.submit input').prop("disabled", false);
+    }
+
+    if ($body.is('.edit, .new, .translate')) {
+      initPreValidation();
+      initSummaryCount();
+      initCodeMirrorEditor();
     }
 
     if ($body.is('.translate')) {  // Translate page
@@ -151,7 +152,7 @@ import ShowFor from "sumo/js/showfor";
         // Set the `tabindex` attribute of the `summary` element to 0 to make it keyboard accessible
         $detailsSummary.attr('tabindex', 0).on("click", function() {
           // Focus on the `summary` element
-          $detailsSummary.focus();
+          $detailsSummary.trigger('focus');
           // Toggle the `open` attribute of the `details` element
           if (typeof $details.attr('open') !== 'undefined') {
             $details.prop('open', false);
@@ -173,24 +174,6 @@ import ShowFor from "sumo/js/showfor";
         });
       });
     }
-  }
-
-  function initPrepopulatedSlugs() {
-    var fields = {
-      title: {
-        id: '#id_slug',
-        dependency_ids: ['#id_title'],
-        dependency_list: ['#id_title'],
-        maxLength: 50
-      }
-    };
-
-    $.each(fields, function(i, field) {
-      $(field.id).addClass('prepopulated_field');
-      $(field.id).data('dependency_list', field.dependency_list)
-        .prepopulate($(field.dependency_ids.join(',')),
-          field.maxLength);
-    });
   }
 
   function initSummaryCount() {

--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -45,6 +45,7 @@ import ShowFor from "sumo/js/showfor";
           return false;
         }
       });
+
       initExitSupportFor();
       initArticlePreview();
       initPreviewDiff();
@@ -70,15 +71,10 @@ import ShowFor from "sumo/js/showfor";
     }
 
     initEditingTools();
-
     initDiffPicker();
-
     Marky.createFullToolbar('.editor-tools', '#id_content');
-
     initReadyForL10n();
-
     initArticleApproveModal();
-
     initRevisionList();
 
     $('img.lazy').lazyload();
@@ -411,8 +407,11 @@ import ShowFor from "sumo/js/showfor";
     // Hide and show the comment box based on the status of the
     // "Needs change" checkbox. Also, make the textarea required
     // when checked.
+    console.log('inside initNeedsChange');
+
     var $checkbox = $('#id_needs_change'),
-      $comment = $('#document-form li.comment,#approve-modal div.comment');
+      $comment = $('#id_needs_change_comment'),
+      $commentlabel = $('label[for="id_needs_change_comment"]');
 
     if ($checkbox.length > 0) {
       updateComment();
@@ -421,9 +420,11 @@ import ShowFor from "sumo/js/showfor";
 
     function updateComment() {
       if ($checkbox.is(':checked')) {
+        $commentlabel.slideDown();
         $comment.slideDown();
         $comment.find('textarea').prop('required', true);
       } else {
+        $commentlabel.hide();
         $comment.hide();
         $comment.find('textarea').prop('required', false);
       }

--- a/kitsune/wiki/jinja2/wiki/edit.html
+++ b/kitsune/wiki/jinja2/wiki/edit.html
@@ -8,11 +8,12 @@
 {# TODO: Change KB url to landing page when we have one #}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  (None, _('Edit Article'))] %}
-{% set classes = 'edit' %}
+
 {% set scripts = ('wiki', 'wiki.diff', 'wiki.editor') %}
 {% if document.is_switching_devices_document %}
   {% set scripts = scripts + ('switching-devices',) %}
 {% endif %}
+{% set classes = 'edit' %}
 
 {% block content %}
   <div class="user-messages">
@@ -22,7 +23,7 @@
 
   <div class="sumo-page-section">
     <article id="edit-document" {% if locked %}class="locked"{% endif %} data-slug="{{ document.slug }}">
-      <h1 class="sumo-page-heading">{{ _('<em>Editing</em> {title}')|fe(title=document.title) }}</h1>
+      <h1 class="sumo-page-heading">{{ _('<em>Editing Content For:</em><br>{title}')|fe(title=document.title) }}</h1>
       {% if document.needs_change %}
         <p>
           {% trans comment=document.needs_change_comment %}
@@ -30,75 +31,51 @@
           {% endtrans %}
         </p>
       {% endif %}
+            {% if request.user.is_staff %}
+              <p><a href="{{ url('wiki.edit_document_metadata', document.slug) }}" class="sumo-button primary-button">{{ _('Edit Article Description') }}</a></p>
+            {% endif %}
+            {% if revision_form %}
+            <div id="revision-form">
+                <p>
+                  {% trans url=url('wiki.document', 'support-document-guide') %}For help with writing articles, check out the
+                    <a href="{{ url }}">Support Document Guide</a>.{% endtrans %}
+                </p>
+                {{ errorlist(revision_form) }}
+                <form action="" method="post">
+                  {% csrf_token %}
+                    {% for field in revision_form.visible_fields() %}
+                      <div class="field {% if field.name == 'content' %}has-large-textarea{% endif %}">
+                        {% if field.name not in ['comment', 'content'] %}
+                          {% if not field.name == 'keywords' or document.allows(user, 'edit_keywords') %}
+                            {{ field|label_with_help }}{{ field|safe }}
+                          {% endif %}
+                        {% elif field.name == 'content' %}
+                          {{ revision_form.content.label_tag()|safe }}
+                          {{ content_editor(revision_form.content) }}
+                        {% endif %}
+                        {% if field.name == 'summary' %}
+                          <p><span id="remaining-characters">{{ field.field.max_length }}</span> {{_('characters remaining.') }}</p>
+                        {% endif %}
+                      </div>
+                    {% endfor %}
+                  {{ revision_form.hidden_fields()|join|safe }}
+                  <input type="hidden" name="form" value="rev" />
+                  <input type="hidden" name="slug" value="{{ document.slug }}" />
+                  <input type="hidden" name="locale" value="{{ document.locale }}" />
+                  {{ submit_revision(revision_form, include_diff=True) }}
+                  <div id="preview"></div>
+                  <div id="preview-diff">
+                    <div class="from">{{ revision_form.content.value() }}</div>
+                    <div class="to"></div>
+                    <div class="output"></div>
+                  </div>
+                  <div class="submit" id="preview-bottom">
+                    {{ submit_revision(revision_form, buttons_only=True, include_diff=True) }}
+                  </div>
+                </form>
+            </div>
+          {% endif %}
 
-      {% if document_form %}
-        <div id="document-form">
-          <details {% if disclose_description %} open="open"{% endif %}>
-            <summary class="sumo-page-subheading">{{ _('Edit Description') }}</summary>
-            {{ errorlist(document_form) }}
-            <form action="" method="post" data-json-url="{{ url('wiki.json') }}" data-document-id="{{ document.id }}">
-              {% csrf_token %}
-                {% for field in document_form.visible_fields() if
-                   (field.name != 'is_localizable' or not document.translations.exists()) %}
-                  <div class="field {% if field.name == 'needs_change_comment' %}has-large-textarea comment{% endif %}">
-                    {{ field|label_with_help }}{{ field }}
-                  </div>
-                {% endfor %}
-              {% if document.translations.exists() %}
-                {{ document_form.is_localizable.as_hidden()|safe }}
-              {% endif %}
-              <input type="hidden" name="form" value="doc" />
-              <div class="submit sumo-button-wrap align-end">
-                <button class="sumo-button primary-button" type="submit">{{ _('Save description') }}</button>
-              </div>
-            </form>
-          </details>
-        </div>
-      {% endif %}
-      {% if revision_form %}
-        <div id="revision-form">
-          <details open="open">
-            <summary class="sumo-page-subheading">{{ _('Edit Content') }}</summary>
-            <p>
-              {% trans url=url('wiki.document', 'support-document-guide') %}For help with writing articles, check out the
-                <a href="{{ url }}">Support Document Guide</a>.{% endtrans %}
-            </p>
-            {{ errorlist(revision_form) }}
-            <form action="" method="post">
-              {% csrf_token %}
-                {% for field in revision_form.visible_fields() %}
-                  <div class="field {% if field.name == 'content' %}has-large-textarea{% endif %}">
-                    {% if field.name not in ['comment', 'content'] %}
-                      {% if not field.name == 'keywords' or document.allows(user, 'edit_keywords') %}
-                        {{ field|label_with_help }}{{ field|safe }}
-                      {% endif %}
-                    {% elif field.name == 'content' %}
-                      {{ revision_form.content.label_tag()|safe }}
-                      {{ content_editor(revision_form.content) }}
-                    {% endif %}
-                    {% if field.name == 'summary' %}
-                      <p><span id="remaining-characters">{{ field.field.max_length }}</span> {{_('characters remaining.') }}</p>
-                    {% endif %}
-                  </div>
-                {% endfor %}
-              {{ revision_form.hidden_fields()|join|safe }}
-              <input type="hidden" name="form" value="rev" />
-              <input type="hidden" name="slug" value="{{ document.slug }}" />
-              <input type="hidden" name="locale" value="{{ document.locale }}" />
-              {{ submit_revision(revision_form, include_diff=True) }}
-              <div id="preview"></div>
-              <div id="preview-diff">
-                <div class="from">{{ revision_form.content.value() }}</div>
-                <div class="to"></div>
-                <div class="output"></div>
-              </div>
-              <div class="submit" id="preview-bottom">
-                {{ submit_revision(revision_form, buttons_only=True, include_diff=True) }}
-              </div>
-            </form>
-          </details>
-        </div>
-      {% endif %}
     </article>
   </div>
 

--- a/kitsune/wiki/jinja2/wiki/edit_metadata.html
+++ b/kitsune/wiki/jinja2/wiki/edit_metadata.html
@@ -4,7 +4,7 @@
 {% from "includes/common_macros.html" import content_editor with context %}
 {% from "wiki/includes/document_macros.html" import edit_messages, submit_revision %}
 {% from "wiki/includes/document_macros.html" import document_lock_warning with context %}
-{% set title = _('Edit Article | {document}')|f(document=document.title) %}
+{% set title = _('Edit Article Description | {document}')|f(document=document.title) %}
 {# TODO: Change KB url to landing page when we have one #}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  (None, _('Edit Article'))] %}
@@ -35,7 +35,7 @@
                   {% csrf_token %}
                     {% for field in document_form.visible_fields() if
                       (field.name != 'is_localizable' or not document.translations.exists()) %}
-                      <div class="field {% if field.name == 'needs_change_comment' %}has-large-textarea comment{% endif %}">
+                      <div class="field">
                         {{ field|label_with_help }}{{ field }}
                       </div>
                     {% endfor %}
@@ -43,7 +43,7 @@
                     {{ document_form.is_localizable.as_hidden()|safe }}
                   {% endif %}
                   <input type="hidden" name="form" value="doc" />
-                  <div class="submit sumo-button-wrap align-end">
+                  <div class="submit sumo-button-wrap align-full">
                     <button class="sumo-button primary-button" type="submit">{{ _('Save description') }}</button>
                   </div>
                 </form>

--- a/kitsune/wiki/jinja2/wiki/edit_metadata.html
+++ b/kitsune/wiki/jinja2/wiki/edit_metadata.html
@@ -1,0 +1,62 @@
+{% extends "wiki/base.html" %}
+{% from "layout/errorlist.html" import errorlist %}
+{% from "wiki/includes/sidebar_modules.html" import document_tools with context %}
+{% from "includes/common_macros.html" import content_editor with context %}
+{% from "wiki/includes/document_macros.html" import edit_messages, submit_revision %}
+{% from "wiki/includes/document_macros.html" import document_lock_warning with context %}
+{% set title = _('Edit Article | {document}')|f(document=document.title) %}
+{# TODO: Change KB url to landing page when we have one #}
+{% set crumbs = [(document.get_absolute_url(), document.title),
+                 (None, _('Edit Article'))] %}
+
+{% set scripts = ('wiki', 'wiki.diff', 'wiki.editor') %}
+{% set classes = 'edit_doc' %}
+
+{% block content %}
+  <div class="user-messages">
+    {{ edit_messages(document, show_revision_warning) }}
+    {{ document_lock_warning() }}
+  </div>
+
+  <div class="sumo-page-section">
+    <article id="edit-document" {% if locked %}class="locked"{% endif %} data-slug="{{ document.slug }}">
+      <h1 class="sumo-page-heading">{{ _('<em>Editing Description For:</em><br>{title}')|fe(title=document.title) }}</h1>
+      {% if document.needs_change %}
+        <p>
+          {% trans comment=document.needs_change_comment %}
+            <label>Needs Change:</label> {{comment}}
+          {% endtrans %}
+        </p>
+      {% endif %}
+      {% if document_form %}
+            <div id="document-form">
+                {{ errorlist(document_form) }}
+                <form action="" method="post" data-json-url="{{ url('wiki.json') }}" data-document-id="{{ document.id }}">
+                  {% csrf_token %}
+                    {% for field in document_form.visible_fields() if
+                      (field.name != 'is_localizable' or not document.translations.exists()) %}
+                      <div class="field {% if field.name == 'needs_change_comment' %}has-large-textarea comment{% endif %}">
+                        {{ field|label_with_help }}{{ field }}
+                      </div>
+                    {% endfor %}
+                  {% if document.translations.exists() %}
+                    {{ document_form.is_localizable.as_hidden()|safe }}
+                  {% endif %}
+                  <input type="hidden" name="form" value="doc" />
+                  <div class="submit sumo-button-wrap align-end">
+                    <button class="sumo-button primary-button" type="submit">{{ _('Save description') }}</button>
+                  </div>
+                </form>
+            </div>
+      {% endif %}
+    </article>
+  </div>
+
+  <script type="application/json" class="showfor-data">
+    {{ showfor_data(document.get_products()) }}
+  </script>
+{% endblock %}
+
+{% block side_top %}
+  {{ document_tools(document, document.parent, user, 'edit_doc', settings) }}
+{% endblock %}

--- a/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
+++ b/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
@@ -24,9 +24,14 @@
             </li>
           {% endif %}
           {% if document and not document.is_archived and (document.allows(user, 'create_revision') or document.allows(user, 'edit')) and fallback_reason != "fallback_locale" %}
-            <li {{ active|class_selected('edit') }}>
-              <a href="{{ url('wiki.edit_document', document.slug) }}">{{ _('Edit Article') }}</a>
+          <li {{ active|class_selected('edit') }}>
+            <a href="{{ url('wiki.edit_document', document.slug) }}">{{ _('Edit Article') }}</a>
+          </li>
+            {% if request.user.is_staff %}
+            <li {{ active|class_selected('edit_doc') }}>
+              <a href="{{ url('wiki.edit_document_metadata', document.slug) }}">{{ _('Edit Article Description') }}</a>
             </li>
+            {% endif %}
           {% endif %}
           {% if document and not document.is_archived and document.is_localizable %}
             <li {{ active|class_selected('localize') }}>

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -950,7 +950,7 @@ class NewRevisionTests(TestCaseBase):
     def test_edit_document_POST_removes_old_tags(self):
         """Changing the tags on a document removes the old tags from
         that document."""
-        user = UserFactory()
+        user = UserFactory(is_staff=True)
         add_permission(user, Revision, "review_revision")
         self.client.login(username=user.username, password="testpass")
         self.d.current_revision = None
@@ -961,7 +961,7 @@ class NewRevisionTests(TestCaseBase):
         new_topics = [topics[0], TopicFactory()]
         data = new_document_data(t.id for t in new_topics)
         data["form"] = "doc"
-        self.client.post(reverse("wiki.edit_document", args=[self.d.slug]), data)
+        self.client.post(reverse("wiki.edit_document_metadata", args=[self.d.slug]), data)
         topic_ids = self.d.topics.values_list("id", flat=True)
         self.assertEqual(2, len(topic_ids))
         assert new_topics[0].id in topic_ids
@@ -1241,7 +1241,7 @@ class DocumentEditTests(TestCaseBase):
         super(DocumentEditTests, self).setUp()
         self.d = _create_document()
 
-        u = UserFactory()
+        u = UserFactory(is_staff=True)
         add_permission(u, Document, "change_document")
         self.client.login(username=u.username, password="testpass")
 
@@ -1250,7 +1250,7 @@ class DocumentEditTests(TestCaseBase):
         # Create a translation
         _create_document(title="Document Prueba", parent=self.d, locale="es")
         # Make sure is_localizable hidden field is rendered
-        response = get(self.client, "wiki.edit_document", args=[self.d.slug])
+        response = get(self.client, "wiki.edit_document_metadata", args=[self.d.slug])
         self.assertEqual(200, response.status_code)
         doc = pq(response.content)
         is_localizable = doc('input[name="is_localizable"]')
@@ -1262,7 +1262,7 @@ class DocumentEditTests(TestCaseBase):
         data.update(title=new_title)
         data.update(form="doc")
         data.update(is_localizable="True")
-        response = post(self.client, "wiki.edit_document", data, args=[self.d.slug])
+        response = post(self.client, "wiki.edit_document_metadata", data, args=[self.d.slug])
         self.assertEqual(200, response.status_code)
         doc = Document.objects.get(pk=self.d.pk)
         self.assertEqual(new_title, doc.title)
@@ -1273,7 +1273,7 @@ class DocumentEditTests(TestCaseBase):
         new_slug = "Test-Document"
         data.update(slug=new_slug)
         data.update(form="doc")
-        response = post(self.client, "wiki.edit_document", data, args=[self.d.slug])
+        response = post(self.client, "wiki.edit_document_metadata", data, args=[self.d.slug])
         self.assertEqual(200, response.status_code)
         doc = Document.objects.get(pk=self.d.pk)
         self.assertEqual(new_slug, doc.slug)
@@ -1284,7 +1284,7 @@ class DocumentEditTests(TestCaseBase):
         new_title = "TeST DoCuMent"
         data.update(title=new_title)
         data.update(form="doc")
-        response = post(self.client, "wiki.edit_document", data, args=[self.d.slug])
+        response = post(self.client, "wiki.edit_document_metadata", data, args=[self.d.slug])
         self.assertEqual(200, response.status_code)
         doc = Document.objects.get(pk=self.d.pk)
         self.assertEqual(new_title, doc.title)
@@ -1305,13 +1305,13 @@ class DocumentEditTests(TestCaseBase):
     # TODO: Factor with test_archive_permission_off.
     def test_archive_permission_on(self):
         """Shouldn't be able to change is_archive bit without permission."""
-        u = UserFactory()
+        u = UserFactory(is_staff=True)
         add_permission(u, Document, "change_document")
         add_permission(u, Document, "archive_document")
         self.client.login(username=u.username, password="testpass")
         data = new_document_data()
         data.update(form="doc", is_archived="on")
-        response = post(self.client, "wiki.edit_document", data, args=[self.d.slug])
+        response = post(self.client, "wiki.edit_document_metadata", data, args=[self.d.slug])
         self.assertEqual(200, response.status_code)
         doc = Document.objects.get(pk=self.d.pk)
         assert doc.is_archived

--- a/kitsune/wiki/tests/test_views.py
+++ b/kitsune/wiki/tests/test_views.py
@@ -269,12 +269,14 @@ class EditDocumentVisibilityTests(TestCaseBase):
         authenticated users without the proper permission.
         """
         rev = RevisionFactory(is_approved=False)
-        user = UserFactory()
+        user = UserFactory(is_staff=True)
         # The document is in the "en-US" locale, so this permission won't provide access.
         locale_team, _ = Locale.objects.get_or_create(locale="de")
         locale_team.reviewers.add(user)
         self.client.login(username=user.username, password="testpass")
-        response = self.client.get(reverse("wiki.edit_document", args=[rev.document.slug]))
+        response = self.client.get(
+            reverse("wiki.edit_document_metadata", args=[rev.document.slug])
+        )
         self.assertEqual(404, response.status_code)
 
     def test_visibility_when_no_approved_content_and_authenticated_user_with_permission(self):
@@ -291,7 +293,7 @@ class EditDocumentVisibilityTests(TestCaseBase):
             "en-US__reviewers",
         ):
             with self.subTest(perm):
-                user = UserFactory(is_superuser=(perm == "superuser"))
+                user = UserFactory(is_superuser=(perm == "superuser"), is_staff=True)
                 if perm == "review_revision":
                     add_permission(user, Revision, "review_revision")
                 elif perm == "delete_document":
@@ -302,7 +304,9 @@ class EditDocumentVisibilityTests(TestCaseBase):
                     getattr(locale_team, role).add(user)
                 self.client.login(username=user.username, password="testpass")
                 rev = RevisionFactory(is_approved=False)
-                response = self.client.get(reverse("wiki.edit_document", args=[rev.document.slug]))
+                response = self.client.get(
+                    reverse("wiki.edit_document_metadata", args=[rev.document.slug])
+                )
                 self.assertEqual(response.status_code, 200)
                 self.client.logout()
 
@@ -310,10 +314,12 @@ class EditDocumentVisibilityTests(TestCaseBase):
         """
         Documents without approved content can be seen by their creator.
         """
-        creator = UserFactory()
+        creator = UserFactory(is_staff=True)
         rev = RevisionFactory(is_approved=False, creator=creator)
         self.client.login(username=creator.username, password="testpass")
-        response = self.client.get(reverse("wiki.edit_document", args=[rev.document.slug]))
+        response = self.client.get(
+            reverse("wiki.edit_document_metadata", args=[rev.document.slug])
+        )
         self.assertEqual(response.status_code, 200)
 
 
@@ -1548,7 +1554,7 @@ class DocumentEditingTests(TestCaseBase):
 
     def setUp(self):
         super(DocumentEditingTests, self).setUp()
-        self.u = UserFactory()
+        self.u = UserFactory(is_staff=True)
         # The "delete_document" permission is one of the ways to allow
         # a user to "see" documents that have no approved content.
         add_permission(self.u, Document, "delete_document")
@@ -1566,7 +1572,7 @@ class DocumentEditingTests(TestCaseBase):
         old_title = d.title
         data = new_document_data()
         data.update({"title": new_title, "slug": d.slug, "form": "doc"})
-        self.client.post(reverse("wiki.edit_document", args=[d.slug]), data)
+        self.client.post(reverse("wiki.edit_document_metadata", args=[d.slug]), data)
         self.assertEqual(new_title, Document.objects.get(id=d.id).title)
         assert Document.objects.get(title=old_title).redirect_url()
 
@@ -1576,7 +1582,7 @@ class DocumentEditingTests(TestCaseBase):
         new_title = "Ümlaut test"
         data = new_document_data()
         data.update({"title": new_title, "slug": d.slug, "form": "doc"})
-        self.client.post(reverse("wiki.edit_document", args=[d.slug]), data)
+        self.client.post(reverse("wiki.edit_document_metadata", args=[d.slug]), data)
         self.assertEqual(new_title, Document.objects.get(id=d.id).title)
 
     def test_retitling_template(self):
@@ -1589,7 +1595,7 @@ class DocumentEditingTests(TestCaseBase):
         # First try and change the title without also changing the category. It should fail.
         data = new_document_data()
         data.update({"title": new_title, "category": d.category, "slug": d.slug, "form": "doc"})
-        url = reverse("wiki.edit_document", args=[d.slug])
+        url = reverse("wiki.edit_document_metadata", args=[d.slug])
         res = self.client.post(url, data, follow=True)
         self.assertEqual(Document.objects.get(id=d.id).title, old_title)
         # This message gets HTML encoded.
@@ -1600,7 +1606,7 @@ class DocumentEditingTests(TestCaseBase):
 
         # Now try and change the title while also changing the category.
         data["category"] = CATEGORIES[0][0]
-        url = reverse("wiki.edit_document", args=[d.slug])
+        url = reverse("wiki.edit_document_metadata", args=[d.slug])
         self.client.post(url, data, follow=True)
         self.assertEqual(Document.objects.get(id=d.id).title, new_title)
 
@@ -1615,7 +1621,7 @@ class DocumentEditingTests(TestCaseBase):
         data.update(
             {"title": d.title, "category": CATEGORIES[0][0], "slug": d.slug, "form": "doc"}
         )
-        url = reverse("wiki.edit_document", args=[d.slug])
+        url = reverse("wiki.edit_document_metadata", args=[d.slug])
         res = self.client.post(url, data, follow=True)
         self.assertEqual(Document.objects.get(id=d.id).category, TEMPLATES_CATEGORY)
         # This message gets HTML encoded.
@@ -1626,7 +1632,7 @@ class DocumentEditingTests(TestCaseBase):
 
         # Now try and change the title while also changing the category.
         data["title"] = "not a template"
-        url = reverse("wiki.edit_document", args=[d.slug])
+        url = reverse("wiki.edit_document_metadata", args=[d.slug])
         self.client.post(url, data)
         self.assertEqual(Document.objects.get(id=d.id).category, CATEGORIES[0][0])
 
@@ -1646,7 +1652,7 @@ class DocumentEditingTests(TestCaseBase):
                 "form": "doc",
             }
         )
-        self.client.post(reverse("wiki.edit_document", args=[d.slug]), data)
+        self.client.post(reverse("wiki.edit_document_metadata", args=[d.slug]), data)
 
         self.assertEqual(
             sorted(Document.objects.get(id=d.id).products.values_list("id", flat=True)),
@@ -1654,7 +1660,7 @@ class DocumentEditingTests(TestCaseBase):
         )
 
         data.update({"products": [prod_desktop.id], "form": "doc"})
-        self.client.post(reverse("wiki.edit_document", args=[data["slug"]]), data)
+        self.client.post(reverse("wiki.edit_document_metadata", args=[data["slug"]]), data)
         self.assertEqual(
             sorted(Document.objects.get(id=d.id).products.values_list("id", flat=True)),
             sorted([prod.id for prod in [prod_desktop]]),
@@ -1771,14 +1777,14 @@ class DocumentEditingTests(TestCaseBase):
 
         # Give the user permission, now it should work.
         add_permission(self.u, Document, "edit_needs_change")
-        self.client.post(reverse("wiki.edit_document", args=[doc.slug]), data)
+        self.client.post(reverse("wiki.edit_document_metadata", args=[doc.slug]), data)
         doc = Document.objects.get(pk=doc.pk)
         assert doc.needs_change
         self.assertEqual(comment, doc.needs_change_comment)
 
         # Clear out needs_change.
         data.update({"needs_change": False, "needs_change_comment": comment})
-        self.client.post(reverse("wiki.edit_document", args=[doc.slug]), data)
+        self.client.post(reverse("wiki.edit_document_metadata", args=[doc.slug]), data)
         doc = Document.objects.get(pk=doc.pk)
         assert not doc.needs_change
         self.assertEqual("", doc.needs_change_comment)
@@ -2125,7 +2131,9 @@ class TestDocumentLocking(TestCaseBase):
     def test_trans_lock_workflow(self):
         """End to end test of locking on a translated document."""
         trans_doc = TranslatedRevisionFactory().document
-        edit_url = reverse("wiki.edit_document", locale=trans_doc.locale, args=[trans_doc.slug])
+        edit_url = reverse(
+            "wiki.edit_document_metadata", locale=trans_doc.locale, args=[trans_doc.slug]
+        )
         self._lock_workflow(trans_doc, edit_url)
 
 

--- a/kitsune/wiki/urls.py
+++ b/kitsune/wiki/urls.py
@@ -11,6 +11,7 @@ document_patterns = [
     re_path(r"^/revision/(?P<revision_id>\d+)$", views.revision, name="wiki.revision"),
     re_path(r"^/history$", views.document_revisions, name="wiki.document_revisions"),
     re_path(r"^/edit$", views.edit_document, name="wiki.edit_document"),
+    re_path(r"^/edit/document$", views.edit_document_metadata, name="wiki.edit_document_metadata"),
     re_path(
         r"^/edit/(?P<revision_id>\d+)$", views.edit_document, name="wiki.new_revision_based_on"
     ),

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -455,7 +455,7 @@ def steal_lock(request, document_slug, revision_id=None):
 @require_http_methods(["GET", "POST"])
 @login_required
 def edit_document(request, document_slug, revision_id=None):
-    """Create a new revision of a wiki document, or edit document metadata."""
+    """Create a new revision of a wiki document"""
     user = request.user
 
     doc = get_visible_document_or_404(
@@ -471,95 +471,44 @@ def edit_document(request, document_slug, revision_id=None):
         url = reverse("wiki.translate", locale=request.LANGUAGE_CODE, args=[document_slug])
         return HttpResponseRedirect(url)
 
-    can_edit_needs_change = doc.allows(user, "edit_needs_change")
-    can_archive = doc.allows(user, "archive")
-
     # If this document has a parent, then the edit is handled by the
     # translate view. Pass it on.
     if doc.parent:
         return translate(request, doc.parent.slug, revision_id)
+
+    if not doc.allows(user, "create_revision"):
+        raise PermissionDenied
+
     if revision_id:
         rev = get_object_or_404(Revision, pk=revision_id, document=doc)
     else:
         rev = doc.current_revision or doc.revisions.order_by("-created", "-id")[0]
 
-    disclose_description = bool(request.GET.get("opendescription"))
-    doc_form = rev_form = None
-    if doc.allows(user, "create_revision"):
+    if request.method == "GET":
         rev_form = RevisionForm(instance=rev, initial={"based_on": rev.id, "comment": ""})
-    if doc.allows(user, "edit"):
-        doc_form = DocumentForm(
-            initial=_document_form_initial(doc),
-            can_archive=can_archive,
-            can_edit_needs_change=can_edit_needs_change,
+        show_revision_warning = _show_revision_warning(doc, rev)
+        locked, locked_by = _document_lock(doc.id, user.username)
+
+        return render(
+            request,
+            "wiki/edit.html",
+            {
+                "revision_form": rev_form,
+                "document": doc,
+                "show_revision_warning": show_revision_warning,
+                "locked": locked,
+                "locked_by": locked_by,
+            },
         )
 
-    if request.method == "GET":
-        if not (rev_form or doc_form):
-            # You can't do anything on this page, so get lost.
-            raise PermissionDenied
-
-    else:  # POST
-        # Comparing against localized names for the Save button bothers me, so
-        # I embedded a hidden input:
-        which_form = request.POST.get("form")
-
-        _document_lock_clear(doc.id, user.username)
-
-        if which_form == "doc":
-            if doc.allows(user, "edit"):
-                post_data = request.POST.copy()
-                post_data.update({"locale": request.LANGUAGE_CODE})
-
-                topics = []
-                for t in post_data.getlist("topics"):
-                    topics.append(int(t))
-                post_data.setlist("topics", topics)
-
-                doc_form = DocumentForm(
-                    post_data,
-                    instance=doc,
-                    can_archive=can_archive,
-                    can_edit_needs_change=can_edit_needs_change,
-                )
-                if doc_form.is_valid():
-                    # Get the possibly new slug for the imminent redirection:
-                    try:
-                        doc = doc_form.save(None)
-                    except (TitleCollision, SlugCollision) as e:
-                        # TODO: .add_error() when we upgrade to Django 1.7
-                        errors = doc_form._errors.setdefault("title", ErrorList())
-                        message = "The {type} you selected is already in use."
-                        message = message.format(
-                            type="title" if isinstance(e, TitleCollision) else "slug"
-                        )
-                        errors.append(_(message))
-                    else:
-                        # Do we need to rebuild the KB?
-                        _maybe_schedule_rebuild(doc_form)
-
-                        return HttpResponseRedirect(
-                            urlparams(
-                                reverse("wiki.edit_document", args=[doc.slug]), opendescription=1
-                            )
-                        )
-                disclose_description = True
-            else:
-                raise PermissionDenied
-        elif which_form == "rev":
-            if doc.allows(user, "create_revision"):
-                rev_form = RevisionForm(request.POST)
-                rev_form.instance.document = doc  # for rev_form.clean()
-                if rev_form.is_valid():
-                    _save_rev_and_notify(rev_form, user, doc, base_rev=rev)
-                    if "notify-future-changes" in request.POST:
-                        EditDocumentEvent.notify(request.user, doc)
-
-                    return HttpResponseRedirect(
-                        reverse("wiki.document_revisions", args=[document_slug])
-                    )
-            else:
-                raise PermissionDenied
+    _document_lock_clear(doc.id, user.username)
+    rev_form = RevisionForm(request.POST)
+    rev_form.instance.document = doc  # for rev_form.clean()
+    if rev_form.is_valid():
+        _save_rev_and_notify(rev_form, user, doc, base_rev=rev)
+        if "notify-future-changes" in request.POST:
+            EditDocumentEvent.notify(request.user, doc)
+        return HttpResponseRedirect(reverse("wiki.document_revisions", args=[document_slug]))
 
     show_revision_warning = _show_revision_warning(doc, rev)
     locked, locked_by = _document_lock(doc.id, user.username)
@@ -569,8 +518,97 @@ def edit_document(request, document_slug, revision_id=None):
         "wiki/edit.html",
         {
             "revision_form": rev_form,
+            "document": doc,
+            "show_revision_warning": show_revision_warning,
+            "locked": locked,
+            "locked_by": locked_by,
+        },
+    )
+
+
+@require_http_methods(["GET", "POST"])
+@login_required
+def edit_document_metadata(request, document_slug, revision_id=None):
+    """Edit document metadata."""
+    user = request.user
+
+    doc = get_visible_document_or_404(
+        user,
+        locale=request.LANGUAGE_CODE,
+        slug=document_slug,
+        look_for_translation_via_parent=True,
+        return_parent_if_no_translation=True,
+    )
+
+    if doc.locale != request.LANGUAGE_CODE:
+        # We've fallen back to the parent, since no visible translation existed.
+        url = reverse("wiki.translate", locale=request.LANGUAGE_CODE, args=[document_slug])
+        return HttpResponseRedirect(url)
+
+    # If this document has a parent, then the edit is handled by the
+    # translate view. Pass it on.
+    if doc.parent:
+        return translate(request, doc.parent.slug, revision_id)
+
+    if not doc.allows(user, "edit") and user.is_staff:
+        raise PermissionDenied
+
+    can_edit_needs_change = doc.allows(user, "edit_needs_change")
+    can_archive = doc.allows(user, "archive")
+
+    if revision_id:
+        rev = get_object_or_404(Revision, pk=revision_id, document=doc)
+    else:
+        rev = doc.current_revision or doc.revisions.order_by("-created", "-id")[0]
+
+    if request.method == "GET":
+        doc_form = DocumentForm(
+            initial=_document_form_initial(doc),
+            can_archive=can_archive,
+            can_edit_needs_change=can_edit_needs_change,
+        )
+
+    else:  # POST
+        _document_lock_clear(doc.id, user.username)
+
+        post_data = request.POST.copy()
+        post_data.update({"locale": request.LANGUAGE_CODE})
+
+        topics = []
+        for t in post_data.getlist("topics"):
+            topics.append(int(t))
+        post_data.setlist("topics", topics)
+
+        doc_form = DocumentForm(
+            post_data,
+            instance=doc,
+            can_archive=can_archive,
+            can_edit_needs_change=can_edit_needs_change,
+        )
+        if doc_form.is_valid():
+            # Get the possibly new slug for the imminent redirection:
+            try:
+                doc = doc_form.save(None)
+            except (TitleCollision, SlugCollision) as e:
+                # TODO: .add_error() when we upgrade to Django 1.7
+                errors = doc_form._errors.setdefault("title", ErrorList())
+                message = "The {type} you selected is already in use."
+                message = message.format(type="title" if isinstance(e, TitleCollision) else "slug")
+                errors.append(_(message))
+            else:
+                # Do we need to rebuild the KB?
+                _maybe_schedule_rebuild(doc_form)
+
+                return HttpResponseRedirect(urlparams(reverse("wiki.document", args=[doc.slug])))
+
+    show_revision_warning = _show_revision_warning(doc, rev)
+    locked, locked_by = _document_lock(doc.id, user.username)
+
+    return render(
+        request,
+        "wiki/edit_metadata.html",
+        {
             "document_form": doc_form,
-            "disclose_description": disclose_description,
             "document": doc,
             "show_revision_warning": show_revision_warning,
             "locked": locked,


### PR DESCRIPTION
**Requires 1234 Be Pushed First - based on that**
* Edit Article Description, on save, now takes you to article vs. edit page
* "Comment:" label and textarea now hidden on load, shown when checkbox clicked
* textarea reasonably sized