### PR TITLE
ensure nulls ordered last when desc in DRF viewsets

### DIFF
--- a/kitsune/kpi/api.py
+++ b/kitsune/kpi/api.py
@@ -10,7 +10,7 @@ from django.db.models.functions import Now
 
 import django_filters
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters, serializers, viewsets
+from rest_framework import serializers, viewsets
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
@@ -29,6 +29,7 @@ from kitsune.kpi.models import (
     EXIT_SURVEY_DONT_KNOW_CODE,
 )
 from kitsune.questions.models import Question, Answer, AnswerVote
+from kitsune.sumo.api_utils import OrderingFilter
 from kitsune.wiki.models import HelpfulVote
 from functools import reduce
 
@@ -491,7 +492,7 @@ class CohortViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = CohortFilter
     filter_backends = [
         DjangoFilterBackend,
-        filters.OrderingFilter,
+        OrderingFilter,
     ]
     ordering_fields = [
         "start",

--- a/kitsune/questions/api.py
+++ b/kitsune/questions/api.py
@@ -6,7 +6,7 @@ import django_filters
 from django import forms
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters, pagination, permissions, serializers, status, viewsets
+from rest_framework import pagination, permissions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from taggit.models import Tag
@@ -26,6 +26,7 @@ from kitsune.sumo.api_utils import (
     DateTimeUTCField,
     GenericAPIException,
     OnlyCreatorEdits,
+    OrderingFilter,
     SplitSourceField,
 )
 from kitsune.sumo.utils import is_ratelimited
@@ -246,7 +247,7 @@ class QuestionViewSet(viewsets.ModelViewSet):
     filterset_class = QuestionFilter
     filter_backends = [
         DjangoFilterBackend,
-        filters.OrderingFilter,
+        OrderingFilter,
     ]
     ordering_fields = [
         "id",
@@ -486,7 +487,7 @@ class AnswerViewSet(viewsets.ModelViewSet):
     filterset_class = AnswerFilter
     filter_backends = [
         DjangoFilterBackend,
-        filters.OrderingFilter,
+        OrderingFilter,
     ]
     filterset_fields = [
         "question",

--- a/kitsune/questions/tests/test_api.py
+++ b/kitsune/questions/tests/test_api.py
@@ -350,18 +350,29 @@ class TestQuestionViewSet(TestCase):
     def test_ordering(self):
         q1 = QuestionFactory()
         q2 = QuestionFactory()
+        q3 = QuestionFactory()
+        AnswerFactory(question=q1)
+        AnswerFactory(question=q2)
 
         res = self.client.get(reverse("question-list"))
-        self.assertEqual(res.data["results"][0]["id"], q2.id)
-        self.assertEqual(res.data["results"][1]["id"], q1.id)
+        self.assertEqual(res.data["results"][0]["id"], q3.id)
+        self.assertEqual(res.data["results"][1]["id"], q2.id)
+        self.assertEqual(res.data["results"][2]["id"], q1.id)
 
         res = self.client.get(reverse("question-list") + "?ordering=id")
         self.assertEqual(res.data["results"][0]["id"], q1.id)
         self.assertEqual(res.data["results"][1]["id"], q2.id)
+        self.assertEqual(res.data["results"][2]["id"], q3.id)
 
-        res = self.client.get(reverse("question-list") + "?ordering=-id")
+        res = self.client.get(reverse("question-list") + "?ordering=-last_answer")
         self.assertEqual(res.data["results"][0]["id"], q2.id)
         self.assertEqual(res.data["results"][1]["id"], q1.id)
+        self.assertEqual(res.data["results"][2]["id"], q3.id)
+
+        res = self.client.get(reverse("question-list") + "?ordering=last_answer")
+        self.assertEqual(res.data["results"][0]["id"], q1.id)
+        self.assertEqual(res.data["results"][1]["id"], q2.id)
+        self.assertEqual(res.data["results"][2]["id"], q3.id)
 
     def test_filter_product_with_slug(self):
         p1 = ProductFactory()

--- a/kitsune/users/api.py
+++ b/kitsune/users/api.py
@@ -8,7 +8,7 @@ from django.db.models.functions import Now
 from django.utils.encoding import force_str
 from django.views.decorators.http import require_GET
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters, mixins, permissions, serializers, viewsets
+from rest_framework import mixins, permissions, serializers, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 from kitsune.access.decorators import login_required
 from kitsune.questions.models import Answer
 from kitsune.questions.utils import num_answers, num_questions, num_solutions
-from kitsune.sumo.api_utils import DateTimeUTCField, PermissionMod
+from kitsune.sumo.api_utils import DateTimeUTCField, OrderingFilter, PermissionMod
 from kitsune.sumo.decorators import json_view
 from kitsune.users.models import Profile, Setting
 from kitsune.users.templatetags.jinja_helpers import profile_avatar
@@ -248,7 +248,7 @@ class ProfileViewSet(
     ]
     filter_backends = [
         DjangoFilterBackend,
-        filters.OrderingFilter,
+        OrderingFilter,
     ]
     filterset_fields: list[str] = []
     ordering_fields: list[str] = []


### PR DESCRIPTION
mozilla/sumo#1599

## Notes
I believe the `QuestionViewSet` is the only one that includes an ordering field that could contain `null` values (`last_answer`), but I replaced all of the Django Rest Framework `OrderingFilter` backends with the new `kitsune.sumo.api_utils.OrderingFilter` backend just so we're safe if any new fields are added that could contain `null` values.