### PR TITLE
Revert "Revert "change structure of doodle GA events (#5616)""

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -111,7 +111,11 @@ export class FormWizard extends HTMLElement {
 
   connectedCallback() {
     // Report to GA whether or not the user sees the fox doodle.
-    trackEvent("device-migration-wizard", "experiments", "doodle-shown", this.showDoodle);
+    trackEvent(
+      "device-migration-wizard",
+      "experiments",
+      this.showDoodle ? "doodle-shown" : "doodle-not-shown"
+    );
 
     if (this.activeStep) {
       // Make sure the active step is shown.


### PR DESCRIPTION
Reverts mozilla/kitsune#5623 since @hannajones identified that the issue was the yet-undefined `window.gtag` function.