### PR TITLE
Deprecated linting and formatting in VSCODE

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,5 @@
 {
     "python.defaultInterpreterPath": "/venv/bin/python",
-    "python.formatting.provider": "none",
-    "python.formatting.blackPath": "/venv/bin/black",
-    "python.formatting.blackArgs": [
-        "--config=/app/pyproject.toml"
-    ],
-    "python.linting.enabled": true,
-    "python.linting.flake8Enabled": false,
-    "python.linting.pylintEnabled": true,
-    "python.linting.pylintArgs": [
-        "--disable=C0111",
-        "--enable=W0614",
-        "--load-plugins=pylint_django",
-        "--django-settings-module=kitsune.settings"
-    ],
     "python.autoComplete.extraPaths": [
         "/vendor"
     ],


### PR DESCRIPTION
Remove python.formatting calls
Remove python.linting calls

Both are deprecated in VSCode, with the recommendation to now use extensions.