### PR TITLE
Fix for IP based ratelimit

### DIFF
--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -263,7 +263,8 @@ def is_ratelimited(request, name, rate, method="POST"):
         if request.user.is_authenticated:
             key = f"user '{request.user.username}'"
         else:
-            key = f"anonymous user {request.META['REMOTE_ADDR']}"
+            ip = request.META.get("HTTP_X_CLUSTER_CLIENT_IP", request.META["REMOTE_ADDR"])
+            key = f"anonymous user {ip}"
         Record.objects.info(
             "sumo.ratelimit", "{key} hit the rate limit for {name}", key=key, name=name
         )


### PR DESCRIPTION
- Add back the check for HTTP_X_CLUSTER_CLIENT_IP

Best guess is that this source for the IP is needed due to our infra.