### PR TITLE
Catch redirected Pocket articles

### DIFF
--- a/kitsune/wiki/tests/test_views.py
+++ b/kitsune/wiki/tests/test_views.py
@@ -2320,3 +2320,24 @@ class FallbackSystem(TestCaseBase):
         trans_content = "This article is translated into fr"
         assert en_content not in doc_content
         assert trans_content in doc_content
+
+
+class PocketArticleTests(TestCaseBase):
+    """Pocket article redirect tests."""
+
+    def setUp(self):
+        ProductFactory()
+
+    def test_pocket_redirect_to_kb_for_document_that_exists(self):
+        """Are we redirecting to our article page?"""
+        doc = DocumentFactory(title="an article title", slug="article-title")
+        RevisionFactory(document=doc, is_approved=True)
+        pocket_style_url = f"/kb/pocket/1111-{doc.slug}"
+        response = self.client.get(pocket_style_url, follow=True)
+        self.assertEqual(response.redirect_chain[-1][0], "/en-US/kb/article-title")
+
+    def test_pocket_redirect_when_kb_article_doesnt_exist(self):
+        """No match found, we should be sent to /products/pocket"""
+        pocket_style_url = "/kb/pocket/1111-wont-match"
+        response = self.client.get(pocket_style_url, follow=True)
+        self.assertEqual(response.redirect_chain[-1][0], "/products/pocket")

--- a/kitsune/wiki/urls.py
+++ b/kitsune/wiki/urls.py
@@ -161,3 +161,14 @@ urlpatterns += [
         r"^/discuss/watch_locale$", kbforums_views.watch_locale, name="wiki.discuss.watch_locale"
     ),
 ]
+
+urlpatterns += [
+    # Redirect for pocket articles
+    # This assumes pocket redirects take the form of:
+    # /pocket/<article_id>-<document_slug>
+    re_path(
+        r"^/pocket/(?:(?P<article_id>\d+)-)?(?P<document_slug>[\w-]+)(?P<extra_path>/[\w/-]*)?/?$",
+        views.pocket_article,
+        name="wiki.pocket_article",
+    ),
+]

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -17,7 +17,7 @@ from django.db.models import Aggregate, TextField  # TODO: Delete once we move t
 from django.db.models.functions import TruncDate
 from django.forms.utils import ErrorList
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _lazy
@@ -26,6 +26,7 @@ from django.views.decorators.http import require_GET, require_http_methods, requ
 from kitsune.access.decorators import login_required
 from kitsune.lib.sumo_locales import LOCALES
 from kitsune.products.models import Product, Topic
+from kitsune.products.views import product_landing
 from kitsune.sumo.decorators import ratelimit
 from kitsune.sumo.redis_utils import RedisError, redis_client
 from kitsune.sumo.templatetags.jinja_helpers import urlparams
@@ -1768,3 +1769,18 @@ def parse_accept_lang_header(lang_string):
     # Changed here to get the locale name only
     result = [k for k, v in result]
     return result
+
+
+def pocket_article(request, article_id=None, document_slug=None, extra_path=None):
+    """Pocket articles migrated to SUMO are redirected to the new URL"""
+    try:
+        # If we migrated the document, we should be able to find it
+        Document.objects.get(slug=document_slug)
+    except Document.DoesNotExist:
+        # If document doesn't exist, fail back to Pocket product page with message
+        messages.warning(
+            request,
+            _("Sorry, that article wasn't found."),
+        )
+        return redirect(product_landing, slug="pocket", permanent=True)
+    return HttpResponseRedirect(reverse("wiki.document", args=[document_slug]))


### PR DESCRIPTION
* Match urls with /kb/pocket/articleid-article-slug
* View tries to find kb document with article-slug - if exists it goes there
* If it doesn't exist, the view fails back to /products/pocket
* If it has to fail, it posts a message to the /products/pocket page