### PR TITLE
Playwright code cleanup (removing explicit cookies deletion where unnecessarry)

### DIFF
--- a/playwright_tests/core/testutilities.py
+++ b/playwright_tests/core/testutilities.py
@@ -15,6 +15,12 @@ from requests.exceptions import HTTPError
 
 @pytest.mark.usefixtures("setup")
 class TestUtilities:
+    logger = None
+    page = None
+    context = None
+    sumo_pages = None
+    requested_browser = None
+
     # Fetching test data from json files.
     with open("test_data/profile_edit.json", "r") as edit_test_data_file:
         profile_edit_test_data = json.load(edit_test_data_file)

--- a/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
+++ b/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
@@ -157,8 +157,8 @@ class QuestionPage(BasePage):
         xpath = f"//ol[@id='breadcrumbs']/li[text()='{question_title}']"
         return super()._get_element_locator(xpath)
 
-    def _click_on_breadcrumb_locator(self, element: Locator):
-        super()._click(element)
+    def _click_on_breadcrumb(self, breadcrumb_xpath: str):
+        super()._click(breadcrumb_xpath)
 
     # Get email updates actions.
     def _get_email_updates_option(self) -> Locator:
@@ -273,8 +273,8 @@ class QuestionPage(BasePage):
         return super()._get_text_of_elements(self.__question_tags_options)
 
     def _get_remove_tag_button_locator(self, tag_name: str) -> Locator:
-        xpath = xpath = (f"//ul[@class='tag-list cf']//a[text()='{tag_name}']/following-sibling"
-                         f"::button[@class='remover']")
+        xpath = (f"//ul[@class='tag-list cf']//a[text()='{tag_name}']/following-sibling::button["
+                 f"@class='remover']")
         return super()._get_element_locator(xpath)
 
     def _add_text_to_add_a_tag_input_field(self, text: str):
@@ -421,7 +421,7 @@ class QuestionPage(BasePage):
         xpath = f"//div[@id='{reply_id}']//div[@class='content']/em/p"
         return super()._get_text_of_element(xpath)
 
-    def _click_posted_reply_said_link(self, reply_id: str) -> str:
+    def _click_posted_reply_said_link(self, reply_id: str):
         xpath = f"//div[@id='{reply_id}']//div[@class='content']//a"
         super()._click(xpath)
 

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_page.py
@@ -51,7 +51,8 @@ class EditKBArticlePage(BasePage):
         super()._fill(self.__edit_article_content_textarea_field, text)
 
     def _get_edit_article_expiry_date_value(self) -> str:
-        return super()._get_element_attribute_value(self.__edit_article_expiry_date_field)
+        return super()._get_element_attribute_value(self.__edit_article_expiry_date_field,
+                                                    "value")
 
     def _fill_edit_article_expiry_date(self, text: str):
         super()._type(self.__edit_article_expiry_date_field, text, 0)

--- a/playwright_tests/pages/explore_help_articles/product_support_page.py
+++ b/playwright_tests/pages/explore_help_articles/product_support_page.py
@@ -31,9 +31,9 @@ class ProductSupportPage(BasePage):
     # Join our community section locators.
     __join_our_community_section_header = ("//div[@class='card card--callout is-full-width "
                                            "has-moz-headings']//h3[@class='card--title']")
-    __join_our_community_section_paragrah_and_learn_more_option = ("//div[@class='card "
-                                                                   "card--callout is-full-width "
-                                                                   "has-moz-headings']//p")
+    __join_our_community_section_paragraph_and_learn_more_option = ("//div[@class='card "
+                                                                    "card--callout is-full-width "
+                                                                    "has-moz-headings']//p")
 
     def __init__(self, page: Page):
         super().__init__(page)
@@ -97,10 +97,10 @@ class ProductSupportPage(BasePage):
 
     def _get_join_our_community_content_text(self) -> str:
         return super()._get_text_of_elements(
-            self.__join_our_community_section_paragrah_and_learn_more_option
+            self.__join_our_community_section_paragraph_and_learn_more_option
         )[0]
 
     def _click_join_our_community_learn_more_link(self):
         return (super()._click_on_an_element_by_index
-                (self.__join_our_community_section_paragrah_and_learn_more_option, 1)
+                (self.__join_our_community_section_paragraph_and_learn_more_option, 1)
                 )

