### PR TITLE
temporaily use 3.11.7 until timeout deco is fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #######################
 # Common dependencies #
 #######################
-FROM python:3.11-bookworm AS base
+FROM python:3.11.7-bookworm AS base
 
 WORKDIR /app
 EXPOSE 8000
@@ -79,7 +79,7 @@ RUN poetry install --no-dev
 ##########################
 # Clean production image #
 ##########################
-FROM python:3.11-slim-bookworm AS prod
+FROM python:3.11.7-slim-bookworm AS prod
 
 WORKDIR /app
 


### PR DESCRIPTION
mozilla/sumo#1676

This PR temporarily resolves mozilla/sumo#1676 until we can solve the real problem. The real problem is that the `timeout-decorator` package is no longer actively maintained and its `timeout` decorator doesn't work with Python 3.11.8.