### PR TITLE
Include proper CTA in FFA documents

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -1277,3 +1277,16 @@ FIREFOX_SWITCHING_DEVICES_ARTICLES = config(
 FIREFOX_SWITCHING_DEVICES_TOPIC = config(
     "FIREFOX_SWITCHING_DEVICES_TOPIC", default="back-up-your-data"
 )
+
+# Slugs of articles that have a special CTA for Mozilla account
+MOZILLA_ACCOUNT_ARTICLES = [
+    "firefox-accounts-supportmozillaorg",
+    "log-pocket-your-firefox-account",
+    "how-do-i-delete-my-firefox-account",
+    "how-reset-your-password-without-account-recovery-keys-access-data",
+    "reset-your-firefox-account-password-recovery-keys",
+    "what-if-im-locked-out-two-step-authentication",
+    "im-having-problems-my-firefox-account",
+    "accounts-blocked",
+    "im-having-problems-confirming-my-firefox-account",
+]

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -1,9 +1,9 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/sidebar_modules.html" import document_tools, document_notifications, related_products_sidebar with context %}
 {% from 'products/includes/topic_macros.html' import topic_sidebar %}
-{% from "wiki/includes/document_macros.html" import contributor_list, document_title, document_messages, document_content, topic_list, related_documents, kb_subtopic_tabs  %}
+{% from "wiki/includes/document_macros.html" import contributor_list, document_title, document_messages, document_content, inpage_contact_cta, topic_list, related_documents, kb_subtopic_tabs  %}
 {% from "wiki/includes/document_macros.html" import vote_form with context %}
-{% from "includes/common_macros.html" import download_firefox, survey_cta_banner %}
+{% from "includes/common_macros.html" import download_firefox, sumo_banner, survey_cta_banner %}
 {% from "questions/includes/aaq_macros.html" import aaq_widget %}
 {% set classes = 'document' %}
 {% set canonical_url = canonicalize(model_url=document.get_absolute_url()) %}
@@ -88,6 +88,10 @@
         {{ kb_subtopic_tabs(request, settings, switching_devices_product, switching_devices_topic, switching_devices_subtopics, document) }}
       {% endif %}
 
+      {% if document.gets_mozilla_account_cta %}
+        {{ inpage_contact_cta(product=product, product_key='mozilla-account') }}
+      {% endif %}
+      
       {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}
       {% if share_link %}
         <p class="share-link">

--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -479,3 +479,36 @@
     {{ kb_subtopic_documents(request, settings, documents, subtopic.slug) }}
   {% endfor %}
 {%- endmacro %}
+
+{% macro inpage_contact_cta(product=None, product_key=None) %}
+{% if product_key %}
+  <section class="support-callouts mzp-l-content sumo-page-section--inner">
+    <div class="card card--ribbon is-inverse heading-is-one-line">
+      <div class="card--details">
+        <h3 class="card--title">
+          <svg class="card--icon-sm" width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+              <g transform="translate(2.000000, 1.878680)" stroke="#FFFFFF" stroke-width="2">
+                <path d="M9,1.12132031 L2,1.12132031 C0.8954305,1.12132031 5.32907052e-15,2.01675081 5.32907052e-15,3.12132031 L5.32907052e-15,15.1213203 C5.32907052e-15,16.2258898 0.8954305,17.1213203 2,17.1213203 L11,17.1213203 L13,21.1213203 L15,17.1213203 L17,17.1213203 C18.1045695,17.1213203 19,16.2258898 19,15.1213203 L19,9.12132031"></path>
+                <path d="M15.5,0.621320312 C16.3284271,-0.207106783 17.6715729,-0.207106769 18.5,0.621320344 C19.3284271,1.44974746 19.3284271,2.79289318 18.5,3.62132031 L11,11.1213203 L7,12.1213203 L8,8.12132031 L15.5,0.621320312 Z"></path>
+              </g>
+            </g>
+          </svg>
+          {{ _('Still need help?') }}
+        </h3>
+        <p class="card--desc">         
+            {{ _("If you've tried the steps above and you're still unable to log in, send a message to our support team.") }}
+        </p>
+        {% set aaq_url=url('questions.aaq_step3', product_key=product_key) %}
+        <a class="sumo-button primary-button button-lg"
+          href="{{ aaq_url }}" 
+          data-event-category="link click"
+          data-event-action="{{ location }}"
+          data-event-label="inpage_cta">
+            {{ _('Contact Support') }}
+        </a>
+      </div>
+    </div>
+  </section>
+{% endif %}
+{%- endmacro %}

--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -745,6 +745,12 @@ class Document(NotificationsMixin, ModelBase, BigVocabTaggableMixin, DocumentPer
             self.parent.slug if self.parent else self.slug
         ) in settings.FIREFOX_SWITCHING_DEVICES_ARTICLES
 
+    @property
+    def gets_mozilla_account_cta(self):
+        return (
+            self.parent.slug if self.parent else self.slug
+        ) in settings.MOZILLA_ACCOUNT_ARTICLES
+
 
 class AbstractRevision(models.Model):
     # **%(class)s** is being used because it will allow  a unique reverse name for the field


### PR DESCRIPTION
This puts the CTA for "Contact Us" in documents that are attached to the Mozilla account offering.