### PR TITLE
remove locale from loginless referer sources

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -635,16 +635,17 @@ def aaq_step3(request, product_key, category_key=None):
 
     # Since removing the @login_required decorator for MA form
     # need to catch unauthenticated, non-MA users here """
-    is_loginless = product_key in settings.LOGIN_EXCEPTIONS
-
     referer = request.META.get("HTTP_REFERER", "")
-    skip_auth = is_loginless and any(
+    is_loginless = (product_key in settings.LOGIN_EXCEPTIONS) and any(
         uri in referer
         for uri in settings.MOZILLA_ACCOUNT_ARTICLES
-        + [reverse("users.auth"), reverse("questions.aaq_step3", args=[product_key])]
+        + [
+            path.removeprefix(f"/{request.LANGUAGE_CODE}")
+            for path in (reverse("users.auth"), reverse("questions.aaq_step3", args=[product_key]))
+        ]
     )
 
-    if not (skip_auth or request.user.is_authenticated):
+    if not (is_loginless or request.user.is_authenticated):
         return redirect_to_login(next=request.path, login_url=reverse("users.login"))
 
     return aaq(


### PR DESCRIPTION
mozilla/sumo#1547

Here's what was happening prior to this PR:
- `/de/users/auth`
- click on `Contact support`
- redirects to `/de/questions/new/mozilla-account/form`
- redirects to `/en-US/questions/new/mozilla-account/form`
- the original referer of `/de/users/auth` is maintained, but it doesn't match `/en-US/users/auth` -- the value of `reverse("users.auth")`, so it's redirected to...
- `/en-US/users/login?next=/en-US/questions/new/mozilla-account/form`

So this PR simply removes the locale prefix from our referer sources when setting `is_loginless`, since the locale doesn't matter.

Also, I couldn't help it. I removed the `skip_auth` confusion as well.