--- a/playwright_tests/pages/user_pages/my_profile_edit_settings_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit_settings_page.py
@@ -72,65 +72,21 @@ class MyProfileEditSettingsPage(BasePage):
     def _is_watch_forum_threads_i_start_checkbox_checked(self) -> bool:
         return super()._is_checkbox_checked(self.__watch_forum_threads_I_start_checkbox)
 
-        # checkbox_background_color = super()._get_css_value_of_pseudo_html_element(
-        #     "label[" 'for="id_forums_watch_new_thread"]', ":before", "background-color"
-        # )
-        # if checkbox_background_color == EditSettingsPageMessages.CHECKBOX_CHECKED_COLOR:
-        #     return True
-        # else:
-        #     return False
-
     def _is_watch_forum_threads_i_comment_checkbox_checked(self) -> bool:
         return super()._is_checkbox_checked(self.__watch_forum_threads_I_comment_in_checkbox)
 
-        # checkbox_background_color = super()._get_css_value_of_pseudo_html_element(
-        #     "label[" 'for="id_forums_watch_after_reply"]', ":before", "background-color"
-        # )
-        # if checkbox_background_color == EditSettingsPageMessages.CHECKBOX_CHECKED_COLOR:
-        #     return True
-        # else:
-        #     return False
-
     def _is_watch_kb_discussion_threads_i_start_checkbox_checked(self) -> bool:
         return super()._is_checkbox_checked(self.__watch_kb_discussions_threads_I_start_checkbox)
-        # checkbox_background_color = super()._get_css_value_of_pseudo_html_element(
-        #     "label[" 'for="id_kbforums_watch_new_thread"]', ":before", "background-color"
-        # )
-        # if checkbox_background_color == EditSettingsPageMessages.CHECKBOX_CHECKED_COLOR:
-        #     return True
-        # else:
-        #     return False
 
     def _is_watch_kb_discussion_threads_i_comment_checkbox_checked(self) -> bool:
         return super()._is_checkbox_checked(
             self.__watch_kb_discussion_threads_I_comment_in_checkbox)
-        # checkbox_background_color = super()._get_css_value_of_pseudo_html_element(
-        #     "label[" 'for="id_kbforums_watch_after_reply"]', ":before", "background-color"
-        # )
-        # if checkbox_background_color == EditSettingsPageMessages.CHECKBOX_CHECKED_COLOR:
-        #     return True
-        # else:
-        #     return False
 
     def _is_watch_question_threads_i_comment_checkbox_checked(self) -> bool:
         return super()._is_checkbox_checked(self.__watch_question_threads_I_comment_in_checkbox)
-        # checkbox_background_color = super()._get_css_value_of_pseudo_html_element(
-        #     "label[" 'for="id_questions_watch_after_reply"]', ":before", "background-color"
-        # )
-        # if checkbox_background_color == EditSettingsPageMessages.CHECKBOX_CHECKED_COLOR:
-        #     return True
-        # else:
-        #     return False
 
     def _is_send_emails_for_private_messages_checkbox_checked(self) -> bool:
         return super()._is_checkbox_checked(self.__send_emails_for_private_messages_checkbox)
-        # checkbox_background_color = super()._get_css_value_of_pseudo_html_element(
-        #     "label[" 'for="id_email_private_messages"]', ":before", "background-color"
-        # )
-        # if checkbox_background_color == EditSettingsPageMessages.CHECKBOX_CHECKED_COLOR:
-        #     return True
-        # else:
-        #     return False
 
     def _notification_banner_element(self) -> Locator:
         return super()._get_element_locator(

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -24,9 +24,6 @@ class TestPostedQuestions(TestUtilities):
                          "question")
         self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
-        self.logger.info("Deleting session cookies and signing in with an admin account")
-        super().delete_cookies()
-
         if username == 'TEST_ACCOUNT_13':
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_13"]
@@ -49,9 +46,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.product_solutions_page._get_scam_alert_banner_link(),
             QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
         )
-
-        self.logger.info("Deleting session cookies")
-        super().delete_cookies()
 
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -128,7 +122,6 @@ class TestPostedQuestions(TestUtilities):
 
         if username == 'TEST_ACCOUNT_MODERATOR':
             self.logger.info("Deleting session cookies and signing in with an admin account")
