### PR TITLE
Submit request for switching-devices email in the document language.

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard-setup-device-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-setup-device-step.js
@@ -80,6 +80,16 @@ export class SetupDeviceStep extends BaseFormStep {
     this.#emailEl.addEventListener("input", this);
     this.#submitButton = this.shadowRoot.getElementById("submit");
 
+    let lang = document.documentElement.getAttribute("lang");
+    if (lang) {
+      // If we found the document language, update the one that we'll
+      // request the email in. This defaults to navigator.language as
+      // a safe fallback in the event that lang isn't defined for some
+      // reason.
+      let langEl = this.#formEl.querySelector("input[name=lang]");
+      langEl.value = lang;
+    }
+
     // If the user went through Step 1 and gave us an email address,
     // it got stored in session storage, so we can prefill the email
     // field here.

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-setup-device-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-setup-device-tests.js
@@ -74,6 +74,23 @@ describe("setup-device-step custom element", () => {
       });
     });
 
+    it("should have the form send the document language if defined", () => {
+      const TEST_LANG = "test-lang";
+      document.documentElement.setAttribute("lang", TEST_LANG);
+
+      // Setting the language from the documentElement occurs at
+      // DOM binding time, so we remove and re-add the step to the
+      // DOM to kick it off.
+      step.remove();
+      document.body.appendChild(step);
+      assertFormElements(form, {
+        newsletters: { type: "hidden", value: "download-firefox-desktop-migration", disabled: false },
+        "source-url": { type: "hidden", value: window.location.href, disabled: false },
+        lang: { type: "hidden", value: TEST_LANG, disabled: false },
+        email: { type: "email", value: "", disabled: false },
+      });
+    });
+
     it("should display an error message if an incomplete email address is supplied", () => {
       expect([...emailErrorMessage.classList]).to.not.include("visible");
 


### PR DESCRIPTION
The email request to Basket was originally using navigator.language, but this doesn't take into account users that might be viewing the switching-devices page in a language that doesn't match the browser default.

This patch makes it so that we can pull the language code off of the document element, and use that when we submit the newsletter request.

If for some reason, the language attribute isn't set, we fallback to using navigator.language.