### PR TITLE
Moz account footer typo

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -252,7 +252,7 @@
         </section>
 
         <section class="mzp-c-footer-col">
-          <h5 class="mzp-c-footer-heading">{{ _('Mozilla accounts') }}</h5>
+          <h5 class="mzp-c-footer-heading">{{ _('Mozilla Account') }}</h5>
           <ul class="mzp-c-footer-list">
             <li><a rel="nofollow" href="{{ url('users.auth') }}">{{ _('Sign In/Up') }}</a></li>
             <li><a href="{{ url('wiki.document', 'access-mozilla-services-firefox-account' )}}">{{ _('What is it?') }}</a></li>


### PR DESCRIPTION
- According to style guide, Mozilla Account is the correct header