### PR TITLE
Move focus and validation logic to an 'activate' method

### DIFF
--- a/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
@@ -69,8 +69,7 @@ export class SignInStep extends BaseFormStep {
     this.#formEl.addEventListener("submit", this);
     this.#emailEl.addEventListener("blur", this);
     this.#emailEl.addEventListener("input", this);
-
-    this.#emailEl.focus();
+    this.activate();
   }
 
   disconnectedCallback() {
@@ -78,6 +77,11 @@ export class SignInStep extends BaseFormStep {
     this.#formEl.removeEventListener("submit", this);
     this.#emailEl.removeEventListener("blur", this);
     this.#emailEl.removeEventListener("input", this);
+  }
+
+  activate() {
+    this.#emailErrorEl.classList.remove("visible");
+    this.#emailEl.focus();
   }
 
   handleEvent(event) {

--- a/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
@@ -69,7 +69,7 @@ export class SignInStep extends BaseFormStep {
     this.#formEl.addEventListener("submit", this);
     this.#emailEl.addEventListener("blur", this);
     this.#emailEl.addEventListener("input", this);
-    this.activate();
+    this.#emailEl.focus();
   }
 
   disconnectedCallback() {
@@ -79,9 +79,11 @@ export class SignInStep extends BaseFormStep {
     this.#emailEl.removeEventListener("input", this);
   }
 
-  activate() {
-    this.#emailErrorEl.classList.remove("visible");
-    this.#emailEl.focus();
+  deactivate() {
+    if (this.shadowRoot.activeElement == this.#emailEl) {
+      this.#emailEl.blur();
+      this.#emailErrorEl.classList.remove("visible");
+    }
   }
 
   handleEvent(event) {

--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -302,9 +302,9 @@ export class FormWizard extends HTMLElement {
       let name = step.getAttribute("name");
       if (name === activeStep) {
         step.slot = "active";
-        step.activate && step.activate();
       } else {
         step.slot = "";
+        step.deactivate && step.deactivate();
       }
     }
   }
@@ -423,6 +423,14 @@ export class BaseFormStep extends HTMLElement {
     let prevState = Object.assign({}, this.#state);
     this.#state = Object.assign(this.#state, nextState);
     this.render(prevState, this.#state);
+  }
+
+  /**
+   * Method that can be implemented to handle any clean up needed when a form
+   * step is no longer active e.g. clearing error states.
+   */
+  deactivate() {
+    // NOOP
   }
 
   /**

--- a/kitsune/sumo/static/sumo/js/form-wizard.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard.js
@@ -302,6 +302,7 @@ export class FormWizard extends HTMLElement {
       let name = step.getAttribute("name");
       if (name === activeStep) {
         step.slot = "active";
+        step.activate && step.activate();
       } else {
         step.slot = "";
       }


### PR DESCRIPTION
This PR makes a slight change to how we're autofocusing the email input, wrapping the focus in an `activate` method that also resets the visibility of the associated error message. It also changes the wizard to call `activate` whenever the active step changes. In theory this could be used for other form steps to implement logic that needs to run every time a step becomes visible.