### PR TITLE
Use `rest_framework.status` instead of hard coded one

### DIFF
--- a/kitsune/questions/api.py
+++ b/kitsune/questions/api.py
@@ -210,7 +210,7 @@ class QuestionFilter(django_filters.FilterSet):
         try:
             value = json.loads(value)
         except ValueError:
-            raise GenericAPIException(400, "metadata must be valid JSON.")
+            raise GenericAPIException(status.HTTP_400_BAD_REQUEST, "metadata must be valid JSON.")
 
         for key, values in list(value.items()):
             if not isinstance(values, list):
@@ -279,15 +279,15 @@ class QuestionViewSet(viewsets.ModelViewSet):
     def helpful(self, request, pk=None):
         if is_ratelimited(request, "question-vote", "10/d"):
             raise GenericAPIException(
-                429, "You've exceeded the number of votes for questions allowed in a day."
+                status.HTTP_429_TOO_MANY_REQUESTS, "You've exceeded the number of votes for questions allowed in a day."
             )
 
         question = self.get_object()
 
         if not question.editable:
-            raise GenericAPIException(403, "Question not editable")
+            raise GenericAPIException(status.HTTP_403_FORBIDDEN, "Question not editable")
         if question.has_voted(request):
-            raise GenericAPIException(409, "Cannot vote twice")
+            raise GenericAPIException(status.HTTP_409_CONFLICT, "Cannot vote twice")
 
         QuestionVote(question=question, creator=request.user).save()
         num_votes = QuestionVote.objects.filter(question=question).count()
@@ -297,13 +297,13 @@ class QuestionViewSet(viewsets.ModelViewSet):
     def follow(self, request, pk=None):
         question = self.get_object()
         actstream.actions.follow(request.user, question, actor_only=False, send_action=False)
-        return Response("", status=204)
+        return Response("", status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=["post"], permission_classes=[permissions.IsAuthenticated])
     def unfollow(self, request, pk=None):
         question = self.get_object()
         actstream.actions.unfollow(request.user, question, send_action=False)
-        return Response("", status=204)
+        return Response("", status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=["post"])
     def set_metadata(self, request, pk=None):
@@ -332,7 +332,7 @@ class QuestionViewSet(viewsets.ModelViewSet):
             meta.delete()
             return Response(status=status.HTTP_204_NO_CONTENT)
         except QuestionMetaData.DoesNotExist:
-            raise GenericAPIException(404, "No matching metadata object found.")
+            raise GenericAPIException(status.HTTP_404_NOT_FOUND, "No matching metadata object found.")
 
     @action(
         detail=True, methods=["post"], permission_classes=[permissions.IsAuthenticatedOrReadOnly]
@@ -345,11 +345,11 @@ class QuestionViewSet(viewsets.ModelViewSet):
         try:
             question.take(request.user, force=force)
         except InvalidUserException:
-            raise GenericAPIException(400, "Question creator cannot take a question.")
+            raise GenericAPIException(status.HTTP_400_BAD_REQUEST, "Question creator cannot take a question.")
         except AlreadyTakenException:
-            raise GenericAPIException(409, "Conflict: question is already taken.")
+            raise GenericAPIException(status.HTTP_409_CONFLICT, "Conflict: question is already taken.")
 
-        return Response(status=204)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=["post"], permission_classes=[permissions.IsAuthenticated])
     def add_tags(self, request, pk=None):
@@ -369,7 +369,7 @@ class QuestionViewSet(viewsets.ModelViewSet):
                 if request.user.has_perm("taggit.add_tag"):
                     question.tags.add(tag)
                 else:
-                    raise GenericAPIException(403, "You are not authorized to create new tags.")
+                    raise GenericAPIException(status.HTTP_403_FORBIDDEN, "You are not authorized to create new tags.")
 
         data = [{"name": tag.name, "slug": tag.slug} for tag in question.tags.all()]
         return Response(data)
@@ -510,15 +510,15 @@ class AnswerViewSet(viewsets.ModelViewSet):
     def helpful(self, request, pk=None):
         if is_ratelimited(request, "answer-vote", "10/d"):
             raise GenericAPIException(
-                429, "You've exceeded the number of votes for answers allowed in a day."
+                status.HTTP_429_TOO_MANY_REQUESTS, "You've exceeded the number of votes for answers allowed in a day."
             )
 
         answer = self.get_object()
 
         if not answer.question.editable:
