### PR TITLE
Attempt to prefill email address in switching devices wizard step 3

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard-setup-device-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-setup-device-step.js
@@ -79,6 +79,19 @@ export class SetupDeviceStep extends BaseFormStep {
     this.#emailEl.addEventListener("blur", this);
     this.#emailEl.addEventListener("input", this);
     this.#submitButton = this.shadowRoot.getElementById("submit");
+
+    // If the user went through Step 1 and gave us an email address,
+    // it got stored in session storage, so we can prefill the email
+    // field here.
+    try {
+      let step1Email = sessionStorage.getItem("switching-devices-email");
+      this.#emailEl.value = step1Email;
+      this.#onInput();
+    } catch (e) {
+      // We wrap this in a try/catch because session storage methods might
+      // throw if the user has disabled cookies or other types of site
+      // data storage, and we want this to be non-fatal.
+    }
   }
 
   handleEvent(event) {
@@ -94,12 +107,7 @@ export class SetupDeviceStep extends BaseFormStep {
         break;
       }
       case "input": {
-        if (this.#emailEl.value?.trim()) {
-          this.#hideError();
-        }
-
-        this.#submitButton.toggleAttribute("success", false);
-        this.#submitButton.disabled = !this.#emailEl.validity.valid;
+        this.#onInput();
         break;
       }
       case "submit": {
@@ -115,6 +123,15 @@ export class SetupDeviceStep extends BaseFormStep {
         break;
       }
     }
+  }
+
+  #onInput() {
+    if (this.#emailEl.value?.trim()) {
+      this.#hideError();
+    }
+
+    this.#submitButton.toggleAttribute("success", false);
+    this.#submitButton.disabled = !this.#emailEl.validity.valid;
   }
 
   #onClick(event) {

--- a/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
@@ -96,6 +96,18 @@ export class SignInStep extends BaseFormStep {
         if (!this.#emailEl.validity.valid) {
           this.#emailErrorEl.classList.add("visible");
           event.preventDefault();
+        } else {
+          // The email is valid and we're about to redirect to FxA login.
+          // Let's quickly stash the email address in session storage so
+          // that we can prefill the email field in Step 3 for getting
+          // the reminder email.
+          try {
+            sessionStorage.setItem("switching-devices-email", this.#emailEl.value);
+          } catch (e) {
+            // We wrap this in a try/catch because session storage methods might
+            // throw if the user has disabled cookies or other types of site
+            // data storage, and we want this to be non-fatal.
+          }
         }
         break;
       }

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-setup-device-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-setup-device-tests.js
@@ -138,4 +138,37 @@ describe("setup-device-step custom element", () => {
       delete ReminderDialog.prototype.showModal;
     });
   });
+
+  describe("email prefilling", () => {
+    it("should not prefil if session storage is empty", async () => {
+      sessionStorage.removeItem("switching-devices-email");
+
+      // Prefilling the email address occurs when the element is bound
+      // to the DOM, so we'll disconnect and reconnect.
+      step.remove();
+      $("body").append(step);
+
+      let email = step.shadowRoot.querySelector("input[name=email]");
+      let submitBtn = step.shadowRoot.querySelector("#submit");
+      expect(email.value).to.be.empty;
+      expect(submitBtn.disabled).to.be.true;
+    });
+
+    it("should not prefil if session storage is empty", async () => {
+      const TEST_EMAIL = "test@test.com";
+      sessionStorage.setItem("switching-devices-email", TEST_EMAIL);
+
+      // Prefilling the email address occurs when the element is bound
+      // to the DOM, so we'll disconnect and reconnect.
+      step.remove();
+      $("body").append(step);
+
+      let email = step.shadowRoot.querySelector("input[name=email]");
+      let submitBtn = step.shadowRoot.querySelector("#submit");
+      expect(email.value).to.equal(TEST_EMAIL);
+      expect(submitBtn.disabled).to.be.false;
+
+      sessionStorage.removeItem("switching-devices-email");
+    });
+  });
 });

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
@@ -287,8 +287,10 @@ describe("sign-in-step custom element", () => {
     it("should display an error message if an incomplete email address is supplied", () => {
       expect([...emailErrorMessage.classList]).to.not.include("visible");
 
+      expect(sessionStorage.getItem("switching-devices-email")).to.be.null;
       emailField.value = "this-is-not-an-email-address";
       submitBtn.click();
+      expect(sessionStorage.getItem("switching-devices-email")).to.be.null;
 
       expect(emailField.validity.valid).to.be.false;
       expect([...emailErrorMessage.classList]).to.include("visible");
@@ -308,11 +310,15 @@ describe("sign-in-step custom element", () => {
         );
       });
 
-      emailField.value = "email@email.com";
+      expect(sessionStorage.getItem("switching-devices-email")).to.be.null;
+
+      const TEST_EMAIL = "email@email.com";
+      emailField.value = TEST_EMAIL;
       submitBtn.click();
       await preventSubmitListener;
 
       expect(emailField.validity.valid).to.be.true;
+      expect(sessionStorage.getItem("switching-devices-email")).to.equal(TEST_EMAIL);
       expect([...emailErrorMessage.classList]).to.not.include("visible");
     });
   });


### PR DESCRIPTION
This uses session storage to store the email address inputted by the user in Step 1, and retrieves it after the FxA redirect in Step 3.

In the event that the user never went through Step 1, this is a no-op.

Fixes mozilla/sumo#1520.