### PR TITLE
Hide/show fox doodle based on a feature flag

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -333,5 +333,7 @@
 {% if settings.STAGE %}
   <script src="https://pontoon.mozilla.org/pontoon.js"></script>
 {% endif %}
+
+  <script src="{{ url("wafflejs") }}"></script>
 </body>
 </html>

--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -110,6 +110,9 @@ export class FormWizard extends HTMLElement {
   }
 
   connectedCallback() {
+    // Report to GA whether or not the user sees the fox doodle.
+    trackEvent("device-migration-wizard", "experiments", "doodle-shown", this.showDoodle);
+
     if (this.activeStep) {
       // Make sure the active step is shown.
       this.#setActiveStepAttributes();
@@ -117,6 +120,10 @@ export class FormWizard extends HTMLElement {
       // If there's no active step, default to the first step.
       this.activeStep = this.firstElementChild?.getAttribute("name");
     }
+  }
+
+  get showDoodle() {
+    return window.waffle?.flag_is_active("show_device_migration_doodle");
   }
 
   get activeStep() {
@@ -282,6 +289,10 @@ export class FormWizard extends HTMLElement {
    * active step. Also toggles visibility.
    */
   #updateDoodle() {
+    if (!this.showDoodle) {
+      return;
+    }
+
     let doodleData = STEP_TO_DOODLE_MAP[this.activeStep];
     if (doodleData) {
       this.#doodle.src = doodleData.src;

--- a/webpack/mocha-require.js
+++ b/webpack/mocha-require.js
@@ -28,3 +28,4 @@ global.jsdom = dom
 global.window.fetch = () => {};
 global.CustomEvent = dom.window.CustomEvent;
 global.requestAnimationFrame = () => {};
+global.window.waffle = { flag_is_active: () => undefined };


### PR DESCRIPTION
So I'm still not 100% sure this will work for A/B testing, but it seems to work to hide/show the doodle locally. This patch:

* reintroduces waffleJS
* uses waffleJS to check the value/presence of a `show_device_migration_doodle` feature flag
* if the flag is on, shows the fox doodle and sends an event to GA

I set up the feature flag through my local admin dashboard with the following configuration:

<img width="776" alt="Screenshot 2023-08-08 at 2 57 54 PM" src="https://github.com/mozilla/kitsune/assets/15138046/5afc5f27-7c0d-4994-8dc7-99bac46f181a">

If this seems like I'm on the right track we'll probably need someone on data science to weigh in on what percentage of users we want to show the doodle to, as well as see if they have opinions on how the GA event should be formatted/tagged.