### PR TITLE
moz account typo on doc cta

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -497,7 +497,7 @@
           {{ _('Still need help?') }}
         </h3>
         <p class="card--desc">         
-            {{ _("If you've tried the steps above and you're still unable to log in, send a message to our support team.") }}
+            {{ _("If you've tried the steps above and you're still unable to sign in, send a message to our support team.") }}
         </p>
         {% set aaq_url=url('questions.aaq_step3', product_key=product_key) %}
         <a class="sumo-button primary-button button-lg"


### PR DESCRIPTION
- `log in` becomes `sign in`