### PR TITLE
remove is_staff metadata restriction

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
+++ b/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
@@ -27,11 +27,9 @@
           <li {{ active|class_selected('edit') }}>
             <a href="{{ url('wiki.edit_document', document.slug) }}">{{ _('Edit Article') }}</a>
           </li>
-            {% if request.user.is_staff %}
-            <li {{ active|class_selected('edit_metadata') }}>
-              <a href="{{ url('wiki.edit_document_metadata', document.slug) }}">{{ _('Edit Article Metadata') }}</a>
-            </li>
-            {% endif %}
+          <li {{ active|class_selected('edit_metadata') }}>
+            <a href="{{ url('wiki.edit_document_metadata', document.slug) }}">{{ _('Edit Article Metadata') }}</a>
+          </li>
           {% endif %}
           {% if document and not document.is_archived and document.is_localizable %}
             <li {{ active|class_selected('localize') }}>

--- a/kitsune/wiki/tests/test_templates.py
+++ b/kitsune/wiki/tests/test_templates.py
@@ -951,7 +951,7 @@ class NewRevisionTests(TestCaseBase):
     def test_edit_document_POST_removes_old_tags(self):
         """Changing the tags on a document removes the old tags from
         that document."""
-        user = UserFactory(is_staff=True)
+        user = UserFactory()
         add_permission(user, Revision, "review_revision")
         self.client.login(username=user.username, password="testpass")
         self.d.current_revision = None
@@ -1242,7 +1242,7 @@ class DocumentEditTests(TestCaseBase):
         super(DocumentEditTests, self).setUp()
         self.d = _create_document()
 
-        u = UserFactory(is_staff=True)
+        u = UserFactory()
         add_permission(u, Document, "change_document")
         self.client.login(username=u.username, password="testpass")
 
@@ -1306,7 +1306,7 @@ class DocumentEditTests(TestCaseBase):
     # TODO: Factor with test_archive_permission_off.
     def test_archive_permission_on(self):
         """Shouldn't be able to change is_archive bit without permission."""
-        u = UserFactory(is_staff=True)
+        u = UserFactory()
         add_permission(u, Document, "change_document")
         add_permission(u, Document, "archive_document")
         self.client.login(username=u.username, password="testpass")

--- a/kitsune/wiki/tests/test_views.py
+++ b/kitsune/wiki/tests/test_views.py
@@ -269,7 +269,7 @@ class EditDocumentVisibilityTests(TestCaseBase):
         authenticated users without the proper permission.
         """
         rev = RevisionFactory(is_approved=False)
-        user = UserFactory(is_staff=True)
+        user = UserFactory()
         # The document is in the "en-US" locale, so this permission won't provide access.
         locale_team, _ = Locale.objects.get_or_create(locale="de")
         locale_team.reviewers.add(user)
@@ -293,7 +293,7 @@ class EditDocumentVisibilityTests(TestCaseBase):
             "en-US__reviewers",
         ):
             with self.subTest(perm):
-                user = UserFactory(is_superuser=(perm == "superuser"), is_staff=True)
+                user = UserFactory(is_superuser=(perm == "superuser"))
                 if perm == "review_revision":
                     add_permission(user, Revision, "review_revision")
                 elif perm == "delete_document":
@@ -314,7 +314,7 @@ class EditDocumentVisibilityTests(TestCaseBase):
         """
         Documents without approved content can be seen by their creator.
         """
-        creator = UserFactory(is_staff=True)
+        creator = UserFactory()
         rev = RevisionFactory(is_approved=False, creator=creator)
         self.client.login(username=creator.username, password="testpass")
         response = self.client.get(
@@ -1554,7 +1554,7 @@ class DocumentEditingTests(TestCaseBase):
 
     def setUp(self):
         super(DocumentEditingTests, self).setUp()
-        self.u = UserFactory(is_staff=True)
+        self.u = UserFactory()
         # The "delete_document" permission is one of the ways to allow
         # a user to "see" documents that have no approved content.
         add_permission(self.u, Document, "delete_document")

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -478,7 +478,7 @@ def edit_init_and_perms(request, document_slug, revision_id=None, doctype="doc")
         if not doc.allows(user, "create_revision"):
             raise PermissionDenied
     if doctype == "meta":
-        if not doc.allows(user, "edit") or not user.is_staff:
+        if not doc.allows(user, "edit"):
             raise PermissionDenied
 
     if doc.locale != request.LANGUAGE_CODE:


### PR DESCRIPTION
Leave all formatting changes, but remove any restrictions to metadata editing that require someone to be staff.