### PR TITLE
Expanding playwright over the following kb sections: show history (coverage increase), article revision page, contributors, recent revisions dashboard

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -153,6 +153,16 @@ jobs:
         if: success() || failure() && steps.create-sessions.outcome == 'success' && steps.kb-threads-setup.outcome == 'success'
         run: |
             poetry run pytest -m afterThreadTests --numprocesses 1 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_article_threads_tear_down.html --capture=tee-sys
+      - name: Run KB article show history Tests (${{ env.BROWSER }})
+        working-directory: playwright_tests
+        if: success() || failure() && steps.create-sessions.outcome == 'success'
+        run: |
+            poetry run pytest -m kbArticleShowHistory --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_article_show_history.html --capture=tee-sys
+      - name: Run KB article revisions dashboard Tests (${{ env.BROWSER }})
+        working-directory: playwright_tests
+        if: success() || failure() && steps.create-sessions.outcome == 'success'
+        run: |
+            poetry run pytest -m recentRevisionsDashboard --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_article_recent_revisions.html --capture=tee-sys
       - name: Combine Reports
         working-directory: playwright_tests
         if: success() || failure()

--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -59,6 +59,10 @@ class BasePage:
     def _get_element_inner_text_from_page(self, xpath: str) -> str:
         return self._page.inner_text(xpath)
 
+    # Get Element text content.
+    def _get_element_text_content(self, xpath: str) -> str:
+        return self._page.text_content(xpath)
+
     # Clicking on a particular element.
     def _click(self, xpath: str):
         self._get_element_locator(xpath).click()

--- a/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
+++ b/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
@@ -44,7 +44,7 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, TestUtilities, Quest
                                                                body_text: str,
                                                                os='',
                                                                attach_image=False):
-        aaq_subject = subject + super().generate_random_number(min_value=0, max_value=1000)
+        aaq_subject = subject + super().generate_random_number(min_value=0, max_value=5000)
         # Adding text to subject field.
         super()._add_text_to_aaq_form_subject_field(aaq_subject)
         # Selecting a topic.

--- a/playwright_tests/flows/explore_help_articles_flows/article_flows/add_kb_article_flow.py
+++ b/playwright_tests/flows/explore_help_articles_flows/article_flows/add_kb_article_flow.py
@@ -15,20 +15,25 @@ class AddKbArticleFlow(TestUtilities, SubmitKBArticlePage):
     def submit_simple_kb_article(self,
                                  article_title=None,
                                  article_slug=None,
+                                 article_category=None,
                                  allow_discussion=True,
                                  selected_relevancy=True,
                                  selected_topics=True,
                                  search_summary=None,
                                  article_content=None,
-                                 submit_article=True) -> dict[str, Any]:
+                                 submit_article=True,
+                                 is_template=False) -> dict[str, Any]:
         self._page.goto(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
         kb_article_test_data = super().kb_article_test_data
 
         if article_title is None:
-            kb_article_title = (kb_article_test_data["kb_article_title"] + self.
-                                generate_random_number(0, 1000))
-
+            if is_template:
+                kb_article_title = (kb_article_test_data["kb_template_title"] + self.
+                                    generate_random_number(0, 5000))
+            else:
+                kb_article_title = (kb_article_test_data["kb_article_title"] + self.
+                                    generate_random_number(0, 5000))
         else:
             kb_article_title = article_title
 
@@ -41,7 +46,10 @@ class AddKbArticleFlow(TestUtilities, SubmitKBArticlePage):
             kb_article_slug = article_slug
             super()._add_text_to_article_slug_field(kb_article_slug)
 
-        super()._select_category_option_by_text(kb_article_test_data["category_options"])
+        if article_category is None:
+            super()._select_category_option_by_text(kb_article_test_data["category_options"])
+        else:
+            super()._select_category_option_by_text(article_category)
 
         if selected_relevancy is True:
             super()._click_on_a_relevant_to_option_checkbox(
@@ -106,5 +114,6 @@ class AddKbArticleFlow(TestUtilities, SubmitKBArticlePage):
                 "article_slug": slug,
                 "article_review_description": kb_article_test_data["changes_description"],
                 "keyword": kb_article_test_data["keywords"],
-                "search_results_summary": kb_article_test_data["search_result_summary"]
+                "search_results_summary": kb_article_test_data["search_result_summary"],
+                "expiry_date": kb_article_test_data["expiry_date"]
                 }

--- a/playwright_tests/flows/explore_help_articles_flows/article_flows/add_kb_revision_flow.py
+++ b/playwright_tests/flows/explore_help_articles_flows/article_flows/add_kb_revision_flow.py
@@ -1,0 +1,74 @@
+from playwright_tests.core.testutilities import TestUtilities
+from playwright.sync_api import Page
+from playwright_tests.pages.explore_help_articles.articles.kb_article_page import KBArticlePage
+from playwright_tests.pages.explore_help_articles.articles.kb_article_show_history_page import \
+    KBArticleShowHistoryPage
+from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_page import (
+    EditKBArticlePage)
+
+
+class AddKBArticleRevision(TestUtilities,
+                           KBArticlePage,
+                           EditKBArticlePage,
+                           KBArticleShowHistoryPage):
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def submit_new_kb_revision(self,
+                               keywords=None,
+                               search_result_summary=None,
+                               content=None,
+                               expiry_date=None,
+                               changes_description=None,
+                               is_admin=False
+                               ) -> str:
+
+        super()._click_on_edit_article_option()
+
+        # Only admin accounts can update article keywords.
+        if is_admin:
+            # Keywords step.
+            if keywords is None:
+                super()._fill_edit_article_keywords_field(
+                    self.kb_article_test_data['updated_keywords']
+                )
+            else:
+                super()._fill_edit_article_keywords_field(keywords)
+
+        # Search Result Summary step.
+        if search_result_summary is None:
+            super()._fill_edit_article_search_result_summary_field(
+                self.kb_article_test_data['updated_search_result_summary']
+            )
+        else:
+            super()._fill_edit_article_search_result_summary_field(search_result_summary)
+
+        # Content step.
+        if content is None:
+            super()._fill_edit_article_content_field(
+                self.kb_article_test_data['updated_article_content']
+            )
+        else:
+            super()._fill_edit_article_content_field(content)
+
+        # Expiry date step.
+        if expiry_date is None:
+            super()._fill_edit_article_expiry_date(
+                self.kb_article_test_data['updated_expiry_date']
+            )
+        else:
+            super()._fill_edit_article_expiry_date(expiry_date)
+
+        # Submitting for preview steps
+        super()._click_submit_for_review_button()
+
+        if changes_description is None:
+            super()._fill_edit_article_changes_panel_comment(
+                self.kb_article_test_data['changes_description']
+            )
+        else:
+            super()._fill_edit_article_changes_panel_comment(changes_description)
+
+        super()._click_edit_article_changes_panel_submit_button()
+
+        return super()._get_last_revision_id()

--- a/playwright_tests/flows/explore_help_articles_flows/article_flows/post_new_thread_flow.py
+++ b/playwright_tests/flows/explore_help_articles_flows/article_flows/post_new_thread_flow.py
@@ -14,10 +14,10 @@ class PostNewDiscussionThreadFlow(TestUtilities, KBArticleDiscussionPage):
     def add_new_kb_discussion_thread(self, title='') -> dict[str, Any]:
         if title == '':
             thread_title = (super().kb_new_thread_test_data['new_thread_title'] + super()
-                            .generate_random_number(0, 1000))
+                            .generate_random_number(0, 5000))
         else:
             thread_title = (title + super()
-                            .generate_random_number(0, 1000))
+                            .generate_random_number(0, 5000))
         thread_body = super().kb_new_thread_test_data['new_thread_body']
 
         # Adding text to the title field.

--- a/playwright_tests/messages/explore_help_articles/kb_article_revision_page_messages.py
+++ b/playwright_tests/messages/explore_help_articles/kb_article_revision_page_messages.py
@@ -3,10 +3,13 @@ class KBArticleRevision:
     UNREVIEWED_REVISION_HEADER = " Unreviewed Revision: "
     KB_ARTICLE_REVISION_NO_CURRENT_REV_TEXT = "This document does not have a current revision."
     KB_ARTICLE_REVISION_KEYWORD_HEADER = "Keywords:"
+    KB_ARTICLE_REVISION_NO_STATUS = "No"
+    KB_ARTICLE_REVISION_YES_STATUS = "Yes"
     KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER = ("Unable to delete only revision of the "
                                                       "document")
     KB_REVISION_CANNOT_DELETE_ONLY_REVISION_SUBHEADER = ("To delete the document, please notify "
                                                          "an admin.")
