### PR TITLE
fix data-absolute-graph attributes

### DIFF
--- a/kitsune/dashboards/jinja2/dashboards/includes/kb_overview.html
+++ b/kitsune/dashboards/jinja2/dashboards/includes/kb_overview.html
@@ -18,7 +18,7 @@
     <td>
       {{ number(row.num_visits) }}
       {% if row.visits_ratio %}
-        <div class="absolute-graph" data-absolute-graph={{ row.visits_ratio * 100 }}></div>
+        <div class="absolute-graph" data-absolute-graph="{{ row.visits_ratio * 100 }}%"></div>
       {% endif %}
     </td>
     <td class="status {% if not row.latest_revision %}needs-review{% endif %}">

--- a/kitsune/dashboards/jinja2/dashboards/includes/kb_readout.html
+++ b/kitsune/dashboards/jinja2/dashboards/includes/kb_readout.html
@@ -20,7 +20,7 @@
       {{ number(row.visits) }}
     </td>
     <td>
-      <div class="absolute-graph" data-absolute-graph="{{ row.percent }}"></div>
+      <div class="absolute-graph" data-absolute-graph="{{ row.percent }}%"></div>
     </td>
     <td class="status">
       {% if row.updated is defined %}


### PR DESCRIPTION
mozilla/sumo#1538

This just makes some minor tweaks to @akatsoulas' #5744 that make it work. Already tested on stage (via the new deploy workflow that allows us to deploy branches other than `main`).

<img width="1026" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/e9462a15-ed75-4bc4-a0a3-30b7aa815496">