### PR TITLE
Ensure translations inherit Topics

### DIFF
--- a/kitsune/wiki/forms.py
+++ b/kitsune/wiki/forms.py
@@ -229,6 +229,8 @@ class DocumentForm(forms.ModelForm):
         if parent_doc:
             # Products are not set on translations.
             doc.products.remove(*[p for p in doc.products.all()])
+            # A child always inherits parent topics.
+            doc.topics.add(*[t for t in parent_doc.topics.all()])
 
         return doc
 


### PR DESCRIPTION
This ensures that when translations are made, they inherit parent topics.

NOTE: There appears to be code that specifically removes Products from the form save - is this desired behavior?

```
        if parent_doc:
            # Products are not set on translations.
            doc.products.remove(*[p for p in doc.products.all()])
```