+    KB_REVISION_PREVIEW = "/revision/"
 
     def get_kb_article_revision_details(self,
                                         revision_id: str,

--- a/playwright_tests/messages/explore_help_articles/kb_article_show_history_page_messages.py
+++ b/playwright_tests/messages/explore_help_articles/kb_article_show_history_page_messages.py
@@ -1,0 +1,16 @@
+class KBArticleShowHistoryPageMessages:
+    PAGE_TITLE = "History of "
+    DEFAULT_REVISION_FOR_LOCALE = "English"
+
+    def get_delete_revision_endpoint(self, article_slug: str, revision_id: int) -> str:
+        return f"https://support.allizom.org/en-US/kb/{article_slug}/revision/{revision_id}/delete"
+
+    def get_remove_contributor_page_header(self, expected_username: str) -> str:
+        return (f"Are you sure you want to remove {expected_username} from the document "
+                f"contributors?")
+
+    def get_contributor_added_message(self, expected_username: str) -> str:
+        return f"{expected_username} added to the contributors successfully!"
+
+    def get_contributor_removed_message(self, expected_username: str) -> str:
+        return f"{expected_username} removed from the contributors successfully!"

--- a/playwright_tests/pages/contribute/contributor_tools_pages/recent_revisions_page.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/recent_revisions_page.py
@@ -1,0 +1,129 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page, Locator
+
+
+class RecentRevisions(BasePage):
+
+    # Right-side menu locators
+    __kb_dashboard_option = "//a[text()='KB Dashboard']"
+    __locale_metrics_option = "//a[text()='Locale Metrics']"
+    __kb_team_option = "//a[contains(text(),'KB Team')]"
+    __selected_right_side_option = "//li[@id='editing-tools-sidebar']//li[@class='selected']/a"
+    __aggregated_metrics = "//a[text()='Aggregated Metrics']"
+
+    # Recent Revisions table locators.
+    __locale_select_field = "//select[@id='id_locale']"
+    __locale_tag = "//span[@class='locale']"
+    __all_editors = "//div[@class='creator']/a"
+    __users_input_field = "//input[@id='id_users']"
+    __start_date_input_field = "//input[@id='id_start']"
+    __end_date_input_field = "//input[@id='id_end']"
+    __all_dates = "//div[@class='date']/a/time"
+
+    # Revision diff locators.
+    __revision_diff_section = "//div[@class='revision-diff']"
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    # Right-side menu actions.
+    def _click_on_kb_dashboard_option(self):
+        super()._click(self.__kb_dashboard_option)
+
+    def _click_on_locale_metrics_option(self):
+        super()._click(self.__locale_metrics_option)
+
+    def _click_on_kb_team_option(self):
+        super()._click(self.__kb_team_option)
+
+    def _get_text_of_selected_menu_option(self) -> str:
+        return super()._get_text_of_element(self.__selected_right_side_option)
+
+    def _click_on_aggregated_metrics_option(self):
+        super()._click(self.__aggregated_metrics)
+
+    # Recent Revisions table actions.
+
+    def _get_all_revision_dates(self) -> list[str]:
+        return super()._get_text_of_elements(self.__all_dates)
+
+    def _get_list_of_all_locale_tage(self) -> list[str]:
+        return super()._get_text_of_elements(self.__locale_tag)
+
+    def _get_list_of_all_editors(self) -> list[str]:
+        return super()._get_text_of_elements(self.__all_editors)
+
+    def _select_locale_option(self, locale_value: str):
+        super()._select_option_by_value(self.__locale_select_field, locale_value)
+
+    def _fill_in_users_field(self, username: str):
+        super()._fill(self.__users_input_field, username)
+        super()._press_a_key(self.__users_input_field, "Enter")
+
+    def _clearing_the_user_field(self):
+        super()._clear_field(self.__users_input_field)
+
+    def _add_start_date(self, start_date: str):
+        super()._type(self.__start_date_input_field, start_date, 0)
+
+    def _add_end_date(self, end_date: str):
+        super()._type(self.__end_date_input_field, end_date, 0)
+
+    def _get_recent_revision_based_on_article_locator(self, title: str) -> Locator:
+        xpath = f"//div[@id='revisions-fragment']//div[@class='title']//a[text()='{title}']"
+        return super()._get_element_locator(xpath)
+
+    def _get_recent_revision_based_on_article_title_and_user(self, title: str,
+                                                             username: str) -> Locator:
+        xpath = (f"//div[@id='revisions-fragment']//div[@class='title']//a[text()='{title}'"
+                 f"]/../../div[@class='creator']/a[contains(text(),'{username}')]")
+        return super()._get_element_locator(xpath)
+
+    def _click_on_article_title(self, article_title: str, creator: str):
+        xpath = (f"//div[@id='revisions-fragment']//div[@class='creator']"
+                 f"/a[contains(text(),'{creator}')]/../../div[@class='title']/"
+                 f"a[text()='{article_title}']")
+        super()._click(xpath)
+
+    def _click_article_creator_link(self, article_title: str, creator: str):
+        xpath = (f"//div[@id='revisions-fragment']//div[@class='title']/a[text()='{article_title}'"
+                 f"]/../..//div[@class='creator']/a[contains(text(),'{creator}')]")
+        super()._click(xpath)
+
+    def _click_on_show_diff_for_article(self, article_title: str, creator: str):
+        xpath = (f"//div[@id='revisions-fragment']//div[@class='title']/a[text()='{article_title}'"
+                 f"]/../../div[@class='creator']/a[contains(text(),'{creator}')]/../../"
+                 f"div[@class='showdiff']/a[@class='show-diff']")
+        super()._click(xpath)
+
+    def _get_show_diff_article_locator(self, article_title: str, creator: str) -> Locator:
+        xpath = (f"//div[@id='revisions-fragment']//div[@class='title']/a[text()='{article_title}'"
+                 f"]/../../div[@class='creator']/a[contains(text(),'{creator}')]/../../"
+                 f"div[@class='showdiff']/a[@class='show-diff']")
+        return super()._get_element_locator(xpath)
+
+    def _click_on_hide_diff_for_article(self, article_title: str, creator: str):
+        xpath = (f"//div[@id='revisions-fragment']//div[@class='title']/a[text()='{article_title}'"
+                 f"]/../../div[@class='creator']/a[contains(text(),'{creator}')]/../../"
+                 f"div[@class='showdiff']/a[@class='close-diff']")
+        super()._click(xpath)
+
+    def _click_on_revision_date_for_article(self, article_title: str, username: str):
+        xpath = (f"//div[@class='creator']/a[contains(text(),'{username}')]/../../div["
+                 f"@class='title']/a[text()='{article_title}']/../../div[@class='date']/a")
+        super()._click(xpath)
+
+    def _get_revision_comment(self, article_title: str, username: str) -> str:
+        xpath = (f"//div[@id='revisions-fragment']//div[@class='title']/a[text()='{article_title}'"
+                 f"]/../../div[@class='creator']/a[contains(text(),'{username}')]/../../"
+                 f"div[@class='comment wider']")
+        return super()._get_element_inner_text_from_page(xpath)
+
+    def _get_revision_and_username_locator(self, article_title: str, username: str) -> Locator:
+        xpath = (f"//div[@id='revisions-fragment']//div[@class='title']/a[text()='{article_title}'"
+                 f"]/../../div[@class='creator']/a[contains(text(),'{username}')]")
+        return super()._get_element_locator(xpath)
+
+    # Diff section actions
+    def _get_diff_section_locator(self) -> Locator:
+        return super()._get_element_locator(self.__revision_diff_section)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
@@ -6,10 +6,12 @@ class KBArticlePage(BasePage):
     __kb_article_heading = "//h1[@class='sumo-page-heading']"
     __kb_article_content = "//section[@id='doc-content']"
     __kb_article_content_approved_content = "//section[@id='doc-content']/p"
+    __kb_article_contributors = "//div[@class='document--contributors-list text-body-xs']/a"
 
     # Editing Tools options
     __editing_tools_article_option = "//a[text()='Article']"
     __editing_tools_edit_article_option = "//li/a[text()='Edit Article']"
+    __editing_tools_edit_article_metadata_option = "//a[text()='Edit Article Metadata']"
     __editing_tools_discussion_option = "//ul[@class='sidebar-nav--list']//a[text()='Discussion']"
     __editing_tools_show_history_option = "//a[contains(text(), 'Show History')]"
 
@@ -19,6 +21,13 @@ class KBArticlePage(BasePage):
     # KB Article page content actions.
     def _get_text_of_article_title(self) -> str:
         return super()._get_text_of_element(self.__kb_article_heading)
+
+    def _get_list_of_kb_article_contributors(self) -> list[str]:
+        return super()._get_text_of_elements(self.__kb_article_contributors)
+
+    def _click_on_a_particular_article_contributor(self, username: str):
+        xpath = f"//div[@class='document--contributors-list text-body-xs']/a[text()='{username}']"
+        super()._click(xpath)
 
     def _get_text_of_kb_article_content_approved(self) -> str:
         return super()._get_text_of_element(self.__kb_article_content_approved_content)
@@ -32,6 +41,9 @@ class KBArticlePage(BasePage):
 
     def _click_on_edit_article_option(self):
         super()._click(self.__editing_tools_edit_article_option)
+
+    def _click_on_edit_article_metadata(self):
+        super()._click(self.__editing_tools_edit_article_metadata_option)
 
     def _click_on_article_option(self):
         super()._click(self.__editing_tools_article_option)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_review_revision_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_review_revision_page.py
@@ -2,7 +2,7 @@ from playwright.sync_api import Page
 from playwright_tests.core.basepage import BasePage
 
 
-class KBArticleRevisionPage(BasePage):
+class KBArticleReviewRevisionPage(BasePage):
     __revision_header = "//h1[@class='sumo-page-heading']"
     __reviewing_revision_text = "//article[@id='review-revision']//a[text()='Back to History']/.."
     __back_to_history_link = "//article[@id='review-revision']//a[text()='Back to History']"
@@ -96,3 +96,6 @@ class KBArticleRevisionPage(BasePage):
 
     def _click_accept_revision_accept_button(self):
         super()._click(self.__modal_accept_button)
+
+    def _check_ready_for_localization_checkbox(self):
+        super()._click(self.__ready_for_localization_modal_checkbox)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
@@ -3,6 +3,23 @@ from playwright_tests.core.basepage import BasePage
 
 
 class KBArticleShowHistoryPage(BasePage):
+    # Show History page locators.
+    __show_history_page_header = "//h1[@class='title sumo-page-subheading']"
+    __show_history_category_link = "//dt[text()='Category:']/following-sibling::dd/a"
+    __show_history_revision_history_for = ("//dt[text()='Revision history "
+                                           "for:']/following-sibling::dd[1]")
+
+    # Document contributors locators
+    __show_history_page_banner = "//li[@class='mzp-c-notification-bar mzp-t-success']/p"
+    __all_contributors_list_items = "//ul[@class='avatar-wrap']/li"
+    __all_contributors_usernames = "//ul[@class='avatar-wrap']//a/span"
+    __edit_contributors_option = "//section[@id='contributors']//a[@class='edit']"
+    __add_contributor_input_field = "//input[@id='token-input-id_users']"
+    __add_contributor_button = "//input[@value='Add Contributor']"
+    __delete_contributor_confirmation_page_header = "//h1[@class='title sumo-page-subheading']"
+    __delete_contributor_confirmation_page_cancel_button = "//a[text()='Cancel']"
+    __delete_contributor_confirmation_page_submit_button = "//input[@value='Remove contributor']"
+
     # Show History delete document section locators.
     __delete_this_document_button = "//div[@id='delete-doc']/a"
     __delete_this_document_confirmation_delete_button = "//div[@class='submit']/input"
@@ -16,6 +33,26 @@ class KBArticleShowHistoryPage(BasePage):
 
     def __init__(self, page: Page):
         super().__init__(page)
+
+    # Page actions.
+    def _get_show_history_page_banner(self) -> str:
+        return super()._get_text_of_element(self.__show_history_page_banner)
+
+    def _get_show_history_page_title(self) -> str:
+        return super()._get_text_of_element(self.__show_history_page_header)
+
+    def _get_show_history_category_text(self) -> str:
+        return super()._get_text_of_element(self.__show_history_category_link)
+
+    def _click_on_show_history_category(self):
+        super()._click(self.__show_history_category_link)
+
+    def _get_show_history_revision_for_locale_text(self) -> str:
+        return super()._get_text_of_element(self.__show_history_revision_history_for)
+
+    def _click_on_a_particular_revision_editor(self, revision_id: str, username: str):
+        xpath = f"//tr[@id='{revision_id}']//a[contains(text(),'{username}')]"
+        super()._click(xpath)
 
     # Delete document actions.
     def _click_on_delete_this_document_button(self):
@@ -41,6 +78,14 @@ class KBArticleShowHistoryPage(BasePage):
         )
 
     # For unreviewed revisions but user session doesn't permit review.
+    def _click_on_a_revision_date(self, revision_id):
+        xpath = f"//tr[@id='{revision_id}']/td[@class='date']/a"
+        super()._click(xpath)
+
+    def _get_revision_time(self, revision_id) -> str:
+        xpath = f"//tr[@id='{revision_id}']/td[@class='date']/a/time"
+        return super()._get_text_of_element(xpath)
+
     def _get_revision_status(self, revision_id) -> str:
         xpath = f"//tr[@id='{revision_id}']/td[@class='status']/span"
         return super()._get_text_of_element(xpath)
@@ -70,3 +115,44 @@ class KBArticleShowHistoryPage(BasePage):
 
     def _click_go_back_to_document_history_option(self):
         super()._click(self.__unable_to_delete_revision_page_go_back_to_document_history)
