### PR TITLE
disable graphql introspection

### DIFF
--- a/kitsune/graphql/middleware.py
+++ b/kitsune/graphql/middleware.py
@@ -1,0 +1,8 @@
+from graphene.utils.is_introspection_key import is_introspection_key
+
+
+class DisableIntrospectionMiddleware:
+    def resolve(self, next, root, info, **kwargs):
+        if is_introspection_key(info.field_name):
+            raise Exception("GraphQL introspection is disabled.")
+        return next(root, info, **kwargs)

--- a/kitsune/schema.py
+++ b/kitsune/schema.py
@@ -1,15 +1,6 @@
 import graphene
 
-from kitsune.graphql import query as kitsune_query
-
-
-class Query(kitsune_query.Query, graphene.ObjectType):
-    """Top level Query.
-
-    Inherits from Query classes in other apps.
-    """
-
-    ...
+from kitsune.graphql.query import Query
 
 
 schema = graphene.Schema(query=Query)

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -1250,9 +1250,11 @@ TRUSTED_GROUPS = [
 ]
 
 # GraphQL configuration
-GRAPHENE = {
+GRAPHENE: dict[str, str | tuple[str, ...]] = {
     "SCHEMA": "kitsune.schema.schema",
 }
+if not DEV:
+    GRAPHENE["MIDDLEWARE"] = ("kitsune.graphql.middleware.DisableIntrospectionMiddleware",)
 
 # Contributor Groups
 LEGACY_CONTRIBUTOR_GROUPS = [

--- a/kitsune/sumo/tests/test_graphql.py
+++ b/kitsune/sumo/tests/test_graphql.py
@@ -1,0 +1,95 @@
+from graphene_django.utils.testing import GraphQLTestCase
+
+from kitsune.users.tests import GroupFactory, UserFactory
+
+
+class GraphQLTestCases(GraphQLTestCase):
+    def test_graphql_anonymous(self):
+        response = self.query(
+            """
+            query {
+                currentUser {
+                    email
+                }
+            }
+            """
+        )
+        self.assertResponseNoErrors(response)
+        self.assertEqual(response.json(), {"data": {"currentUser": None}})
+
+    def test_graphql_authenticated(self):
+        user = UserFactory()
+        self.client.login(username=user.username, password="testpass")
+        response = self.query(
+            """
+            query {
+                currentUser {
+                    id
+                    email
+                    username
+                    isContributor
+                }
+            }
+            """
+        )
+        self.assertResponseNoErrors(response)
+        self.assertEqual(
+            response.json(),
+            {
+                "data": {
+                    "currentUser": {
+                        "id": str(user.id),
+                        "email": user.email,
+                        "username": user.username,
+                        "isContributor": False,
+                    }
+                }
+            },
+        )
+
+    def test_graphql_authenticated_contributor(self):
+        user = UserFactory(groups=[GroupFactory(name="l10n-contributors")])
+        self.client.login(username=user.username, password="testpass")
+        response = self.query(
+            """
+            query {
+                currentUser {
+                    isContributor
+                }
+            }
+            """
+        )
+        self.assertResponseNoErrors(response)
+        self.assertEqual(
+            response.json(),
+            {
+                "data": {
+                    "currentUser": {
+                        "isContributor": True,
+                    }
+                }
+            },
+        )
+
+    def test_graphql_introspection(self):
+        query = """
+            query {
+                __schema {
+                    types {
+                        name
+                        description
+                    }
+                }
+            }
+        """
+        user = UserFactory()
+        self.client.login(username=user.username, password="testpass")
+        response = self.query(query)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("errors", data)
+        self.assertEqual(len(data["errors"]), 1)
+        self.assertIn("message", data["errors"][0])
+        self.assertEqual(data["errors"][0]["message"], "GraphQL introspection is disabled.")
+        self.assertIn("data", data)
+        self.assertIs(data["data"], None)


### PR DESCRIPTION
mozilla/sumo#1362

This PR also adds tests for the `graphql` endpoint.