### PR TITLE
Mozilla Account - AAQ, CTA

### DIFF
--- a/kitsune/questions/config.py
+++ b/kitsune/questions/config.py
@@ -650,6 +650,17 @@ products = OrderedDict(
                 ),
             },
         ),
+        (
+            "mozilla-account",
+            {
+                "name": _lazy("Mozilla Account"),
+                "subtitle": _lazy("Mozilla account is the account system for Mozilla"),
+                "extra_fields": [],
+                "tags": [],
+                "product": "mozilla-account",
+                "categories": OrderedDict([]),
+            },
+        ),
     ]
 )
 


### PR DESCRIPTION
- Add Mozilla Account to `questions/config.py` so it will appear in AAQ
- Ensure correct CTA banner is shown on FFA Support page
- Proper CTA box on right side

- You need to add Mozilla Account to the products in admin for this to work
- You need to have English as a Locale for the product or you will get redirect loop