+
+    # Article contribution actions.
+    def _click_on_edit_contributors_option(self):
+        super()._click(self.__edit_contributors_option)
+
+    def _get_edit_contributors_option_locator(self) -> Locator:
+        return super()._get_element_locator(self.__edit_contributors_option)
+
+    def _add_a_new_contributor_inside_the_contributor_field(self, text: str):
+        # Adding contributor username inside the contributor field.
+        super()._type(self.__add_contributor_input_field, text, 100)
+
+    def _click_on_new_contributor_search_result(self, username: str):
+        xpath = f"//div[@class='name_search']/b[contains(text(), '{username}')]"
+        super()._click(xpath)
+
+    def _click_on_add_contributor_button(self):
+        super()._click(self.__add_contributor_button)
+
+    def _click_on_a_particular_contributor(self, username: str):
+        xpath = f"//span[text()='{username}']/.."
+        super()._click(xpath)
+
+    def _click_on_delete_button_for_a_particular_contributor(self, username: str):
+        xpath = f"//span[text()='{username}']/../..//a[@class='remove-button']"
+        super()._click(xpath)
+
+    def _get_list_of_all_contributors(self) -> list[str]:
+        return super()._get_text_of_elements(self.__all_contributors_usernames)
+
+    def _get_delete_contributor_confirmation_page_header(self) -> str:
+        return super()._get_text_of_element(self.__delete_contributor_confirmation_page_header)
+
+    def _click_on_delete_contributor_confirmation_page_cancel_button(self):
+        super()._click(self.__delete_contributor_confirmation_page_cancel_button)
+
+    def _click_on_delete_contributor_confirmation_page_confirm_button(self):
+        super()._click(self.__delete_contributor_confirmation_page_submit_button)
+
+    def _get_all_contributors_locator(self) -> Locator:
+        return super()._get_element_locator(self.__all_contributors_list_items)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_metadata.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_metadata.py
@@ -1,0 +1,93 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page
+
+
+class KBArticleEditMetadata(BasePage):
+    # Edit article metadata page locators.
+    __edit_article_metadata_page_header = "//h1[@class='sumo-page-heading']"
+    __restrict_visibility_input_field = "//input[@id='id_restrict_to_groups-selectized']"
+    __restricted_visibility_chosen_groups = ("//input[@id='id_restrict_to_groups-selectized"
+                                             "']/../div[@class='item']")
+    __clear_all_selected_groups_button = "//a[@class='clear']"
+    __title_input_field = "//input[@id='id_title']"
+    __slug_input_field = "//input[@id='id_slug']"
+    __category_select_field = "//select[@id='id_category']"
+    __obsolete_checkbox = "//input[@id='id_is_archived']"
+    __allow_discussion_checkbox = "//input[@id='id_allow_discussion']"
+    __needs_change_checkbox = "//input[@id='id_needs_change']"
+    __save_changes_button = "//button[text()='Save']"
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    # Edit article metadata page actions.
+    def _get_edit_article_metadata_page_header(self) -> str:
+        return super()._get_element_text_content(self.__edit_article_metadata_page_header)
+
+    def _delete_a_chosen_restricted_visibility_group(self, chosen_group: str):
+        xpath = (f"//input[@id='id_restrict_to_groups-selectized']/../div[text()='{chosen_group}']"
+                 f"/a")
+        super()._click(xpath)
+
+    def _clear_all_restricted_visibility_group_selections(self):
+        super()._click(self.__clear_all_selected_groups_button)
+
+    def _get_text_of_title_input_field(self):
+        return super()._get_text_of_element(self.__title_input_field)
+
+    def _add_text_to_title_field(self, text: str):
+        super()._clear_field(self.__title_input_field)
+        super()._fill(self.__title_input_field, text)
+
+    def _get_slug_input_field(self) -> str:
+        return super()._get_text_of_element(self.__slug_input_field)
+
+    def _add_text_to_slug_field(self, text: str):
+        super()._clear_field(self.__slug_input_field)
+        super()._fill(self.__slug_input_field, text)
+
+    def _select_category(self, option: str):
+        super()._select_option_by_label(self.__category_select_field, option)
+
+    def _is_relevant_checkbox_checked(self, option: str) -> bool:
+        xpath = f"//div[@id='id_products']//label[text()='\n {option}']/input"
+        return super()._is_checkbox_checked(xpath)
+
+    def _check_a_particular_checkbox(self, option: str):
+        xpath = f"//div[@id='id_products']//label[text()='\n {option}']/input"
+        super()._click(xpath)
+
+    def _click_on_a_particular_topics_foldout_section(self, option: str):
+        xpath = f"//section[@id='accordion']//button[text()='{option}']"
+        super()._click(xpath)
+
+    def _is_a_particular_topic_checkbox_checked(self, option: str) -> bool:
+        xpath = (f"//ul[@id='expand-mzpcdetailsh-0' and @aria-hidden='false']//label"
+                 f"[text()='{option}']/../input")
+        return super()._is_checkbox_checked(xpath)
+
+    def _check_a_particular_topic_checkbox(self, option: str):
+        xpath = (f"//ul[@id='expand-mzpcdetailsh-0' and @aria-hidden='false']//label"
+                 f"[text()='{option}']")
+        super()._click(xpath)
+
+    def _is_obsolete_checkbox_checked(self) -> bool:
+        return super()._is_checkbox_checked(self.__obsolete_checkbox)
+
+    def _click_on_obsolete_checkbox(self):
+        super()._click(self.__obsolete_checkbox)
+
+    def _is_allow_discussion_checkbox_checked(self) -> bool:
+        return super()._is_checkbox_checked(self.__allow_discussion_checkbox)
+
+    def _click_on_allow_discussion_on_article_checkbox(self):
+        super()._click(self.__allow_discussion_checkbox)
+
+    def _is_needs_change_checkbox_checked(self) -> bool:
+        return super()._is_checkbox_checked(self.__needs_change_checkbox)
+
+    def _click_needs_change_checkbox(self):
+        super()._click(self.__needs_change_checkbox)
+
+    def _click_on_save_changes_button(self):
+        super()._click(self.__save_changes_button)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_page.py
@@ -1,0 +1,68 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page
+
+
+class EditKBArticlePage(BasePage):
+    # KB Article edit page locators.
+    __edit_article_page_header = "//h1"
+
+    # KB Article edit page field locators.
+    __edit_article_keywords_field = "//input[@id='id_keywords']"
+    __edit_article_search_result_summary_field = "//textarea[@id='id_summary']"
+    __edit_article_content_textarea_field = "//textarea[@id='id_content']"
+    __edit_article_toggle_syntax_highlight = "//a[text()='Toggle syntax highlighting']"
+    __edit_article_expiry_date_field = "//input[@id='id_expires']"
+    __edit_article_submit_for_review_button = ("//article[@id='edit-document']//button[text("
+                                               ")='Submit for Review']")
+
+    # Submit your changes locators.
+    __edit_article_submit_changes_panel_comment_field = "//input[@id='id_comment']"
+    __edit_article_submit_changes_panel_submit_button = "//button[@id='submit-document-form']"
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    # Edit kb article page actions.
+    def _get_edit_article_page_header(self) -> str:
+        return super()._get_text_of_element(self.__edit_article_page_header)
+
+    # Edit kb article page field actions.
+    def _get_edit_article_keywords_field_value(self) -> str:
+        return super()._get_element_input_value(self.__edit_article_keywords_field)
+
+    def _fill_edit_article_keywords_field(self, text: str):
+        super()._clear_field(self.__edit_article_keywords_field)
+        super()._fill(self.__edit_article_keywords_field, text)
+
+    def _get_edit_article_search_result_summary_text(self) -> str:
+        return super()._get_text_of_element(self.__edit_article_search_result_summary_field)
+
+    def _fill_edit_article_search_result_summary_field(self, text: str):
+        super()._clear_field(self.__edit_article_search_result_summary_field)
+        super()._fill(self.__edit_article_search_result_summary_field, text)
+
+    def _get_edit_article_content_field_text(self) -> str:
+        return super()._get_text_of_element(self.__edit_article_content_textarea_field)
+
+    def _fill_edit_article_content_field(self, text: str):
+        # We need to toggle the content field from syntax highlighting to make interaction easier.
+        super()._click(self.__edit_article_toggle_syntax_highlight)
+        super()._clear_field(self.__edit_article_content_textarea_field)
+        super()._fill(self.__edit_article_content_textarea_field, text)
+
+    def _get_edit_article_expiry_date_value(self) -> str:
+        return super()._get_element_attribute_value(self.__edit_article_expiry_date_field)
+
+    def _fill_edit_article_expiry_date(self, text: str):
+        super()._type(self.__edit_article_expiry_date_field, text, 0)
+
+    # Edit kb button actions.
+    def _click_submit_for_review_button(self):
+        super()._click_on_first_item(self.__edit_article_submit_for_review_button)
+
+    # Submit you changes panel actions.
+    def _fill_edit_article_changes_panel_comment(self, text: str):
+        super()._fill(self.__edit_article_submit_changes_panel_comment_field, text)
+
+    def _click_edit_article_changes_panel_submit_button(self):
+        super()._click(self.__edit_article_submit_changes_panel_submit_button)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_revision_preview_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_revision_preview_page.py
@@ -1,0 +1,123 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page, Locator
+
+
+class KBArticleRevisionsPreviewPage(BasePage):
+    # Preview Revision page locators.
+    __preview_revision_page_header = "//h1[@class='sumo-page-heading']"
+    # Revision Information locators.
+    __revision_information_foldout_section = "//summary[text()='Revision Information']"
+    __revision_information_content = "//div[@class='revision-info']"
+    __revision_id = "//strong[text()='Revision id:']/following-sibling::span"
+    __created_date = "//strong[text()='Created:']/following-sibling::span/time"
+    __creator = "//strong[text()='Creator:']/following-sibling::span/a"
+    __comment = "//strong[text()='Comment:']/following-sibling::span"
+    __reviewed = "//strong[text()='Reviewed:']/following-sibling::span[not(child::time)]"
+    __reviewed_time = "//strong[text()='Reviewed:']/following-sibling::span/time"
+    __reviewed_by = "//strong[text()='Reviewed by:']/following-sibling::span"
+    __is_approved = "//strong[text()='Is approved?']/following-sibling::span"
+    __is_current_revision = "//strong[text()='Is current revision?']/following-sibling::span"
+    __ready_for_localization = "//strong[text()='Ready for localization:']/following-sibling::span"
+    __readied_for_localization_date = ("//strong[text()='Readied for "
+                                       "localization:']/following-sibling::span")
+    __readied_for_localization_by = ("//strong[text()='Readied for localization "
+                                     "by:']/following-sibling::span")
+    __edit_article_based_on_revision_link = "//a[text()='Edit article based on this revision']"
+    # Revision Source locators.
+    __revision_source_foldout_section = "//summary[text()='Revision Source']"
+    __revision_source_textarea = "//div[@id='doc-source']/textarea"
+    # Revision Content locators.
+    __revision_content_foldout_section = "//summary[text()='Revision Content']"
+    __revision_content_html_section = "//div[@id='doc-content']"
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    # Preview Revision page actions.
+    def _get_preview_revision_header(self) -> str:
+        return super()._get_text_of_element(self.__preview_revision_page_header)
+
+    # Revision Information actions.
+    def _click_on_revision_information_foldout_section(self):
+        super()._click(self.__revision_information_foldout_section)
+
+    def _get_revision_information_content_locator(self) -> Locator:
+        return super()._get_element_locator(self.__revision_information_content)
+
+    def _get_preview_revision_id_text(self) -> str:
+        return super()._get_text_of_element(self.__revision_id)
+
+    def _get_preview_revision_created_date_text(self) -> str:
+        return super()._get_text_of_element(self.__created_date)
+
+    def _get_preview_revision_creator_text(self) -> str:
+        return super()._get_text_of_element(self.__creator)
+
+    def _click_on_creator_link(self):
+        super()._click(self.__creator)
+
+    def _get_preview_revision_comment_text(self) -> str:
+        return super()._get_text_of_element(self.__comment)
+
+    def _get_preview_revision_reviewed_text(self) -> str:
+        return super()._get_text_of_element(self.__reviewed)
+
+    # This locator is available inside the page only when a review was performed.
+    def _get_preview_revision_reviewed_date_locator(self) -> Locator:
+        return super()._get_element_locator(self.__reviewed_time)
+
+    # This locator is available inside the page only when a review was performed.
+    # The text returned is the username extracted from the e-mail address.
+    def _get_reviewed_by_text(self) -> str:
+        return super()._get_text_of_element(self.__reviewed_by)
+
+    def _get_reviewed_by_locator(self) -> Locator:
+        return super()._get_element_locator(self.__reviewed_by)
+
+    def _get_is_approved_text(self) -> str:
+        return super()._get_text_of_element(self.__is_approved)
+
+    def _get_is_approved_text_locator(self) -> Locator:
+        return super()._get_element_locator(self.__is_approved)
+
+    def _get_is_current_revision_text(self) -> str:
+        return super()._get_text_of_element(self.__is_current_revision)
+
+    def _is_current_revision_locator(self) -> Locator:
+        return super()._get_element_locator(self.__is_current_revision)
+
+    def _get_preview_revision_ready_for_localization_text(self) -> str:
+        return super()._get_text_of_element(self.__ready_for_localization)
+
+    # Is displayed only if the revision was marked as ready for localization
+    def _ready_for_localization_date(self) -> Locator:
+        return super()._get_element_locator(self.__readied_for_localization_date)
+
+    def _readied_for_localization_by_text(self) -> str:
+        return super()._get_text_of_element(self.__readied_for_localization_by)
+
+    def _readied_for_localization_by_locator(self) -> Locator:
+        return super()._get_element_locator(self.__readied_for_localization_by)
+
+    def _get_edit_article_based_on_this_revision_link_locator(self) -> Locator:
+        return super()._get_element_locator(self.__edit_article_based_on_revision_link)
+
+    def _click_on_edit_article_based_on_this_revision_link(self):
+        super()._click(self.__edit_article_based_on_revision_link)
+
+    # Revision Source actions.
+    def _click_on_revision_source_foldout_section(self):
+        super()._click(self.__revision_source_foldout_section)
+
+    def _get_preview_revision_source_textarea_content(self) -> str:
+        return super()._get_element_input_value(self.__revision_source_textarea)
+
+    def _get_preview_revision_source_textarea_locator(self) -> Locator:
+        return super()._get_element_locator(self.__revision_source_textarea)
+
+    # Revision Content actions.
+    def _click_on_revision_content_foldout_section(self):
+        super()._click(self.__revision_content_foldout_section)
+
+    def _get_revision_content_html_locator(self) -> Locator:
+        return super()._get_element_locator(self.__revision_content_html_section)

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -4,6 +4,8 @@ from playwright_tests.flows.ask_a_question_flows.aaq_flows.aaq_flow import AAQFl
 from playwright_tests.flows.explore_help_articles_flows.article_flows.add_kb_article_flow import (
     AddKbArticleFlow)
 from playwright_tests.flows.auth_flows.auth_flow import AuthFlowPage
