### PR TITLE
Moz account allow form submissions

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -646,6 +646,10 @@ def aaq_step3(request, product_key, category_key=None):
         ]
     )
 
+    is_loginless = is_loginless or request.path == reverse(
+        "questions.aaq_step3", args=["mozilla-account"]
+    )
+
     if not is_loginless and not request.user.is_authenticated:
         return redirect_to_login(next=request.path, login_url=reverse("users.login"))
 


### PR DESCRIPTION
When we altered `is_loginless` in a prior PR, we altered how the form submissions would flow. 

Issue is here:  https://github.com/mozilla/sumo/issues/1544

https://github.com/mozilla/kitsune/pull/5720 was the initial PR from @akatsoulas but was failing linting, so this solves that issue.