### PR TITLE
"python.pythonPath" appears to be deprecated

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.pythonPath": "/venv/bin/python",
+    "python.defaultInterpreterPath": "/venv/bin/python",
     "python.formatting.provider": "none",
     "python.formatting.blackPath": "/venv/bin/black",
     "python.formatting.blackArgs": [


### PR DESCRIPTION
* Replacing with "python.defaultInterpreterPath"