### PR TITLE
Correct SUMO Docs

### DIFF
--- a/docs/hacking_howto.md
+++ b/docs/hacking_howto.md
@@ -54,7 +54,7 @@ faster and easier if you need to do that:
 
 ```
 make runshell
-bin/run-dev.sh
+./manage.py runserver 0.0.0.0:8000
 ```
 
 The end result of this method should be the same as using `make run`, but will potentially aid in debugging


### PR DESCRIPTION
Docs reference run-dev.sh which doesn't exist 
* It was removed in /commit/ff1828981a30915fcebd9e7c2b72d7ece6e91023