### PR TITLE
Update download links created for calendar events

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard-reminder-dialog.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-reminder-dialog.js
@@ -3,6 +3,7 @@ import closeIconURL from "sumo/img/close.svg";
 import successIconUrl from "sumo/img/success.svg";
 
 const NEW_DEVICE_DOWNLOAD_URL = "https://mzl.la/newdevice";
+const NEW_DEVICE_DOWNLOAD_REMINDER_URL = "https://mzl.la/newdevice-reminder";
 
 const CALENDAR_FORMATS = Object.freeze({
   ICAL: 1,
@@ -245,9 +246,8 @@ export class ReminderDialog extends HTMLDialogElement {
     let { dtStart, dtEnd } = this.#generateDTStartDTEnd(CALENDAR_FORMATS.ICAL);
     let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-    // mozilla/sumo#1503: The NEW_DEVICE_DOWNLOAD_URL should be replaced with
-    // a link that attributes the download to an event from an ICS file.
-    let { summary, description } = this.#generateEventSummaryAndDescription(NEW_DEVICE_DOWNLOAD_URL, CALENDAR_FORMATS.ICAL);
+    let linkURL = this.#generateCalendarLink(CALENDAR_FORMATS.ICAL);
+    let { summary, description } = this.#generateEventSummaryAndDescription(linkURL, CALENDAR_FORMATS.ICAL);
 
     // The random value here is not meant to be cryptographically
     // secure. The randomValue is used to create a unique UID for
@@ -270,6 +270,33 @@ END:VCALENDAR
     let blob = new Blob([icsFile], {type: "text/calendar;charset=utf-8;"});
     let blobURL = window.URL.createObjectURL(blob);
     return blobURL;
+  }
+
+  #generateCalendarLink(format) {
+    let params = new URLSearchParams();
+    params.set("utm_medium", "short-link-calendar");
+
+    let calendarType;
+
+    switch (format) {
+      case CALENDAR_FORMATS.OUTLOOK: {
+        calendarType = "outlook";
+        break;
+      }
+      case CALENDAR_FORMATS.ICAL:
+        calendarType = "ical"
+        break;
+      case CALENDAR_FORMATS.GCAL: {
+        calendarType = "gcal";
+        break;
+      }
+      default: {
+        throw new Error("#generateCalendarLink wasn't given a format for the link.");
+      }
+    }
+    params.set("utm_content", calendarType);
+
+    return `${NEW_DEVICE_DOWNLOAD_REMINDER_URL}?${params}`;
   }
 
   /**
@@ -308,9 +335,8 @@ END:VCALENDAR
   #openGCalTab() {
     const GCAL_ENDPOINT = "https://calendar.google.com/calendar/render?";
 
-    // mozilla/sumo#1503: The NEW_DEVICE_DOWNLOAD_URL should be replaced with
-    // a link that attributes the download to an event from Google Calendar.
-    let { summary, description } = this.#generateEventSummaryAndDescription(NEW_DEVICE_DOWNLOAD_URL, CALENDAR_FORMATS.GCAL);
+    let linkURL = this.#generateCalendarLink(CALENDAR_FORMATS.GCAL);
+    let { summary, description } = this.#generateEventSummaryAndDescription(linkURL, CALENDAR_FORMATS.GCAL);
     let { dtStart, dtEnd } = this.#generateDTStartDTEnd(CALENDAR_FORMATS.GCAL);
     let params = new URLSearchParams();
     params.set("action", "TEMPLATE");
@@ -323,9 +349,8 @@ END:VCALENDAR
   #openOutlookTab() {
     const OUTLOOK_ENDPOINT = "https://outlook.live.com/calendar/0/deeplink/compose/?";
 
-    // mozilla/sumo#1503: The NEW_DEVICE_DOWNLOAD_URL should be replaced with
-    // a link that attributes the download to an event from Microsoft Outlook.
-    let { summary, description } = this.#generateEventSummaryAndDescription(NEW_DEVICE_DOWNLOAD_URL, CALENDAR_FORMATS.OUTLOOK);
+    let linkURL = this.#generateCalendarLink(CALENDAR_FORMATS.OUTLOOK);
+    let { summary, description } = this.#generateEventSummaryAndDescription(linkURL, CALENDAR_FORMATS.OUTLOOK);
     let { dtStart, dtEnd } = this.#generateDTStartDTEnd(CALENDAR_FORMATS.OUTLOOK);
     let params = new URLSearchParams();
 

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-reminder-dialog-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-reminder-dialog-tests.js
@@ -76,6 +76,7 @@ describe("reminder-dialog custom element", () => {
     expect(params.get("dates")).to.equal("20231015/20231015");
     expect(params.get("text")).to.not.be.empty;
     expect(params.get("details")).to.not.be.empty;
+    expect(params.get("details").includes("https://mzl.la/newdevice-reminder")).to.be.true;
 
     windowOpenSpy.restore();
   });


### PR DESCRIPTION
This uses the updated mzl.la link for the calendar events so that they can be properly attributed.

Fixes mozilla/sumo#1503