### PR TITLE
require a reason when reporting abuse

### DIFF
--- a/kitsune/sumo/static/sumo/js/reportabuse.js
+++ b/kitsune/sumo/static/sumo/js/reportabuse.js
@@ -6,10 +6,24 @@
   'use strict';
 
   $(function() {
-    $('#report-abuse [type="submit"]').on('click', function(ev) {
+    $('#report-abuse input[type=radio][name=reason]').on('change', function(ev) {
+      $(this).closest('form').siblings('.message').text('');
+    });
+
+    $('#report-abuse [type=submit]').on('click', function(ev) {
       ev.preventDefault();
-      var $this = $(this);
-      var $form = $this.closest('form');
+      let $form = $(this).closest('form');
+      let reason = $form.find('input[type=radio][name=reason]:checked').val();
+
+      if (!reason) {
+        $form.siblings('.message').text(gettext('Please select a reason.'));
+        return;
+      }
+
+      if (reason === 'other' && !$form.find('textarea[name=other]').val().trim()) {
+        $form.siblings('.message').text(gettext('Please provide more detail.'));
+        return;
+      }
 
       $.ajax({
         url: $form.attr('action'),

--- a/kitsune/wiki/jinja2/wiki/includes/flag_form.html
+++ b/kitsune/wiki/jinja2/wiki/includes/flag_form.html
@@ -5,27 +5,30 @@
     <form action="{{ post_target }}" method="post">
       {% csrf_token %}
       <div class="field radio is-condensed">
-        <input type="radio" id="id_{{ post_target|slugify}}_spam" name="reason" value="spam" />
+        <input type="radio" name="reason" id="id_{{ post_target|slugify}}_spam" value="spam" required />
         <label for="id_{{ post_target|slugify}}_spam">{{ _('Spam or other unrelated content') }}</label>
       </div>
       <div class="field radio is-condensed">
-        <input type="radio" name="reason" id="id_{{ post_target|slugify}}_language" value="language" />
+        <input type="radio" name="reason" id="id_{{ post_target|slugify}}_language" value="language" required />
         <label for="id_{{ post_target|slugify}}_language">{{ _('Inappropriate language/dialog') }}</label>
       </div>
       {% if bug_support %}
       <div class="field radio is-condensed">
-        <input type="radio" name="reason" value="bug_support" id="id_{{ post_target|slugify}}_bug_support" />
+        <input type="radio" name="reason" id="id_{{ post_target|slugify}}_bug_support" value="bug_support" required />
         <label for="id_{{ post_target|slugify}}_bug_support">{{ _('Misplaced bug report or support request') }}</label>
       </div>
       {% endif %}
+      <div class="field radio is-condensed">
+        <input type="radio" name="reason" id="id_{{ post_target|slugify}}_abuse" value="abuse" required />
+        <label for="id_{{ post_target|slugify}}_abuse">{{ _('Abusive content') }}</label>
+      </div>
       <div class="field radio">
-        <input type="radio" id="id_{{ post_target|slugify}}_other" name="reason" value="other" />
+        <input type="radio" name="reason" id="id_{{ post_target|slugify}}_other" value="other" required />
         <label for="id_{{ post_target|slugify}}_other">{{ _('Other (please specify)') }}</label>
       </div>
       <div class="field has-md-textarea">
         <textarea name="other" placeholder="{{ _('Have more to say?') }}"></textarea>
       </div>
-
       <div class="sumo-button-wrap align-end">
         <button class="sumo-button primary-button" type="submit">{{ _('Submit') }}</button>
       </div>


### PR DESCRIPTION
mozilla/sumo#1435

## Notes
- MySQL allows the [`reason`](https://github.com/mozilla/kitsune/blob/6efbb5c1ac7ea2a1153cc9a827a2258fb29d7e91/kitsune/flagit/models.py#L43) field to be empty (`null`) when reporting abuse, because the column in the database is actually out-of-sync with the Django model, which requires a `reason` to be specified. Postgres is fully synchronized with the Django model, so it doesn't allow the `reason` to be `null`.
- With this PR, a `reason` is required, and also, if `Other` is selected, more detail must be provided as well.
- I also added another `reason` option to the form -- `Abusive content` -- because it was specified [here](https://github.com/mozilla/kitsune/blob/6efbb5c1ac7ea2a1153cc9a827a2258fb29d7e91/kitsune/flagit/models.py#L25), but never added to the form.

## Screenshots
The `Abusive content` option has been added:
<img width="869" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/3aa62220-faf8-4e95-a82e-278605edf89d">

When clicking the submit button without selecting a reason:
<img width="832" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/a429ddd3-dbad-468c-a0ef-b8787d759a2e">

When clicking the submit button and not specifying more detail after selecting `Other`:
<img width="829" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/04a23cb4-d581-4e34-af78-33f0c34a1fa0">