-            raise GenericAPIException(403, "Answer not editable")
+            raise GenericAPIException(status.HTTP_403_FORBIDDEN, "Answer not editable")
         if answer.has_voted(request):
-            raise GenericAPIException(409, "Cannot vote twice")
+            raise GenericAPIException(status.HTTP_409_CONFLICT, "Cannot vote twice")
 
         AnswerVote(answer=answer, creator=request.user, helpful=True).save()
         num_helpful_votes = AnswerVote.objects.filter(answer=answer, helpful=True).count()
@@ -534,10 +534,10 @@ class AnswerViewSet(viewsets.ModelViewSet):
     def follow(self, request, pk=None):
         answer = self.get_object()
         actstream.actions.follow(request.user, answer, actor_only=False)
-        return Response("", status=204)
+        return Response("", status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=["post"], permission_classes=[permissions.IsAuthenticated])
     def unfollow(self, request, pk=None):
         answer = self.get_object()
         actstream.actions.unfollow(request.user, answer)
-        return Response("", status=204)
+        return Response("", status=status.HTTP_204_NO_CONTENT)

--- a/kitsune/questions/api.py
+++ b/kitsune/questions/api.py
@@ -279,7 +279,8 @@ class QuestionViewSet(viewsets.ModelViewSet):
     def helpful(self, request, pk=None):
         if is_ratelimited(request, "question-vote", "10/d"):
             raise GenericAPIException(
-                status.HTTP_429_TOO_MANY_REQUESTS, "You've exceeded the number of votes for questions allowed in a day."
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                "You've exceeded the number of votes for questions allowed in a day.",
             )
 
         question = self.get_object()
@@ -332,7 +333,9 @@ class QuestionViewSet(viewsets.ModelViewSet):
             meta.delete()
             return Response(status=status.HTTP_204_NO_CONTENT)
         except QuestionMetaData.DoesNotExist:
-            raise GenericAPIException(status.HTTP_404_NOT_FOUND, "No matching metadata object found.")
+            raise GenericAPIException(
+                status.HTTP_404_NOT_FOUND, "No matching metadata object found."
+            )
 
     @action(
         detail=True, methods=["post"], permission_classes=[permissions.IsAuthenticatedOrReadOnly]
@@ -345,9 +348,13 @@ class QuestionViewSet(viewsets.ModelViewSet):
         try:
             question.take(request.user, force=force)
         except InvalidUserException:
-            raise GenericAPIException(status.HTTP_400_BAD_REQUEST, "Question creator cannot take a question.")
+            raise GenericAPIException(
+                status.HTTP_400_BAD_REQUEST, "Question creator cannot take a question."
+            )
         except AlreadyTakenException:
-            raise GenericAPIException(status.HTTP_409_CONFLICT, "Conflict: question is already taken.")
+            raise GenericAPIException(
+                status.HTTP_409_CONFLICT, "Conflict: question is already taken."
+            )
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -369,7 +376,9 @@ class QuestionViewSet(viewsets.ModelViewSet):
                 if request.user.has_perm("taggit.add_tag"):
                     question.tags.add(tag)
                 else:
-                    raise GenericAPIException(status.HTTP_403_FORBIDDEN, "You are not authorized to create new tags.")
+                    raise GenericAPIException(
+                        status.HTTP_403_FORBIDDEN, "You are not authorized to create new tags."
+                    )
 
         data = [{"name": tag.name, "slug": tag.slug} for tag in question.tags.all()]
         return Response(data)
@@ -510,7 +519,8 @@ class AnswerViewSet(viewsets.ModelViewSet):
     def helpful(self, request, pk=None):
         if is_ratelimited(request, "answer-vote", "10/d"):
             raise GenericAPIException(
-                status.HTTP_429_TOO_MANY_REQUESTS, "You've exceeded the number of votes for answers allowed in a day."
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                "You've exceeded the number of votes for answers allowed in a day.",
             )
 
         answer = self.get_object()


### PR DESCRIPTION
Instead of using hard coded integer, use `rest_framework.status` to make more readable code.