+from playwright_tests.flows.explore_help_articles_flows.article_flows.add_kb_revision_flow import \
+    AddKBArticleRevision
 from playwright_tests.flows.explore_help_articles_flows.article_flows.post_new_thread_flow import \
     PostNewDiscussionThreadFlow
 from playwright_tests.flows.messaging_system_flows.messaging_system_flow import (
@@ -12,14 +14,22 @@ from playwright_tests.flows.user_profile_flows.edit_profile_data_flow import Edi
 from playwright_tests.pages.ask_a_question.aaq_pages.aaq_form_page import AAQFormPage
 from playwright_tests.pages.contribute.contributor_tools_pages.moderate_forum_content import \
     ModerateForumContent
+from playwright_tests.pages.contribute.contributor_tools_pages.recent_revisions_page import \
+    RecentRevisions
 from playwright_tests.pages.explore_help_articles.articles.kb_article_discussion_page import \
     KBArticleDiscussionPage
 from playwright_tests.pages.explore_help_articles.articles.kb_article_page import KBArticlePage
-from playwright_tests.pages.explore_help_articles.articles.kb_article_revision_page import \
-    KBArticleRevisionPage
+from playwright_tests.pages.explore_help_articles.articles.kb_article_review_revision_page import \
+    KBArticleReviewRevisionPage
+from playwright_tests.pages.explore_help_articles.articles.kb_revision_preview_page import \
+    KBArticleRevisionsPreviewPage
 from playwright_tests.pages.explore_help_articles.articles.kb_article_show_history_page import (
     KBArticleShowHistoryPage)
 from playwright_tests.pages.auth_page import AuthPage
+from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_metadata import \
+    KBArticleEditMetadata
+from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_page import \
+    EditKBArticlePage
 from playwright_tests.pages.explore_help_articles.articles.products_page import ProductsPage
 from playwright_tests.pages.explore_help_articles.articles.submit_kb_article_page import \
     SubmitKBArticlePage
@@ -108,9 +118,12 @@ class SumoPages:
         # KB Articles.
         self.kb_submit_kb_article_form_page = SubmitKBArticlePage(page)
         self.kb_article_page = KBArticlePage(page)
+        self.kb_edit_article_page = EditKBArticlePage(page)
         self.kb_article_discussion_page = KBArticleDiscussionPage(page)
         self.kb_article_show_history_page = KBArticleShowHistoryPage(page)
-        self.kb_article_revision_page = KBArticleRevisionPage(page)
+        self.kb_article_review_revision_page = KBArticleReviewRevisionPage(page)
+        self.kb_article_preview_revision_page = KBArticleRevisionsPreviewPage(page)
+        self.kb_article_edit_article_metadata_page = KBArticleEditMetadata(page)
 
         # Product Topics page
         self.product_topics_page = ProductTopicPage(page)
@@ -127,6 +140,9 @@ class SumoPages:
         # Forums
         self.support_forums_page = SupportForumsPage(page)
         self.product_support_forum = ProductSupportForum(page)
+
+        # Dashboard pages.
+        self.recent_revisions_page = RecentRevisions(page)
 
         # Moderate Forum Page
         self.moderate_forum_content_page = ModerateForumContent(page)
@@ -145,6 +161,9 @@ class SumoPages:
 
         # KB article Flow
         self.submit_kb_article_flow = AddKbArticleFlow(page)
+
+        # KB article revision Flow
+        self.kb_article_revision_flow = AddKBArticleRevision(page)
 
         # KB article discussion Flow
         self.post_kb_discussion_thread_flow = PostNewDiscussionThreadFlow(page)

--- a/playwright_tests/pages/top_navbar.py
+++ b/playwright_tests/pages/top_navbar.py
@@ -27,6 +27,8 @@ class TopNavbar(BasePage):
     __contributor_tools_option = "//a[contains(text(),'Contributor Tools')]"
     __moderate_forum_content = ("//div[@id='main-navigation']//a[@data-event-label='Moderate "
                                 "Forum Content']")
+    __recent_revisions_option = ("//ul[@class='mzp-c-menu-item-list sumo-nav--sublist']//a[text("
+                                 ")='Recent Revisions']")
 
     # Sign in button
     __signin_signup_button = "//div[@id='profile-navigation']//a[@data-event-label='Sign In']"
@@ -62,6 +64,10 @@ class TopNavbar(BasePage):
     def _click_on_moderate_forum_content_option(self):
         super()._hover_over_element(self.__contributor_tools_option)
         super()._click(self.__moderate_forum_content)
+
+    def _click_on_recent_revisions_option(self):
+        super()._hover_over_element(self.__contributor_tools_option)
+        super()._click(self.__recent_revisions_option)
 
     # Explore our Help Articles actions.
     def _click_on_explore_our_help_articles_option(self):
@@ -114,3 +120,6 @@ class TopNavbar(BasePage):
 
     def _sign_in_up_button_displayed_element(self) -> Locator:
         return super()._get_element_locator(self.__signin_signup_button)
+
+    def is_sign_in_up_button_displayed(self) -> bool:
+        return super()._is_element_visible(self.__signin_signup_button)

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -22,3 +22,5 @@ markers =
     articleThreads: Tests belonging to the kb article threads.
     beforeThreadTests: Article threads tests prerequisites.
     afterThreadTests: Article threads tests teardown.
+    kbArticleShowHistory: Tests belonging to the kb article show history section.
+    recentRevisionsDashboard: Tests belonging to the recent revisions dashboard.

--- a/playwright_tests/test_data/add_kb_article.json
+++ b/playwright_tests/test_data/add_kb_article.json
@@ -1,5 +1,7 @@
 {
   "kb_article_title": "Automation test article ",
+  "kb_template_title": "Template: Automation test article",
+  "updated_kb_article_title": "Updated test article",
   "different_slug": "different-slug-",
   "category_options": "Navigation",
   "relevant_to_option": "Hubs",
@@ -7,12 +9,17 @@
   "selected_child_topic": "How to use Firefox for Android",
   "related_documents": "Stage test owl",
   "keywords": "auto test keyword",
+  "updated_keywords": "auto updated keyword",
   "search_result_summary": "This is a search result summary test",
+  "updated_search_result_summary": "Updated This is a search result summary test",
   "article_content": "'''Lorem ipsum''' dolor ''sit amet'', consectetur [https://www.mediafax.ro adipiscing] elit, [[Stage test owl|sed]] do eiusmod tempor incididunt # ut labore * et dolore magna aliqua. Tincidunt id aliquet risus feugiat in ante. Etiam non quam lacus suspendisse faucibus interdum posuere. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Velit egestas dui id ornare arcu odio ut sem nulla. Risus nec feugiat in fermentum posuere urna nec tincidunt. Sed egestas egestas fringilla phasellus faucibus. Amet consectetur adipiscing elit duis tristique. Lorem mollis aliquam ut porttitor. Purus sit amet volutpat consequat mauris. Lobortis mattis aliquam faucibus purus in. Enim praesent elementum facilisis leo vel. Volutpat lacus laoreet non curabitur gravida arcu. Tempus iaculis urna id volutpat.",
+  "updated_article_content": "Updated Content",
   "article_content_html_rendered": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt # ut labore * et dolore magna aliqua. Tincidunt id aliquet risus feugiat in ante. Etiam non quam lacus suspendisse faucibus interdum posuere. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Velit egestas dui id ornare arcu odio ut sem nulla. Risus nec feugiat in fermentum posuere urna nec tincidunt. Sed egestas egestas fringilla phasellus faucibus. Amet consectetur adipiscing elit duis tristique. Lorem mollis aliquam ut porttitor. Purus sit amet volutpat consequat mauris. Lobortis mattis aliquam faucibus purus in. Enim praesent elementum facilisis leo vel. Volutpat lacus laoreet non curabitur gravida arcu. Tempus iaculis urna id volutpat.",
+  "updated_article_content_html_rendered": "Updated Content",
   "article_heading_one": "=Heading one=",
   "article_heading_two": "==Heading two==",
   "article_heading_three": "===Heading three===",
   "expiry_date": "05.02.2050",
+  "updated_expiry_date": "07.05.2051",
   "changes_description": "Automation description test"
 }

--- a/playwright_tests/test_data/different_endpoints.json
+++ b/playwright_tests/test_data/different_endpoints.json
@@ -1,0 +1,12 @@
+{
+  "kb_categories_links":
+          {
+            "Troubleshooting": "https://support.allizom.org/en-US/kb/category/10",
+            "How to": "https://support.allizom.org/en-US/kb/category/20",
+            "How to contribute": "https://support.allizom.org/en-US/kb/category/30",
+            "Administration": "https://support.allizom.org/en-US/kb/category/40",
+            "Navigation": "https://support.allizom.org/en-US/kb/category/50",
+            "Templates": "https://support.allizom.org/en-US/kb/category/60",
+            "Canned Responses": "https://support.allizom.org/en-US/kb/category/70"
+          }
+}

--- a/playwright_tests/test_data/general_data.json
+++ b/playwright_tests/test_data/general_data.json
@@ -17,6 +17,15 @@
     "Hubs",
     "Mozilla Account"
   ],
+  "kb_article_categories": [
+    "Troubleshooting",
+    "How to",
+    "How to contribute",
+    "Administration",
+    "Navigation",
+    "Templates",
+    "Canned Responses"
+  ],
   "product_topics": {
     "Firefox": "https://support.allizom.org/en-US/products/firefox/fix-problems",
     "Firefox for Android": "https://support.allizom.org/en-US/products/mobile/fix-problems",
@@ -62,5 +71,8 @@
     "Thunderbird": "https://support.allizom.org/en-US/questions/new/thunderbird",
     "Firefox Focus": "https://support.allizom.org/en-US/questions/new/focus",
     "Mozilla Account": "https://support.allizom.org/en-US/questions/new/mozilla-account"
+  },
+  "dashboard_links": {
+    "recent_revisions": "https://support.allizom.org/en-US/kb/revisions"
   }
 }

