### PR TITLE
what is it link change

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -255,7 +255,7 @@
           <h5 class="mzp-c-footer-heading">{{ _('Mozilla Accounts') }}</h5>
           <ul class="mzp-c-footer-list">
             <li><a rel="nofollow" href="{{ url('users.auth') }}">{{ _('Sign In/Up') }}</a></li>
-            <li><a href="https://www.mozilla.org/en-US/firefox/accounts/">{{ _('What is it?') }}</a></li>
+            <li><a href="{{ url('wiki.document', 'access-mozilla-services-firefox-account') }}">{{ _('What is it?') }}</a></li>
             <li><a href="https://accounts.firefox.com/reset_password">{{ _('Reset Password') }}</a></li>
             <li><a href="{{ url('wiki.document', 'switching-devices') }}">{{ _('Sync My Data') }}</a></li>
             <li><a href="{{ url('products.product', 'mozilla-accounts')}}">{{ _('Get Help') }}</a></li>

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -144,7 +144,7 @@
               </p>
             </a>
             <ul class="mzp-c-menu-item-list sumo-nav--sublist">
-              <li><a href="https://www.mozilla.org/en-US/firefox/accounts/">{{ _('What is it?') }}</a></li>
+              <li><a href="{{ url('wiki.document', 'access-mozilla-services-firefox-account') }}">{{ _('What is it?') }}</a></li>
               <li><a href="https://accounts.firefox.com/reset_password">{{ _('Reset Password') }}</a></li>
               <li><a href="{{ url('wiki.document', 'switching-devices') }}">{{ _('Sync My Data') }}</a></li>
               <li><a href="{{ url('products.product', 'mozilla-account')}}">{{ _('Get Help') }}</a></li>


### PR DESCRIPTION
Changing "What Is It' link to point to a KB article vs. `mozilla.org/en-US/firefox/accounts/`

