### PR TITLE
skip auth when submitting from self

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -639,7 +639,9 @@ def aaq_step3(request, product_key, category_key=None):
 
     referer = request.META.get("HTTP_REFERER", "")
     skip_auth = is_loginless and any(
-        uri in referer for uri in settings.MOZILLA_ACCOUNT_ARTICLES + [reverse("users.auth")]
+        uri in referer
+        for uri in settings.MOZILLA_ACCOUNT_ARTICLES
+        + [reverse("users.auth"), reverse("questions.aaq_step3", args=[product_key])]
     )
 
     if not (skip_auth or request.user.is_authenticated):


### PR DESCRIPTION
mozilla/sumo#1544

Forgot to include the ability to submit from self in #5726 🤦 

I'm using the `product_key` as the argument for the `reverse("questions.aaq_step3", ...)` call because it needs to be future proof and account for all product keys that are part of `settings.LOGIN_EXCEPTIONS`. Since the reference to `product_key` is preceded by the `is_loginless` check, it's guaranteed to be part of `settings.LOGIN_EXCEPTIONS`.