-            super().delete_cookies()
 
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -211,7 +204,6 @@ class TestPostedQuestions(TestUtilities):
 
         if username != 'TEST_ACCOUNT_MODERATOR':
             self.logger.info("Deleting session cookies and signing in with an admin account")
-            super().delete_cookies()
 
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -227,9 +219,6 @@ class TestPostedQuestions(TestUtilities):
         self.logger.info("Signing in with a non admin user account and posting a Firefox product "
                          "question")
         posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_13')
-
-        self.logger.info("Deleting session cookies")
-        self.delete_cookies()
 
         self.logger.info("Signing in with a non admin user account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -279,9 +268,7 @@ class TestPostedQuestions(TestUtilities):
         )
 
         if username == 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Deleting session cookies and signing in with an admin account")
-            super().delete_cookies()
-
+            self.logger.info("Signing in with an admin account")
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
@@ -371,9 +358,7 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._click_on_the_additional_system_panel_close_button()
 
         if username != 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Deleting session cookies and signing in with an admin account")
-            super().delete_cookies()
-
+            self.logger.info("Signing in with an admin account")
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
@@ -388,9 +373,6 @@ class TestPostedQuestions(TestUtilities):
         self.logger.info("Signing in with a non admin user account and posting a Firefox product "
                          "question")
         posted_question_one = self.post_firefox_product_question_flow('TEST_ACCOUNT_13')
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with a non admin user account and posting a Firefox product "
                          "question")
@@ -442,7 +424,6 @@ class TestPostedQuestions(TestUtilities):
 
         self.logger.info("Navigating back to the question page and deleting session cookies")
         self.navigate_back()
-        self.delete_cookies()
 
         self.logger.info("Signing in with a admin user account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -483,9 +464,6 @@ class TestPostedQuestions(TestUtilities):
         self.logger.info("Signing in with a non admin user account and posting a Firefox product "
                          "question")
         posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_13')
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with a different non admin user account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -532,9 +510,7 @@ class TestPostedQuestions(TestUtilities):
                 self.sumo_pages.question_page._get_archive_this_question_locator()
             ).to_be_hidden()
 
-        self.logger.info("Deleting session cookies and signing in with an admin account")
-        super().delete_cookies()
-
+        self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -545,9 +521,6 @@ class TestPostedQuestions(TestUtilities):
         elif status == "archived":
             self.logger.info("Clicking on the 'Archive this question' option")
             self.sumo_pages.question_page._click_on_archive_this_question_option()
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with a different non admin user account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -604,9 +577,7 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_add_image_section_locator()
         ).to_be_hidden()
 
-        self.logger.info("Deleting session cookies and signing in with an admin account")
-        super().delete_cookies()
-
+        self.logger.info("Signing in with an admin account")
         repliant_username = super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         )
@@ -642,9 +613,7 @@ class TestPostedQuestions(TestUtilities):
         self.logger.info("Signing in with a normal user account and verifying that the admin's "
                          "reply is visible")
 
-        self.logger.info("Deleting session cookies and signing in with an admin account")
-        super().delete_cookies()
-
+        self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
@@ -653,9 +622,7 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_posted_reply_locator(reply_id)
         ).to_be_visible()
 
-        self.logger.info("Deleting session cookies and signing in with an admin account")
-        super().delete_cookies()
-
+        self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -667,9 +634,7 @@ class TestPostedQuestions(TestUtilities):
             self.logger.info("Clicking on the 'Archive this question' option")
             self.sumo_pages.question_page._click_on_archive_this_question_option()
 
-        self.logger.info("Deleting session cookies and signing in with an admin account")
-        super().delete_cookies()
-
+        self.logger.info("Signing in with an admin account")
         second_repliant = super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_12"]
         )
@@ -697,9 +662,7 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_posted_reply_locator(reply_id_two)
         ).to_be_visible()
 
-        self.logger.info("Deleting session cookies and signing in with an admin account")
-        super().delete_cookies()
-
+        self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -734,9 +697,6 @@ class TestPostedQuestions(TestUtilities):
             attach_image=False
         )
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with a different non admin user account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_12"]
@@ -758,7 +718,7 @@ class TestPostedQuestions(TestUtilities):
 
         self.logger.info("Clicking on the 'Subscribe to feed' option from different user posted "
                          "question")
