### PR TITLE
Increase playwright coverage over kb article removal

### DIFF
--- a/playwright_tests/messages/explore_help_articles/kb_article_revision_page_messages.py
+++ b/playwright_tests/messages/explore_help_articles/kb_article_revision_page_messages.py
@@ -3,6 +3,10 @@ class KBArticleRevision:
     UNREVIEWED_REVISION_HEADER = " Unreviewed Revision: "
     KB_ARTICLE_REVISION_NO_CURRENT_REV_TEXT = "This document does not have a current revision."
     KB_ARTICLE_REVISION_KEYWORD_HEADER = "Keywords:"
+    KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER = ("Unable to delete only revision of the "
+                                                      "document")
+    KB_REVISION_CANNOT_DELETE_ONLY_REVISION_SUBHEADER = ("To delete the document, please notify "
+                                                         "an admin.")
 
     def get_kb_article_revision_details(self,
                                         revision_id: str,

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
@@ -10,6 +10,9 @@ class KBArticleShowHistoryPage(BasePage):
     __article_deleted_confirmation_message = "//article[@id='delete-document']/h1"
     __article_revision_list_items = ("//div[@id='revision-list']//tbody/tr[contains(@id,"
                                      "'rev-list')]")
+    __unable_to_delete_revision_page_header = "//article[@id='delete-revision']/h1"
+    __unable_to_delete_revision_page_subheader = "//article[@id='delete-revision']/p"
+    __unable_to_delete_revision_page_go_back_to_document_history = "//div[@class='submit']/a"
 
     def __init__(self, page: Page):
         super().__init__(page)
@@ -18,8 +21,14 @@ class KBArticleShowHistoryPage(BasePage):
     def _click_on_delete_this_document_button(self):
         super()._click(self.__delete_this_document_button)
 
+    def _get_delete_this_document_button_locator(self) -> Locator:
+        return super()._get_element_locator(self.__delete_this_document_button)
+
     def _click_on_confirmation_delete_button(self):
         super()._click(self.__delete_this_document_confirmation_delete_button)
+
+    def _click_on_confirmation_cancel_button(self):
+        super()._click(self.__delete_this_document_confirmation_cancel_button)
 
     def _is_article_deleted_confirmation_messages_displayed(self) -> Locator:
         super()._wait_for_selector(self.__article_deleted_confirmation_message)
@@ -44,3 +53,20 @@ class KBArticleShowHistoryPage(BasePage):
     def _click_on_review_revision(self, revision_id):
         xpath = f"//tr[@id='{revision_id}']/td[@class='status']/a"
         super()._click(xpath)
+
+    def _get_delete_revision_button_locator(self, revision_id) -> Locator:
+        xpath = f"//tr[@id='{revision_id}']/td[@class='delete']/a"
+        return super()._get_element_locator(xpath)
+
+    def _click_on_delete_revision_button(self, revision_id):
+        xpath = f"//tr[@id='{revision_id}']/td[@class='delete']/a"
+        return super()._click(xpath)
+
+    def _get_unable_to_delete_revision_header(self) -> str:
+        return super()._get_text_of_element(self.__unable_to_delete_revision_page_header)
+
+    def _get_unable_to_delete_revision_subheader(self) -> str:
+        return super()._get_text_of_element(self.__unable_to_delete_revision_page_subheader)
+
+    def _click_go_back_to_document_history_option(self):
+        super()._click(self.__unable_to_delete_revision_page_go_back_to_document_history)

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
@@ -818,3 +818,111 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         self.sumo_pages.kb_article_page._click_on_show_history_option()
         self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
         self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+    # C891309
+    @pytest.mark.kbArticleCreationAndAccess
+    def test_kb_article_removal(self):
+        self.logger.info("Signing in with a normal account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_12"]
+        ))
+
+        self.logger.info("Create a new simple article")
+        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        self.logger.info("Clicking on the 'Show History' option")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Fetching the revision id")
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+
+        self.logger.info("Verifying that the delete button is not available for the only revision")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
+                revision_id
+            )
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that the delete button for the article is not displayed")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Delete user session")
+        self.logger.info("Verifying that the delete button is not available for the only revision")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
+                revision_id
+            )
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that the delete button for the article is not displayed")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Signing in with a admin user account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.logger.info("Clicking on the delete revision button for the only available revision")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(revision_id)
+
+        self.logger.info("Verifying that the correct 'Unable to delete the revision' page header")
+        check.equal(
+            self.sumo_pages.kb_article_show_history_page._get_unable_to_delete_revision_header(),
+            KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER
+        )
+
+        self.logger.info("Verifying that the correct 'Unable to delete the revision' page "
+                         "subheader")
+        check.equal(
+            self.sumo_pages.kb_article_show_history_page.
+            _get_unable_to_delete_revision_subheader(),
+            KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_SUBHEADER
+        )
+
+        self.logger.info("Clicking on the 'Go back to document history button'")
+        self.sumo_pages.kb_article_show_history_page._click_go_back_to_document_history_option()
+
+        self.logger.info("Verifying that we are redirected to the document history page")
+        expect(
+            self.page
+        ).to_have_url(
+            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
+            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
+        )
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the cancel button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_cancel_button()
+
+        self.logger.info("Verifying that we are back on the show history page for the article")
+        expect(
+            self.page
+        ).to_have_url(
+            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
+            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
+        )
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the 'Delete' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+        self.logger.info("Verifying that the article was successfully deleted by navigating to "
+                         "the article")
+
+        with self.page.expect_navigation() as navigation_info:
+            self.navigate_to_link(
+                KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details['article_slug'] + "/"
+            )
+        response = navigation_info.value
+        check.equal(
+            response.status,
+            404
+        )

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -248,7 +248,7 @@ class TestMyProfilePage(TestUtilities):
             self.sumo_pages.product_support_page._product_product_title_element()
         ).to_be_visible()
 
-    #  C2094285, C2094284
+    #  C2094285, C2094284, C891309
     @pytest.mark.userProfile
     def test_number_of_posted_articles_is_successfully_displayed(self):
         self.logger.info("Logging in with an moderator account")


### PR DESCRIPTION
Expanding playwright to cover a wider range of article deletion scenarios:
- Ensuring that articles cannot be deleted by a user that doesn't have the necessary permissions or while the user is signed out.
- Ensuring that the article is not deleted when clicking on the "Cancel and go back to document history" option.
- Ensuring that the only available article revision cannot be deleted (also performing page assertions for the 'Unable to delete only revision of the document' page).
- Ensuring that the user is redirected back to the article history after clicking on the "Go back to document history" option from the 'Unable to delete only revision of the document' page.
- Ensuring that the article can be successfully deleted and manually navigating to the deleted article's url will return a 404.