### PR TITLE
optipng won't compile on mac silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ run: .docker-build
 init: .docker-build
 	${DC} run web bin/run-bootstrap.sh
 
+init-mac: .docker-build
+	${DC} run web bin/run-bootstrap.sh --optipng-fix
+
 shell: .docker-build
 	${DC} run web bash
 

--- a/bin/run-bootstrap.sh
+++ b/bin/run-bootstrap.sh
@@ -5,6 +5,12 @@ set -ex
 # Install and setup localization
 ./scripts/l10n-fetch-lint-compile.sh
 
+# If flag --optipng-fix is passed
+if [[ $* == *--optipng-fix* ]]; then
+    # Install fix for optipng on mac silicon
+    export CPPFLAGS=-DPNG_ARM_NEON_OPT=0
+fi
+
 # Collect the JavaScript catalog files.
 python manage.py compilejsi18n
 

--- a/docs/hacking_howto.md
+++ b/docs/hacking_howto.md
@@ -23,9 +23,21 @@ and follow the following steps.
     make .env
     ```
 3. Pull base Kitsune Docker images, install node packages and build the Webpack bundle, and create your database.
+    On non-Apple silicon:
 
     ```
     make init
+    ```
+
+    On Apple silicon (M1, M2):
+
+    ```
+    make init-mac
+    ```
+
+    Then:
+    
+    ```
     make build
     ```
 


### PR DESCRIPTION
- create a Make option 'init-mac' to account for it
- allow run-boostrap.sh to process the new --optipng-fix flag
- update doc

Open to better ideas (yes, move to linux is valid)
- Determining if you are on Apple silicon from run-bootstrap.sh directly appeared to be problematic since it is running in a container
- Doing it prior in the make call seemed to make sense
  - change nothing for exisiting processes but add a simpler way forward for Mac folk