### PR TITLE
fix duplicate magnifying glass icon in search boxes

### DIFF
--- a/kitsune/questions/jinja2/questions/includes/question_editing_frame.html
+++ b/kitsune/questions/jinja2/questions/includes/question_editing_frame.html
@@ -92,7 +92,7 @@ we can compute the edit-title URL.
               <div class="info card shade-bg highlight mb">
               {% if is_loginless and not user.is_authenticated %}
                 {% trans %}
-                  Can't sign in to your account and need help? 
+                  Can't sign in to your account and need help?
                   You've found the right place. Complete the form below
                   to contact our support staff.
                 {% endtrans %}
@@ -136,7 +136,7 @@ we can compute the edit-title URL.
                       {{ troubleshooting_instructions(field) }}
                     {% elif field.name == 'description' and is_loginless %}
                       <label for="{{ field.id_for_label }}">
-                        <span class="mzp-c-fieldnote">
+                        <span class="fieldnote">
                           {{ _(
                           "Include details such as your account e-mail or specifics about"
                           " your sign-in issue to help us get you back into your account quicker."

--- a/kitsune/sumo/static/sumo/scss/_protocol.scss
+++ b/kitsune/sumo/static/sumo/scss/_protocol.scss
@@ -25,7 +25,7 @@ $image-path: 'protocol/img' !default;
 @import 'protocol/css/base/elements/containers';
 @import 'protocol/css/base/elements/details';
 @import 'protocol/css/base/elements/document';
-@import 'protocol/css/base/elements/forms';
+// @import 'protocol/css/base/elements/forms';
 @import 'protocol/css/base/elements/links';
 @import 'protocol/css/base/elements/lists';
 @import 'protocol/css/base/elements/quotes';

--- a/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
@@ -418,3 +418,12 @@ label.required::after {
   line-height: 1.5;
   margin-bottom: 0;
 }
+
+.fieldnote {
+  display: block;
+  font-size: 14px;
+  font-size: .875rem;
+  font-weight: 400;
+  line-height: 1.5;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
mozilla/sumo#1545

In #5708, I recommended we use the `mzp-c-fieldnote` class from the Mozilla protocol design system, which in-turn meant pulling in the Mozilla protocol forms classes. The Mozilla protocol forms classes introduced the extra magnifying-glass icon within the search input boxes. For now, let's use our own `fieldnote` class until we can determine how to move more fully to using the Mozilla protocol design system form classes without clashing with our current designs.