### PR TITLE
1556 - Subject and Description changes

### DIFF
--- a/kitsune/customercare/forms.py
+++ b/kitsune/customercare/forms.py
@@ -68,10 +68,9 @@ class ZendeskForm(forms.Form):
         else:
             self.fields["email"].initial = user.email
         self.label_suffix = ""
-
         if product.slug not in PRODUCTS_WITH_OS:
             del self.fields["os"]
 
-    def send(self, user):
+    def send(self, user, product_config):
         client = ZendeskClient()
-        return client.create_ticket(user, self.cleaned_data)
+        return client.create_ticket(user, self.cleaned_data, product_config)

--- a/kitsune/customercare/zendesk.py
+++ b/kitsune/customercare/zendesk.py
@@ -1,8 +1,11 @@
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _lazy
 from zenpy import Zenpy
 from zenpy.lib.api_objects import Identity as ZendeskIdentity
 from zenpy.lib.api_objects import Ticket
 from zenpy.lib.api_objects import User as ZendeskUser
+
+NO_RESPONSE = _lazy("No response provided.")
 
 
 class ZendeskClient(object):
@@ -76,7 +79,7 @@ class ZendeskClient(object):
             user=zendesk_user_id, identity=ZendeskIdentity(id=identity_id, value=email)
         )
 
-    def create_ticket(self, user, ticket_fields):
+    def create_ticket(self, user, ticket_fields, product_config):
         """Create a ticket in Zendesk."""
         custom_fields = [
             {"id": settings.ZENDESK_PRODUCT_FIELD_ID, "value": ticket_fields.get("product")},
@@ -101,8 +104,8 @@ class ZendeskClient(object):
                 ]
             )
         ticket = Ticket(
-            subject=ticket_fields.get("subject") or ticket_fields.get("category"),
-            comment={"body": ticket_fields.get("description") or ticket_fields.get("category")},
+            subject=ticket_fields.get("subject") or f"{product_config['name']} support",
+            comment={"body": ticket_fields.get("description") or str(NO_RESPONSE)},
             ticket_form_id=settings.ZENDESK_TICKET_FORM_ID,
             custom_fields=custom_fields,
         )

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -560,7 +560,7 @@ def aaq(request, product_key=None, category_key=None, step=1, is_loginless=False
 
             if zendesk_form.is_valid() and not is_ratelimited(request, "loginless", "3/d"):
                 try:
-                    zendesk_form.send(request.user)
+                    zendesk_form.send(request.user, product_config)
                     email = zendesk_form.cleaned_data["email"]
                     messages.add_message(
                         request,


### PR DESCRIPTION
* Update subject of Loginless form to fallback to product friendly name + "support" (ex. "Mozilla account support") if no subject provided
* Update description to read "No response provided." if description is left empty
* * Earlier PR issue was that _lazy was not ever being called, so changing the `NO_RESPONSE` call to `str(NO_RESPONSE)` was the fix.

Replaces https://github.com/mozilla/kitsune/pull/5784 which was reverted.