### PR TITLE
Fixing question topics test flakiness & adding marker for article threads tests

### DIFF
--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -19,3 +19,4 @@ markers =
     kbProductsPage: Tests belonging to the kb products page.
     productSupportPage: Tests belonging to the product support page.
     kbArticleCreationAndAccess: Tests belonging to the kb article creation and access.
+    articleThreads: Tests belonging to the kb article threads.

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -1133,6 +1133,9 @@ class TestPostedQuestions(TestUtilities):
             super().aaq_question_test_data['valid_firefox_question']['custom_tag']
         )
 
+        # Adding a custom wait to avoid test flakiness.
+        self.wait_for_given_timeout(1000)
+
         self.logger.info("Verifying that the tag was removed")
         expect(
             self.sumo_pages.question_page._get_a_certain_tag(


### PR DESCRIPTION
- Adding custom wait for test_question_topics test to avoid flakiness.
- Adding marker for articleThreads tests.