### PR TITLE
fix issues 1399 and 1416

### DIFF
--- a/kitsune/sumo/static/sumo/js/protocol-details-init.js
+++ b/kitsune/sumo/static/sumo/js/protocol-details-init.js
@@ -1,5 +1,16 @@
 import "sumo/js/protocol";
 
+
+export function collapsibleAccordionInit() {
+  'use strict';
+  // Initialize any header elements, or header elements wrapped by a "div.for"
+  // element (which is generated from the Wiki syntax "{for ...}{/for}") that
+  // are direct children of an element with the "mzp-c-details" class.
+  for (let hdr of ['h2', 'h3', 'h4', 'h5', 'h6']) {
+    window.Mzp.Details.init(`.mzp-c-details > ${hdr}, .mzp-c-details > div.for > ${hdr}`);
+  }
+}
+
 export default function detailsInit() {
   'use strict';
   var _mqWide = matchMedia('(max-width: 1055px)');
@@ -41,6 +52,8 @@ export default function detailsInit() {
   if ( forumDropdown ) {
     window.Mzp.Details.init('[data-has-dropdown]');
   }
+
+  collapsibleAccordionInit();
 }
 
 detailsInit();

--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -13,6 +13,7 @@ import AjaxPreview from "sumo/js/ajaxpreview";
 import { initDiff } from "sumo/js/diff";
 import Marky from "sumo/js/markup";
 import ShowFor from "sumo/js/showfor";
+import collapsibleAccordionInit from "sumo/js/protocol-details-init";
 
 /*
  * wiki.js
@@ -181,7 +182,7 @@ import ShowFor from "sumo/js/showfor";
       });
     }
   }
-  
+
   function initPrepopulatedSlugs() {
     var fields = {
       title: {
@@ -241,6 +242,7 @@ import ShowFor from "sumo/js/showfor";
         $preview.find('select.enable-if-js').prop("disabled", false);
         $preview.find('.kbox').kbox();
         $('#preview-diff .output').empty();
+        collapsibleAccordionInit();
       }
     });
   }


### PR DESCRIPTION
mozilla/sumo#1399
mozilla/sumo#1416

Fixes the handling `[[UI:details_start]]...[[UI:details_end]]` in the following cases:
- article preview mode
- article review mode
- also when one or more of the contained headers is wrapped in the `{for ...}{/for}` wiki syntax

## Screenshots
### Changes
Header wrapped in a `{for ...}{/for}` and sub-headers that shouldn't be activated as part of the "collapsible accordion".

<img width="797" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/fd6b5eaa-4722-4f1a-8278-f9fa4cd1881e">

### Preview
<img width="1002" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/ac14f5af-7ceb-40ee-b767-f0600352a0bf">

<img width="978" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/6f85b996-de79-4ea9-849a-410bb4e48824">

### Review
<img width="955" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/54e7d4f2-9ea9-46f2-bd75-dfe40b4e8d5f">

<img width="977" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/79c2cf8b-565f-4742-9e6b-079d1fa8676b">

<img width="1003" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/0b5ed40e-c32f-4b75-ac7d-c97f52e42546">

### Article
<img width="991" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/0b982b13-3d0e-46e4-a224-5550e94192a3">

<img width="957" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/99ac284d-8522-46b9-be52-9e17c0679a37">



