### PR TITLE
1319 - Improve tab hightlights

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_tabs.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_tabs.scss
@@ -30,6 +30,10 @@
     margin-right: p.$spacing-md;
   }
 
+  &:focus {
+    outline: 1px solid var(--color-link);
+  }
+
   &:hover  {
     color: var(--color-link);
   }
@@ -112,7 +116,6 @@
     .tabs--item {
       border-top: 1px solid var(--color-border);
       background-color: var(--page-bg);
-
       span {
         padding: 0;
       }


### PR DESCRIPTION
 * When browsing tabs on the page using the tab key, focused tabs were displaying two bars vs. expected box.
 * Now they show expected box.