--- a/playwright_tests/test_data/profile_edit.json
+++ b/playwright_tests/test_data/profile_edit.json
@@ -1,7 +1,7 @@
 {
   "valid_user_edit": {
     "username": "modifiedUsernameAutoTestt",
-      "display_name": "Modified display name",
+    "display_name": "Modified display name",
     "display_name_chrome": "Modified display name ch",
     "display_name_firefox": "Modified displayed name fx",
     "biography": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
@@ -1,0 +1,601 @@
+import pytest
+import pytest_check as check
+from playwright.sync_api import expect
+from playwright_tests.core.testutilities import TestUtilities
+from playwright_tests.messages.explore_help_articles.kb_article_revision_page_messages import (
+    KBArticleRevision)
+from playwright_tests.messages.my_profile_pages_messages.my_profile_page_messages import (
+    MyProfileMessages)
+
+
+class TestRecentRevisionsDashboard(TestUtilities):
+
+    # C2499112
+    @pytest.mark.recentRevisionsDashboard
+    def test_recent_revisions_revision_availability(self):
+        self.logger.info("Signing in with a non-Admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts['TEST_ACCOUNT_12']
+        ))
+
+        username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Create a new simple article")
+        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        article_url = self.get_page_url()
+
+        self.logger.info("Navigating to the recent revisions dashboard")
+        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+
+        self.logger.info("Verifying that the posted article is displayed for admin accounts")
+        expect(
+            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
+                article_details['article_title']
+            )
+        ).to_be_visible()
+
+        self.logger.info("Deleting user session and verifying that the revision is not displayed")
+        self.delete_cookies()
+
+        expect(
+            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
+                article_details['article_title']
+            )
+        ).to_be_hidden()
+
+        self.logger.info("Typing the article creator username inside the 'Users' field and "
+                         "verifying that the article is not displayed")
+        self.sumo_pages.recent_revisions_page._fill_in_users_field(username)
+
+        self.wait_for_given_timeout(2000)
+
+        expect(
+            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
+                article_details['article_title']
+            )
+        ).to_be_hidden()
+
+        self.logger.info("Clearing the user search field")
+        self.sumo_pages.recent_revisions_page._clearing_the_user_field()
+
+        self.logger.info("Signing in with a different user account")
+        self.username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+        )
+
+        self.logger.info("Verifying that the revision is not displayed")
+        expect(
+            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
+                article_details['article_title']
+            )
+        ).to_be_hidden()
+
+        self.logger.info("Typing the article creator username inside the 'Users' field and "
+                         "verifying that the article is not displayed")
+        self.sumo_pages.recent_revisions_page._fill_in_users_field(username)
+        self.wait_for_given_timeout(2000)
+
+        expect(
+            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
+                article_details['article_title']
+            )
+        ).to_be_hidden()
+
+        self.logger.info("Clearing the user search field")
+        self.sumo_pages.recent_revisions_page._clearing_the_user_field()
+
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+
+        self.logger.info("Signing back in with the admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.logger.info("Navigating to the article page and deleting it")
+        self.navigate_to_link(article_url)
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+        self.logger.info("Navigating back to the recent revisions page and verifying that the "
+                         "article is no longer displayed")
+
+        self.logger.info("Navigating to the recent revisions dashboard")
+        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+
+        self.logger.info("Verifying that the posted article is no longer displayed for admin "
+                         "accounts")
+        expect(
+            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
+                article_details['article_title']
+            )
+        ).to_be_hidden()
+
+    # C2266240
+    @pytest.mark.recentRevisionsDashboard
+    def test_second_revisions_availability(self):
+        self.logger.info("Signing back in with the admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.logger.info("Create a new simple article")
+        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        article_url = self.get_page_url()
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+
+        self.logger.info("Signing in with a non admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_13"]
+        ))
+
+        username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Creating a new revision for the article")
+        second_revision_id = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
+
+        self.logger.info("Navigating to the Recent Revisions dashboard and verifying that own "
+                         "revision is visible")
+        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+        expect(
+            self.sumo_pages.recent_revisions_page.
+            _get_recent_revision_based_on_article_title_and_user(
+                article_details['article_title'], username
+            )
+        ).to_be_visible()
+
+        self.logger.info("Deleting user session and verifying that the recent revision is "
+                         "displayed")
+        self.delete_cookies()
+        expect(
+            self.sumo_pages.recent_revisions_page.
+            _get_recent_revision_based_on_article_title_and_user(
+                article_details['article_title'], username
+            )
+        ).to_be_visible()
+
+        self.logger.info("Signing in with a different non-admin user and verifying that the "
+                         "revision is displayed")
+        self.username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+        )
+        expect(
+            self.sumo_pages.recent_revisions_page.
+            _get_recent_revision_based_on_article_title_and_user(
+                article_details['article_title'], username
+            )
+        ).to_be_visible()
+
+        self.logger.info("Signing in with an admin account and verifying that the revision is "
+                         "displayed")
+        self.delete_cookies()
+
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+        expect(
+            self.sumo_pages.recent_revisions_page.
+            _get_recent_revision_based_on_article_title_and_user(
+                article_details['article_title'], username
+            )
+        ).to_be_visible()
+
+        self.logger.info("Navigating to the article and approving the revision")
+        self.navigate_to_link(article_url)
+
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            second_revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+
+        expect(
+            self.page
+        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
+
+        self.logger.info("Signing out and verifying that the revision is displayed inside the "
+                         "Recent Revisions dashboard")
+        self.delete_cookies()
+        expect(
+            self.sumo_pages.recent_revisions_page.
+            _get_recent_revision_based_on_article_title_and_user(
+                article_details['article_title'], username
+            )
+        ).to_be_visible()
+
+        self.logger.info("Signing in with a different non-admin user account and verifying that "
+                         "the revision is visible")
+        self.username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+        )
+        expect(
+            self.sumo_pages.recent_revisions_page.
+            _get_recent_revision_based_on_article_title_and_user(
+                article_details['article_title'], username
+            )
+        ).to_be_visible()
+
+        self.logger.info("Signing back in with an admin account an deleting the article")
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+
+        self.logger.info("Signing back in with the admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.logger.info("Navigating to the article page and deleting it")
+        self.navigate_to_link(article_url)
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+
+        expect(
+            self.page
+        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
+
+        self.logger.info("Signing out and and verifying that the revision is no longer displayed "
+                         "inside the Recent Revisions dashboard")
+        self.delete_cookies()
+        expect(
+            self.sumo_pages.recent_revisions_page.
+            _get_recent_revision_based_on_article_title_and_user(
+                article_details['article_title'], username
+            )
+        ).to_be_hidden()
+
+        self.logger.info("Signing in with a different non-admin user account and verifying that "
+                         "the revision is not visible")
+        self.username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+        )
+        expect(
+            self.sumo_pages.recent_revisions_page.
+            _get_recent_revision_based_on_article_title_and_user(
+                article_details['article_title'], username
+            )
+        ).to_be_hidden()
+
+    # C2266240
+    @pytest.mark.recentRevisionsDashboard
+    def test_recent_revisions_dashboard_links(self):
+        self.logger.info("Signing back in with the admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+        first_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Create a new simple article")
+        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        self.sumo_pages.kb_article_page._click_on_article_option()
+        article_url = self.get_page_url()
+
+        self.logger.info("Clicking on the 'Show History' option")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        self.logger.info("Navigating to the recent revisions dashboard")
+        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+
+        expect(
+            self.page
+        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
+
+        self.logger.info("Verifying that the Show Diff option is not available for first revision")
+        expect(
+            self.sumo_pages.recent_revisions_page._get_show_diff_article_locator(
+                article_title=article_details['article_title'], creator=first_username
+            )
+        ).to_be_hidden()
+
+        self.navigate_to_link(article_url)
+
+        self.logger.info("Signing in with a different user non-admin user")
+        self.delete_cookies()
+
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_12"]
+        ))
+        username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Creating a new revision for the article")
+        second_revision_id = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
+
+        self.logger.info("Navigating to the Recent Revisions dashboard")
+        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+
+        expect(
+            self.page
+        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
+
+        self.logger.info("Signing out from SUMO")
+        self.delete_cookies()
+
+        self.logger.info("Clicking on the revision date link")
+        self.sumo_pages.recent_revisions_page._click_on_revision_date_for_article(
+            article_title=article_details['article_title'], username=username
+        )
+
+        self.logger.info("Verifying that the user is redirected to the correct page")
+        expect(
+            self.page
+        ).to_have_url(
+            article_url + KBArticleRevision.
+            KB_REVISION_PREVIEW + str(self.number_extraction_from_string(second_revision_id))
+        )
+
+        self.logger.info("Verifying that the revision id is the correct one")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_id_text(),
+            str(self.number_extraction_from_string(second_revision_id))
+        )
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Clicking on the revision title")
+        self.sumo_pages.recent_revisions_page._click_on_article_title(
+            article_title=article_details['article_title'], creator=username
+        )
+
+        self.logger.info("Verifying that the user is redirected to the article title")
+        expect(
+            self.page
+        ).to_have_url(article_url)
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Verifying that the correct comment is displayed")
+        check.equal(
+            self.sumo_pages.recent_revisions_page._get_revision_comment(
+                article_title=article_details['article_title'], username=username
+            ),
+            self.kb_article_test_data['changes_description']
+        )
+
+        self.logger.info("Clicking on the editor")
+        self.sumo_pages.recent_revisions_page._click_article_creator_link(
+            article_title=article_details['article_title'], creator=username
+        )
+
+        self.logger.info("Verifying that the user was redirected to the correct user page")
+        expect(
+            self.page
+        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username))
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Clicking on show diff option")
+        self.sumo_pages.recent_revisions_page._click_on_show_diff_for_article(
+            article_title=article_details['article_title'], creator=username
+        )
+
+        self.logger.info("Verifying that the diff section is displayed")
+        expect(
+            self.sumo_pages.recent_revisions_page._get_diff_section_locator()
+        ).to_be_visible()
+
+        self.logger.info("Hiding the diff")
+        self.sumo_pages.recent_revisions_page._click_on_hide_diff_for_article(
+            article_title=article_details['article_title'], creator=username
+        )
+
+        self.logger.info("Verifying that the diff section is not displayed")
+        expect(
+            self.sumo_pages.recent_revisions_page._get_diff_section_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Signing in with an admin account")
+        self.delete_cookies()
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.logger.info("Navigating back to the article page")
+        self.navigate_to_link(article_url)
+
+        self.logger.info("Clicking on the 'Show History' option")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the 'Delete' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+    # C2266240
+    @pytest.mark.recentRevisionsDashboard
+    def test_recent_revisions_dashboard_title_and_username_update(self):
+        self.logger.info("Signing back in with the admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+        first_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Create a new simple article")
+        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        self.sumo_pages.kb_article_page._click_on_article_option()
+        article_url = self.get_page_url()
+
+        self.logger.info("Clicking on the 'Show History' option")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        self.logger.info("Clicking on the 'Edit Article Metadata' option")
+        self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+
+        self.sumo_pages.kb_article_edit_article_metadata_page._add_text_to_title_field(
+            self.kb_article_test_data['updated_kb_article_title'] + article_details
+            ['article_title']
+        )
+
+        self.logger.info("Clicking on the 'Save' button")
+        self.sumo_pages.kb_article_edit_article_metadata_page._click_on_save_changes_button()
+
+        self.logger.info("Editing the username")
+        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+
+        new_username = self.profile_edit_test_data['valid_user_edit']['username']
+        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(
+            new_username
+        )
+
+        self.logger.info("Clicking on the 'Update My Profile' button")
+        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+
+        self.logger.info("Navigating to the recent revisions dashboard")
+        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+
+        expect(
+            self.page
+        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
+
+        expect(
+            self.sumo_pages.recent_revisions_page._get_revision_and_username_locator(
+                self.kb_article_test_data['updated_kb_article_title'] + article_details
+                ['article_title'],
+                new_username
+            )
+        ).to_be_visible()
+
+        self.logger.info("Editing the username back")
+        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+
+        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(
+            first_username
+        )
+
+        self.logger.info("Clicking on the 'Update My Profile' button")
+        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+
+        self.logger.info("Deleting the article")
+        self.navigate_to_link(article_url)
+
+        self.logger.info("Clicking on the 'Show History' option")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the 'Delete' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+    # C2266241
+    @pytest.mark.recentRevisionsDashboard
+    def test_recent_revisions_dashboard_filters(self):
+        start_date = "04052023"
+        end_date = "05012023"
+        self.logger.info("Navigating to the 'Recent Revisions' dashboard")
+        self.navigate_to_link(
+            self.general_test_data['dashboard_links']['recent_revisions']
+        )
+
+        self.logger.info("Selecting the ro locale from the locale filter")
+        self.sumo_pages.recent_revisions_page._select_locale_option("ro")
+
+        self.wait_for_given_timeout(3000)
+
+        self.logger.info("Verifying that all the displayed revisions are for the 'ro' locale")
+        for tag in self.sumo_pages.recent_revisions_page._get_list_of_all_locale_tage():
+            check.equal(
+                tag,
+                "ro"
+            )
+
+        self.logger.info("Select the US filter")
+        self.sumo_pages.recent_revisions_page._select_locale_option("en-US")
+
+        self.wait_for_given_timeout(3000)
+
+        self.logger.info("Typing a username inside the 'Users' filter")
+        username = self.username_extraction_from_email(
+            self.user_secrets_accounts['TEST_ACCOUNT_12']
+        )
+
+        self.sumo_pages.recent_revisions_page._fill_in_users_field(username)
+
+        self.wait_for_given_timeout(2000)
+
+        self.logger.info("Verifying that all the displayed revisions are for the posted user")
+        for user in self.sumo_pages.recent_revisions_page._get_list_of_all_editors():
+            check.equal(
+                user,
+                username
+            )
+
+        self.sumo_pages.recent_revisions_page._clearing_the_user_field()
+        self.wait_for_given_timeout(2000)
+
+        self.logger.info("Adding date inside the start field")
+        self.sumo_pages.recent_revisions_page._add_start_date("04052023")
+
+        self.logger.info("Adding date inside the end field")
+        self.sumo_pages.recent_revisions_page._add_end_date("05012023")
+
+        self.wait_for_given_timeout(2000)
+
+        self.logger.info("Verifying that the displayed revision dates are between (inclusive) "
+                         "the set start and end date filters")
+        extracted_date = []
+        date_filters = [int(start_date), int(end_date)]
+        for date in self.sumo_pages.recent_revisions_page._get_all_revision_dates():
+            extracted_date.append(self.extract_date_to_digit_format(
+                self.extract_month_day_year_from_string(date)
+            ))
+
+        for date in extracted_date:
+            check.between_equal(
+                date,
+                date_filters[0],
+                date_filters[1]
+            )

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
@@ -1,0 +1,1043 @@
+import pytest_check as check
+import pytest
+from playwright_tests.core.testutilities import TestUtilities
+from playwright.sync_api import expect
+
+from playwright_tests.messages.ask_a_question_messages.AAQ_messages.question_page_messages import \
+    QuestionPageMessages
+from playwright_tests.messages.auth_pages_messages.fxa_page_messages import FxAPageMessages
+from playwright_tests.messages.explore_help_articles.kb_article_page_messages import (
+    KBArticlePageMessages)
+from playwright_tests.messages.explore_help_articles.kb_article_revision_page_messages import (
+    KBArticleRevision)
+from playwright_tests.messages.explore_help_articles.kb_article_show_history_page_messages import \
+    KBArticleShowHistoryPageMessages
+from playwright_tests.messages.my_profile_pages_messages.my_profile_page_messages import (
+    MyProfileMessages)
+
+
+class TestKBArticleShowHistory(TestUtilities, KBArticleShowHistoryPageMessages):
+
+    # C891309, C2102170,  C2102168, C2489545
+    @pytest.mark.kbArticleShowHistory
+    def test_kb_article_removal(self):
+        self.logger.info("Signing in with a normal account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_12"]
+        ))
+
+        self.logger.info("Create a new simple article")
+        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        self.logger.info("Fetching the revision id")
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        revision_id_number = self.number_extraction_from_string(revision_id)
+
+        self.logger.info("Verifying that the delete button is not available for the only revision")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
+                revision_id
+            )
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that manually navigating to the delete revision endpoint "
+                         "returns 403")
+        with self.page.expect_navigation() as navigation_info:
+            self.navigate_to_link(super().get_delete_revision_endpoint(
+                article_details["article_slug"], revision_id_number
+            ))
+            response = navigation_info.value
+            check.equal(
+                response.status,
+                403
+            )
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Verifying that the delete button for the article is not displayed")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that manually navigating to the delete endpoint returns 403")
+        with self.page.expect_navigation() as navigation_info:
+            self.navigate_to_link(
+                KBArticlePageMessages
+                .KB_ARTICLE_PAGE_URL + article_details['article_slug'] + QuestionPageMessages
+                .DELETE_QUESTION_URL_ENDPOINT
+            )
+            response = navigation_info.value
+            check.equal(
+                response.status,
+                403
+            )
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Delete user session")
+        self.delete_cookies()
+
+        self.logger.info("Manually navigating to the delete revision endpoint and verifying that "
+                         "the auth page is returned")
+        self.navigate_to_link(super().get_delete_revision_endpoint(
+            article_details["article_slug"], revision_id_number
+        ))
+
+        check.is_true(
+            FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
+        )
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Verifying that manually navigating to the delete endpoint returns the "
+                         "auth page")
+        self.navigate_to_link(
+            KBArticlePageMessages
+            .KB_ARTICLE_PAGE_URL + article_details['article_slug'] + QuestionPageMessages
+            .DELETE_QUESTION_URL_ENDPOINT
+        )
+
+        check.is_true(
+            FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
+        )
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Verifying that the delete button is not available for the only revision")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
+                revision_id
+            )
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that the delete button for the article is not displayed")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Signing in with a admin user account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.logger.info("Clicking on the delete revision button for the only available revision")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(revision_id)
+
+        self.logger.info("Verifying that the correct 'Unable to delete the revision' page header")
+        check.equal(
+            self.sumo_pages.kb_article_show_history_page._get_unable_to_delete_revision_header(),
+            KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER
+        )
+
+        self.logger.info("Verifying that the correct 'Unable to delete the revision' page "
+                         "subheader")
+        check.equal(
+            self.sumo_pages.kb_article_show_history_page.
+            _get_unable_to_delete_revision_subheader(),
+            KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_SUBHEADER
+        )
+
+        self.logger.info("Clicking on the 'Go back to document history button'")
+        self.sumo_pages.kb_article_show_history_page._click_go_back_to_document_history_option()
+
+        self.logger.info("Verifying that we are redirected to the document history page")
+        expect(
+            self.page
+        ).to_have_url(
+            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
+            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
+        )
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the cancel button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_cancel_button()
+
+        self.logger.info("Verifying that we are back on the show history page for the article")
+        expect(
+            self.page
+        ).to_have_url(
+            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
+            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
+        )
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the 'Delete' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+        self.logger.info("Verifying that the article was successfully deleted by navigating to "
+                         "the article")
+
+        with self.page.expect_navigation() as navigation_info:
+            self.navigate_to_link(
+                KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details['article_slug'] + "/"
+            )
+        response = navigation_info.value
+        check.equal(
+            response.status,
+            404
+        )
+
+    # C2490047, C2490048
+    @pytest.mark.kbArticleShowHistory
+    def test_kb_article_category_link_and_header(self):
+        self.logger.info("Signing in with an admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        for category in self.general_test_data["kb_article_categories"]:
+
+            if category != "Templates":
+                self.logger.info("Create a new article")
+                article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                    article_category=category
+                )
+            else:
+                self.logger.info("Create a new article")
+                article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                    article_category=category,
+                    is_template=True
+                )
+
+            self.logger.info("Verifying that the correct page header is displayed")
+            check.equal(
+                self.sumo_pages.kb_article_show_history_page._get_show_history_page_title(),
+                KBArticleShowHistoryPageMessages.PAGE_TITLE + article_details["article_title"]
+            )
+
+            self.logger.info("Verifying that the correct category is displayed inside the 'Show "
+                             "History' page")
+            check.equal(
+                self.sumo_pages.kb_article_show_history_page._get_show_history_category_text(),
+                category
+            )
+
+            self.logger.info("Verifying that the correct revision history for locale is displayed")
+            check.equal(
+                self.sumo_pages.kb_article_show_history_page.
+                _get_show_history_revision_for_locale_text(),
+                KBArticleShowHistoryPageMessages.DEFAULT_REVISION_FOR_LOCALE
+            )
+
+            self.logger.info("Clicking on the 'Category' link")
+            self.sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+
+            self.logger.info("Verifying that the user is redirected to the correct page")
+            expect(
+                self.page
+            ).to_have_url(self.different_endpoints['kb_categories_links'][category])
+
+            self.logger.info("Navigating back")
+            self.navigate_back()
+
+            self.logger.info("Clicking on the 'Show History' option")
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+            self.logger.info("Clicking on the 'Delete article' button")
+            self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+            self.logger.info("Clicking on the 'Delete' button")
+            self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+    # C2101637, C2489543, C2102169
+    @pytest.mark.kbArticleShowHistory
+    def test_kb_article_contributor_removal(self):
+        self.logger.info("Signing in with an admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Create a new simple article")
+        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        self.logger.info("Verifying that no users are added inside the contributors list")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_all_contributors_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Clicking on the Article menu option")
+        self.sumo_pages.kb_article_page._click_on_article_option()
+
+        self.logger.info("Verifying that the user is not displayed inside the article "
+                         "contributors section")
+        check.is_not_in(
+            username_one,
+            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        )
+
+        self.logger.info("Navigating back to the 'Show History page'")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        self.logger.info("Verifying that the username which created the revision is added inside "
+                         "the 'Contributors' list")
+        check.is_in(
+            username_one,
+            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors(),
+        )
+
+        self.logger.info("Fetching the contributor id")
+        self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+        (self.sumo_pages.kb_article_show_history_page.
+         _click_on_delete_button_for_a_particular_contributor(username_one))
+        deletion_link = self.get_page_url()
+
+        self.logger.info("Navigating back by hitting the cancel button")
+        (self.sumo_pages.kb_article_show_history_page.
+         _click_on_delete_contributor_confirmation_page_cancel_button())
+
+        self.logger.info("Clicking on the Article menu option")
+        self.sumo_pages.kb_article_page._click_on_article_option()
+
+        self.logger.info("Verifying that the user is displayed inside the article "
+                         "contributors section")
+        check.is_in(
+            username_one,
+            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        )
+
+        self.logger.info("Navigating back to the 'Show History page'")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+
+        self.logger.info("Signing in with a non-Admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_12"]
+        ))
+
+        username_two = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Creating a new revision for the document")
+        self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
+
+        self.logger.info("Verifying that the 'Edit Contributors' option is not displayed for "
+                         "users which don't have the necessary permissions")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_edit_contributors_option_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Manually navigating to the deletion link and verifying that 403 is "
+                         "returned")
+
+        with self.page.expect_navigation() as navigation_info:
+            self.navigate_to_link(
+                deletion_link
+            )
+        response = navigation_info.value
+        check.equal(
+            response.status,
+            403
+        )
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Clicking on the Article menu option")
+        self.sumo_pages.kb_article_page._click_on_article_option()
+
+        self.logger.info("Verifying that the user is not displayed inside the article "
+                         "contributors section")
+        check.is_not_in(
+            username_two,
+            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        )
+
+        self.logger.info("Navigating back to the 'Show History page'")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+
+        self.logger.info("Verifying that the 'Edit Contributors' option is not displayed for "
+                         "signed out users")
+        expect(
+            self.sumo_pages.kb_article_show_history_page._get_edit_contributors_option_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Manually navigating to the deletion link and the user is redirected to "
+                         "the auth page")
+
+        self.navigate_to_link(deletion_link)
+        check.is_true(
+            FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
+        )
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Signing in with a normal account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.logger.info("Verifying that the username two is not displayed inside the "
+                         "Contributors list")
+        check.is_not_in(
+            username_two,
+            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors()
+        )
+
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        self.logger.info("Verifying that second username is displayed inside the 'Contributors' "
+                         "list")
+        check.is_in(
+            username_two,
+            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors()
+        )
+
+        self.logger.info("Clicking on the Article menu option")
+        self.sumo_pages.kb_article_page._click_on_article_option()
+
+        self.logger.info("Verifying that the user is displayed inside the article "
+                         "contributors section")
+        check.is_in(
+            username_one,
+            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        )
+
+        self.logger.info("Navigating back to the 'Show History page'")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Clicking on the 'Edit contributors' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+
+        self.logger.info("Clicking on the delete button for user two")
+        (self.sumo_pages.kb_article_show_history_page.
+         _click_on_delete_button_for_a_particular_contributor(username_two))
+
+        self.logger.info("Verifying that the correct delete contributor page header is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_show_history_page.
+            _get_delete_contributor_confirmation_page_header(),
+            self.get_remove_contributor_page_header(username_two)
+        )
+
+        self.logger.info("Clicking on the 'Cancel' button")
+        (self.sumo_pages.kb_article_show_history_page.
+         _click_on_delete_contributor_confirmation_page_cancel_button())
+
+        self.logger.info("Verifying that second username is displayed inside the 'Contributors' "
+                         "list")
+        check.is_in(
+            username_two,
+            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors()
+        )
+
+        self.logger.info("Clicking on the Article menu option")
+        self.sumo_pages.kb_article_page._click_on_article_option()
+
+        self.logger.info("Verifying that the user is displayed inside the article "
+                         "contributors section")
+        check.is_in(
+            username_one,
+            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        )
+
+        self.logger.info("Navigating back to the 'Show History page'")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Clicking on the 'Edit contributors' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+
+        self.logger.info("Clicking on the delete button for user two")
+        (self.sumo_pages.kb_article_show_history_page.
+         _click_on_delete_button_for_a_particular_contributor(username_two))
+
+        self.logger.info("Clicking on the 'Remove contributor' button")
+        (self.sumo_pages.kb_article_show_history_page.
+         _click_on_delete_contributor_confirmation_page_confirm_button())
+
+        self.logger.info("Verifying that the correct banner is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_show_history_page._get_show_history_page_banner(),
+            super().get_contributor_removed_message(username_two)
+        )
+
+        self.logger.info("Verifying that second username is not displayed inside the "
+                         "'Contributors' list")
+        check.is_not_in(
+            username_two,
+            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors()
+        )
+
+        self.logger.info("Clicking on the Article menu option")
+        self.sumo_pages.kb_article_page._click_on_article_option()
+
+        self.logger.info("Verifying that the user is not displayed inside the article "
+                         "contributors section")
+        check.is_not_in(
+            username_two,
+            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        )
+
+        self.logger.info("Navigating back to the 'Show History page'")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the 'Delete' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+    # C2101638
+    @pytest.mark.kbArticleShowHistory
+    def test_contributors_can_be_manually_added(self):
+        self.logger.info("Signing in with an admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Create a new simple article")
+        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        self.logger.info("Clicking on the 'Edit contributors' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+
+        new_contributor = super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_12"]
+        )
+
+        self.logger.info("Adding and selecting the username from the search field")
+        (self.sumo_pages.kb_article_show_history_page.
+         _add_a_new_contributor_inside_the_contributor_field(new_contributor))
+
+        (self.sumo_pages.kb_article_show_history_page.
+         _click_on_new_contributor_search_result(new_contributor))
+
+        self.logger.info("Clicking on the 'Add Contributor' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_add_contributor_button()
+
+        self.logger.info("Verifying that the correct banner is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_show_history_page._get_show_history_page_banner(),
+            super().get_contributor_added_message(new_contributor)
+        )
+
+        self.logger.info("Verifying that the user was successfully added inside the contributors "
+                         "list")
+        check.is_in(
+            new_contributor,
+            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors(),
+        )
+
+        self.logger.info("Clicking on the Article menu option")
+        self.sumo_pages.kb_article_page._click_on_article_option()
+
+        self.logger.info("Verifying that the user is displayed inside the article "
+                         "contributors section")
+        check.is_in(
+            new_contributor,
+            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        )
+
+        self.logger.info("Navigating back to the 'Show History page'")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the 'Delete' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+    # C2101634, C2489553
+    @pytest.mark.kbArticleShowHistory
+    def test_kb_article_contributor_profile_access(self):
+        self.logger.info("Signing in with an admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Create a new simple article")
+        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        self.sumo_pages.kb_article_page._click_on_article_option()
+        article_url = self.get_page_url()
+
+        self.logger.info("Clicking on the 'Show History' option")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+
+        self.logger.info("Signing in with a non-Admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_12"]
+        ))
+
+        username_two = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+
+        self.logger.info("Creating a new revision for the document")
+        self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
+
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+
+        self.logger.info("Signing in with a normal account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+
+        self.logger.info("Clicking on the second contributor and verifying that we are "
+                         "redirected to it's profile page")
+        (self.sumo_pages.kb_article_show_history_page._click_on_a_particular_contributor
+         (username_two)
+         )
+
+        expect(
+            self.page
+        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Clicking on the revision editor")
+        self.sumo_pages.kb_article_show_history_page._click_on_a_particular_revision_editor(
+            revision_id, username_two
+        )
+
+        self.logger.info("Verifying that we are redirected to the editor homepage")
+        expect(
+            self.page
+        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Navigating to the article main menu")
+        self.navigate_to_link(
+            article_url
+        )
+
+        self.logger.info("Clicking on the contributor listed inside the article page")
+        self.sumo_pages.kb_article_page._click_on_a_particular_article_contributor(username_two)
+
+        self.logger.info("Verifying that we are redirected to the editor homepage")
+        expect(
+            self.page
+        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Signing in with an admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.logger.info("Clicking on the Article menu option")
+        self.sumo_pages.kb_article_page._click_on_article_option()
+
+        self.logger.info("Clicking on the contributor listed inside the article page")
+        self.sumo_pages.kb_article_page._click_on_a_particular_article_contributor(username_two)
+
+        self.logger.info("Verifying that we are redirected to the editor homepage")
+        expect(
+            self.page
+        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Navigating to the show history page")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Clicking on the second contributor and verifying that we are "
+                         "redirected to it's profile page")
+        (self.sumo_pages.kb_article_show_history_page._click_on_a_particular_contributor
+         (username_two)
+         )
+
+        expect(
+            self.page
+        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Clicking on the revision editor")
+        self.sumo_pages.kb_article_show_history_page._click_on_a_particular_revision_editor(
+            revision_id, username_two
+        )
+
+        self.logger.info("Verifying that we are redirected to the editor homepage")
+        expect(
+            self.page
+        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the 'Delete' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+
+    # C2499415
+    @pytest.mark.kbArticleShowHistory
+    def test_kb_article_revision_date_functionality(self):
+        self.logger.info("Signing in with an admin account")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+        main_user = super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        )
+
+        self.logger.info("Create a new simple article")
+        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        self.sumo_pages.kb_article_page._click_on_article_option()
+        article_url = self.get_page_url()
+
+        self.logger.info("Clicking on the 'Show History' option")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        self.logger.info("Delete user session")
+        self.delete_cookies()
+
+        self.logger.info("Signing in with a non-admin account")
+        creator_username = self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts['TEST_ACCOUNT_12']
+        ))
+
+        self.logger.info("Submitting a new revision")
+        second_revision_id = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
+
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+        revision_time = self.sumo_pages.kb_article_show_history_page._get_revision_time(
+            second_revision_id
+        )
+
+        self.logger.info("Clicking on the first revision")
+        self.sumo_pages.kb_article_show_history_page._click_on_a_revision_date(revision_id)
+
+        self.logger.info("Verifying that the correct 'Is current revision?' text is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_is_current_revision_text(),
+            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
+        )
+
+        self.logger.info("Navigating back")
+        self.navigate_back()
+
+        self.logger.info("Clicking on the revision time")
+        self.sumo_pages.kb_article_show_history_page._click_on_a_revision_date(second_revision_id)
+
+        self.logger.info("Verifying that the revision information content is expanded by default")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_revision_information_content_locator()
+        ).to_be_visible()
+
+        self.logger.info("Clicking on the 'Revision Information' foldout section")
+        (self.sumo_pages.kb_article_preview_revision_page.
+         _click_on_revision_information_foldout_section())
+
+        self.logger.info("Verifying that the revision information content is collapsed/no longer "
+                         "displayed")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_revision_information_content_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Clicking on the 'Revision Information' foldout section")
+        (self.sumo_pages.kb_article_preview_revision_page.
+         _click_on_revision_information_foldout_section())
+
+        self.logger.info("Verifying that the revision information content is displayed")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_revision_information_content_locator()
+        ).to_be_visible()
+
+        self.logger.info("Verifying that the preview revision page contains the correct info "
+                         "inside the 'revision information' section")
+
+        self.logger.info("Verifying that the revision id is the correct one")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_id_text(),
+            str(self.number_extraction_from_string(second_revision_id))
+        )
+
+        self.logger.info("Verifying that the correct revision time is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_preview_revision_created_date_text(),
+            revision_time
+        )
+
+        self.logger.info("Verifying that the correct creator is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_creator_text(),
+            creator_username
+        )
+
+        self.logger.info("Clicking on the creator link and verifying that we are redirected to "
+                         "the username page")
+        self.sumo_pages.kb_article_preview_revision_page._click_on_creator_link()
+
+        expect(
+            self.page
+        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(creator_username))
+
+        self.logger.info("Navigating back to the revision preview page")
+        self.navigate_back()
+
+        self.logger.info("Verifying that the correct review comment is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_comment_text(),
+            self.kb_article_test_data['changes_description']
+        )
+
+        self.logger.info("Verifying that the correct reviewed status is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_reviewed_text(),
+            KBArticleRevision.KB_ARTICLE_REVISION_NO_STATUS
+        )
+
+        self.logger.info("Verifying that the reviewed by locator is hidden")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page._get_reviewed_by_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that the is approved locator is hidden")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page._get_is_approved_text_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that the is current revision locator is hidden")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page._is_current_revision_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that the correct ready for localization locator is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_preview_revision_ready_for_localization_text(),
+            KBArticleRevision.KB_ARTICLE_REVISION_NO_STATUS
+        )
+
+        self.logger.info("Verifying that the readied for localization by is hidden")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page._readied_for_localization_by_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that the 'Edit article based on this revision' is not "
+                         "displayed")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_edit_article_based_on_this_revision_link_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Verifying that the 'Revision Source' section is hidden by default")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_preview_revision_source_textarea_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Clicking on the 'Revision Source' foldout section option")
+        (self.sumo_pages.kb_article_preview_revision_page.
+         _click_on_revision_source_foldout_section())
+
+        self.logger.info("Verifying that the 'Revision Source' textarea contains the correct "
+                         "details")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_preview_revision_source_textarea_content(),
+            self.kb_article_test_data['updated_article_content']
+        )
+
+        self.logger.info("Verifying that the 'Revision Content' section is hidden by default")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page._get_revision_content_html_locator()
+        ).to_be_hidden()
+
+        self.logger.info("Clicking on the 'Revision Content' foldout option")
+        (self.sumo_pages.kb_article_preview_revision_page.
+         _click_on_revision_content_foldout_section())
+
+        self.logger.info("Verifying that the 'Revision Content' section is visible")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page._get_revision_content_html_locator()
+        ).to_be_visible()
+
+        self.logger.info("Signing in with an admin account and approving the revision")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Clicking on the 'Review' option")
+        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+            second_revision_id
+        )
+
+        self.logger.info("Click on 'Approve Revision' button")
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+
+        self.logger.info("Clicking on the 'Ready for Localization' checkbox")
+        self.sumo_pages.kb_article_review_revision_page._check_ready_for_localization_checkbox()
+
+        self.logger.info("Clicking on the 'Accept' button")
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        self.logger.info("Deleting user session")
+        self.delete_cookies()
+
+        self.logger.info("Clicking on the revision time")
+        self.sumo_pages.kb_article_show_history_page._click_on_a_revision_date(second_revision_id)
+
+        self.logger.info("Verifying that the correct reviewed status is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_reviewed_text(),
+            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
+        )
+
+        self.logger.info("Verifying that the reviewed by date is displayed")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_preview_revision_reviewed_date_locator()
+        ).to_be_visible()
+
+        self.logger.info("Verifying that the correct 'Reviewed by' text is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_reviewed_by_text(),
+            main_user
+        )
+
+        self.logger.info("Verifying that the correct is approved status displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_is_approved_text(),
+            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
+        )
+
+        self.logger.info("Verifying that the correct is current revision status displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._get_is_current_revision_text(),
+            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
+        )
+
+        self.logger.info("Verifying that the correct is ready for localization status displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page.
+            _get_preview_revision_ready_for_localization_text(),
+            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
+        )
+
+        self.logger.info("Verifying that the 'Readied for localization' date is displayed")
+        expect(
+            self.sumo_pages.kb_article_preview_revision_page._ready_for_localization_date()
+        ).to_be_visible()
+
+        self.logger.info("Verifying that the correct localization by text is displayed")
+        check.equal(
+            self.sumo_pages.kb_article_preview_revision_page._readied_for_localization_by_text(),
+            main_user
+        )
+
+        self.logger.info("Signing in with an admin account and deleting the article")
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.logger.info("Clicking on the 'Edit article based on this revision option'")
+        (self.sumo_pages.kb_article_preview_revision_page.
+         _click_on_edit_article_based_on_this_revision_link())
+
+        self.logger.info("Verifying that the correct link is displayed")
+        expect(
+            self.page
+        ).to_have_url(
+            article_url + QuestionPageMessages.EDIT_QUESTION_URL_ENDPOINT + "/" + str(
+                self.number_extraction_from_string(second_revision_id))
+        )
+
+        self.logger.info("Clicking on the 'Show History' option")
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+
+        self.logger.info("Clicking on the 'Delete article' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+
+        self.logger.info("Clicking on the 'Delete' button")
+        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
@@ -1282,9 +1282,9 @@ class TestArticleThreads(TestUtilities):
                 revision_id
             )
 
