### PR TITLE
set progress bar widths on readout mode changes

### DIFF
--- a/kitsune/sumo/static/sumo/js/dashboards.js
+++ b/kitsune/sumo/static/sumo/js/dashboards.js
@@ -5,6 +5,7 @@
     initNeedsChange();
     initAnnouncements();
     initL10nStringsStats();
+    setProgressBarWidth();
   }
 
   // Hook up readout mode links (like "This Week" and "All Time") to swap
@@ -27,6 +28,7 @@
           $.get($button.attr('data-url'),
           function succeed(html) {
             $table.html(html).removeClass('busy');
+            setProgressBarWidth();
           });
           return false;
         });
@@ -192,6 +194,13 @@
           )
         );
       });
+  }
+
+  function setProgressBarWidth() {
+    const graphBars = document.getElementsByClassName("absolute-graph");
+    for (const bar of graphBars) {
+      bar.style.width = bar.getAttribute("data-absolute-graph");
+    }
   }
 
   $(init);

--- a/kitsune/sumo/static/sumo/js/wiki.dashboard.js
+++ b/kitsune/sumo/static/sumo/js/wiki.dashboard.js
@@ -52,7 +52,6 @@ import { getQueryParamsAsDict } from "sumo/js/main";
       }
       document.location = document.location.pathname + '?' + $.param(queryParams);
     });
-    setProgessBarWidth();
   });
 
   function addDatePicker(inputId) {
@@ -152,7 +151,6 @@ import { getQueryParamsAsDict } from "sumo/js/main";
     });
 
   }
-
 
   function makeWikiMetricGraph($container, descriptors, legend, bucket, results) {
     var graph = new Graph($container, {
@@ -284,14 +282,6 @@ import { getQueryParamsAsDict } from "sumo/js/main";
     };
 
     $.getJSON($contributors.data('url'), callback);
-  }
-
-  function setProgessBarWidth() {
-    const graphBars = document.getElementsByClassName("absolute-graph");
-    for (const bar of graphBars) {
-      bar.style.width = bar.getAttribute("data-absolute-graph");
-    }
-
   }
 
 })(jQuery);


### PR DESCRIPTION
mozilla/sumo#1582

## Notes
Since the `wiki.dashboard` JS bundle is always used in conjunction with the `wiki` JS bundle, which includes`dashboard.js`, and also since the `setProgressBarWidth()` function is needed when switching readout modes, which happens in `dashboard.js`, as well as at page load time, I decided to move that function out of `wiki.dashboard.js` and into `dashboard.js`.

[This has already been deployed to stage](https://github.com/mozilla-sre-deploy/deploy-sumo/actions/runs/6899605701) for review, testing and QA (since testing is difficult without good test data).