-        if self.browser == "chrome":
+        if self.requested_browser == "chrome":
             self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
             self.logger.info("Verifying that the url is updated to the feed endpoint")
             expect(
@@ -788,7 +748,7 @@ class TestPostedQuestions(TestUtilities):
         self.navigate_to_link(
             question_info_two['question_page_url']
         )
-        if self.browser == "chrome":
+        if self.requested_browser == "chrome":
             self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
             self.logger.info("Verifying that the url is updated to the feed endpoint")
             expect(
@@ -819,7 +779,7 @@ class TestPostedQuestions(TestUtilities):
         self.logger.info("Signing out")
         super().delete_cookies()
 
-        if self.browser == "chrome":
+        if self.requested_browser == "chrome":
             self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
             self.logger.info("Verifying that the url is updated to the feed endpoint")
             expect(
@@ -853,7 +813,7 @@ class TestPostedQuestions(TestUtilities):
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
 
-        if self.browser == "chrome":
+        if self.requested_browser == "chrome":
             self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
             self.logger.info("Verifying that the url is updated to the feed endpoint")
             expect(
@@ -919,9 +879,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_mark_as_spam_locator()
         ).to_be_hidden()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         username = self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -966,7 +923,6 @@ class TestPostedQuestions(TestUtilities):
             404
         )
 
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -997,7 +953,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_marked_as_spam_banner_locator()
         ).to_be_hidden()
 
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -1048,9 +1003,6 @@ class TestPostedQuestions(TestUtilities):
             expect(
                 self.sumo_pages.question_page._get_remove_tag_button_locator(tag)
             ).to_be_hidden()
-
-        if username == 'TEST_ACCOUNT_13':
-            super().delete_cookies()
 
         self.logger.info("Signing in with a admin user account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -1103,9 +1055,6 @@ class TestPostedQuestions(TestUtilities):
             posted_question['question_details']['question_page_url']
         )
 
-        if username == 'TEST_ACCOUNT_13':
-            super().delete_cookies()
-
         self.logger.info("Signing in with a admin user account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -1143,9 +1092,6 @@ class TestPostedQuestions(TestUtilities):
             )
         ).to_be_hidden()
 
-        if username == "TEST_ACCOUNT_13":
-            super().delete_cookies()
-
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -1179,9 +1125,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_email_updates_option()
         ).to_be_visible()
 
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
-
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -1209,9 +1152,6 @@ class TestPostedQuestions(TestUtilities):
         reply_id_one = self.sumo_pages.question_page._click_on_post_reply_button(
             posted_question['username_one']
         )
-
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
 
         self.logger.info("Signin in with a different non admin user")
         username_two = self.start_existing_session(super().username_extraction_from_email(
@@ -1244,9 +1184,6 @@ class TestPostedQuestions(TestUtilities):
 
         self.logger.info("Closing the dropdown menu")
         self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id_one)
-
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
 
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -1281,8 +1218,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
         ).to_be_hidden()
 
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
         self.logger.info("Signing in with the reply OP user account and verifying that the reply "
                          "marked as spam is no longer displayed")
 
@@ -1293,9 +1228,6 @@ class TestPostedQuestions(TestUtilities):
         expect(
             self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
         ).to_be_hidden()
