### PR TITLE
fix set-up and loading of GA gtag function

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -6,6 +6,8 @@
 <!DOCTYPE html>
 <html class="no-js" lang="{{ request.LANGUAGE_CODE }}"{% if DIR %} dir="{{ DIR }}"{% endif %}{% if settings.GTM_CONTAINER_ID %} data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %}>
 <head>
+  {% include "includes/google-analytics.html" %}
+
   {% block head_top %}{% endblock %}
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
@@ -56,8 +58,6 @@
   {% if canonical_url %}
     <link rel="canonical" href="{{ canonical_url|safe }}" />
   {% endif %}
-
-  {% include "includes/google-analytics.html" %}
 </head>
 
 <body class="html-{{ DIR }} logged-{% if user.is_authenticated %}in{% else %}out{% endif %} responsive {{ classes }} {{ request.LANGUAGE_CODE }}"

--- a/kitsune/sumo/static/sumo/js/gtm-snippet.js
+++ b/kitsune/sumo/static/sumo/js/gtm-snippet.js
@@ -34,7 +34,6 @@ import dntEnabled from "./libs/dnt-helper";
     // product should be first match or null
     product = (matches && matches.length > 0) ? matches[1] : null;
 
-
     w.gtag('config', GTM_CONTAINER_ID, {
       'dimension1': product
     });

--- a/webpack/entrypoints-html.js
+++ b/webpack/entrypoints-html.js
@@ -18,6 +18,16 @@ module.exports = Object.keys(entrypoints).map(entry =>
       htmlWebpackPlugin.tags.headTags.forEach(element => {
         element.attributes.nonce = "{{ request.csp_nonce }}";
       });
+      if (entry == "gtm-snippet") {
+        // Using "blocking" for the "scriptLoading" option doesn't work, so
+        // for now, let's delete the "defer" attribute for the "gtm-snippet"
+        // case, because it must block until loaded in order to ensure that
+        // the "gtag" function is defined before any other JavaScript files
+        // are executed.
+        htmlWebpackPlugin.tags.headTags.forEach(element => {
+          delete element.attributes.defer;
+        });
+      }
       return htmlWebpackPlugin.tags.headTags.join("");
     }
   }),


### PR DESCRIPTION
The SUMO [`gtm-snippet.js` code](https://github.com/mozilla/kitsune/blob/main/kitsune/sumo/static/sumo/js/gtm-snippet.js) defines a `window.gtag` function and, if do-not-track is not enabled, also kicks-off an `async` load of https://www.googletagmanager.com/gtag/js. As [recommended by Google](https://developers.google.com/analytics/devguides/collection/gtagjs), the `window.gtag` function must be defined inline -- or, alternatively, the JS code that does that must be fetched in a blocking mode -- immediately after the `head` tag. This is to ensure that `window.gtag` is defined prior to the execution of any other JS code that's loaded.

Currently, we're not doing that. We're fetching the `gtm-snippet.js` code in `defer` mode, so there's no guarantee that `window.gtag` is defined prior to GA calls. In fact, that's what we're seeing. For example, we're seeing that `window.gtag` is often not defined prior to the `trackEvent()` call [here](https://github.com/mozilla/kitsune/blob/02ec5146204adbf149ed425dc5c9553b01897a2e/kitsune/sumo/static/sumo/js/form-wizard.js#L114).

This PR resolves that by synchronously loading (i.e., blocking until complete) the `gtm-snippet.js` code immediately after the `head` tag. This is exactly what `www.mozilla.org` does as well.

<img width="894" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/29f8f052-e68b-480b-be14-5f0bef237090">

## Before
<img width="895" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/365d260a-93f6-4c59-949d-ba6172c341bb">

## After
<img width="913" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/a30ed94f-d8b6-43eb-96c1-4894e828cfc4">
