### PR TITLE
fix popular searches

### DIFF
--- a/kitsune/sumo/static/sumo/js/instant_search.js
+++ b/kitsune/sumo/static/sumo/js/instant_search.js
@@ -129,7 +129,7 @@ import nunjucksEnv from "sumo/js/nunjucks"; // has to be loaded after templates
     ev.preventDefault();
     $(this).find('.searchbox').trigger('focus');
   });
-  
+
   $(document).on('input', '[data-instant-search="form"] input[type="search"]', function(ev) {
     var $this = $(this);
     var $form = $this.closest('form');
@@ -234,7 +234,7 @@ import nunjucksEnv from "sumo/js/nunjucks"; // has to be loaded after templates
     var $mainInput = $('#support-search-masthead input[name=q]');
     var thisLink = $(this).text();
     $('#support-search-masthead input[name=q]').trigger('focus').val(thisLink);
-    $mainInput.trigger("keyup");
+    $mainInput.trigger("input");
     ev.preventDefault();
   });
 


### PR DESCRIPTION
mozilla/sumo#1486

This fixes popular searches. When https://github.com/mozilla/kitsune/pull/5621 was released, it changed the event that triggers searches from "keyup" to "input", but forgot to trigger the same event when popular searches are clicked.