-            self.sumo_pages.kb_article_revision_page._click_on_approve_revision_button()
+            self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
 
-            self.sumo_pages.kb_article_revision_page._click_accept_revision_accept_button()
+            self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
 
         return kb_article_url
 
@@ -1312,9 +1312,9 @@ class TestArticleThreads(TestUtilities):
             revision_id
         )
 
-        self.sumo_pages.kb_article_revision_page._click_on_approve_revision_button()
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
 
-        self.sumo_pages.kb_article_revision_page._click_accept_revision_accept_button()
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
 
     # Will perform a cleanup by deleting the test article at the end.
     # Need be executed after all other methods from this test class in th GH workflow file.

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
@@ -92,9 +92,6 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         self.logger.info("Create a new simple article")
         article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with an Admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -110,13 +107,13 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
 
         self.logger.info("Verifying that the correct revision header is displayed")
         check.equal(
-            self.sumo_pages.kb_article_revision_page._get_revision_header(),
+            self.sumo_pages.kb_article_review_revision_page._get_revision_header(),
             KBArticleRevision.KB_ARTICLE_REVISION_HEADER + article_details['article_title'],
         )
 
         self.logger.info("Verifying that the correct subtext is displayed")
         check.equal(
-            self.sumo_pages.kb_article_revision_page._get_reviewing_revision_text()
+            self.sumo_pages.kb_article_review_revision_page._get_reviewing_revision_text()
             .replace("\n", "").strip(),
             self.get_kb_article_revision_details(
                 revision_id=re.findall(r'\d+', revision_id)[0],
@@ -127,7 +124,7 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
 
         self.logger.info("Click on the 'Back to History' option and verifying that the user is "
                          "redirected to the article history page")
-        self.sumo_pages.kb_article_revision_page._click_on_back_to_history_option()
+        self.sumo_pages.kb_article_review_revision_page._click_on_back_to_history_option()
         expect(
             self.page
         ).to_have_url(
@@ -140,54 +137,55 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
 
         self.logger.info("Verifying that the 'Keywords:' header is displayed")
         check.is_true(
-            self.sumo_pages.kb_article_revision_page._is_keywords_header_visible()
+            self.sumo_pages.kb_article_review_revision_page._is_keywords_header_visible()
         )
 
         self.logger.info("Verifying that the correct keyword is displayed")
         check.equal(
-            self.sumo_pages.kb_article_revision_page._get_keywords_content(),
+            self.sumo_pages.kb_article_review_revision_page._get_keywords_content(),
             article_details['keyword']
         )
 
         self.logger.info("Verifying that the 'Search results summary:' header is displayed")
         check.is_true(
-            self.sumo_pages.kb_article_revision_page._is_search_results_summary_visible()
+            self.sumo_pages.kb_article_review_revision_page._is_search_results_summary_visible()
         )
 
         self.logger.info("Verifying that the correct search result summary is displayed")
         check.equal(
-            self.sumo_pages.kb_article_revision_page._get_search_results_summary_content(),
+            self.sumo_pages.kb_article_review_revision_page._get_search_results_summary_content(),
             article_details['search_results_summary']
         )
 
         self.logger.info("Verifying that the 'Revision source:' header is displayed")
         check.is_true(
-            self.sumo_pages.kb_article_revision_page._is_revision_source_visible()
+            self.sumo_pages.kb_article_review_revision_page._is_revision_source_visible()
         )
 
         self.logger.info("Verifying that the correct revision source content is displayed")
         check.equal(
-            self.sumo_pages.kb_article_revision_page._revision_source_content(),
+            self.sumo_pages.kb_article_review_revision_page._revision_source_content(),
             article_details['article_content']
         )
 
         self.logger.info("Verifying that the 'Revision rendered html:' header is displayed")
         check.is_true(
-            self.sumo_pages.kb_article_revision_page._is_revision_rendered_html_header_visible()
+            self.sumo_pages.kb_article_review_revision_page.
+            _is_revision_rendered_html_header_visible()
         )
 
         self.logger.info("Verifying that the correct 'Revision rendered html:' content is "
                          "displayed")
         check.equal(
-            self.sumo_pages.kb_article_revision_page._get_revision_rendered_html_content(),
+            self.sumo_pages.kb_article_review_revision_page._get_revision_rendered_html_content(),
             article_details['article_content_html']
         )
 
         self.logger.info("Click on 'Approve Revision' button")
-        self.sumo_pages.kb_article_revision_page._click_on_approve_revision_button()
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
 
         self.logger.info("Clicking on the 'Accept' button")
-        self.sumo_pages.kb_article_revision_page._click_accept_revision_accept_button()
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
 
         self.logger.info("Verifying that the review status updates to 'Current'")
         check.equal(
@@ -224,9 +222,6 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
             self.sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(),
             article_details['article_content_html']
         )
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with an admin account and deleting the article")
         self.start_existing_session(super().username_extraction_from_email(
@@ -281,9 +276,6 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
             self.page
         ).to_have_url(article_url)
 
-        self.logger.info("Deleting session cookies")
-        self.delete_cookies()
-
         self.logger.info("Signing in with an Admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -298,17 +290,17 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         )
 
         self.logger.info("Click on 'Approve Revision' button")
-        self.sumo_pages.kb_article_revision_page._click_on_approve_revision_button()
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
 
         self.logger.info("Clicking on the 'Accept' button")
-        self.sumo_pages.kb_article_revision_page._click_accept_revision_accept_button()
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
 
         self.logger.info("Navigating to the article page")
         self.navigate_to_link(article_url)
 
-        self.wait_for_url_to_be(
-            article_url
-        )
+        expect(
+            self.page
+        ).to_have_url(article_url)
 
         self.logger.info("Deleting user session")
         self.delete_cookies()
@@ -365,9 +357,6 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
             )
         ).to_be_visible()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -418,9 +407,6 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
             self.page
         ).to_have_url(article_url)
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -434,10 +420,10 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         )
 
         self.logger.info("Click on 'Approve Revision' button")
-        self.sumo_pages.kb_article_revision_page._click_on_approve_revision_button()
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
 
         self.logger.info("Clicking on the 'Accept' button")
-        self.sumo_pages.kb_article_revision_page._click_accept_revision_accept_button()
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
 
         self.logger.info("Navigating back to the article page")
         self.navigate_to_link(article_url)
@@ -495,6 +481,7 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
+
         self.sumo_pages.kb_article_page._click_on_show_history_option()
         self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
         self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
@@ -760,10 +747,10 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         )
 
         self.logger.info("Click on 'Approve Revision' button")
