### PR TITLE
fix flicker in article restriction group select

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_wiki.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_wiki.scss
@@ -6,7 +6,7 @@
 #id_restrict_to_groups {
   // Prevents flickering by hiding the un-selectized select
   // until selectize uses it to make a new one that's visible.
-  visibility: hidden;
+  display: none;
 }
 
 // These styles were pulled directly from the less files.

--- a/kitsune/wiki/forms.py
+++ b/kitsune/wiki/forms.py
@@ -141,9 +141,9 @@ class DocumentForm(forms.ModelForm):
     is_archived = forms.BooleanField(label=_lazy("Obsolete:"), required=False)
 
     restrict_to_groups = forms.ModelMultipleChoiceField(
-        label=_lazy("The document will be restricted to members of the selected group(s)."),
         required=False,
         queryset=Group.objects.order_by("name").all(),
+        label=_lazy("The document will be restricted to members of the selected group(s)."),
         help_text=_lazy("The document will be visible only to users in the selected group(s)."),
     )
 


### PR DESCRIPTION
mozilla/sumo#1657

Second attempt to fix the flicker. Boy, the styling of the `<select>` element is difficult to control.