-
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
 
         self.logger.info("Signing in with the admin account and unmarking the reply from spam")
         self.start_existing_session(super().username_extraction_from_email(
@@ -1338,9 +1270,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
         ).to_be_hidden()
 
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
-
         self.logger.info("Signing in with the reply OP and verifying that the reply is visible "
                          "again")
         self.start_existing_session(super().username_extraction_from_email(
@@ -1355,9 +1284,6 @@ class TestPostedQuestions(TestUtilities):
         expect(
             self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
         ).to_be_hidden()
-
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
 
         self.logger.info("Signing in with the admin account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -1397,9 +1323,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_displayed_user_title_of_question_reply(reply_id),
             QuestionPageMessages.QUESTION_REPLY_OWNER
         )
-
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
 
         if username == 'TEST_ACCOUNT_13':
             self.logger.info("Signin in with a different non admin user")
@@ -1531,7 +1454,6 @@ class TestPostedQuestions(TestUtilities):
         )
 
         if username == 'TEST_ACCOUNT_13':
-            super().delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
@@ -1583,7 +1505,6 @@ class TestPostedQuestions(TestUtilities):
         self.logger.info("Navigating back")
         self.navigate_back()
 
-        self.delete_cookies()
         if username == 'TEST_ACCOUNT_13':
             username_two = self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_13"]
@@ -1620,7 +1541,6 @@ class TestPostedQuestions(TestUtilities):
 
             self.logger.info("Navigating back")
             self.navigate_back()
-            self.delete_cookies()
 
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -1717,9 +1637,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_i_have_this_problem_too_locator()
         ).to_be_hidden()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -1781,9 +1698,6 @@ class TestPostedQuestions(TestUtilities):
         expect(
             self.sumo_pages.question_page._get_solved_the_problem_button_locator(reply_id)
         ).to_be_hidden()
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with the first username")
         self.start_existing_session(super().username_extraction_from_email(
@@ -1853,9 +1767,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_undo_button_locator()
         ).to_be_hidden()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -1895,9 +1806,6 @@ class TestPostedQuestions(TestUtilities):
             reply_id = self.sumo_pages.question_page._click_on_post_reply_button(
                 posted_question['username_one']
             )
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         username_two = self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
@@ -1966,9 +1874,6 @@ class TestPostedQuestions(TestUtilities):
             ).to_have_url(
                 posted_question['question_details']['question_page_url'] + "#" + question_id
             )
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -2169,9 +2074,6 @@ class TestPostedQuestions(TestUtilities):
             self.sumo_pages.question_page._get_post_a_reply_textarea_locator()
         ).to_be_visible()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
@@ -2205,9 +2107,6 @@ class TestPostedQuestions(TestUtilities):
         expect(
             self.sumo_pages.question_page._get_reply_votes_section_locator(reply_id)
         ).to_be_hidden()
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in a different user")
         self.start_existing_session(super().username_extraction_from_email(
@@ -2435,8 +2334,7 @@ class TestPostedQuestions(TestUtilities):
         self.sumo_pages.question_page._click_abuse_modal_close_button()
 
         if username == "TEST_ACCOUNT_13":
-            self.logger.info("Deleting user cookies and signing in with a admin account")
-            self.delete_cookies()
+            self.logger.info("Signing in with a admin account")
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
             ))
@@ -2485,9 +2383,6 @@ class TestPostedQuestions(TestUtilities):
         self.logger.info("Signing in with a non admin user account and posting a Firefox product "
                          "question")
         self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
-
-        self.logger.info("Deleting session cookies")
-        self.delete_cookies()
 
         self.logger.info("Signing in with a different account")
         username = self.start_existing_session(super().username_extraction_from_email(
@@ -2596,9 +2491,6 @@ class TestPostedQuestions(TestUtilities):
             f"Expected: {self.sumo_pages.question_page._get_text_content_of_reply(reply_id)} "
             f"Received: {response}"
         )
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]

--- a/playwright_tests/tests/conftest.py
+++ b/playwright_tests/tests/conftest.py
@@ -30,7 +30,7 @@ def setup(request, browser, logger_setup):
         request.cls.page = page
         request.cls.context = context
         request.cls.sumo_pages = sumo_pages
-        request.cls.browser = requested_browser
+        request.cls.requested_browser = requested_browser
         request.cls.logger = logger
         yield
         context.close()

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
@@ -85,9 +85,6 @@ class TestRecentRevisionsDashboard(TestUtilities):
         self.logger.info("Clearing the user search field")
         self.sumo_pages.recent_revisions_page._clearing_the_user_field()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing back in with the admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -137,9 +134,6 @@ class TestRecentRevisionsDashboard(TestUtilities):
         self.logger.info("Clicking on the 'Accept' button")
         self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with a non admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
@@ -184,7 +178,6 @@ class TestRecentRevisionsDashboard(TestUtilities):
 
         self.logger.info("Signing in with an admin account and verifying that the revision is "
                          "displayed")
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -237,11 +230,7 @@ class TestRecentRevisionsDashboard(TestUtilities):
             )
         ).to_be_visible()
 
-        self.logger.info("Signing back in with an admin account an deleting the article")
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
-        self.logger.info("Signing back in with the admin account")
+        self.logger.info("Signing back in with an admin account and deleting the article")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -324,9 +313,6 @@ class TestRecentRevisionsDashboard(TestUtilities):
         ).to_be_hidden()
 
         self.navigate_to_link(article_url)
