### PR TITLE
Autofocus the sign-in-step email field for the switching-devices wizard

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
@@ -69,6 +69,8 @@ export class SignInStep extends BaseFormStep {
     this.#formEl.addEventListener("submit", this);
     this.#emailEl.addEventListener("blur", this);
     this.#emailEl.addEventListener("input", this);
+
+    this.#emailEl.focus();
   }
 
   disconnectedCallback() {

--- a/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/form-wizard-sign-in-step-tests.js
@@ -92,6 +92,11 @@ describe("sign-in-step custom element", () => {
     assertFormElements(form, EXPECTED_FORM_ELEMENTS_WITH_FLOW_METRICS);
   });
 
+  it("should focus the email field automatically", () => {
+    let email = step.shadowRoot.querySelector("#email");
+    expect(step.shadowRoot.activeElement).to.equal(email);
+  });
+
   it("should set an email address if one is set in the state", () => {
     const TEST_STATE = {
       utm_source: "utm_source",


### PR DESCRIPTION
Fixes mozilla/sumo#1614.