-        self.sumo_pages.kb_article_revision_page._click_on_approve_revision_button()
+        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
 
         self.logger.info("Clicking on the 'Accept' button")
-        self.sumo_pages.kb_article_revision_page._click_accept_revision_accept_button()
+        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
 
         self.logger.info("Clicking on the top navbar sumo nav logo")
         self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
@@ -772,8 +759,6 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         self.wait_for_given_timeout(65000)
 
         if username == 'simple_user':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_12"]
             ))
@@ -841,111 +826,3 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         self.sumo_pages.kb_article_page._click_on_show_history_option()
         self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
         self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
-
-    # C891309
-    @pytest.mark.kbArticleCreationAndAccess
-    def test_kb_article_removal(self):
-        self.logger.info("Signing in with a normal account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
-
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.logger.info("Fetching the revision id")
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
-
-        self.logger.info("Verifying that the delete button is not available for the only revision")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
-                revision_id
-            )
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the delete button for the article is not displayed")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Delete user session")
-        self.logger.info("Verifying that the delete button is not available for the only revision")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
-                revision_id
-            )
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the delete button for the article is not displayed")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the delete revision button for the only available revision")
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(revision_id)
-
-        self.logger.info("Verifying that the correct 'Unable to delete the revision' page header")
-        check.equal(
-            self.sumo_pages.kb_article_show_history_page._get_unable_to_delete_revision_header(),
-            KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER
-        )
-
-        self.logger.info("Verifying that the correct 'Unable to delete the revision' page "
-                         "subheader")
-        check.equal(
-            self.sumo_pages.kb_article_show_history_page.
-            _get_unable_to_delete_revision_subheader(),
-            KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_SUBHEADER
-        )
-
-        self.logger.info("Clicking on the 'Go back to document history button'")
-        self.sumo_pages.kb_article_show_history_page._click_go_back_to_document_history_option()
-
-        self.logger.info("Verifying that we are redirected to the document history page")
-        expect(
-            self.page
-        ).to_have_url(
-            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
-            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the 'Delete article' button")
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-
-        self.logger.info("Clicking on the cancel button")
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_cancel_button()
-
-        self.logger.info("Verifying that we are back on the show history page for the article")
-        expect(
-            self.page
-        ).to_have_url(
-            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
-            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the 'Delete article' button")
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-
-        self.logger.info("Clicking on the 'Delete' button")
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
-
-        self.logger.info("Verifying that the article was successfully deleted by navigating to "
-                         "the article")
-
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details['article_slug'] + "/"
-            )
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            404
-        )


### PR DESCRIPTION
- Expanding Show History playwright coverage.
- Expanding playwright coverage over KB article revision page.
- Expanding playwright coverage over KB contributors.
- Expanding playwright coverage over the Recent Revisions dashboard.
- Updating the GH workflow file to include the newly added tests in our runs.
- Cleaning up the code a bit and improving the user session deletion & creation mechanism.