-
-        self.logger.info("Signing in with a different user non-admin user")
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_12"]
@@ -423,7 +409,6 @@ class TestRecentRevisionsDashboard(TestUtilities):
         ).to_be_hidden()
 
         self.logger.info("Signing in with an admin account")
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
@@ -319,9 +319,6 @@ class TestKBArticleShowHistory(TestUtilities, KBArticleShowHistoryPageMessages):
         self.logger.info("Navigating back to the 'Show History page'")
         self.sumo_pages.kb_article_page._click_on_show_history_option()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with a non-Admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_12"]
@@ -606,9 +603,6 @@ class TestKBArticleShowHistory(TestUtilities, KBArticleShowHistoryPageMessages):
         self.logger.info("Clicking on the 'Accept' button")
         self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with a non-Admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_12"]
@@ -618,9 +612,6 @@ class TestKBArticleShowHistory(TestUtilities, KBArticleShowHistoryPageMessages):
 
         self.logger.info("Creating a new revision for the document")
         self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with a normal account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -770,9 +761,6 @@ class TestKBArticleShowHistory(TestUtilities, KBArticleShowHistoryPageMessages):
 
         self.logger.info("Clicking on the 'Accept' button")
         self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
-
-        self.logger.info("Delete user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with a non-admin account")
         creator_username = self.start_existing_session(super().username_extraction_from_email(

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
@@ -243,8 +243,7 @@ class TestArticleThreads(TestUtilities):
         self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
         self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
 
-        self.logger.info("Deleting session cookies and signing in with a normal account")
-        self.delete_cookies()
+        self.logger.info("Signing in with a normal account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts['TEST_ACCOUNT_12']
         ))
@@ -266,8 +265,7 @@ class TestArticleThreads(TestUtilities):
             self.get_page_url()
         )
 
-        self.logger.info("Deleting session cookies and signing in with an admin account")
-        self.delete_cookies()
+        self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
         ))
@@ -373,9 +371,6 @@ class TestArticleThreads(TestUtilities):
             KB_ARTICLE_DISCUSSIONS_ENDPOINT
         )
 
-        self.logger.info("Deleting user session and signing in with a non-admin account")
-        self.delete_cookies()
-
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
@@ -393,7 +388,6 @@ class TestArticleThreads(TestUtilities):
         )
 
         if username == 'TEST_ACCOUNT_MODERATOR':
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
@@ -464,7 +458,6 @@ class TestArticleThreads(TestUtilities):
         )
 
         if username == "TEST_ACCOUNT_12":
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_12"]
             ))
@@ -504,9 +497,6 @@ class TestArticleThreads(TestUtilities):
         kb_url = self.__posting_a_new_test_article_manually(approve_it=False,
                                                             post_it=True)
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with an admin account and approving the article")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -523,9 +513,6 @@ class TestArticleThreads(TestUtilities):
         self.logger.info("Posting a new kb article discussion thread")
         thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
                            add_new_kb_discussion_thread())
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with a normal user account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -612,9 +599,6 @@ class TestArticleThreads(TestUtilities):
         thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
                            add_new_kb_discussion_thread())
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with a normal user account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts['TEST_ACCOUNT_12']
@@ -637,9 +621,6 @@ class TestArticleThreads(TestUtilities):
             TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
         )
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -654,8 +635,6 @@ class TestArticleThreads(TestUtilities):
         self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
 
         if username == 'TEST_ACCOUNT_12':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
@@ -686,7 +665,6 @@ class TestArticleThreads(TestUtilities):
         )
 
         if username != 'TEST_ACCOUNT_MODERATOR':
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
@@ -700,8 +678,6 @@ class TestArticleThreads(TestUtilities):
         self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
 
         if username == 'TEST_ACCOUNT_12':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
@@ -747,9 +723,6 @@ class TestArticleThreads(TestUtilities):
         thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
                            add_new_kb_discussion_thread())
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with a normal user account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts['TEST_ACCOUNT_12']
@@ -771,9 +744,6 @@ class TestArticleThreads(TestUtilities):
         self.navigate_to_link(
             TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
         )
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -801,8 +771,6 @@ class TestArticleThreads(TestUtilities):
         )
 
         if username == 'TEST_ACCOUNT_12':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
