### PR TITLE
Add AAQ/Zendesk Support Flow for Monitor

### DIFF
--- a/kitsune/questions/config.py
+++ b/kitsune/questions/config.py
@@ -494,6 +494,17 @@ products = OrderedDict(
             },
         ),
         (
+            "monitor",
+            {
+                "name": _lazy("Monitor"),
+                "subtitle": _lazy("Stay informed and take back control of your exposed data"),
+                "extra_fields": [],
+                "tags": ["monitor"],
+                "product": "monitor",
+                "categories": OrderedDict([]),
+            },
+        ),
+        (
             "pocket",
             {
                 "name": _lazy("Pocket"),


### PR DESCRIPTION
* Enabled in questions/config.py
* Will need Admin changes to enable product as having support ticket capability
