### PR TITLE
Revert "change structure of doodle GA events (#5616)"

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -111,11 +111,7 @@ export class FormWizard extends HTMLElement {
 
   connectedCallback() {
     // Report to GA whether or not the user sees the fox doodle.
-    trackEvent(
-      "device-migration-wizard",
-      "experiments",
-      this.showDoodle ? "doodle-shown" : "doodle-not-shown"
-    );
+    trackEvent("device-migration-wizard", "experiments", "doodle-shown", this.showDoodle);
 
     if (this.activeStep) {
       // Make sure the active step is shown.


### PR DESCRIPTION
We haven't been able to see any `doodle-shown` events in stage since merging https://github.com/mozilla/kitsune/pull/5616, so let's revert the change and see if the events return.