@@ -819,8 +787,6 @@ class TestArticleThreads(TestUtilities):
             ).to_be_hidden()
 
         if username != 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.logger.info("Signing in with an admin account")
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -830,8 +796,6 @@ class TestArticleThreads(TestUtilities):
         self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
 
         if username == 'TEST_ACCOUNT_12':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
@@ -860,8 +824,6 @@ class TestArticleThreads(TestUtilities):
         ).to_be_hidden()
 
         if username != "TEST_ACCOUNT_MODERATOR":
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
@@ -892,8 +854,6 @@ class TestArticleThreads(TestUtilities):
         )
 
         if username == 'TEST_ACCOUNT_12':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
@@ -910,8 +870,6 @@ class TestArticleThreads(TestUtilities):
             ).to_be_hidden()
 
         if username != 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.logger.info("Signing in with an admin account")
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -921,8 +879,6 @@ class TestArticleThreads(TestUtilities):
         self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
 
         if username == 'TEST_ACCOUNT_12':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
@@ -973,9 +929,6 @@ class TestArticleThreads(TestUtilities):
         thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
                            add_new_kb_discussion_thread())
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with a normal user account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts['TEST_ACCOUNT_12']
@@ -1003,9 +956,6 @@ class TestArticleThreads(TestUtilities):
             kb_article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
         )
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
         self.logger.info("Signing in with an admin account")
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -1026,17 +976,16 @@ class TestArticleThreads(TestUtilities):
         )
 
         if username == 'TEST_ACCOUNT_12':
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
-            self.logger.info("Verifying that the unsitcky this thread option is not availabe")
+            self.logger.info("Verifying that the unsitcky this thread option is not available")
             expect(
                 self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_locator()
             ).to_be_hidden()
         if username == '':
             self.delete_cookies()
-            self.logger.info("Verifying that the unsitcky this thread option is not availabe")
+            self.logger.info("Verifying that the unsitcky this thread option is not available")
             expect(
                 self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_locator()
             ).to_be_hidden()
@@ -1058,7 +1007,6 @@ class TestArticleThreads(TestUtilities):
         )
 
         if username != 'TEST_ACCOUNT_MODERATOR':
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
@@ -1078,7 +1026,6 @@ class TestArticleThreads(TestUtilities):
         )
 
         if username == 'TEST_ACCOUNT_12':
-            self.delete_cookies()
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
@@ -1101,7 +1048,6 @@ class TestArticleThreads(TestUtilities):
             thread_info_two['thread_title']
         )
 
-        self.delete_cookies()
         self.start_existing_session(self.username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -1128,9 +1074,6 @@ class TestArticleThreads(TestUtilities):
         self.logger.info("Posting a new kb article discussion thread")
         thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
                            add_new_kb_discussion_thread())
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
 
         self.logger.info("Signing in with a normal user account")
         self.start_existing_session(super().username_extraction_from_email(
@@ -1333,7 +1276,6 @@ class TestArticleThreads(TestUtilities):
 
     # Clears all posted article threads.
     def __clearing_newly_created_thread(self, thread_id: str):
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -97,7 +97,7 @@ class TestMessagingSystem(TestUtilities):
             "Verifying that the receiver is automatically added inside the 'To' field"
         )
         # Firefox GH runner fails here. We are running this assertion only in Chrome for now
-        if self.browser == "chrome":
+        if self.requested_browser == "chrome":
             assert self.sumo_pages.new_message_page._get_user_to_text() == user_two, (
                 f"Incorrect 'To' receiver. Expected: {user_two}. "
                 f"Received: {self.sumo_pages.new_message_page._get_user_to_text()}"
@@ -157,7 +157,6 @@ class TestMessagingSystem(TestUtilities):
         ).to_be_hidden()
 
         self.logger.info("Signing in with the user which received the message")
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_2"]
@@ -246,7 +245,6 @@ class TestMessagingSystem(TestUtilities):
             "Signing in with the receiver account and verifying that the message "
             "is displayed inside the inbox section"
         )
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]

--- a/playwright_tests/tests/user_page_tests/test_edit_contribution_areas.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_contribution_areas.py
@@ -72,7 +72,6 @@ class TestEditContributionAreas(TestUtilities):
             "Signing in with a different account and verifying "
             "that the original user groups are displayed"
         )
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts['TEST_ACCOUNT_13']
         ))
