### PR TITLE
Remove Outlook.com from switching-devices wizard.

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard-reminder-dialog.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-reminder-dialog.js
@@ -40,7 +40,6 @@ export class ReminderDialog extends HTMLDialogElement {
             <div class="hbox">
               <select id="choose-calendar">
                 <option value="gcal">Google Calendar</option>
-                <option value="outlook">Outlook.com</option>
                 <option value="ics">${gettext("ICS file")}</option>
               </select>
               <button id="create-event" class="mzp-c-button mzp-t-product" data-event-category="device-migration-wizard" data-event-action="click" data-event-label="create-calendar-event">${gettext("Save")}</button>

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-reminder-dialog-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-reminder-dialog-tests.js
@@ -80,7 +80,11 @@ describe("reminder-dialog custom element", () => {
     windowOpenSpy.restore();
   });
 
-  it("selector should allow the user to add an event to Microsoft Outlook", () => {
+  /**
+   * This test is disabled until we can sort out issues with how Outlook.com
+   * deeplinking works.
+   */
+  it.skip("selector should allow the user to add an event to Microsoft Outlook", () => {
     let windowOpenSpy = sandbox.spy(window, "open");
 
     let selector = dialog.shadow.querySelector("#choose-calendar");


### PR DESCRIPTION
Outlook.com has issues with deeplinking into the event editor. While
we work with the Outlook.com team to see if we can get that sorted,
we're going to remove Outlook.com as one of the calendar options.

Fixes mozilla/sumo#1527.