### PR TITLE
Add more GA events for the switching-devices reminder dialog

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard-reminder-dialog.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-reminder-dialog.js
@@ -1,3 +1,4 @@
+import trackEvent from "sumo/js/analytics";
 import reminderDialogStylesURL from "../scss/reminder-dialog.styles.scss";
 import closeIconURL from "sumo/img/close.svg";
 import successIconUrl from "sumo/img/success.svg";
@@ -95,6 +96,14 @@ export class ReminderDialog extends HTMLDialogElement {
 
     let createEventButton = this.#shadow.querySelector("#create-event");
     createEventButton.addEventListener("click", this);
+
+    this.addEventListener("close", e => {
+      trackEvent(
+        "device-migration-wizard",
+        "close",
+        "reminder-dialog"
+      );
+    })
   }
 
   handleEvent(event) {
@@ -293,6 +302,13 @@ END:VCALENDAR
   }
 
   #createEvent(calendarType) {
+    trackEvent(
+      "device-migration-wizard",
+      "create",
+      "create-calendar-event",
+      calendarType
+    );
+
     switch (calendarType) {
       case "gcal": {
         this.#openGCalTab();


### PR DESCRIPTION
This adds GA events for when the reminder dialog is closed, regardless
of how it's closed (in case, for example, it's closed by the keyboard),
as well as an event that describes which kind of calendar was selected
from the dropdown.

Closes mozilla/sumo#1528.