@@ -92,7 +91,6 @@ class TestEditContributionAreas(TestUtilities):
         )
 
         self.logger.info("Signing in back with the original user")
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts['TEST_ACCOUNT_12']
         ))
@@ -136,7 +134,6 @@ class TestEditContributionAreas(TestUtilities):
         self.logger.info(
             "Logging in with a different user and accessing the original user profile"
         )
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts['TEST_ACCOUNT_13']
         ))

--- a/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
@@ -62,11 +62,11 @@ class TestEditMyProfile(TestUtilities):
 
         profile_edit_data = super().profile_edit_test_data
 
-        if self.browser == "chrome":
+        if self.requested_browser == "chrome":
             new_username = profile_edit_data["valid_user_edit_with_symbols"][
                 "username_with_valid_symbols_chrome"
             ]
-        elif self.browser == "firefox":
+        elif self.requested_browser == "firefox":
             new_username = profile_edit_data["valid_user_edit_with_symbols"][
                 "username_with_valid_symbols_firefox"
             ]
@@ -441,11 +441,11 @@ class TestEditMyProfile(TestUtilities):
 
         original_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        if self.browser == "chrome":
+        if self.requested_browser == "chrome":
             new_display_name = super().profile_edit_test_data["valid_user_edit"][
                 "display_name_chrome"
             ]
-        elif self.browser == "firefox":
+        elif self.requested_browser == "firefox":
             new_display_name = super().profile_edit_test_data["valid_user_edit"][
                 "display_name_firefox"
             ]
@@ -566,7 +566,6 @@ class TestEditMyProfile(TestUtilities):
         )
 
         self.logger.info("Signing in with a different user")
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
@@ -628,8 +627,6 @@ class TestEditMyProfile(TestUtilities):
         ).to_be_hidden()
 
         self.logger.info("Signing in with a different user")
-        self.delete_cookies()
-
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
@@ -781,7 +778,6 @@ class TestEditMyProfile(TestUtilities):
             "Signing in with a different user and verifying that the correct website information "
             "is displayed for the first user"
         )
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
@@ -894,7 +890,6 @@ class TestEditMyProfile(TestUtilities):
             "Signing in with a different user and verifying "
             "that the correct community portal information is displayed for the first user"
         )
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
@@ -959,7 +954,6 @@ class TestEditMyProfile(TestUtilities):
         self.navigate_back()
 
         self.logger.info("Clearing the community portal field changes")
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_12"]
@@ -1010,8 +1004,6 @@ class TestEditMyProfile(TestUtilities):
             "Signing in with a different user and verifying that "
             "the correct people directory information is displayed for the first user"
         )
-        self.delete_cookies()
-
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
@@ -1089,7 +1081,6 @@ class TestEditMyProfile(TestUtilities):
             "Signing in with a different user and verifying that the correct Matrix information "
             "is displayed for the first user"
         )
-        self.delete_cookies()
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
@@ -1167,7 +1158,6 @@ class TestEditMyProfile(TestUtilities):
             "Signing in with a different user and verifying that the correct Country information "
             "is displayed for the first user"
         )
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
@@ -1188,7 +1178,6 @@ class TestEditMyProfile(TestUtilities):
             "Signing out, accessing the profile and verifying that the "
             "Country information is displayed"
         )
-
         self.delete_cookies()
         self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
 
@@ -1244,7 +1233,6 @@ class TestEditMyProfile(TestUtilities):
             "Signing in with a different user and verifying that the correct City information "
             "is displayed for the first user"
         )
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
@@ -1333,7 +1321,6 @@ class TestEditMyProfile(TestUtilities):
             "Signing in with a different user and verifying that the "
             "correct involved from information is displayed for the first user"
         )
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
@@ -1599,7 +1586,6 @@ class TestEditMyProfile(TestUtilities):
 
         self.logger.info("Signing in with a moderator account")
         self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
-        self.delete_cookies()
 
         self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]


### PR DESCRIPTION
- Cleaning up the code a bit with emphasis on removing explicit cookie deletion before starting a new logged-in session (the start_existing_session function already contains the cookie deletion step before applying the new set of session cookies)