### PR TITLE
Switching playwright reporting from HTML to Allure.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -51,132 +51,135 @@ jobs:
         id: create-sessions
         working-directory: playwright_tests
         run: |
-         poetry run pytest -m loginSessions --browser ${{ env.BROWSER }} --reruns 1 --html=reports/creating_user_sessions.html --capture=tee-sys
+         poetry run pytest -m loginSessions --browser ${{ env.BROWSER }} --reruns 1
       - name: Run Homepage tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-         poetry run pytest -m homePageTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_homepage_tests_report.html --capture=tee-sys
+         poetry run pytest -m homePageTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run Top-Navbar tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m topNavbarTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_top_navbar_tests_report.html --capture=tee-sys
+          poetry run pytest -m topNavbarTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run Footer tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m footerSectionTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_footer_tests_report.html --capture=tee-sys
+          poetry run pytest -m footerSectionTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run Contribute Pages tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m contributePagesTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_contribute_page_tests_report.html --capture=tee-sys
+          poetry run pytest -m contributePagesTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run Messaging System Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m messagingSystem --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_messaging_system_tests_report.html --capture=tee-sys
+          poetry run pytest -m messagingSystem --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run User Contribution Page Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m userContributionTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_user_contribution_tests.html --capture=tee-sys
+          poetry run pytest -m userContributionTests --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run User Page Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m userProfile --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_user_page_tests.html --capture=tee-sys
+          poetry run pytest -m userProfile --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run User Settings Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m userSettings --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_user_settings_page_tests.html --capture=tee-sys
+          poetry run pytest -m userSettings --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run User Profile Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m editUserProfileTests --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_user_profile_page_tests.html --capture=tee-sys
+          poetry run pytest -m editUserProfileTests --browser ${{ env.BROWSER }} --reruns 1
       - name: Run User Questions Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m userQuestions --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_user_questions_page_tests.html --capture=tee-sys
+          poetry run pytest -m userQuestions --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run Contact Support Page Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m contactSupportPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_contact_support_page_tests.html --capture=tee-sys
+          poetry run pytest -m contactSupportPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run Product Solutions Page Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m productSolutionsPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_product_solutions_page_tests.html --capture=tee-sys
+          poetry run pytest -m productSolutionsPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run Product Topics Page Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m productTopicsPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_product_topics_page_tests.html --capture=tee-sys
+          poetry run pytest -m productTopicsPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run AAQ Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m aaqPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_aaq_tests.html --capture=tee-sys
+          poetry run pytest -m aaqPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run AAQ Questions Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-          poetry run pytest -m postedQuestions --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_aaq_questions_tests.html --capture=tee-sys
+          poetry run pytest -m postedQuestions --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name : Run KB Products Page Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-            poetry run pytest -m kbProductsPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_products_page.html --capture=tee-sys
+            poetry run pytest -m kbProductsPage --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run KB Article Creation And Access Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-            poetry run pytest -m kbArticleCreationAndAccess --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_article_creation_and_access.html --capture=tee-sys
+            poetry run pytest -m kbArticleCreationAndAccess --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run before kb thread tests setup (${{ env.BROWSER }})
         id: kb-threads-setup
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-            poetry run pytest -m beforeThreadTests --numprocesses 1 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_before_thread_tests_setup.html --capture=tee-sys
+            poetry run pytest -m beforeThreadTests --numprocesses 1 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run KB article threads Tests  (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success' && steps.kb-threads-setup.outcome == 'success'
         run: |
-            poetry run pytest -m articleThreads --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_article_threads.html --capture=tee-sys
+            poetry run pytest -m articleThreads --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run KB article threads tear down (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success' && steps.kb-threads-setup.outcome == 'success'
         run: |
-            poetry run pytest -m afterThreadTests --numprocesses 1 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_article_threads_tear_down.html --capture=tee-sys
+            poetry run pytest -m afterThreadTests --numprocesses 1 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run KB article show history Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-            poetry run pytest -m kbArticleShowHistory --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_article_show_history.html --capture=tee-sys
+            poetry run pytest -m kbArticleShowHistory --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run KB article revisions dashboard Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-            poetry run pytest -m recentRevisionsDashboard --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_article_recent_revisions.html --capture=tee-sys
+            poetry run pytest -m recentRevisionsDashboard --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
       - name: Run KB Dashboard Tests (${{ env.BROWSER }})
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-            poetry run pytest -m kbDashboard --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1 --html=reports/${{ env.BROWSER }}_kb_dashboard.html --capture=tee-sys
-      - name: Combine Reports
+            poetry run pytest -m kbDashboard --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1
+      - name: Generating Allure Report
         working-directory: playwright_tests
         if: success() || failure()
         run: |
-          cat reports/*.html > reports/combined_report_${{ env.BROWSER }}.html
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+            brew install allure
+            allure generate --single-file reports/allure_reports
       - name: Upload the combined test report as artifact
         if: success() || failure()
         uses: actions/upload-artifact@v2
         with:
           name: Playwright test report
           path: |
-            playwright_tests/reports/
+            playwright_tests/allure-report

--- a/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
+++ b/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
@@ -13,13 +13,13 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, TestUtilities, Quest
 
     # Submitting an aaq question for a product flow.
     # Mozilla VPN has an extra optional dropdown menu for choosing an operating system.
-    def submit_an_aaq_question_for_a_product(self,
-                                             subject: str,
-                                             topic_name: str,
-                                             body: str,
-                                             os="",
-                                             attach_image=False):
-        question_subject = self.add__valid_data_to_all_input_fields_without_submitting(
+    def submit_an_aaq_question(self,
+                               subject: str,
+                               topic_name: str,
+                               body: str,
+                               os="",
+                               attach_image=False):
+        question_subject = self.add__valid_data_to_all_aaq_fields_without_submitting(
             subject,
             topic_name,
             body,
@@ -38,12 +38,12 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, TestUtilities, Quest
 
     # Populating the aaq form fields with given values without submitting the form.
     # Mozilla VPN has an extra optional dropdown menu for choosing an operating system.
-    def add__valid_data_to_all_input_fields_without_submitting(self,
-                                                               subject: str,
-                                                               topic_value: str,
-                                                               body_text: str,
-                                                               os='',
-                                                               attach_image=False):
+    def add__valid_data_to_all_aaq_fields_without_submitting(self,
+                                                             subject: str,
+                                                             topic_value: str,
+                                                             body_text: str,
+                                                             os='',
+                                                             attach_image=False):
         aaq_subject = subject + super().generate_random_number(min_value=0, max_value=5000)
         # Adding text to subject field.
         super()._add_text_to_aaq_form_subject_field(aaq_subject)

--- a/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
+++ b/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
@@ -331,7 +331,7 @@ class QuestionPage(BasePage):
     def _click_on_more_system_details_option(self):
         super()._click(self.__more_system_details_option)
 
-    def _click_on_the_additional_system_panel_close_button(self):
+    def _click_on_the_additional_system_panel_close(self):
         super()._click(self.__close_additional_system_details_button)
 
     def _get_reply_section_locator(self, answer_id: str) -> Locator:

--- a/playwright_tests/pages/contribute/contribute_pages/contribute_page.py
+++ b/playwright_tests/pages/contribute/contribute_pages/contribute_page.py
@@ -58,7 +58,7 @@ class ContributePage(BasePage):
     def _get_way_to_contribute_header_text(self) -> str:
         return super()._get_text_of_element(self.__way_to_contribute_header)
 
-    def _get_way_to_contribute_card_titles_text(self) -> list[str]:
+    def _get_way_to_contribute_cards(self) -> list[str]:
         return super()._get_text_of_elements(self.__way_to_contribute_card_titles)
 
     # About us

--- a/playwright_tests/pages/contribute/contribute_pages/ways_to_contribute_pages.py
+++ b/playwright_tests/pages/contribute/contribute_pages/ways_to_contribute_pages.py
@@ -56,10 +56,10 @@ class WaysToContributePages(BasePage):
     def _get_how_to_contribute_header_text(self) -> str:
         return super()._get_text_of_element(self.__how_to_contribute_header)
 
-    def _get_how_to_contribute_link_options_text(self) -> list[str]:
+    def _get_how_to_contribute_link_options(self) -> list[str]:
         return super()._get_text_of_elements(self.__all_how_to_contribute_option_links)
 
-    def _get_how_to_contribute_option_four_text(self) -> str:
+    def _get_how_to_contribute_option_four(self) -> str:
         return super()._get_text_of_element(self.__start_answering_how_to_contribute_option_text)
 
     def _get_first_fact_text(self) -> str:
@@ -72,7 +72,7 @@ class WaysToContributePages(BasePage):
     def _get_other_ways_to_contribute_header(self) -> str:
         return super()._get_text_of_element(self.__other_ways_to_contribute_header)
 
-    def _get_other_ways_to_contribute_card_title(self) -> list[str]:
+    def _get_other_ways_to_contribute_cards(self) -> list[str]:
         return super()._get_text_of_elements(self.__other_ways_to_contribute_card_titles)
 
     def _get_other_ways_to_contribute_card_list(self) -> list[ElementHandle]:

--- a/playwright_tests/pages/contribute/contributor_tools_pages/recent_revisions_page.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/recent_revisions_page.py
@@ -69,7 +69,7 @@ class RecentRevisions(BasePage):
     def _add_end_date(self, end_date: str):
         super()._type(self.__end_date_input_field, end_date, 0)
 
-    def _get_recent_revision_based_on_article_locator(self, title: str) -> Locator:
+    def _get_recent_revision_based_on_article(self, title: str) -> Locator:
         xpath = f"//div[@id='revisions-fragment']//div[@class='title']//a[text()='{title}']"
         return super()._get_element_locator(xpath)
 

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_discussion_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_discussion_page.py
@@ -146,7 +146,7 @@ class KBArticleDiscussionPage(BasePage):
     def _get_thread_post_a_reply_textarea_field(self) -> Locator:
         return super()._get_element_locator(self.__thread_post_a_reply_textarea_field)
 
-    def _fill_the_thread_post_a_reply_textarea_field(self, text: str):
+    def _fill_the_thread_post_a_reply_textarea(self, text: str):
         super()._fill(self.__thread_post_a_reply_textarea_field, text)
 
     def _get_thread_page_counter_replies_text(self) -> str:

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
@@ -7,6 +7,7 @@ class KBArticlePage(BasePage):
     __kb_article_content = "//section[@id='doc-content']"
     __kb_article_content_approved_content = "//section[@id='doc-content']/p"
     __kb_article_contributors = "//div[@class='document--contributors-list text-body-xs']/a"
+    __learn_more_kb_article_option = "//a[text()='Learn More']"
 
     # Editing Tools options
     __editing_tools_article_option = "//a[text()='Article']"
@@ -53,3 +54,6 @@ class KBArticlePage(BasePage):
 
     def _click_on_editing_tools_discussion_option(self):
         super()._click(self.__editing_tools_discussion_option)
+
+    def _click_on_volunteer_learn_more_option(self):
+        super()._click(self.__learn_more_kb_article_option)

--- a/playwright_tests/pages/messaging_system_pages/mess_system_user_navbar.py
+++ b/playwright_tests/pages/messaging_system_pages/mess_system_user_navbar.py
@@ -18,10 +18,10 @@ class MessagingSystemUserNavbar(BasePage):
     def _click_on_messaging_system_navbar_inbox(self):
         super()._click(self.__messaging_system_user_navbar_inbox_option)
 
-    def _click_on_messaging_system_navbar_sent_messages(self):
+    def _click_on_messaging_system_nav_sent_messages(self):
         super()._click(self.__messaging_system_user_navbar_sent_messages_option)
 
-    def _click_on_messaging_system_navbar_new_message(self):
+    def _click_on_messaging_system_nav_new_message(self):
         super()._click(self.__messaging_system_user_navbar_new_message_option)
 
     # Need to add logic for fetching the background color of selected navbar elements

--- a/playwright_tests/pages/user_pages/my_profile_edit_contribution_areas_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit_contribution_areas_page.py
@@ -85,7 +85,7 @@ class MyProfileEditContributionAreasPage(BasePage):
         return super()._is_checkbox_checked(
             self.__edit_contribution_areas_mobile_support_contributors)
 
-    def _are_all_cont_pref_checkboxes_checked(self) -> bool:
+    def _are_all_cont_pref_checked(self) -> bool:
         is_checked = [
             self._is_kb_contributors_checkbox_checked(),
             self._is_l10n_contributors_checkbox_checked(),

--- a/playwright_tests/pages/user_pages/my_profile_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_page.py
@@ -196,6 +196,6 @@ class MyProfilePage(BasePage):
     def _is_deactivate_this_user_button_displayed(self) -> Locator:
         return super()._get_element_locator(self.__deactivate_this_user_button)
 
-    def _deactivate_this_user_and_mark_content_as_spam_elem(self) -> Locator:
+    def _deactivate_user_and_mark_content_as_spam_button(self) -> Locator:
         return super()._get_element_locator(
             self.__deactivate_this_user_and_mark_all_content_as_spam)

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -25,3 +25,4 @@ markers =
     kbArticleShowHistory: Tests belonging to the kb article show history section.
     recentRevisionsDashboard: Tests belonging to the recent revisions dashboard.
     kbDashboard: Tests belonging to the KB dashboard.
+addopts = --alluredir=./reports/allure_reports

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 
 from playwright.sync_api import expect
 from playwright_tests.core.testutilities import TestUtilities
@@ -18,408 +19,374 @@ class TestAAQPage(TestUtilities):
     # C2188694, C2188695
     @pytest.mark.aaqPage
     def test_community_card_and_helpful_tip_are_displayed_for_freemium_product(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Navigating to each freemium aaq form")
-        for freemium_product in super().general_test_data["freemium_products"]:
-            self.navigate_to_link(
-                super().aaq_question_test_data["products_aaq_url"][freemium_product]
-            )
+        with allure.step("Navigating to each freemium aaq form"):
+            for freemium_product in super().general_test_data["freemium_products"]:
+                self.navigate_to_link(
+                    super().aaq_question_test_data["products_aaq_url"][freemium_product]
+                )
 
-            self.logger.info("Verifying that the helpful tip card is displayed")
-            expect(
-                self.sumo_pages.aaq_form_page._get_helpful_tip_locator()
-            ).to_be_visible()
+                with allure.step(f"Verifying that the helpful tip card is displayed for the "
+                                 f"{freemium_product} product"):
+                    expect(
+                        self.sumo_pages.aaq_form_page._get_helpful_tip_locator()
+                    ).to_be_visible()
 
-            self.logger.info("Clicking on the 'Learn More' button from the community help card")
-            self.sumo_pages.aaq_form_page._click_on_learn_more_button()
-
-            self.logger.info("Verifying that we are on the contribute_messages page")
-            expect(
-                self.page
-            ).to_have_url(ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL)
+                with allure.step("Clicking on the 'Learn More' button from the community help "
+                                 "card and verifying that we are on the contribute messages page"):
+                    self.sumo_pages.aaq_form_page._click_on_learn_more_button()
+                    expect(
+                        self.page
+                    ).to_have_url(ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL)
 
     # C2188694, C2188695
     @pytest.mark.aaqPage
     def test_community_card_and_helpful_tip_not_displayed_for_premium_products(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Navigating to each premium aaq form")
-        for premium_product in super().general_test_data["premium_products"]:
-            self.navigate_to_link(
-                super().aaq_question_test_data["products_aaq_url"][premium_product]
-            )
+        with allure.step("Navigating to each premium aaq form"):
+            for premium_product in super().general_test_data["premium_products"]:
+                self.navigate_to_link(
+                    super().aaq_question_test_data["products_aaq_url"][premium_product]
+                )
 
-            self.logger.info("Verifying that the helpful tip option is not displayed")
-            expect(
-                self.sumo_pages.aaq_form_page._get_helpful_tip_locator()
-            ).to_be_hidden()
+                with allure.step(f"Verifying that the helpful tip options is displayed for the "
+                                 f"{premium_product}"):
+                    expect(
+                        self.sumo_pages.aaq_form_page._get_helpful_tip_locator()
+                    ).to_be_hidden()
 
-            self.logger.info("Verifying that the 'Learn More' button from the community help "
-                             "banner is not displayed")
-            expect(
-                self.sumo_pages.aaq_form_page._get_learn_more_button_locator()
-            ).to_be_hidden()
+                with allure.step("Verifying that the 'Learn More' button from the community help "
+                                 "banner is not displayed"):
+                    expect(
+                        self.sumo_pages.aaq_form_page._get_learn_more_button_locator()
+                    ).to_be_hidden()
 
     # C1511570
     @pytest.mark.aaqPage
     @pytest.mark.parametrize("username", ['', 'TEST_ACCOUNT_12', 'TEST_ACCOUNT_MODERATOR'])
     def test_scam_banner_premium_products_not_displayed(self, username):
         if username != '':
-            self.logger.info("Signing in with a user account")
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts[username]
-            ))
-        self.logger.info("Navigating to each premium product solutions page")
-        for premium_product in super().general_test_data["premium_products"]:
-            self.navigate_to_link(
-                super().general_test_data["product_solutions"][premium_product]
-            )
+            with allure.step(f"Singing in with {username} user"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts[username]
+                ))
 
-            self.logger.info("Verifying that the scam banner is not displayed")
-            expect(
-                self.sumo_pages.product_solutions_page._get_scam_banner_locator()
-            ).to_be_hidden()
-
-            if username != '':
-                self.logger.info("Clicking on the ask now button")
-                self.sumo_pages.product_solutions_page._click_ask_now_button()
-                self.wait_for_url_to_be(
-                    super().aaq_question_test_data["products_aaq_url"][premium_product]
+        with allure.step("Navigating to each premium product solutions page"):
+            for premium_product in super().general_test_data["premium_products"]:
+                self.navigate_to_link(
+                    super().general_test_data["product_solutions"][premium_product]
                 )
 
-                self.logger.info("Verifying that the scam banner is not displayed")
-                expect(
-                    self.sumo_pages.product_solutions_page._get_scam_banner_locator()
-                ).to_be_hidden()
+                with allure.step(f"Verifying that the sam banner is not displayed for "
+                                 f"{premium_product} card"):
+                    expect(
+                        self.sumo_pages.product_solutions_page._get_scam_banner_locator()
+                    ).to_be_hidden()
+
+                if username != '':
+                    with allure.step("Clicking on the Ask Now button and verifying that the scam "
+                                     "banner is not displayed"):
+                        self.sumo_pages.product_solutions_page._click_ask_now_button()
+                        self.wait_for_url_to_be(
+                            super().aaq_question_test_data["products_aaq_url"][premium_product]
+                        )
+                        expect(
+                            self.sumo_pages.product_solutions_page._get_scam_banner_locator()
+                        ).to_be_hidden()
 
     # C2190040
     @pytest.mark.aaqPage
     @pytest.mark.parametrize("username", ['', 'TEST_ACCOUNT_12', 'TEST_ACCOUNT_MODERATOR'])
     def test_scam_banner_for_freemium_products_is_displayed(self, username):
         if username != '':
-            self.logger.info("Signing in with a user account")
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts[username]
-            ))
+            with allure.step(f"Signing in with {username} user"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts[username]
+                ))
 
-        self.logger.info("Navigating to each freemium product solutions page")
-        for freemium_product in super().general_test_data["freemium_products"]:
-            self.navigate_to_link(
-                super().general_test_data["product_solutions"][freemium_product]
-            )
-
-            self.logger.info("Verifying that the 'Learn More' button contains the correct link")
-            check.equal(
-                self.sumo_pages.product_solutions_page._get_scam_alert_banner_link(),
-                QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
-            )
-
-            if username != '':
-                self.logger.info("Clicking on the ask now button")
-                self.sumo_pages.product_solutions_page._click_ask_now_button()
-                self.wait_for_url_to_be(
-                    super().aaq_question_test_data["products_aaq_url"][freemium_product]
+        with allure.step("Navigating to each freemium product solutions page"):
+            for freemium_product in super().general_test_data["freemium_products"]:
+                self.navigate_to_link(
+                    super().general_test_data["product_solutions"][freemium_product]
                 )
 
-                self.logger.info(
-                    "Verifying that the 'Learn More' button contains the correct link")
-                check.equal(
-                    self.sumo_pages.product_solutions_page._get_scam_alert_banner_link(),
-                    QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
-                )
+                with check, allure.step("Verifying that the 'Learn More' button contains the "
+                                        "correct link"):
+                    assert self.sumo_pages.product_solutions_page._get_scam_alert_banner_link(
+                    ) == QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
+
+                if username != '':
+                    with check, allure.step("Clicking on the Ask Now button and verifying that "
+                                            "the 'Learn More' button contains the correct link"):
+                        self.sumo_pages.product_solutions_page._click_ask_now_button()
+                        self.wait_for_url_to_be(
+                            super().aaq_question_test_data["products_aaq_url"][freemium_product]
+                        )
+                        assert self.sumo_pages.product_solutions_page._get_scam_alert_banner_link(
+                        ) == QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
 
     # C890537
     @pytest.mark.aaqPage
     def test_corresponding_aaq_product_name_and_image_are_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Navigating to each product aaq form")
-        for product in super().aaq_question_test_data["products_aaq_url"]:
-            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
+        with allure.step("Navigating to each product aaq form"):
+            for product in super().aaq_question_test_data["products_aaq_url"]:
+                self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
 
-            # This needs to change when we add the Mozilla Account icon/product.
-            if product != "Mozilla Account":
-                self.logger.info("Verifying that the product image is displayed")
-                expect(
-                    self.sumo_pages.aaq_form_page._get_product_image_locator()
-                ).to_be_visible()
-            else:
-                self.logger.info("Verifying that the product image is hidden for Mozilla Account "
-                                 "product")
-                expect(
-                    self.sumo_pages.aaq_form_page._get_product_image_locator()
-                ).to_be_visible()
+                # This needs to change when we add the Mozilla Account icon/product.
+                if product != "Mozilla Account":
+                    with allure.step("Verifying that the product image is displayed"):
+                        expect(
+                            self.sumo_pages.aaq_form_page._get_product_image_locator()
+                        ).to_be_visible()
+                else:
+                    with allure.step("Verifying that the product image is hidden for Mozilla "
+                                     "Account product"):
+                        expect(
+                            self.sumo_pages.aaq_form_page._get_product_image_locator()
+                        ).to_be_visible()
 
-            self.logger.info("Verifying that the correct product header is displayed")
-            check.equal(
-                self.sumo_pages.aaq_form_page._get_aaq_form_page_heading(),
-                product,
-                f"Incorrect form header displayed. "
-                f"Expected: {product} "
-                f"Received: {self.sumo_pages.aaq_form_page._get_aaq_form_page_heading()}"
-            )
+                with check, allure.step("Verifying that the correct product header is displayed"):
+                    assert self.sumo_pages.aaq_form_page._get_aaq_form_page_heading() == product
 
     # C890535, C890536
     @pytest.mark.aaqPage
     def test_progress_milestone_redirect(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Navigating to each product aaq form")
-        for product in super().aaq_question_test_data["products_aaq_url"]:
-            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
+        with allure.step("Navigating to each product AAQ form"):
+            for product in super().aaq_question_test_data["products_aaq_url"]:
+                self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
 
-            self.logger.info("Verifying that the correct in progress milestone is displayed")
-            check.equal(
-                self.sumo_pages.aaq_form_page._get_in_progress_item_label(),
-                AAQFormMessages.IN_PROGRESS_MILESTONE,
-                f"Incorrect current milestone. "
-                f"Expected: {AAQFormMessages.IN_PROGRESS_MILESTONE} "
-                f"Received: {self.sumo_pages.aaq_form_page._get_in_progress_item_label()}"
-            )
+                with check, allure.step("Verifying that the correct in progress milestone is "
+                                        "displayed"):
+                    assert self.sumo_pages.aaq_form_page._get_in_progress_item_label(
+                    ) == AAQFormMessages.IN_PROGRESS_MILESTONE
 
-            self.logger.info(
-                f"Clicking on the {AAQFormMessages.COMPLETED_MILESTONE_TWO} milestone'"
-            )
-            self.sumo_pages.aaq_form_page._click_on_a_particular_completed_milestone(
-                AAQFormMessages.COMPLETED_MILESTONE_TWO)
+                with allure.step(f"Clicking on the {AAQFormMessages.COMPLETED_MILESTONE_TWO} "
+                                 f"milestone and verifying that we are on the correct product "
+                                 f"solutions page"):
+                    self.sumo_pages.aaq_form_page._click_on_a_particular_completed_milestone(
+                        AAQFormMessages.COMPLETED_MILESTONE_TWO)
+                    expect(
+                        self.page
+                    ).to_have_url(super().general_test_data["product_solutions"][product])
 
-            self.logger.info("Verifying that the we are on the correct product solutions page")
-            expect(
-                self.page
-            ).to_have_url(super().general_test_data["product_solutions"][product])
-
-            self.logger.info(
-                f"Navigating back to the aaq form and "
-                f"clicking on the {AAQFormMessages.COMPLETED_MILESTONE_ONE} milestone")
-            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
-            self.sumo_pages.aaq_form_page._click_on_a_particular_completed_milestone(
-                AAQFormMessages.COMPLETED_MILESTONE_ONE)
-
-            self.logger.info("Verifying that we are redirected to the correct page")
-            expect(
-                self.page
-            ).to_have_url(ContactSupportMessages.PAGE_URL_CHANGE_PRODUCT_REDIRECT)
+                with allure.step(f"Navigating back to the aaq form and clicking on the "
+                                 f"{AAQFormMessages.COMPLETED_MILESTONE_ONE} milestone"):
+                    self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]
+                                          [product])
+                    self.sumo_pages.aaq_form_page._click_on_a_particular_completed_milestone(
+                        AAQFormMessages.COMPLETED_MILESTONE_ONE)
+                    expect(
+                        self.page
+                    ).to_have_url(ContactSupportMessages.PAGE_URL_CHANGE_PRODUCT_REDIRECT)
 
     # C890612
     @pytest.mark.aaqPage
     def test_aaq_form_cancel_button_freemium_products(self):
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_1"]
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_1"]
+            ))
 
-        self.logger.info("Accessing the 'My profile' page via the top-navbar menu")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with allure.step("Accessing the 'My profile' page via the top-navbar menu and extracting "
+                         "the original number of posted questions"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            original_number_of_questions = self.number_extraction_from_string(
+                self.sumo_pages.my_profile_page._get_my_profile_questions_text()
+            )
 
-        self.logger.info("Extracting original number of posted questions")
-        original_number_of_questions = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_questions_text()
-        )
+        with allure.step("Navigating to each product AAQ form"):
+            for product in super().general_test_data["freemium_products"]:
+                self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
 
-        self.logger.info("Navigating to each product aaq form")
-        for product in super().general_test_data["freemium_products"]:
-            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
+                with allure.step("Adding data inside the AAQ form fields and clicking on the "
+                                 "cancel button"):
+                    self.sumo_pages.aaq_flow.add__valid_data_to_all_aaq_fields_without_submitting(
+                        subject=super().aaq_question_test_data["valid_firefox_question"]
+                        ["subject"],
+                        topic_value=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                        body_text=super().aaq_question_test_data["valid_firefox_question"]
+                        ["question_body"]
+                    )
+                    self.sumo_pages.aaq_form_page._click_aaq_form_cancel_button()
 
-            self.logger.info("Adding data inside AAQ form fields without submitting the form")
-            self.sumo_pages.aaq_flow.add__valid_data_to_all_input_fields_without_submitting(
+                with allure.step("Verifying that we are redirected back to the correct product "
+                                 "solutions page"):
+                    expect(
+                        self.page
+                    ).to_have_url(super().general_test_data["product_solutions"][product])
+
+                with check, allure.step("Navigating back to the My Profile page and verifying "
+                                        "that the correct number of posted questions is "
+                                        "displayed"):
+                    self.sumo_pages.top_navbar._click_on_view_profile_option()
+                    new_number = self.number_extraction_from_string(
+                        self.sumo_pages.my_profile_page._get_my_profile_questions_text()
+                    )
+                    assert new_number == original_number_of_questions
+
+    # C890614, C890613, C890538
+    @pytest.mark.aaqPage
+    def test_post_aaq_questions_for_all_freemium_products_topics(self):
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        with allure.step("Navigating to each product AAQ form"):
+            for product in super().general_test_data["freemium_products"]:
+                self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
+
+                for topic in self.sumo_pages.aaq_form_page._get_aaq_form_topic_options():
+                    with allure.step(f"Submitting question for {product} product"):
+                        question_info = self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                            subject=super().aaq_question_test_data["valid_firefox_question"]
+                            ["subject"],
+                            topic_name=topic,
+                            body=super().aaq_question_test_data["valid_firefox_question"]
+                            ["question_body"],
+                            attach_image=False
+                        )
+
+                    with allure.step("Verifying that the correct implicit tags are added to the "
+                                     "question"):
+                        slugs = [super().aaq_question_test_data['aaq_topic_tags'][product][topic]]
+                        if (super().aaq_question_test_data['aaq_topic_tags'][product]
+                            ['default_slug']
+                                != "none"):
+                            slugs.append(
+                                super().aaq_question_test_data['aaq_topic_tags'][product]
+                                ['default_slug']
+                            )
+                        assert (
+                            all(map(
+                                lambda x: x in self.sumo_pages.question_page.
+                                _get_question_tag_options(),
+                                slugs))
+                        )
+
+                    with allure.step("Clicking on the 'My Questions' banner option and Verifying "
+                                     "that the posted question is displayed inside the 'My "
+                                     "Questions page"):
+                        self.sumo_pages.question_page._click_on_my_questions_banner_option()
+                        expect(
+                            self.sumo_pages.my_questions_page._get_listed_question(
+                                question_info['aaq_subject']
+                            )
+                        ).to_be_visible()
+
+                    with allure.step("Clicking on the question and deleting it"):
+                        self.sumo_pages.my_questions_page._click_on_a_question_by_name(
+                            question_info['aaq_subject']
+                        )
+                        self.sumo_pages.aaq_flow.deleting_question_flow()
+
+                    with allure.step("Verifying that the question is no longer displayed inside "
+                                     "My Questions page"):
+                        self.sumo_pages.top_navbar._click_on_my_questions_profile_option()
+                        expect(
+                            self.sumo_pages.my_questions_page._get_listed_question(
+                                question_info['aaq_subject']
+                            )
+                        ).to_be_hidden()
+
+                    with allure.step(f"Navigating back to the {product} product aa form"):
+                        self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]
+                                              [product])
+
+    @pytest.mark.aaqPage
+    def test_share_firefox_data_functionality(self):
+        with allure.step("Signing in with an admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        with allure.step("Navigating to the Firefox AAQ form page and clicking on the 'Share "
+                         "Data' option"):
+            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
+            self.sumo_pages.aaq_form_page._click_on_share_data_button()
+
+        with check, allure.step("Verifying that the 'try these manual steps' contains the "
+                                "correct link"):
+            assert self.sumo_pages.aaq_form_page._get_try_these_manual_steps_link(
+            ) == QuestionPageMessages.TRY_THESE_MANUAL_STEPS_LINK
+
+        with allure.step("Adding data inside AAQ form fields without submitting the form"):
+            self.sumo_pages.aaq_flow.add__valid_data_to_all_aaq_fields_without_submitting(
                 subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
                 topic_value=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
                 body_text=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
             )
 
-            self.logger.info("Clicking on the Cancel button")
-            self.sumo_pages.aaq_form_page._click_aaq_form_cancel_button()
-
-            self.logger.info("Verifying that we are redirected back to the correct product "
-                             "solutions page")
-            expect(
-                self.page
-            ).to_have_url(super().general_test_data["product_solutions"][product])
-
-            self.logger.info("Navigating back to the My Profile page")
-            self.sumo_pages.top_navbar._click_on_view_profile_option()
-
-            new_number = self.number_extraction_from_string(
-                self.sumo_pages.my_profile_page._get_my_profile_questions_text()
-            )
-
-            self.logger.info("Verifying that the correct number of posted questions is displayed "
-                             "at profile level")
-            check.equal(
-                new_number,
-                original_number_of_questions,
-                f"Incorrect number of questions displayed. "
-                f"Expected: {original_number_of_questions} "
-                f"Received: {new_number}"
-            )
-
-    # C890614, C890613, C890538
-    @pytest.mark.aaqPage
-    def test_post_aaq_questions_for_all_freemium_products_topics(self):
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Navigating to each product aaq form")
-        for product in super().general_test_data["freemium_products"]:
-            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
-
-            for topic in self.sumo_pages.aaq_form_page._get_aaq_form_topic_options():
-                self.logger.info(f"Submitting question for {product} product")
-                question_info = self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-                    subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-                    topic_name=topic,
-                    body=super().aaq_question_test_data["valid_firefox_question"]["question_body"],
-                    attach_image=False
-                )
-
-                self.logger.info("Verifying that the correct implicit tags are added to the "
-                                 "question")
-                slugs = [super().aaq_question_test_data['aaq_topic_tags'][product][topic]]
-                if (super().aaq_question_test_data['aaq_topic_tags'][product]['default_slug']
-                        != "none"):
-                    slugs.append(
-                        super().aaq_question_test_data['aaq_topic_tags'][product]['default_slug']
-                    )
-                assert (
-                    all(map(
-                        lambda x: x in self.sumo_pages.question_page._get_question_tag_options(),
-                        slugs))
-                )
-
-                self.logger.info("Clicking on the 'My Questions' banner option")
-                self.sumo_pages.question_page._click_on_my_questions_banner_option()
-
-                self.logger.info(
-                    "Verifying that the posted question is displayed inside the 'My Questions "
-                    "page'")
-
-                expect(
-                    self.sumo_pages.my_questions_page._get_listed_question(
-                        question_info['aaq_subject']
-                    )
-                ).to_be_visible()
-
-                self.logger.info("Clicking on the question and deleting it")
-                self.sumo_pages.my_questions_page._click_on_a_question_by_name(
-                    question_info['aaq_subject']
-                )
-
-                self.sumo_pages.aaq_flow.deleting_question_flow()
-
-                self.logger.info(
-                    "Verifying that the question is no longer displayed inside My Questions page")
-                self.sumo_pages.top_navbar._click_on_my_questions_profile_option()
-
-                expect(
-                    self.sumo_pages.my_questions_page._get_listed_question(
-                        question_info['aaq_subject']
-                    )
-                ).to_be_hidden()
-
-                self.logger.info(f"Navigating back to the {product} product aa form")
-                self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
-
-    @pytest.mark.aaqPage
-    def test_share_firefox_data_functionality(self):
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Navigating to the Firefox AAQ form page")
-        self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
-
-        self.logger.info("Clicking on the 'Share Data' option")
-        self.sumo_pages.aaq_form_page._click_on_share_data_button()
-
-        self.logger.info("Verifying that the 'try these manual steps' contains the correct link")
-        check.equal(
-            self.sumo_pages.aaq_form_page._get_try_these_manual_steps_link(),
-            QuestionPageMessages.TRY_THESE_MANUAL_STEPS_LINK
-        )
-
-        self.logger.info("Adding data inside AAQ form fields without submitting the form")
-        self.sumo_pages.aaq_flow.add__valid_data_to_all_input_fields_without_submitting(
-            subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_value=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
-            body_text=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
-        )
-
-        self.logger.info("Adding text inside the troubleshooting information field")
-        self.sumo_pages.aaq_form_page._add_text_to_troubleshooting_information_textarea(
-            super().aaq_question_test_data["troubleshooting_information"]
-        )
-
-        self.logger.info("Submitting the aaq question")
-        self.sumo_pages.aaq_form_page._click_aaq_form_submit_button()
-
-        self.logger.info("Verifying that the troubleshooting information is displayed")
-        self.sumo_pages.question_page._click_on_question_details_button()
-        self.sumo_pages.question_page._click_on_more_system_details_option()
-
-        expect(
-            self.sumo_pages.question_page._get_more_information_with_text_locator(
+        with allure.step("Adding text inside the troubleshooting information field and "
+                         "submitting the AAQ question"):
+            self.sumo_pages.aaq_form_page._add_text_to_troubleshooting_information_textarea(
                 super().aaq_question_test_data["troubleshooting_information"]
             )
-        ).to_be_visible()
+            self.sumo_pages.aaq_form_page._click_aaq_form_submit_button()
 
-        self.logger.info("Closing additional details panel")
-        self.sumo_pages.question_page._click_on_the_additional_system_panel_close_button()
+        with allure.step("Verifying that the troubleshooting information is displayed"):
+            self.sumo_pages.question_page._click_on_question_details_button()
+            self.sumo_pages.question_page._click_on_more_system_details_option()
+            expect(
+                self.sumo_pages.question_page._get_more_information_with_text_locator(
+                    super().aaq_question_test_data["troubleshooting_information"]
+                )
+            ).to_be_visible()
 
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Closing the additional details panel and deleting the posted question"):
+            self.sumo_pages.question_page._click_on_the_additional_system_panel_close()
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     @pytest.mark.aaqPage
     def test_additional_system_details_user_agent_information(self):
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Navigating to each product aaq form")
-        for product in super().general_test_data["freemium_products"]:
-            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
+        with allure.step("Navigating to each product aaq form"):
+            for product in super().general_test_data["freemium_products"]:
+                self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
 
-            self.logger.info(f"Submitting question for {product} product")
-            self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
-                body=super().aaq_question_test_data["valid_firefox_question"]["question_body"],
-                attach_image=True
-            )
+                with allure.step(f"Submitting a question for the {product} product"):
+                    self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                        subject=super().aaq_question_test_data["valid_firefox_question"]
+                        ["subject"],
+                        topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                        body=super().aaq_question_test_data["valid_firefox_question"]
+                        ["question_body"],
+                        attach_image=True
+                    )
 
-            self.logger.info("Verifying that the correct user-agent information is displayed")
-            self.sumo_pages.question_page._click_on_question_details_button()
-            self.sumo_pages.question_page._click_on_more_system_details_option()
+                with check, allure.step("Verifying that the correct user-agent information is "
+                                        "displayed"):
+                    self.sumo_pages.question_page._click_on_question_details_button()
+                    self.sumo_pages.question_page._click_on_more_system_details_option()
+                    assert "User Agent: " + self.get_user_agent(
+                    ) == self.sumo_pages.question_page._get_user_agent_information()
 
-            check.equal(
-                "User Agent: " + self.get_user_agent(),
-                self.sumo_pages.question_page._get_user_agent_information(),
-                f"Incorrect user agent displayed. "
-                f"Expected: {'User Agent: ' + self.get_user_agent()} "
-                f"Received: {self.sumo_pages.question_page._get_user_agent_information()}"
-            )
-
-            self.logger.info("Closing additional details panel")
-            self.sumo_pages.question_page._click_on_the_additional_system_panel_close_button()
-
-            self.logger.info("Deleting the posted question")
-            self.sumo_pages.aaq_flow.deleting_question_flow()
+                with allure.step("Closing the additional details panel and deleting the posted "
+                                 "questions"):
+                    self.sumo_pages.question_page._click_on_the_additional_system_panel_close()
+                    self.sumo_pages.aaq_flow.deleting_question_flow()
 
     @pytest.mark.aaqPage
     def test_system_details_information(self):
@@ -429,52 +396,47 @@ class TestAAQPage(TestUtilities):
             "Firefox " + super().aaq_question_test_data["troubleshoot_product_and_os_versions"][1]
         ]
 
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Navigating to each product aaq form")
-        for product in super().general_test_data["freemium_products"]:
-            self.logger.info(product)
-            if product == 'Firefox Reality' or product == "Thunderbird":
-                continue
-            else:
-                self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"][product])
+        with allure.step("Navigating to each product aaq form and and adding data without "
+                         "submitting the form"):
+            for product in super().general_test_data["freemium_products"]:
+                self.logger.info(product)
+                if product == 'Firefox Reality' or product == "Thunderbird":
+                    continue
+                else:
+                    self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]
+                                          [product])
+                    self.sumo_pages.aaq_flow.add__valid_data_to_all_aaq_fields_without_submitting(
+                        subject=super().aaq_question_test_data["valid_firefox_question"]
+                        ["subject"],
+                        topic_value=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                        body_text=super().aaq_question_test_data["valid_firefox_question"][
+                            "question_body"]
+                    )
 
-                self.logger.info("Adding data inside AAQ form fields without submitting the form")
-                self.sumo_pages.aaq_flow.add__valid_data_to_all_input_fields_without_submitting(
-                    subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-                    topic_value=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
-                    body_text=super().aaq_question_test_data["valid_firefox_question"][
-                        "question_body"]
-                )
+                    with allure.step("Clicking on the 'Show details' option and adding data to "
+                                     "product version and OS fields"):
+                        self.sumo_pages.aaq_form_page._click_on_show_details_option()
+                        self.sumo_pages.aaq_form_page._add_text_to_product_version_field(
+                            super().aaq_question_test_data[
+                                "troubleshoot_product_and_os_versions"][1]
+                        )
+                        self.sumo_pages.aaq_form_page._add_text_to_os_field(
+                            super().aaq_question_test_data[
+                                "troubleshoot_product_and_os_versions"][0]
+                        )
 
-                self.logger.info("Clicking on the 'Show details' option")
-                self.sumo_pages.aaq_form_page._click_on_show_details_option()
+                    with check, allure.step("Submitting the AAQ question and verifying that the "
+                                            "correct provided troubleshooting information is "
+                                            "displayed"):
+                        self.sumo_pages.aaq_form_page._click_aaq_form_submit_button()
+                        self.sumo_pages.question_page._click_on_question_details_button()
+                        assert self.sumo_pages.question_page._get_system_details_information(
+                        ) == troubleshooting_info
 
-                self.logger.info("Adding data to product version and OS fields")
-                self.sumo_pages.aaq_form_page._add_text_to_product_version_field(
-                    super().aaq_question_test_data[
-                        "troubleshoot_product_and_os_versions"][1]
-                )
-                self.sumo_pages.aaq_form_page._add_text_to_os_field(
-                    super().aaq_question_test_data[
-                        "troubleshoot_product_and_os_versions"][0]
-                )
-
-                self.logger.info("Submitting the aaq question")
-                self.sumo_pages.aaq_form_page._click_aaq_form_submit_button()
-
-                self.logger.info(
-                    "Verifying that the correct provided troubleshooting information is displayed")
-                self.sumo_pages.question_page._click_on_question_details_button()
-                check.equal(
-                    self.sumo_pages.question_page._get_system_details_information(),
-                    troubleshooting_info,
-                    f"Expected: {troubleshooting_info} "
-                    f"Received:{self.sumo_pages.question_page._get_system_details_information()}"
-                )
-
-                self.logger.info("Deleting the posted question")
-                self.sumo_pages.aaq_flow.deleting_question_flow()
+                    with allure.step("Deleting the posted question"):
+                        self.sumo_pages.aaq_flow.deleting_question_flow()

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -1,7 +1,8 @@
 import os
 
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 from playwright_tests.core.testutilities import TestUtilities
 from playwright.sync_api import expect
 
@@ -20,9 +21,9 @@ class TestPostedQuestions(TestUtilities):
     @pytest.mark.postedQuestions
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_13', ''])
     def test_posted_question_details(self, username):
-        self.logger.info("Signing in with an admin user account and posting a Firefox product "
-                         "question")
-        self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non-admin user account and posting a Firefox product "
+                         "question"):
+            self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
         if username == 'TEST_ACCOUNT_13':
             self.start_existing_session(super().username_extraction_from_email(
@@ -30,1433 +31,1197 @@ class TestPostedQuestions(TestUtilities):
             ))
             self.page.reload()
 
-        self.logger.info("Verifying that the scam banner is displayed")
-        expect(
-            self.sumo_pages.product_solutions_page._get_scam_banner_locator()
-        ).to_be_visible()
+        with allure.step("Verifying that the scam banner is displayed"):
+            expect(
+                self.sumo_pages.product_solutions_page._get_scam_banner_locator()
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the still need help banner is not displayed")
-        expect(
-            self.sumo_pages.product_solutions_page._get_still_need_help_locator()
-        ).to_be_hidden()
+        with allure.step("Verifying that the still need help banner is not displayed"):
+            expect(
+                self.sumo_pages.product_solutions_page._get_still_need_help_locator()
+            ).to_be_hidden()
 
-        self.logger.info(
-            "Verifying that the 'Learn More' button contains the correct link")
-        check.equal(
-            self.sumo_pages.product_solutions_page._get_scam_alert_banner_link(),
-            QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
-        )
+        with check, allure.step("Verifying that the Learn More button contains the correct link"):
+            assert self.sumo_pages.product_solutions_page._get_scam_alert_banner_link(
+            ) == QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
 
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account and verifying that the scam banner is "
+                         "displayed and the still need hel banner is not displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            expect(
+                self.sumo_pages.product_solutions_page._get_scam_banner_locator()
+            ).to_be_visible()
+            expect(
+                self.sumo_pages.product_solutions_page._get_still_need_help_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the scam banner is displayed")
-        expect(
-            self.sumo_pages.product_solutions_page._get_scam_banner_locator()
-        ).to_be_visible()
+        with check, allure.step("Verifying that the Learn More button contains the correct link"):
+            assert self.sumo_pages.product_solutions_page._get_scam_alert_banner_link(
+            ) == QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
 
-        self.logger.info("Verifying that the still need help banner is not displayed")
-        expect(
-            self.sumo_pages.product_solutions_page._get_still_need_help_locator()
-        ).to_be_hidden()
-
-        self.logger.info(
-            "Verifying that the 'Learn More' button contains the correct link")
-        check.equal(
-            self.sumo_pages.product_solutions_page._get_scam_alert_banner_link(),
-            QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
-        )
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Deleting the posted question"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191092,  C2191263
     @pytest.mark.postedQuestions
     def test_edit_this_question_functionality_not_signed_in(self):
-        self.logger.info("Signing in with an admin user account and posting a Firefox product "
-                         "question")
-        self.post_firefox_product_question_flow('TEST_ACCOUNT_MODERATOR')
+        with allure.step("Signing in with an admin account and posting a Firefox question"):
+            self.post_firefox_product_question_flow('TEST_ACCOUNT_MODERATOR')
 
-        self.logger.info("Deleting session cookies")
-        self.delete_cookies()
+        with allure.step("Deleting user session and verifying that the 'edit this question' nav "
+                         "option is not available"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.question_page._get_edit_this_question_option_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'edit this question' nav option is not available")
+        with allure.step("Navigating to the edit endpoint and verifying that the user is "
+                         "redirected to the auth page"):
+            self.navigate_to_link(
+                self.get_page_url() + QuestionPageMessages.EDIT_QUESTION_URL_ENDPOINT
+            )
+            assert (
+                FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
+            )
 
-        expect(
-            self.sumo_pages.question_page._get_edit_this_question_option_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Navigating to the edit endpoint")
-        self.navigate_to_link(
-            self.get_page_url() + QuestionPageMessages.EDIT_QUESTION_URL_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the user is to the auth page")
-        assert (
-            FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
-        )
-
-        self.logger.info("Navigating back to the question")
-        self.navigate_back()
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Deleting the posted question"):
+            self.navigate_back()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191262, C2436105,  C2191263
     # To add image tests
     @pytest.mark.postedQuestions
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_12', 'TEST_ACCOUNT_MODERATOR'])
     def test_cancel_edit_this_question_functionality(self, username):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
         if username == 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Deleting session cookies and signing in with an admin account")
+            with allure.step("Signing in with an admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
 
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-            ))
+        with check, allure.step("Navigating to the posted question, clicking on the 'Edit this "
+                                "question' option and verifying that the subject field contains "
+                                "the correct value"):
+            self.navigate_to_link(posted_question['question_details']['question_page_url'])
+            self.sumo_pages.question_page._click_on_edit_this_question_question_tools_option()
+            assert self.sumo_pages.aaq_form_page._get_value_of_subject_input_field(
+            ) == posted_question['question_details']['aaq_subject']
 
-        self.navigate_to_link(posted_question['question_details']['question_page_url'])
-        self.logger.info("Clicking on the 'Edit this question' option")
-        self.sumo_pages.question_page._click_on_edit_this_question_question_tools_option()
+        with check, allure.step("Verifying that the question body contains the correct value"):
+            assert self.sumo_pages.aaq_form_page._get_value_of_question_body_textarea_field(
+            ) == posted_question['question_details']['question_body']
 
-        self.logger.info("Verifying that the subject field contains the correct value")
-        check.equal(
-            self.sumo_pages.aaq_form_page._get_value_of_subject_input_field(),
-            posted_question['question_details']['aaq_subject'],
-            f"Incorrect question subject displayed. "
-            f"Expected: {posted_question['question_details']['aaq_subject']} "
-            f"Received: {self.sumo_pages.aaq_form_page._get_value_of_subject_input_field()}"
-        )
+        with allure.step("Editing the question with new data"):
+            self.sumo_pages.aaq_flow.editing_question_flow(
+                subject=super().aaq_question_test_data['valid_firefox_question']
+                ['subject_updated'],
+                body=super().aaq_question_test_data['valid_firefox_question']['body_updated'],
+                troubleshoot=super().aaq_question_test_data['troubleshooting_information'],
+                submit_edit=False
+            )
 
-        self.logger.info("Verifying that the question body contains the correct value")
-        check.equal(
-            self.sumo_pages.aaq_form_page._get_value_of_question_body_textarea_field(),
-            posted_question['question_details']['question_body']
-        )
-
-        self.logger.info("Editing the question with new data")
-        self.sumo_pages.aaq_flow.editing_question_flow(
-            subject=super().aaq_question_test_data['valid_firefox_question']['subject_updated'],
-            body=super().aaq_question_test_data['valid_firefox_question']['body_updated'],
-            troubleshoot=super().aaq_question_test_data['troubleshooting_information'],
-            submit_edit=False
-        )
-
-        self.logger.info("Clicking on the 'Cancel' button")
-        self.sumo_pages.aaq_form_page._click_aaq_form_cancel_button()
-
-        self.logger.info("Verifying that the 'Modified' text is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_modified_question_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the subject and body fields are the same")
-        check.equal(
-            self.sumo_pages.question_page._get_question_header(),
-            posted_question['question_details']['aaq_subject']
-        )
-
-        check.equal(
-            self.sumo_pages.question_page._get_question_body(),
-            posted_question['question_details']['question_body'] + '\n'
-        )
+        with check, allure.step("Clicking on the 'Cancel' button and verifying that the modified "
+                                "text is not displayed"):
+            self.sumo_pages.aaq_form_page._click_aaq_form_cancel_button()
+            expect(
+                self.sumo_pages.question_page._get_modified_question_locator()
+            ).to_be_hidden()
+            assert self.sumo_pages.question_page._get_question_header(
+            ) == posted_question['question_details']['aaq_subject']
+            assert self.sumo_pages.question_page._get_question_body(
+            ) == posted_question['question_details']['question_body'] + '\n'
 
         if username == 'TEST_ACCOUNT_12':
-            self.logger.info("Verifying that the additional question details option is hidden")
-            expect(
-                self.sumo_pages.question_page._get_question_details_button_locator()
-            ).to_be_hidden()
+            with allure.step("Verifying that the additional question details option is hidden"):
+                expect(
+                    self.sumo_pages.question_page._get_question_details_button_locator()
+                ).to_be_hidden()
         elif username == "TEST_ACCOUNT_MODERATOR":
-            self.logger.info("Clicking on the 'Question Details' option")
-            self.sumo_pages.question_page._click_on_question_details_button()
+            with allure.step("Verifying that the more information section from the 'More System "
+                             "Details' is not displayed"):
+                self.sumo_pages.question_page._click_on_question_details_button()
+                self.sumo_pages.question_page._click_on_more_system_details_option()
+                expect(
+                    self.sumo_pages.question_page._get_more_information_locator()
+                ).to_be_hidden()
 
-            self.logger.info("Clicking on the 'More system details' option")
-            self.sumo_pages.question_page._click_on_more_system_details_option()
+            with allure.step("Closing the more information panel and deleting the question"):
+                self.sumo_pages.question_page._click_on_the_additional_system_panel_close()
 
-            self.logger.info("Verifying that the more information section is not displayed")
-            expect(
-                self.sumo_pages.question_page._get_more_information_locator()
-            ).to_be_hidden()
+                if username != 'TEST_ACCOUNT_MODERATOR':
+                    self.start_existing_session(super().username_extraction_from_email(
+                        self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                    ))
 
-            self.logger.info("Closing the more information panel")
-            self.sumo_pages.question_page._click_on_the_additional_system_panel_close_button()
-
-        if username != 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Deleting session cookies and signing in with an admin account")
-
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-            ))
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+                self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191263
     @pytest.mark.postedQuestions
     def test_edit_other_user_question_non_admin(self):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_13')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_13')
 
-        self.logger.info("Signing in with a non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non admin user account and verifying that the 'Edit "
+                         "this question' option is not available"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_edit_this_question_option_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'Edit this question' option is not available")
-        expect(
-            self.sumo_pages.question_page._get_edit_this_question_option_locator()
-        ).to_be_hidden()
+        with check, allure.step("Manually navigating to the '/edit' endpoint and verifying that "
+                                "403 is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    posted_question['question_details']
+                    ['question_page_url'] + QuestionPageMessages.
+                    EDIT_QUESTION_URL_ENDPOINT)
+            response = navigation_info.value
+            assert response.status == 403
 
-        self.logger.info("Manually navigating to the '/edit' endpoint and verifying that 403 is "
-                         "returned")
-
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                posted_question['question_details']['question_page_url'] + QuestionPageMessages.
-                EDIT_QUESTION_URL_ENDPOINT)
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            403
-        )
-
-        self.logger.info("Navigating back to the posted question")
-        self.navigate_to_link(posted_question['question_details']['question_page_url'])
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Signing in with an admin account and deleting the posted question"):
+            self.navigate_to_link(posted_question['question_details']['question_page_url'])
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191262, C2436105, C2191263
     # To add image tests
     @pytest.mark.postedQuestions
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_12', 'TEST_ACCOUNT_MODERATOR'])
     def test_edit_this_question_functionality(self, username):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
-        user = super().username_extraction_from_email(
-            self.user_secrets_accounts[username]
-        )
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+            user = super().username_extraction_from_email(
+                self.user_secrets_accounts[username]
+            )
 
         if username == 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Signing in with an admin account")
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-            ))
+            with allure.step("Signing in with an admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
 
-        self.navigate_to_link(posted_question['question_details']['question_page_url'])
-        self.logger.info("Clicking on the 'Edit this question' option")
-        self.sumo_pages.question_page._click_on_edit_this_question_question_tools_option()
+        with check, allure.step("Clicking on the 'Edit this question' option and verifying that "
+                                "the subject and body fields contain the correct value"):
+            self.navigate_to_link(posted_question['question_details']['question_page_url'])
+            self.sumo_pages.question_page._click_on_edit_this_question_question_tools_option()
+            assert self.sumo_pages.aaq_form_page._get_value_of_subject_input_field(
+            ) == posted_question['question_details']['aaq_subject']
+            assert self.sumo_pages.aaq_form_page._get_value_of_question_body_textarea_field(
+            ) == posted_question['question_details']['question_body']
 
-        self.logger.info("Verifying that the subject field contains the correct value")
-        check.equal(
-            self.sumo_pages.aaq_form_page._get_value_of_subject_input_field(),
-            posted_question['question_details']['aaq_subject'],
-            f"Incorrect question subject displayed. "
-            f"Expected: {posted_question['question_details']['aaq_subject']} "
-            f"Received: {self.sumo_pages.aaq_form_page._get_value_of_subject_input_field()}"
-        )
-
-        self.logger.info("Verifying that the question body contains the correct value")
-        check.equal(
-            self.sumo_pages.aaq_form_page._get_value_of_question_body_textarea_field(),
-            posted_question['question_details']['question_body']
-
-        )
-
-        self.logger.info("Editing the question with new data")
-        self.sumo_pages.aaq_flow.editing_question_flow(
-            subject=super().aaq_question_test_data['valid_firefox_question']['subject_updated'],
-            body=super().aaq_question_test_data['valid_firefox_question']['body_updated'],
-            troubleshoot=super().aaq_question_test_data['troubleshooting_information']
-        )
-
-        self.logger.info("Verifying that the 'Modified' text is displayed")
-        expect(
-            self.sumo_pages.question_page._get_modified_question_locator()
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the username is displayed inside the modified by text")
-        check.is_in(
-            user,
-            self.sumo_pages.question_page._get_modified_by_text()
-        )
-
-        self.logger.info("Verifying that the subject and body are modified")
-        check.equal(
-            self.sumo_pages.question_page._get_question_header(),
-            super().aaq_question_test_data['valid_firefox_question']['subject_updated']
-        )
-
-        check.equal(
-            self.sumo_pages.question_page._get_question_body(),
-            super().aaq_question_test_data['valid_firefox_question']['body_updated'] + '\n'
-        )
-
-        if username == 'TEST_ACCOUNT_12':
-            self.logger.info("Verifying that the additional question details option is hidden")
+        with check, allure.step("Editing the question with new data and verifying that the "
+                                "modified text is displayed and the username is displayed inside"
+                                " the modified text"):
+            self.sumo_pages.aaq_flow.editing_question_flow(
+                subject=super().aaq_question_test_data['valid_firefox_question']
+                ['subject_updated'],
+                body=super().aaq_question_test_data['valid_firefox_question']['body_updated'],
+                troubleshoot=super().aaq_question_test_data['troubleshooting_information']
+            )
             expect(
-                self.sumo_pages.question_page._get_question_details_button_locator()
-            ).to_be_hidden()
-        elif username == "TEST_ACCOUNT_MODERATOR":
-            self.logger.info("Clicking on the 'Question Details' option")
-            self.sumo_pages.question_page._click_on_question_details_button()
-
-            self.logger.info("Clicking on the 'More system details' option")
-            self.sumo_pages.question_page._click_on_more_system_details_option()
-
-            self.logger.info("Verifying that the more information section displays the update")
-            expect(
-                self.sumo_pages.question_page._get_more_information_with_text_locator(
-                    super().aaq_question_test_data['troubleshooting_information']
-                )
+                self.sumo_pages.question_page._get_modified_question_locator()
             ).to_be_visible()
 
-            self.logger.info("Closing the more information panel")
-            self.sumo_pages.question_page._click_on_the_additional_system_panel_close_button()
+            assert user in self.sumo_pages.question_page._get_modified_by_text()
+            assert self.sumo_pages.question_page._get_question_header(
+            ) == super().aaq_question_test_data['valid_firefox_question']['subject_updated']
+            assert self.sumo_pages.question_page._get_question_body(
+            ) == super().aaq_question_test_data['valid_firefox_question']['body_updated'] + '\n'
 
-        if username != 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Signing in with an admin account")
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-            ))
+        if username == 'TEST_ACCOUNT_12':
+            with allure.step("Verifying that the additional question details option is hidden"):
+                expect(
+                    self.sumo_pages.question_page._get_question_details_button_locator()
+                ).to_be_hidden()
+        elif username == "TEST_ACCOUNT_MODERATOR":
+            with allure.step("Verifying that the more information section displays the updated "
+                             "information"):
+                self.sumo_pages.question_page._click_on_question_details_button()
+                self.sumo_pages.question_page._click_on_more_system_details_option()
+                expect(
+                    self.sumo_pages.question_page._get_more_information_with_text_locator(
+                        super().aaq_question_test_data['troubleshooting_information']
+                    )
+                ).to_be_visible()
 
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+            self.sumo_pages.question_page._click_on_the_additional_system_panel_close()
+
+        with allure.step("Deleting the posted question"):
+            if username != 'TEST_ACCOUNT_MODERATOR':
+                self.logger.info("Signing in with an admin account")
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
+
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191263
     @pytest.mark.postedQuestions
     def test_delete_question_cancel_button(self):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question_one = self.post_firefox_product_question_flow('TEST_ACCOUNT_13')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question_one = self.post_firefox_product_question_flow('TEST_ACCOUNT_13')
 
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question_two = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a different non-admin user account and posting a "
+                         "Firefox product question"):
+            posted_question_two = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
-        self.navigate_to_link(posted_question_one['question_details']['question_page_url'])
+        with allure.step("Navigating to the posted question by a different user an verifying "
+                         "that the 'Delete this question' option is not available"):
+            self.navigate_to_link(posted_question_one['question_details']['question_page_url'])
+            expect(
+                self.sumo_pages.question_page._get_delete_this_question_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'Delete this question' option is not available")
-        expect(
-            self.sumo_pages.question_page._get_delete_this_question_locator()
-        ).to_be_hidden()
+        with check, allure.step("Manually navigating to the delete endpoint and verifying that "
+                                "403 is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    posted_question_one['question_details']
+                    ['question_page_url'] + QuestionPageMessages.DELETE_QUESTION_URL_ENDPOINT)
+            response = navigation_info.value
+            assert response.status == 403
 
-        self.logger.info("Manually navigating to the delete endpoint and verifying that 403 is "
-                         "returned")
+        with allure.step("Navigating to the posted question by self and verifying that the "
+                         "'Delete this question' option is not available"):
+            self.navigate_to_link(posted_question_two['question_details']['question_page_url'])
+            expect(
+                self.sumo_pages.question_page._get_delete_this_question_locator()
+            ).to_be_hidden()
 
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                posted_question_one['question_details']
-                ['question_page_url'] + QuestionPageMessages.DELETE_QUESTION_URL_ENDPOINT)
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            403
-        )
+        with check, allure.step("Manually navigating to the delete endpoint and verifying that "
+                                "403 is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    posted_question_one['question_details']
+                    ['question_page_url'] + QuestionPageMessages.DELETE_QUESTION_URL_ENDPOINT)
+            response = navigation_info.value
+            assert response.status == 403
 
-        self.navigate_to_link(posted_question_two['question_details']['question_page_url'])
+        with allure.step("Signing in with an admin account, clicking on the delete question for "
+                         "second question and clicking on the 'Cancel' confirmation button"):
+            self.navigate_to_link(posted_question_two['question_details']['question_page_url'])
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
+            self.sumo_pages.aaq_form_page._click_aaq_form_cancel_button()
 
-        self.logger.info("Verifying that the 'Delete this question' option is not available")
-        expect(
-            self.sumo_pages.question_page._get_delete_this_question_locator()
-        ).to_be_hidden()
+        with allure.step("Verifying that the question is not deleted"):
+            expect(
+                self.page
+            ).to_have_url(posted_question_two['question_details']['question_page_url'])
 
-        self.logger.info("Manually navigating to the delete endpoint and verifying that 403 is "
-                         "returned")
-
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                posted_question_one['question_details']
-                ['question_page_url'] + QuestionPageMessages.DELETE_QUESTION_URL_ENDPOINT)
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            403
-        )
-
-        self.logger.info("Navigating back to the question page and deleting session cookies")
-        self.navigate_to_link(posted_question_two['question_details']['question_page_url'])
-
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the 'Delete this question option'")
-        self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
-
-        self.logger.info("Clicking on the 'Cancel' button and verifying that we are on the "
-                         "question page")
-
-        self.sumo_pages.aaq_form_page._click_aaq_form_cancel_button()
-
-        expect(
-            self.page
-        ).to_have_url(posted_question_two['question_details']['question_page_url'])
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
-
-        self.navigate_to_link(posted_question_one['question_details']['question_page_url'])
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Deleting both questions"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()
+            self.navigate_to_link(posted_question_one['question_details']['question_page_url'])
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191264, C2191265
     # To add coverage for images as well
     @pytest.mark.postedQuestions
     @pytest.mark.parametrize("status", ['locked', 'archived'])
     def test_lock_and_archive_this_question(self, status):
-        self.logger.info(f"Executing the {status} question tests")
-        self.logger.info("Signing in with a non admin user account")
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_13')
+        with allure.step("Signing in with a non-admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_13')
 
-        self.logger.info("Signing in with a different non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a different non-admin user account and posting a "
+                         "different question"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
 
-        self.logger.info("Posting a Firefox product question")
-        self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
-
-        question_info_two = self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-            subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
-            body=super().aaq_question_test_data["valid_firefox_question"]["simple_body_text"],
-            attach_image=False
-        )
-
-        self.navigate_to_link(
-            posted_question['question_details']['question_page_url']
-        )
-
-        if status == "locked":
-            self.logger.info("Verifying that the 'Lock this question' option is not available for "
-                             "other posted questions")
-            expect(
-                self.sumo_pages.question_page._get_lock_this_question_locator()
-            ).to_be_hidden()
-        elif status == "archived":
-            expect(
-                self.sumo_pages.question_page._get_archive_this_question_locator()
-            ).to_be_hidden()
-
-        self.navigate_to_link(
-            question_info_two['question_page_url']
-        )
-
-        if status == "locked":
-            self.logger.info("Verifying that the 'Lock this question is not available for self "
-                             "posted questions")
-            expect(
-                self.sumo_pages.question_page._get_lock_this_question_locator()
-            ).to_be_hidden()
-        elif status == "archived":
-            expect(
-                self.sumo_pages.question_page._get_archive_this_question_locator()
-            ).to_be_hidden()
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        if status == "locked":
-            self.logger.info("Clicking on the 'Lock this question' option")
-            self.sumo_pages.question_page._click_on_lock_this_question_locator()
-        elif status == "archived":
-            self.logger.info("Clicking on the 'Archive this question' option")
-            self.sumo_pages.question_page._click_on_archive_this_question_option()
-
-        self.logger.info("Signing in with a different non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        if status == "locked":
-            self.logger.info("Verifying that correct locked thread banner text is displayed")
-            check.equal(
-                self.sumo_pages.question_page._get_thread_locked_text(),
-                QuestionPageMessages.LOCKED_THREAD_BANNER
-            )
-        elif status == "archived":
-            self.logger.info("Verifying that correct archived thread banner text is displayed")
-            check.equal(
-                self.sumo_pages.question_page._get_thread_locked_text(),
-                QuestionPageMessages.ARCHIVED_THREAD_BANNER
+            question_info_two = self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
+                topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                body=super().aaq_question_test_data["valid_firefox_question"]["simple_body_text"],
+                attach_image=False
             )
 
-        self.logger.info("Clicking on the locked thread link and verifying that we are "
-                         "redirected to the correct page")
-        self.sumo_pages.question_page._click_on_thread_locked_link()
-
-        expect(
-            self.page
-        ).to_have_url(ContactSupportMessages.PAGE_URL)
-
-        self.logger.info("Navigating back to the question page")
-        self.navigate_back()
+        with allure.step("Navigating to the first posted question"):
+            self.navigate_to_link(
+                posted_question['question_details']['question_page_url']
+            )
 
         if status == "locked":
-            self.logger.info("Verifying that the 'Unlock this question option is not available'")
-            expect(
-                self.sumo_pages.question_page._get_lock_this_question_locator()
-            ).to_be_hidden()
+            with allure.step("Verifying that the 'Lock this question' option is not available for "
+                             "other posted questions"):
+                expect(
+                    self.sumo_pages.question_page._get_lock_this_question_locator()
+                ).to_be_hidden()
         elif status == "archived":
-            expect(
-                self.sumo_pages.question_page._get_archive_this_question_locator()
-            ).to_be_hidden()
+            with allure.step("Verifying that the 'Archive this question' option is not available "
+                             "for other posted questions"):
+                expect(
+                    self.sumo_pages.question_page._get_archive_this_question_locator()
+                ).to_be_hidden()
 
-        self.logger.info("Verifying that the post a reply textarea field is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_post_a_reply_textarea_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'needs more information from the user' checkbox is "
-                         "not displayed")
-        expect(
-            self.sumo_pages.question_page._get_needs_more_information_checkbox_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'Add images section is not displayed'")
-        expect(
-            self.sumo_pages.question_page._get_add_image_section_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with an admin account")
-        repliant_username = super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        )
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Verifying that the 'needs more information from the user' checkbox is "
-                         "available")
-        expect(
-            self.sumo_pages.question_page._get_needs_more_information_checkbox_locator()
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the 'Add images' section is available")
-        expect(
-            self.sumo_pages.question_page._get_add_image_section_locator()
-        ).to_be_visible()
-
-        self.logger.info("Submitting a reply to the question")
-        reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-            repliant_username=repliant_username,
-            reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
-
-        self.logger.info("Verifying that posted reply is visible")
-        expect(
-            self.sumo_pages.question_page._get_posted_reply_locator(reply_id)
-        ).to_be_visible()
-
-        self.logger.info("Signing in with a normal user account and verifying that the admin's "
-                         "reply is visible")
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        expect(
-            self.sumo_pages.question_page._get_posted_reply_locator(reply_id)
-        ).to_be_visible()
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Navigating to the question posted by self"):
+            self.navigate_to_link(
+                question_info_two['question_page_url']
+            )
 
         if status == "locked":
-            self.logger.info("Unlocking the question")
-            self.sumo_pages.question_page._click_on_lock_this_question_locator()
+            with allure.step("Verifying that the 'Lock this question is not available for self "
+                             "posted questions"):
+                expect(
+                    self.sumo_pages.question_page._get_lock_this_question_locator()
+                ).to_be_hidden()
         elif status == "archived":
-            self.logger.info("Clicking on the 'Archive this question' option")
-            self.sumo_pages.question_page._click_on_archive_this_question_option()
+            with allure.step("Verifying that the 'Archive this question' is not available for "
+                             "self posted questions"):
+                expect(
+                    self.sumo_pages.question_page._get_archive_this_question_locator()
+                ).to_be_hidden()
 
-        self.logger.info("Signing in with an admin account")
-        second_repliant = super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        )
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Verifying that the 'Thread locked' banner is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_thread_locked_locator()
-        ).to_be_hidden()
+        if status == "locked":
+            with allure.step("Clicking on the 'Lock this question' option"):
+                self.sumo_pages.question_page._click_on_lock_this_question_locator()
+        elif status == "archived":
+            with allure.step("Clicking on the 'Archive this question' option"):
+                self.sumo_pages.question_page._click_on_archive_this_question_option()
 
-        self.logger.info("Submitting a reply to the question")
-        reply_id_two = self.sumo_pages.aaq_flow.post_question_reply_flow(
-            repliant_username=second_repliant,
-            reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
+        with allure.step("Signing in with a different non admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Verifying that the posted reply is visible")
+        if status == "locked":
+            with check, allure.step("Verifying that correct locked thread banner text is "
+                                    "displayed"):
+                assert self.sumo_pages.question_page._get_thread_locked_text(
+                ) == QuestionPageMessages.LOCKED_THREAD_BANNER
+        elif status == "archived":
+            with check, allure.step("Verifying that correct archived thread banner text is "
+                                    "displayed"):
+                assert self.sumo_pages.question_page._get_thread_locked_text(
+                ) == QuestionPageMessages.ARCHIVED_THREAD_BANNER
 
-        expect(
-            self.sumo_pages.question_page._get_posted_reply_locator(reply_id_two)
-        ).to_be_visible()
+        with allure.step("Clicking on the locked thread link and verifying that we are "
+                         "redirected to the correct page"):
+            self.sumo_pages.question_page._click_on_thread_locked_link()
+            expect(
+                self.page
+            ).to_have_url(ContactSupportMessages.PAGE_URL)
 
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Navigating back to the question page"):
+            self.navigate_back()
 
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        if status == "locked":
+            with allure.step("Verifying that the 'Unlock this question option' is not available'"):
+                expect(
+                    self.sumo_pages.question_page._get_lock_this_question_locator()
+                ).to_be_hidden()
+        elif status == "archived":
+            with allure.step("Verifying that the 'Archive this question' options is not "
+                             "available"):
+                expect(
+                    self.sumo_pages.question_page._get_archive_this_question_locator()
+                ).to_be_hidden()
 
-        self.navigate_to_link(
-            posted_question['question_details']['question_page_url']
-        )
+        with allure.step("Verifying that the post a reply textarea field is not displayed"):
+            expect(
+                self.sumo_pages.question_page._get_post_a_reply_textarea_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Verifying that the 'needs more information from the user' checkbox is "
+                         "not displayed"):
+            expect(
+                self.sumo_pages.question_page._get_needs_more_information_checkbox_locator()
+            ).to_be_hidden()
+
+        with allure.step("Verifying that the 'Add images section is not displayed'"):
+            expect(
+                self.sumo_pages.question_page._get_add_image_section_locator()
+            ).to_be_hidden()
+
+        with allure.step("Signing in with an admin account and verifying that the 'needs more "
+                         "information from the user' checkbox is available"):
+            repliant_username = super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            )
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_needs_more_information_checkbox_locator()
+            ).to_be_visible()
+
+        with allure.step("Verifying that the 'Add images' section is available"):
+            expect(
+                self.sumo_pages.question_page._get_add_image_section_locator()
+            ).to_be_visible()
+
+        with allure.step("Submitting a reply to the question and verifying that the posted reply "
+                         "is visible"):
+            reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                repliant_username=repliant_username,
+                reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
+            )
+            expect(
+                self.sumo_pages.question_page._get_posted_reply_locator(reply_id)
+            ).to_be_visible()
+
+        with allure.step("Signing in with a normal user account and verifying that the admin's "
+                         "reply is visible"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_posted_reply_locator(reply_id)
+            ).to_be_visible()
+
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        if status == "locked":
+            with allure.step("Unlocking the question"):
+                self.sumo_pages.question_page._click_on_lock_this_question_locator()
+        elif status == "archived":
+            with allure.step("Clicking on the 'Archive this question' option"):
+                self.sumo_pages.question_page._click_on_archive_this_question_option()
+
+        with allure.step("Signing in with a non-admin account and verifying that the 'Thread "
+                         "locked' banner is not displayed"):
+            second_repliant = super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            )
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_thread_locked_locator()
+            ).to_be_hidden()
+
+        with allure.step("Submitting a reply to the question and verifying that the posted reply "
+                         "is visible"):
+            reply_id_two = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                repliant_username=second_repliant,
+                reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
+            )
+            expect(
+                self.sumo_pages.question_page._get_posted_reply_locator(reply_id_two)
+            ).to_be_visible()
+
+        with allure.step("Signing in with an admin account and deleting both questions"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.aaq_flow.deleting_question_flow()
+            self.navigate_to_link(
+                posted_question['question_details']['question_page_url']
+            )
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191267, C2191116, C2134136, C2191091
     @pytest.mark.postedQuestions
     def test_subscribe_to_feed_option(self):
-        self.logger.info("Signing in with a non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with allure.step("Signing in with a non admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
 
-        self.logger.info("Posting a Firefox product question")
-        self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
+        with allure.step("Posting a Firefox product question"):
+            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
 
-        question_info_one = self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-            subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
-            body=super().aaq_question_test_data["valid_firefox_question"]["simple_body_text"],
-            attach_image=False
-        )
-
-        self.logger.info("Signing in with a different non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.logger.info("Posting a Firefox product question")
-        self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
-
-        question_info_two = self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-            subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
-            body=super().aaq_question_test_data["valid_firefox_question"]["simple_body_text"],
-            attach_image=False
-        )
-
-        self.navigate_to_link(
-            question_info_one['question_page_url']
-        )
-
-        self.logger.info("Clicking on the 'Subscribe to feed' option from different user posted "
-                         "question")
-        if self.requested_browser == "chrome":
-            self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
-            self.logger.info("Verifying that the url is updated to the feed endpoint")
-            expect(
-                self.page
-            ).to_have_url(
-                question_info_one['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
+            question_info_one = self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
+                topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                body=super().aaq_question_test_data["valid_firefox_question"]["simple_body_text"],
+                attach_image=False
             )
-        else:
-            with self.page.expect_download() as download_info:
+
+        with allure.step("Signing in with a different non admin user account and posting a "
+                         "Firefox product question"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
+
+            question_info_two = self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
+                topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                body=super().aaq_question_test_data["valid_firefox_question"]["simple_body_text"],
+                attach_image=False
+            )
+
+        with allure.step("Navigating to the first question, clicking on the 'Subscribe to feed' "
+                         "option and verifying that the url is updated to the feed endpoint ("
+                         "Chrome) or has the correct download info (Firefox)"):
+            self.navigate_to_link(
+                question_info_one['question_page_url']
+            )
+
+            if self.requested_browser == "chrome":
                 self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
-            download = download_info.value
+                expect(
+                    self.page
+                ).to_have_url(
+                    question_info_one['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
+                )
+            else:
+                with self.page.expect_download() as download_info:
+                    self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
+                download = download_info.value
 
-            self.logger.info("Verifying that the received file contains the correct name")
-            check.is_in(
-                QuestionPageMessages.FEED_FILE_NAME,
-                download.suggested_filename,
-                f"Incorrect file name. "
-                f"Expected: {QuestionPageMessages.FEED_FILE_NAME} "
-                f"Received: {download.suggested_filename}"
-            )
+                with allure.step("Verifying that the received file contains the correct name"):
+                    assert QuestionPageMessages.FEED_FILE_NAME in download.suggested_filename
 
-            self.logger.info("Verifying that the received file is not empty")
-            assert (
-                os.path.getsize(download.path()) > 0
-            )
+                with allure.step("Verifying that the received file is not empty"):
+                    assert (
+                        os.path.getsize(download.path()) > 0
+                    )
 
-        self.navigate_to_link(
-            question_info_two['question_page_url']
-        )
-        if self.requested_browser == "chrome":
-            self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
-            self.logger.info("Verifying that the url is updated to the feed endpoint")
-            expect(
-                self.page
-            ).to_have_url(
-                question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
+        with allure.step("Navigating to the first question, clicking on the 'Subscribe to feed' "
+                         "option and verifying that the url is updated to the feed endpoint ("
+                         "Chrome) or has the correct download info (Firefox)"):
+            self.navigate_to_link(
+                question_info_two['question_page_url']
             )
-            self.navigate_back()
-        else:
-            with self.page.expect_download() as download_info:
+            if self.requested_browser == "chrome":
                 self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
-            download = download_info.value
+                expect(
+                    self.page
+                ).to_have_url(
+                    question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
+                )
+                self.navigate_back()
+            else:
+                with self.page.expect_download() as download_info:
+                    self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
+                download = download_info.value
 
-            self.logger.info("Verifying that the received file contains the correct name")
-            check.is_in(
-                QuestionPageMessages.FEED_FILE_NAME,
-                download.suggested_filename,
-                f"Incorrect file name. "
-                f"Expected: {QuestionPageMessages.FEED_FILE_NAME} "
-                f"Received: {download.suggested_filename}"
-            )
+                with check, allure.step("Verifying that the received file contains the correct "
+                                        "name"):
+                    assert QuestionPageMessages.FEED_FILE_NAME in download.suggested_filename
 
-            self.logger.info("Verifying that the received file is not empty")
-            assert (
-                os.path.getsize(download.path()) > 0
-            )
+                with allure.step("Verifying that the received file is not empty"):
+                    assert (
+                        os.path.getsize(download.path()) > 0
+                    )
 
-        self.logger.info("Signing out")
-        super().delete_cookies()
+        with allure.step("Signing out and Navigating to the first question,clicking on the "
+                         "'Subscribe to feed' option and verifying that the url is updated to "
+                         "the feed endpoint (Chrome) or has the correct download info (Firefox)"):
+            super().delete_cookies()
 
-        if self.requested_browser == "chrome":
-            self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
-            self.logger.info("Verifying that the url is updated to the feed endpoint")
-            expect(
-                self.page
-            ).to_have_url(
-                question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
-            )
-            self.navigate_back()
-        else:
-            with self.page.expect_download() as download_info:
+            if self.requested_browser == "chrome":
                 self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
-            download = download_info.value
+                expect(
+                    self.page
+                ).to_have_url(
+                    question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
+                )
+                self.navigate_back()
+            else:
+                with self.page.expect_download() as download_info:
+                    self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
+                download = download_info.value
 
-            self.logger.info("Verifying that the received file contains the correct name")
-            check.is_in(
-                QuestionPageMessages.FEED_FILE_NAME,
-                download.suggested_filename,
-                f"Incorrect file name. "
-                f"Expected: {QuestionPageMessages.FEED_FILE_NAME} "
-                f"Received: {download.suggested_filename}"
-            )
+                with check, allure.step("Verifying that the received file contains the correct "
+                                        "name"):
+                    assert QuestionPageMessages.FEED_FILE_NAME in download.suggested_filename
 
-            self.logger.info("Verifying that the received file is not empty")
-            assert (
-                os.path.getsize(download.path()) > 0
-            )
+                with allure.step("Verifying that the received file is not empty"):
+                    assert (
+                        os.path.getsize(download.path()) > 0
+                    )
 
-        self.logger.info("Signing in with an admin account")
+        with allure.step("Signing in with an admin account and Navigating to the first question,"
+                         "clicking on the 'Subscribe to feed' option and verifying that the url "
+                         "is updated to the feed endpoint (Chrome) or has the correct download "
+                         "info (Firefox)"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        if self.requested_browser == "chrome":
-            self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
-            self.logger.info("Verifying that the url is updated to the feed endpoint")
-            expect(
-                self.page
-            ).to_have_url(
-                question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
-            )
-            self.navigate_back()
-        else:
-            with self.page.expect_download() as download_info:
+            if self.requested_browser == "chrome":
                 self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
-            download = download_info.value
+                expect(
+                    self.page
+                ).to_have_url(
+                    question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
+                )
+                self.navigate_back()
+            else:
+                with self.page.expect_download() as download_info:
+                    self.sumo_pages.question_page._click_on_subscribe_to_feed_option()
+                download = download_info.value
 
-            self.logger.info("Verifying that the received file contains the correct name")
-            check.is_in(
-                QuestionPageMessages.FEED_FILE_NAME,
-                download.suggested_filename,
-                f"Incorrect file name. "
-                f"Expected: {QuestionPageMessages.FEED_FILE_NAME} "
-                f"Received: {download.suggested_filename}"
+                with check, allure.step("Verifying that the received file contains the correct "
+                                        "name"):
+                    assert QuestionPageMessages.FEED_FILE_NAME in download.suggested_filename
+
+                with allure.step("Verifying that the received file is not empty"):
+                    assert (
+                        os.path.getsize(download.path()) > 0
+                    )
+
+        with allure.step("Deleting the posted question"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()
+            self.navigate_to_link(
+                question_info_one['question_page_url']
             )
-
-            self.logger.info("Verifying that the received file is not empty")
-            assert (
-                os.path.getsize(download.path()) > 0
-            )
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
-
-        self.navigate_to_link(
-            question_info_one['question_page_url']
-        )
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # To work on adding a check inside the moderate forum content page
     # C2191491
     @pytest.mark.postedQuestions
     def test_mark_as_spam_functionality(self):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with allure.step("Deleting user session and verifying that the 'Mark as spam' option is "
+                         "not displayed"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.question_page._get_mark_as_spam_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'Mark as spam' option is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_mark_as_spam_locator()
-        ).to_be_hidden()
+        with allure.step("Signing in with a non admin user account and verifying that the 'Mark "
+                         "as spam' option is not displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_mark_as_spam_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Signing in with a non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with check, allure.step("Signing in with an admin account, clicking on the 'mark as "
+                                "spam' option and verifying that the correct spam banner message"
+                                " is displayed"):
+            username = self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.question_page._click_on_mark_as_spam_option()
+            assert (QuestionPageMessages.MARKED_AS_SPAM_BANNER + username in self.sumo_pages.
+                    question_page._get_marked_as_spam_banner_text())
 
-        self.logger.info("Verifying that the 'Mark as spam' option is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_mark_as_spam_locator()
-        ).to_be_hidden()
+        with check, allure.step("Deleting the user session, navigating to the posted question "
+                                "and verifying that the 404 is returned"):
+            self.delete_cookies()
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    posted_question['question_details']['question_page_url']
+                )
+            response = navigation_info.value
+            assert response.status == 404
 
-        username = self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with check, allure.step("Signing in with a non admin user account, navigating to the "
+                                "posted question and verifying that 404 is returned"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    posted_question['question_details']['question_page_url']
+                )
+            response = navigation_info.value
+            assert response.status == 404
 
-        self.logger.info("Clicking on the 'Mark as spam' option")
-        self.sumo_pages.question_page._click_on_mark_as_spam_option()
+        with allure.step("Signing in with an admin account, clicking on the 'Mark as spam' "
+                         "option and verifying that the 'Mark as spam' banner is not displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.question_page._click_on_mark_as_spam_option()
+            expect(
+                self.sumo_pages.question_page._get_marked_as_spam_banner_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the correct spam banner message is displayed")
-        check.is_in(
-            QuestionPageMessages.MARKED_AS_SPAM_BANNER + username,
-            self.sumo_pages.question_page._get_marked_as_spam_banner_text()
-        )
+        with allure.step("Deleting the user session and verifying that the 'Marked as spam' "
+                         "banner is not displayed"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.question_page._get_marked_as_spam_banner_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with allure.step("Signing in with a non admin user account and verifying that the "
+                         "'Marked as spam' banner is not displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_marked_as_spam_banner_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Navigating to the posted question and verifying that the 404 is "
-                         "returned while signed out")
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                posted_question['question_details']['question_page_url']
-            )
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            404
-        )
-
-        self.logger.info("Signing in with a non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.logger.info("Navigating to the posted question and verifying that 404 is returned")
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                posted_question['question_details']['question_page_url']
-            )
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            404
-        )
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the 'Mark as spam' option")
-        self.sumo_pages.question_page._click_on_mark_as_spam_option()
-
-        self.logger.info("Verifying that the 'Marked as spam' banner is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_marked_as_spam_banner_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
-        self.logger.info("Verifying that the 'Marked as spam' banner is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_marked_as_spam_banner_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with a non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.logger.info("Verifying that the 'Marked as spam' banner is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_marked_as_spam_banner_locator()
-        ).to_be_hidden()
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Signing in with an admin account and deleting the question"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191096, C2191098, C2191100
     @pytest.mark.postedQuestions
     @pytest.mark.parametrize("username", ['', 'TEST_ACCOUNT_13'])
     def test_question_topics(self, username):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
-        self.logger.info("Verifying that the 'Add a tag' input field is not displayed for OP")
-        expect(
-            self.sumo_pages.question_page._get_add_a_tag_input_field()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'Add' topic section button is not displayed for OP")
-        expect(
-            self.sumo_pages.question_page._get_add_a_tag_button()
-        ).to_be_hidden()
-
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
-
-        if username == 'TEST_ACCOUNT_13':
-            self.logger.info("Signing in with a non admin user account")
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_13"]
-            ))
-
-        self.logger.info("Verifying that the 'Add a tag' input field is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_add_a_tag_input_field()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'Add' topic section button is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_add_a_tag_button()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the remove tag button is not displayed")
-        for tag in self.sumo_pages.question_page._get_question_tag_options():
+        with allure.step("Verifying that the 'Add a tag' input field is not displayed for OP"):
             expect(
-                self.sumo_pages.question_page._get_remove_tag_button_locator(tag)
+                self.sumo_pages.question_page._get_add_a_tag_input_field()
             ).to_be_hidden()
 
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Verifying that the 'Add' topic section button is not displayed for OP"):
+            expect(
+                self.sumo_pages.question_page._get_add_a_tag_button()
+            ).to_be_hidden()
 
-        self.logger.info("Adding data inside the 'Add a tag' input field and selecting the "
-                         "option from the dropdown menu")
-        self.sumo_pages.question_page._add_text_to_add_a_tag_input_field(
-            super().aaq_question_test_data['valid_firefox_question']['custom_tag']
-        )
-
-        self.logger.info("Clicking on the 'Add' button")
-        self.sumo_pages.question_page._click_on_add_a_tag_button()
-        self.logger.info("Verifying that the newly added tag is displayed for all users")
-        super().delete_cookies()
+        with allure.step("Deleting user session"):
+            super().delete_cookies()
 
         if username == 'TEST_ACCOUNT_13':
-            self.logger.info("Signing in with a non admin user account")
+            with allure.step("Signing in with a non admin user account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_13"]
+                ))
+
+        with allure.step("Verifying that the 'Add a tag' input field is not displayed"):
+            expect(
+                self.sumo_pages.question_page._get_add_a_tag_input_field()
+            ).to_be_hidden()
+
+        with allure.step("Verifying that the 'Add' topic section button is not displayed"):
+            expect(
+                self.sumo_pages.question_page._get_add_a_tag_button()
+            ).to_be_hidden()
+
+        with allure.step("Verifying that the remove tag button is not displayed"):
+            for tag in self.sumo_pages.question_page._get_question_tag_options():
+                expect(
+                    self.sumo_pages.question_page._get_remove_tag_button_locator(tag)
+                ).to_be_hidden()
+
+        with allure.step("Signing in with a admin user account, adding data inside the 'Add a "
+                         "tag' input field"):
             self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
-
-        self.page.reload()
-        check.is_in(
-            super().aaq_question_test_data['valid_firefox_question']['custom_tag'],
-            self.sumo_pages.question_page._get_question_tag_options()
-        )
-
-        for question in self.sumo_pages.question_page._get_question_tag_options():
-            self.logger.info(f"Clicking on the {question} tag")
-            self.sumo_pages.question_page._click_on_a_certain_tag(question)
-            self.logger.info("Verifying that the filter is applied to the clicked tag")
-            check.equal(
-                question,
-                self.sumo_pages.product_support_forum._get_text_of_selected_tag_filter_option()
-            )
-
-            self.logger.info("Verifying that each listed question inside the product forum "
-                             "contains the filtered tab")
-            for article_id in self.sumo_pages.product_support_forum._extract_question_ids():
-                check.is_in(
-                    question,
-                    self.sumo_pages.product_support_forum._get_all_question_list_tags(article_id)
-                )
-            self.navigate_back()
-
-        self.logger.info("Navigate back to the posted question")
-        self.navigate_to_link(
-            posted_question['question_details']['question_page_url']
-        )
-
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.page.reload()
-        self.logger.info("Removing the newly added tag")
-        self.sumo_pages.question_page._click_on_tag_remove_button(
-            super().aaq_question_test_data['valid_firefox_question']['custom_tag']
-        )
-
-        # Adding a custom wait to avoid test flakiness.
-        self.wait_for_given_timeout(1000)
-
-        self.logger.info("Verifying that the tag was removed")
-        expect(
-            self.sumo_pages.question_page._get_a_certain_tag(
+            self.sumo_pages.question_page._add_text_to_add_a_tag_input_field(
                 super().aaq_question_test_data['valid_firefox_question']['custom_tag']
             )
-        ).to_be_hidden()
+            self.sumo_pages.question_page._click_on_add_a_tag_button()
 
-        self.logger.info("Deleting the user session")
-        super().delete_cookies()
+        with allure.step("Deleting user session"):
+            super().delete_cookies()
+
+        if username == 'TEST_ACCOUNT_13':
+            with allure.step("Signing in with a non admin user account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_13"]
+                ))
+
+        with check, allure.step("Verifying that the tag is available for all users"):
+            self.page.reload()
+            assert (super().aaq_question_test_data['valid_firefox_question']
+                    ['custom_tag'] in self.sumo_pages.question_page._get_question_tag_options())
+
+        with allure.step("Verifying that the question tags are acting as filters"):
+            for question in self.sumo_pages.question_page._get_question_tag_options():
+                with check, allure.step(f"Clicking on the {question} tag and verifying tha the "
+                                        f"filter is applied to the clicked tag"):
+                    self.sumo_pages.question_page._click_on_a_certain_tag(question)
+                    assert (question == self.sumo_pages.product_support_forum.
+                            _get_text_of_selected_tag_filter_option())
+
+                with check, allure.step("Verifying that each listed question inside the product "
+                                        "forum contains the filtered tab"):
+                    for article_id in self.sumo_pages.product_support_forum._extract_question_ids(
+                    ):
+                        assert (question in self.sumo_pages.product_support_forum.
+                                _get_all_question_list_tags(article_id))
+                    self.navigate_back()
+
+        with allure.step("Navigate back to the posted question, signing in with an admin account "
+                         "and removing the newly added tag"):
+            self.navigate_to_link(
+                posted_question['question_details']['question_page_url']
+            )
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.page.reload()
+            self.sumo_pages.question_page._click_on_tag_remove_button(
+                super().aaq_question_test_data['valid_firefox_question']['custom_tag']
+            )
+            # Adding a custom wait to avoid test flakiness.
+            self.wait_for_given_timeout(1000)
+
+        with allure.step("Verifying that the tag was removed"):
+            expect(
+                self.sumo_pages.question_page._get_a_certain_tag(
+                    super().aaq_question_test_data['valid_firefox_question']['custom_tag']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Deleting the user session"):
+            super().delete_cookies()
 
         if username == "TEST_ACCOUNT_13":
-            self.logger.info("Signing in with a non admin user account")
+            with allure.step("Signing in with a non admin user account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_13"]
+                ))
+
+        with allure.step("Verifying that the tag was removed"):
+            expect(
+                self.sumo_pages.question_page._get_a_certain_tag(
+                    super().aaq_question_test_data['valid_firefox_question']['custom_tag']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Deleting the posted question"):
             self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
 
-        self.logger.info("Verifying that the tag was removed")
-        expect(
-            self.sumo_pages.question_page._get_a_certain_tag(
-                super().aaq_question_test_data['valid_firefox_question']['custom_tag']
-            )
-        ).to_be_hidden()
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+            self.logger.info("Deleting the posted question")
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191091
     @pytest.mark.postedQuestions
     def test_email_updates_option_visibility(self):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with allure.step("Deleting user session and verifying that the 'Get  email updates' "
+                         "option is displayed"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.question_page._get_email_updates_option()
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the 'Get email updates' option is displayed")
-        expect(
-            self.sumo_pages.question_page._get_email_updates_option()
-        ).to_be_visible()
+        with allure.step("Signing in with another non admin user account and verifying that the "
+                         "'Get email updates' option is displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_email_updates_option()
+            ).to_be_visible()
 
-        self.logger.info("Signing in with another non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with an admin account and verifying that the 'Get email "
+                         "updated' options is displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_email_updates_option()
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the 'Get email updates' option is displayed")
-        expect(
-            self.sumo_pages.question_page._get_email_updates_option()
-        ).to_be_visible()
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Verifying that the 'Get email updates' option is displayed")
-        expect(
-            self.sumo_pages.question_page._get_email_updates_option()
-        ).to_be_visible()
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Deleting the posted question"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191268
     @pytest.mark.postedQuestions
     def test_mark_reply_as_spam(self):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
-        self.logger.info("Submitting a reply to the question")
-        reply_id_one = self.sumo_pages.aaq_flow.post_question_reply_flow(
-            repliant_username=posted_question['username_one'],
-            reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
+        with allure.step("Submitting a reply to the question"):
+            reply_id_one = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                repliant_username=posted_question['username_one'],
+                reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
+            )
 
-        self.logger.info("Signin in with a different non admin user")
-        username_two = self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with allure.step("Signin in with a different non admin user and submitting a reply to "
+                         "the question"):
+            username_two = self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            reply_id_two = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                repliant_username=username_two,
+                reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
+            )
 
-        self.logger.info("Submitting a reply to the question")
-        reply_id_two = self.sumo_pages.aaq_flow.post_question_reply_flow(
-            repliant_username=username_two,
-            reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
+        with allure.step("Clicking on the self reply menu and verifying that the 'mark as spam' "
+                         "option is not displayed for non-admin users"):
+            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id_two)
+            expect(
+                self.sumo_pages.question_page._get_mark_as_spam_reply_locator(reply_id_two)
+            ).to_be_hidden()
+            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id_two)
 
-        self.logger.info("Clicking on the self reply menu and verifying that the 'mark as spam' "
-                         "option is not displayed for non-admin users")
+        with allure.step("Clicking on other user posted reply menu and verifying that the 'mark "
+                         "as spam' option is not displayed for non-admin users"):
+            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id_one)
+            expect(
+                self.sumo_pages.question_page._get_mark_as_spam_reply_locator(reply_id_one)
+            ).to_be_hidden()
+            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id_one)
 
-        self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id_two)
-        expect(
-            self.sumo_pages.question_page._get_mark_as_spam_reply_locator(reply_id_two)
-        ).to_be_hidden()
+        with check, allure.step("Signing in with an admin account, clicking on the 'Marks as "
+                                "Spam' option for one of the replies and verifying that the "
+                                "'Marked as spam' message is displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.aaq_flow.spam_marking_a_reply(reply_id_one)
+            assert self.sumo_pages.question_page._get_marked_as_spam_text(
+                reply_id_one
+            ) == QuestionPageMessages.REPLY_MARKED_AS_SPAM_MESSAGE
 
-        self.logger.info("Closing the dropdown menu")
-        self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id_two)
+        with allure.step("Deleting user session and verifying that the reply marked as spam is "
+                         "no longer displayed"):
+            super().delete_cookies()
+            expect(
+                self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on other user posted reply menu and verifying that the 'mark "
-                         "as spam' option is not displayed for non-admin users")
-        self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id_one)
-        expect(
-            self.sumo_pages.question_page._get_mark_as_spam_reply_locator(reply_id_one)
-        ).to_be_hidden()
+        with allure.step("Signing in with a user account and verifying that reply marked as spam "
+                         "is no longer displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
+            ).to_be_hidden()
 
-        self.logger.info("Closing the dropdown menu")
-        self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id_one)
+        with allure.step("Signing in with the reply OP user account and verifying that the reply "
+                         "marked as spam is no longer displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
+            ).to_be_hidden()
 
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with the admin account, unmarking the reply from spam and "
+                         "verifying that the 'Marked as spam' message is no longer displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.aaq_flow.spam_marking_a_reply(reply_id_one)
+            expect(
+                self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on the 'Mark as Spam' option for one of the replies")
-        self.sumo_pages.aaq_flow.spam_marking_a_reply(reply_id_one)
+        with allure.step("Deleting the user session and verifying that the reply is visible to "
+                         "the logged out users"):
+            super().delete_cookies()
+            expect(
+                self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the 'Marked as spam' message is displayed for that reply")
-        check.equal(
-            self.sumo_pages.question_page._get_marked_as_spam_text(reply_id_one),
-            QuestionPageMessages.REPLY_MARKED_AS_SPAM_MESSAGE
-        )
+        with allure.step("Verifying that the 'Marked as spam' message is no longer displayed"):
+            expect(
+                self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
+            ).to_be_hidden()
 
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
+        with allure.step("Signing in with a different user and verifying that the reply is "
+                         "visible again"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the reply marked as spam is no longer displayed")
-        expect(
-            self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
-        ).to_be_hidden()
+        with allure.step("Verifying that the 'Marked as spam' message is no longer displayed"):
+            expect(
+                self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
+            ).to_be_hidden()
 
-        self.logger.info("Signing in with a user account and verifying that reply marked as spam "
-                         "is no longer displayed")
+        with allure.step("Signing in with the reply OP and verifying that the reply is visible "
+                         "again"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
+            ).to_be_visible()
 
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-        expect(
-            self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
-        ).to_be_hidden()
+        with allure.step("Verifying that the 'Marked as spam' message is no longer displayed"):
+            expect(
+                self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
+            ).to_be_hidden()
 
-        self.logger.info("Signing in with the reply OP user account and verifying that the reply "
-                         "marked as spam is no longer displayed")
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        expect(
-            self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with the admin account and unmarking the reply from spam")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Clicking on the 'Mark as Spam' option for one of the replies")
-        self.sumo_pages.aaq_flow.spam_marking_a_reply(reply_id_one)
-
-        self.logger.info("Verifying that the 'Marked as spam' message is no longer displayed")
-        expect(
-            self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
-        ).to_be_hidden()
-
-        self.logger.info("Deleting user session")
-        super().delete_cookies()
-
-        self.logger.info("Verifying that the reply is visible to the logged out users")
-        expect(
-            self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the 'Marked as spam' message is no longer displayed")
-        expect(
-            self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with a different user and verifying that the reply is "
-                         "visible again")
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-        expect(
-            self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the 'Marked as spam' message is no longer displayed")
-        expect(
-            self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with the reply OP and verifying that the reply is visible "
-                         "again")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        expect(
-            self.sumo_pages.question_page._get_reply_section_locator(reply_id_one)
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the 'Marked as spam' message is no longer displayed")
-        expect(
-            self.sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Signing in with an admin account and deleting the posted question"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # Need to expand this to contain additional text format.
     # C2191270, C2191259
     @pytest.mark.postedQuestions
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_13', 'TEST_ACCOUNT_MODERATOR'])
     def test_edit_reply(self, username):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
         page_url = self.get_page_url()
 
-        self.logger.info("Submitting a reply to the question")
-        reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-            repliant_username=posted_question['username_one'],
-            reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
-
-        self.logger.info("Verifying that the reply contains the correct name and user status")
-        check.equal(
-            self.sumo_pages.question_page._get_display_name_of_question_reply_author(reply_id),
-            posted_question['username_one']
-        )
-
-        check.equal(
-            self.sumo_pages.question_page._get_displayed_user_title_of_question_reply(reply_id),
-            QuestionPageMessages.QUESTION_REPLY_OWNER
-        )
-
-        if username == 'TEST_ACCOUNT_13':
-            self.logger.info("Signin in with a different non admin user")
-
-            username_two = self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_13"]
-            ))
-
-            self.logger.info(
-                "Clicking on the more options for the reply posted by another user and "
-                "verifying that the 'edit this post' option is not displayed")
-            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
-            expect(
-                self.sumo_pages.question_page._get_edit_this_post_reply_locator(reply_id)
-            ).to_be_hidden()
-
-            self.logger.info(
-                "Manually navigating to edit reply endpoint and verifying that 403 is "
-                "returned")
-            self.logger.info(page_url + QuestionPageMessages.EDIT_REPLY_URL + str(
-                super().number_extraction_from_string(
-                    reply_id
-                )))
-            with self.page.expect_navigation() as navigation_info:
-                self.navigate_to_link(
-                    page_url + QuestionPageMessages.EDIT_REPLY_URL + str(
-                        super().number_extraction_from_string(
-                            reply_id
-                        ))
-                )
-                response = navigation_info.value
-                check.equal(
-                    response.status,
-                    403
-                )
-
-            self.logger.info("Navigating back")
-            self.navigate_to_link(page_url)
-
+        with allure.step("Submitting a reply to the question"):
             reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-                repliant_username=username_two,
+                repliant_username=posted_question['username_one'],
                 reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
             )
 
-            self.logger.info(
-                "Verifying that the reply contains the correct name and no user status")
-            check.equal(
-                self.sumo_pages.question_page._get_display_name_of_question_reply_author(reply_id),
-                username_two
-            )
+        with check, allure.step("Verifying that the reply contains the correct name and user "
+                                "status"):
+            assert self.sumo_pages.question_page._get_display_name_of_question_reply_author(
+                reply_id
+            ) == posted_question['username_one']
+            assert self.sumo_pages.question_page._get_displayed_user_title_of_question_reply(
+                reply_id
+            ) == QuestionPageMessages.QUESTION_REPLY_OWNER
 
-            expect(
-                self.sumo_pages.question_page._get_displayed_user_title_of_question_reply_locator(
-                    reply_id
+        if username == 'TEST_ACCOUNT_13':
+            with allure.step("Signin in with a different non admin user"):
+                username_two = self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_13"]
+                ))
+
+            with allure.step("Clicking on the more options for the reply posted by another user "
+                             "and verifying that the 'edit this post' option is not displayed"):
+                self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
+                expect(
+                    self.sumo_pages.question_page._get_edit_this_post_reply_locator(reply_id)
+                ).to_be_hidden()
+
+            with check, allure.step("Manually navigating to edit reply endpoint and verifying "
+                                    "that 403 is returned"):
+                self.logger.info(page_url + QuestionPageMessages.EDIT_REPLY_URL + str(
+                    super().number_extraction_from_string(
+                        reply_id
+                    )))
+                with self.page.expect_navigation() as navigation_info:
+                    self.navigate_to_link(
+                        page_url + QuestionPageMessages.EDIT_REPLY_URL + str(
+                            super().number_extraction_from_string(
+                                reply_id
+                            ))
+                    )
+                    response = navigation_info.value
+                    assert response.status == 403
+
+            with check, allure.step("Navigating back and verifying that the reply contains the "
+                                    "correct name and no user status"):
+                self.navigate_to_link(page_url)
+                reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                    repliant_username=username_two,
+                    reply=super().aaq_question_test_data['valid_firefox_question'][
+                        'question_reply']
                 )
-            ).to_be_hidden()
+                assert self.sumo_pages.question_page._get_display_name_of_question_reply_author(
+                    reply_id
+                ) == username_two
+                expect(
+                    self.sumo_pages.question_page
+                    ._get_displayed_user_title_of_question_reply_locator(
+                        reply_id
+                    )
+                ).to_be_hidden()
         else:
             username_two = self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
 
-        self.logger.info("Clicking on the more options for the OP reply")
-        self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
+        with check, allure.step("Clicking on the 'Edit this post option' and verifying that the "
+                                "textarea contains the original reply"):
+            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
+            self.sumo_pages.question_page._click_on_edit_this_post_for_a_certain_reply(reply_id)
+            assert self.sumo_pages.question_page._get_post_a_reply_textarea_text().strip(
+            ) in super().aaq_question_test_data['valid_firefox_question']['question_reply']
 
-        self.logger.info("Clicking on the 'Edit this post option'")
-        self.sumo_pages.question_page._click_on_edit_this_post_for_a_certain_reply(reply_id)
+        with allure.step("Editing the question reply"):
+            self.sumo_pages.aaq_flow.editing_reply_flow(
+                reply_body=super().aaq_question_test_data['valid_firefox_question']
+                ['updated_reply'],
+                submit_reply=False
+            )
 
-        self.logger.info("Verifying that the textarea contains the original reply")
-        check.is_in(
-            self.sumo_pages.question_page._get_post_a_reply_textarea_text().strip(),
-            super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
+        with check, allure.step("Verifying that the question reply is the original one"):
+            assert self.sumo_pages.question_page._get_posted_reply_text(reply_id).strip(
+            ) == super().aaq_question_test_data['valid_firefox_question']['question_reply']
 
-        self.sumo_pages.aaq_flow.editing_reply_flow(
-            reply_body=super().aaq_question_test_data['valid_firefox_question']['updated_reply'],
-            submit_reply=False
-        )
+        with allure.step("Verifying that the 'Modified by' message is not displayed for the "
+                         "reply"):
+            expect(
+                self.sumo_pages.question_page._get_posted_reply_modified_by_locator(reply_id)
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the question reply is the original one")
-        check.equal(
-            self.sumo_pages.question_page._get_posted_reply_text(reply_id).strip(),
-            super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
+        with check, allure.step("Clicking on the 'Edit this post option' and verifying that the "
+                                "textarea contains the original reply"):
+            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
+            self.sumo_pages.question_page._click_on_edit_this_post_for_a_certain_reply(reply_id)
+            assert self.sumo_pages.question_page._get_post_a_reply_textarea_text(
+            ) in super().aaq_question_test_data['valid_firefox_question']['question_reply']
 
-        self.logger.info("Verifying that the 'Modified by' message is not displayed for the reply")
-        expect(
-            self.sumo_pages.question_page._get_posted_reply_modified_by_locator(reply_id)
-        ).to_be_hidden()
+        with check, allure.step("Editing the reply and verifying that the reply contains the "
+                                "updated text"):
+            self.sumo_pages.aaq_flow.editing_reply_flow(
+                reply_body=super().aaq_question_test_data['valid_firefox_question']
+                ['updated_reply']
+            )
+            assert self.sumo_pages.question_page._get_posted_reply_text(reply_id).strip(
+            ) == super().aaq_question_test_data['valid_firefox_question']['updated_reply']
 
-        self.logger.info("Clicking on the more options for the OP reply")
-        self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
+        with check, allure.step("Verifying that the 'Modified by' message is displayed for the "
+                                "reply"):
+            assert (username_two in self.sumo_pages.question_page.
+                    _get_posted_reply_modified_by_text(reply_id))
 
-        self.logger.info("Clicking on the 'Edit this post option'")
-        self.sumo_pages.question_page._click_on_edit_this_post_for_a_certain_reply(reply_id)
-
-        self.logger.info("Verifying that the textarea contains the original reply")
-        check.is_in(
-            self.sumo_pages.question_page._get_post_a_reply_textarea_text(),
-            super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
-
-        self.sumo_pages.aaq_flow.editing_reply_flow(
-            reply_body=super().aaq_question_test_data['valid_firefox_question']['updated_reply']
-        )
-
-        self.logger.info("Verifying that the reply contains the updated text")
-        check.equal(
-            self.sumo_pages.question_page._get_posted_reply_text(reply_id).strip(),
-            super().aaq_question_test_data['valid_firefox_question']['updated_reply']
-        )
-
-        self.logger.info("Verifying that the 'Modified by' message is displayed for the reply")
-        check.is_in(
-            username_two,
-            self.sumo_pages.question_page._get_posted_reply_modified_by_text(reply_id)
-        )
-
-        if username == 'TEST_ACCOUNT_13':
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-            ))
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Deleting the posted question"):
+            if username == 'TEST_ACCOUNT_13':
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191272
     @pytest.mark.postedQuestions
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_13', 'TEST_ACCOUNT_MODERATOR'])
     def test_delete_reply(self, username):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
         page_url = self.get_page_url()
 
-        self.logger.info("Posting a reply to the question")
-        reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-            repliant_username=posted_question['username_one'],
-            reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
-
-        self.logger.info("Verifying that the 'Delete this post' option is not available for self "
-                         "posted reply")
-        expect(
-            self.sumo_pages.question_page._get_delete_this_post_reply_locator(reply_id)
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that manually navigating to the delete page for the posted "
-                         "reply returns 403")
-
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                page_url + QuestionPageMessages.DELETE_QUESTION_REPLY_URL + str(
-                    super().number_extraction_from_string(
-                        reply_id
-                    ))
-            )
-            response = navigation_info.value
-            check.equal(
-                response.status,
-                403
-            )
-
-        self.logger.info("Navigating back")
-        self.navigate_to_link(posted_question['question_details']['question_page_url'])
-
-        if username == 'TEST_ACCOUNT_13':
-            username_two = self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_13"]
-            ))
-
-            self.logger.info("Posting a reply to the question")
-            self.sumo_pages.aaq_flow.post_question_reply_flow(
-                repliant_username=username_two,
+        with allure.step("Posting a reply to the question and verifying that the 'Delete this "
+                         "post' option is not available for self posted reply"):
+            reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                repliant_username=posted_question['username_one'],
                 reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
             )
-
-            self.logger.info("Verifying that the 'Delete this post' option is not available for "
-                             "replies posted by others")
-            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
             expect(
                 self.sumo_pages.question_page._get_delete_this_post_reply_locator(reply_id)
             ).to_be_hidden()
 
-            self.logger.info(
-                "Verifying that manually navigating to the delete page for the posted "
-                "reply returns 403")
-
+        with check, allure.step("Verifying that manually navigating to the delete page for the "
+                                "posted reply returns 403"):
             with self.page.expect_navigation() as navigation_info:
                 self.navigate_to_link(
                     page_url + QuestionPageMessages.DELETE_QUESTION_REPLY_URL + str(
@@ -1465,520 +1230,487 @@ class TestPostedQuestions(TestUtilities):
                         ))
                 )
                 response = navigation_info.value
-                check.equal(
-                    response.status,
-                    403
-                )
+                assert response.status == 403
 
-            self.logger.info("Navigating back")
+        with allure.step("Navigating back to the question and posting a reply to it"):
             self.navigate_to_link(posted_question['question_details']['question_page_url'])
 
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+            if username == 'TEST_ACCOUNT_13':
+                username_two = self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_13"]
+                ))
+                self.sumo_pages.aaq_flow.post_question_reply_flow(
+                    repliant_username=username_two,
+                    reply=super().aaq_question_test_data['valid_firefox_question']
+                    ['question_reply']
+                )
 
-        self.sumo_pages.aaq_flow.delete_question_reply(reply_id, delete_reply=False)
+                with allure.step("Verifying that the 'Delete this post' option is not available "
+                                 "for replies posted by others"):
+                    self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
+                    expect(
+                        self.sumo_pages.question_page._get_delete_this_post_reply_locator(reply_id)
+                    ).to_be_hidden()
 
-        self.logger.info("Verifying that the reply was not deleted")
-        expect(
-            self.sumo_pages.question_page._get_posted_reply_locator(reply_id)
-        ).to_be_visible()
+                with check, allure.step("Verifying that manually navigating to the delete page "
+                                        "for the posted reply returns 403"):
+                    with self.page.expect_navigation() as navigation_info:
+                        self.navigate_to_link(
+                            page_url + QuestionPageMessages.DELETE_QUESTION_REPLY_URL + str(
+                                super().number_extraction_from_string(
+                                    reply_id
+                                ))
+                        )
+                        response = navigation_info.value
+                        assert response.status == 403
 
-        self.sumo_pages.aaq_flow.delete_question_reply(reply_id, delete_reply=True)
+                self.navigate_to_link(posted_question['question_details']['question_page_url'])
 
-        self.logger.info("Verifying that the reply is no longer displayed")
-        expect(
-            self.sumo_pages.question_page._get_posted_reply_locator(reply_id)
-        ).to_be_hidden()
+        with allure.step("Signing in with an admin account and, clicking on the 'Cancel' delete "
+                         "reply confirmation box and verifying that the reply was not deleted"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.aaq_flow.delete_question_reply(reply_id, delete_reply=False)
+            expect(
+                self.sumo_pages.question_page._get_posted_reply_locator(reply_id)
+            ).to_be_visible()
 
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Deleting the reply and verifying that the reply is no longer displayed"):
+            self.sumo_pages.aaq_flow.delete_question_reply(reply_id, delete_reply=True)
+            expect(
+                self.sumo_pages.question_page._get_posted_reply_locator(reply_id)
+            ).to_be_hidden()
+
+        with allure.step("Deleting the posted question"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2192383, C2191224
     # Need to re-verify this for signed out case before submitting this
     @pytest.mark.postedQuestions
     def test_i_have_this_problem_too(self):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
-        self.logger.info("Verifying that the 'I have this problem too' button is not displayed "
-                         "for self posted questions")
+        with allure.step("Verifying that the 'I have this problem too' button is not displayed "
+                         "for self posted questions"):
+            problem_counter = self.sumo_pages.question_page._get_i_have_this_problem_too_counter()
+            expect(
+                self.sumo_pages.question_page._get_i_have_this_problem_too_locator()
+            ).to_be_hidden()
 
-        this_problem_counter = self.sumo_pages.question_page._get_i_have_this_problem_too_counter()
+        with check, allure.step("Deleting the user session, clicking on the 'I have this problem "
+                                "too' button and verifying tha the 'have this problem' counter "
+                                "was successfully incremented"):
+            self.delete_cookies()
+            problem_counter += 1
+            self.sumo_pages.question_page._click_i_have_this_problem_too_button()
+            self.page.reload()
+            assert (problem_counter == self.sumo_pages.question_page
+                    ._get_i_have_this_problem_too_counter())
 
-        expect(
-            self.sumo_pages.question_page._get_i_have_this_problem_too_locator()
-        ).to_be_hidden()
+        with check, allure.step("Signing in with a different non-admin user account, clicking on "
+                                "the 'I have this problem too' and verifying that the 'have this "
+                                "problem' counter has incremented"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            self.sumo_pages.question_page._click_i_have_this_problem_too_button()
+            self.page.reload()
+            problem_counter += 1
+            assert (problem_counter == self.sumo_pages.question_page
+                    ._get_i_have_this_problem_too_counter())
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-        this_problem_counter += 1
-        self.logger.info("Clicking on the 'I have this problem too' button while signed out")
-        self.sumo_pages.question_page._click_i_have_this_problem_too_button()
+        with allure.step("Verifying that the 'I have this problem too' button is no longer "
+                         "displayed"):
+            expect(
+                self.sumo_pages.question_page._get_i_have_this_problem_too_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Reloading the page")
-        self.page.reload()
+        with check, allure.step("Signing in with an admin account, clicking on the 'I have this "
+                                "problem too' and verifying that the 'have this problem' counter "
+                                "incremented successfully"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            problem_counter += 1
+            self.sumo_pages.question_page._click_i_have_this_problem_too_button()
+            self.page.reload()
+            assert (problem_counter == self.sumo_pages.question_page
+                    ._get_i_have_this_problem_too_counter())
 
-        self.logger.info("Verifying that the 'have this problem' counter has successfully "
-                         "incremented")
-        check.equal(
-            this_problem_counter,
-            self.sumo_pages.question_page._get_i_have_this_problem_too_counter()
-        )
+        with allure.step("Verifying that the 'I have this problem too' button is no longer "
+                         "displayed"):
+            expect(
+                self.sumo_pages.question_page._get_i_have_this_problem_too_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Signing in with a different non admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.logger.info("Clicking on the 'I have this problem too' button")
-        self.sumo_pages.question_page._click_i_have_this_problem_too_button()
-
-        self.logger.info("Reloading the page")
-        self.page.reload()
-        this_problem_counter += 1
-
-        self.logger.info("Verifying that the 'have this problem' counter has successfully "
-                         "incremented")
-        check.equal(
-            this_problem_counter,
-            self.sumo_pages.question_page._get_i_have_this_problem_too_counter()
-        )
-
-        self.logger.info("Verifying that the 'I have this problem too' button is no longer "
-                         "displayed")
-        expect(
-            self.sumo_pages.question_page._get_i_have_this_problem_too_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        this_problem_counter += 1
-
-        self.logger.info("Clicking on the 'I have this problem too' button")
-        self.sumo_pages.question_page._click_i_have_this_problem_too_button()
-
-        self.logger.info("Reloading the page")
-        self.page.reload()
-
-        self.logger.info("Verifying that the 'have this problem' counter has successfully "
-                         "incremented")
-        check.equal(
-            this_problem_counter,
-            self.sumo_pages.question_page._get_i_have_this_problem_too_counter()
-        )
-
-        self.logger.info("Verifying that the 'I have this problem too' button is no longer "
-                         "displayed")
-        expect(
-            self.sumo_pages.question_page._get_i_have_this_problem_too_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Deleting the posted question"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2192384
     @pytest.mark.postedQuestions
     def test_solves_this_problem(self):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
-        self.logger.info("Posting a reply to the question")
-        reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-            repliant_username=posted_question['username_one'],
-            reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
+        with allure.step("Posting a reply to the question"):
+            reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                repliant_username=posted_question['username_one'],
+                reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
+            )
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with allure.step("Deleting user session and verifying that the 'Solved the problem' "
+                         "button is not displayed"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.question_page._get_solved_the_problem_button_locator(reply_id)
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'Solved the problem' button is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_solved_the_problem_button_locator(reply_id)
-        ).to_be_hidden()
+        with allure.step("Signing in with a different user account and verifying that the "
+                         "'Solved the problem' button is not displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            expect(
+                self.sumo_pages.question_page._get_solved_the_problem_button_locator(reply_id)
+            ).to_be_hidden()
 
-        self.logger.info("Signing in with a different user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with check, allure.step("Signing in with the first username, clicking on the 'Solved the "
+                                "problem' button and verifying that the correct banner is "
+                                "displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.sumo_pages.question_page._click_on_solves_the_problem_button(reply_id)
+            assert self.sumo_pages.question_page._get_solved_problem_banner_text(
+            ) == QuestionPageMessages.CHOSEN_SOLUTION_BANNER
 
-        self.logger.info("Verifying that the 'Solved the problem' button is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_solved_the_problem_button_locator(reply_id)
-        ).to_be_hidden()
+        with check, allure.step("Verifying that the 'Chosen solution is displayed for the reply'"):
+            assert self.sumo_pages.question_page._get_chosen_solution_reply_message(
+                reply_id
+            ) == QuestionPageMessages.CHOSEN_SOLUTION_REPLY_CARD
 
-        self.logger.info("Signing in with the first username")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with check, allure.step("Verifying that the chosen solution reply section has the "
+                                "correct header"):
+            assert self.sumo_pages.question_page._get_problem_solved_section_header_text(
+            ) == QuestionPageMessages.CHOSEN_SOLUTION_CARD
 
-        self.logger.info("Clicking on the 'Solved the problem' button")
-        self.sumo_pages.question_page._click_on_solves_the_problem_button(reply_id)
+        with check, allure.step("Verifying the chosen solution text"):
+            assert self.sumo_pages.question_page._get_chosen_solution_text(
+            ) == super().aaq_question_test_data['valid_firefox_question']['question_reply']
 
-        self.logger.info("Verifying that the correct banner is displayed")
-        check.equal(
-            self.sumo_pages.question_page._get_solved_problem_banner_text(),
-            QuestionPageMessages.CHOSEN_SOLUTION_BANNER
-        )
+        with allure.step("Clicking on the 'Read this answer in context' link and verifying that "
+                         "the page url updates to point out to the posted reply"):
+            self.sumo_pages.question_page._click_read_this_answer_in_context_link()
+            expect(
+                self.page
+            ).to_have_url(
+                posted_question['question_details']['question_page_url'] + "#" + reply_id
+            )
 
-        self.logger.info("Verifying that the 'Chosen solution is displayed for the reply'")
-        check.equal(
-            self.sumo_pages.question_page._get_chosen_solution_reply_message(reply_id),
-            QuestionPageMessages.CHOSEN_SOLUTION_REPLY_CARD
-        )
+        with check, allure.step("Navigating back, clicking on the undo button and verifying that "
+                                "the correct banner is displayed"):
+            self.navigate_back()
+            self.sumo_pages.question_page._click_on_undo_button()
+            assert self.sumo_pages.question_page._get_solved_problem_banner_text(
+            ) == QuestionPageMessages.UNDOING_A_SOLUTION
 
-        self.logger.info("Verifying that the chosen solution reply section has the correct header")
-        check.equal(
-            self.sumo_pages.question_page._get_problem_solved_section_header_text(),
-            QuestionPageMessages.CHOSEN_SOLUTION_CARD
-        )
+        with allure.step("Verifying that the 'Solved the problem' option is not displayed"):
+            expect(
+                self.sumo_pages.question_page._get_chosen_solution_section_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying the chosen solution text")
-        check.equal(
-            self.sumo_pages.question_page._get_chosen_solution_text(),
-            super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
+        with allure.step("Verifying that the 'Chosen solution' banner is not displayed for the "
+                         "previously provided solution"):
+            expect(
+                self.sumo_pages.question_page._get_chosen_solution_reply_message_locator(reply_id)
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on the 'Read this answer in context' link")
-        self.sumo_pages.question_page._click_read_this_answer_in_context_link()
+        with allure.step("Verifying that the 'Undo' option is not available"):
+            expect(
+                self.sumo_pages.question_page._get_undo_button_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the page url updates to point out to the posted reply")
-        expect(
-            self.page
-        ).to_have_url(posted_question['question_details']['question_page_url'] + "#" + reply_id)
+        with check, allure.step("Signing in with an admin account, clicking on the 'solved this "
+                                "problem option' and verifying the chosen solution text"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.question_page._click_on_solves_the_problem_button(reply_id)
+            assert self.sumo_pages.question_page._get_chosen_solution_text(
+            ) == super().aaq_question_test_data['valid_firefox_question']['question_reply']
 
-        self.logger.info("Navigating back")
-        self.navigate_back()
-
-        self.logger.info("Clicking the Undo")
-        self.sumo_pages.question_page._click_on_undo_button()
-
-        self.logger.info("Verifying that the correct banner is displayed")
-        check.equal(
-            self.sumo_pages.question_page._get_solved_problem_banner_text(),
-            QuestionPageMessages.UNDOING_A_SOLUTION
-        )
-
-        self.logger.info("Verifying that the 'Solved the problem' option is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_chosen_solution_section_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'Chosen solution' banner is not displayed for the "
-                         "previously provided solution")
-        expect(
-            self.sumo_pages.question_page._get_chosen_solution_reply_message_locator(reply_id)
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'Undo' option is not available")
-        expect(
-            self.sumo_pages.question_page._get_undo_button_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking the solved this problem option")
-        self.sumo_pages.question_page._click_on_solves_the_problem_button(reply_id)
-
-        self.logger.info("Verifying that the chosen solution text")
-        check.equal(
-            self.sumo_pages.question_page._get_chosen_solution_text(),
-            super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Deleting the posted question"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # Need to add test for preview as well.
     # C2260447, C2260448, C2191244, C2191242
     @pytest.mark.postedQuestions
     @pytest.mark.parametrize("quote_on", ['reply', 'question'])
     def test_quote_reply_functionality(self, quote_on):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-
         # Using a user which doesn't have any special permissions applied & which doesn't belong to
         # any group in order to catch cases like https://github.com/mozilla/sumo/issues/1676
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
         question_id = self.sumo_pages.question_page._get_question_id()
 
         if quote_on == "reply":
-            self.logger.info("Posting a reply to the question")
-            reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-                repliant_username=posted_question['username_one'],
-                reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-            )
-
-        username_two = self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        if quote_on == "reply":
-            self.logger.info("Posting a quoted reply for question reply")
-            quote_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-                repliant_username=username_two,
-                reply=super().aaq_question_test_data['valid_firefox_question']['updated_reply'],
-                quoted_reply=True,
-                reply_for_id=reply_id
-            )
-        else:
-            self.logger.info("Posting a quoted reply for question")
-            quote_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-                repliant_username=username_two,
-                reply=super().aaq_question_test_data['valid_firefox_question']['updated_reply'],
-                quoted_reply=True,
-                reply_for_id=question_id
-            )
-
-        self.logger.info("Verifying that the original repliant is displayed inside the quote")
-        check.is_in(
-            posted_question['username_one'],
-            self.sumo_pages.question_page._get_posted_quote_reply_username_text(quote_id)
-        )
+            with allure.step("Posting a reply to the question"):
+                reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                    repliant_username=posted_question['username_one'],
+                    reply=super().aaq_question_test_data['valid_firefox_question']
+                    ['question_reply']
+                )
+        with allure.step("Signing in with a different non-admin user"):
+            username_two = self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
 
         if quote_on == "reply":
-            self.logger.info("Verifying that the original reply is displayed inside the quote")
-            check.equal(
-                super().aaq_question_test_data['valid_firefox_question']['question_reply'],
-                self.sumo_pages.question_page._get_blockquote_reply_text(quote_id).strip()
-            )
+            with allure.step("Posting a quoted reply for question reply"):
+                quote_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                    repliant_username=username_two,
+                    reply=super().aaq_question_test_data['valid_firefox_question']
+                    ['updated_reply'],
+                    quoted_reply=True,
+                    reply_for_id=reply_id
+                )
         else:
-            self.logger.info("Verifying that the question details is displayed inside the quote")
-            check.equal(
-                super().aaq_question_test_data['valid_firefox_question']['simple_body_text'],
-                self.sumo_pages.question_page._get_blockquote_reply_text(quote_id).strip()
-            )
+            with allure.step("Posting a quoted reply for question"):
+                quote_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                    repliant_username=username_two,
+                    reply=super().aaq_question_test_data['valid_firefox_question']
+                    ['updated_reply'],
+                    quoted_reply=True,
+                    reply_for_id=question_id
+                )
 
-        self.logger.info("Verifying that the new reply text is also displayed")
-        check.equal(
-            super().aaq_question_test_data['valid_firefox_question']['updated_reply'],
-            self.sumo_pages.question_page._get_posted_reply_text(quote_id).strip()
-        )
-
-        self.logger.info("Clicking on the 'said' link")
-        self.sumo_pages.question_page._click_posted_reply_said_link(quote_id)
+        with check, allure.step("Verifying that the original repliant is displayed inside the "
+                                "quote"):
+            assert (posted_question['username_one'] in self.sumo_pages.question_page
+                    ._get_posted_quote_reply_username_text(quote_id))
 
         if quote_on == "reply":
-            self.logger.info("Verifying that the correct url is displayed")
-            expect(
-                self.page
-            ).to_have_url(
-                posted_question['question_details']['question_page_url'] + "#" + reply_id
-            )
+            with check, allure.step("Verifying that the original reply is displayed inside the "
+                                    "quote"):
+                assert (super()
+                        .aaq_question_test_data['valid_firefox_question']['question_reply'] == self
+                        .sumo_pages.question_page._get_blockquote_reply_text(quote_id).strip())
         else:
-            self.logger.info("Verifying that the correct url is displayed")
-            expect(
-                self.page
-            ).to_have_url(
-                posted_question['question_details']['question_page_url'] + "#" + question_id
-            )
+            with check, allure.step("Verifying that the question details is displayed inside the "
+                                    "quote"):
+                assert (super()
+                        .aaq_question_test_data['valid_firefox_question']
+                        ['simple_body_text'] == self.sumo_pages.question_page
+                        ._get_blockquote_reply_text(quote_id).strip())
 
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with check, allure.step("Verifying that the new reply text is also displayed"):
+            assert (super()
+                    .aaq_question_test_data['valid_firefox_question']['updated_reply'] in self
+                    .sumo_pages.question_page._get_posted_reply_text(quote_id).strip())
+
+        with allure.step("Clicking on the 'said' link"):
+            self.sumo_pages.question_page._click_posted_reply_said_link(quote_id)
 
         if quote_on == "reply":
-            self.logger.info("Posting a quoted reply for question reply")
-            quote_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-                repliant_username=username_two,
-                reply=super().aaq_question_test_data['valid_firefox_question']['updated_reply'],
-                quoted_reply=True,
-                reply_for_id=reply_id
-            )
+            with check, allure.step("Verifying that the correct url is displayed"):
+                expect(
+                    self.page
+                ).to_have_url(
+                    posted_question['question_details']['question_page_url'] + "#" + reply_id
+                )
         else:
-            self.logger.info("Posting a quoted reply for question reply")
-            quote_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-                repliant_username=username_two,
-                reply=super().aaq_question_test_data['valid_firefox_question']['updated_reply'],
-                quoted_reply=True,
-                reply_for_id=question_id
-            )
+            with check, allure.step("Verifying that the correct url is displayed"):
+                expect(
+                    self.page
+                ).to_have_url(
+                    posted_question['question_details']['question_page_url'] + "#" + question_id
+                )
 
-        self.logger.info("Verifying that the original repliant is displayed inside the quote")
-        check.is_in(
-            posted_question['username_one'],
-            self.sumo_pages.question_page._get_posted_quote_reply_username_text(quote_id)
-        )
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
         if quote_on == "reply":
-            self.logger.info("Verifying that the original reply is displayed inside the quote")
-            check.equal(
-                super().aaq_question_test_data['valid_firefox_question']['question_reply'],
-                self.sumo_pages.question_page._get_blockquote_reply_text(quote_id).strip()
-            )
+            with allure.step("Posting a quoted reply for question reply"):
+                quote_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                    repliant_username=username_two,
+                    reply=super().aaq_question_test_data['valid_firefox_question']
+                    ['updated_reply'],
+                    quoted_reply=True,
+                    reply_for_id=reply_id
+                )
         else:
-            self.logger.info("Verifying that the question is displayed inside the quote")
-            check.equal(
-                super().aaq_question_test_data['valid_firefox_question']['simple_body_text'],
-                self.sumo_pages.question_page._get_blockquote_reply_text(quote_id).strip()
-            )
+            with allure.step("Posting a quoted reply for question reply"):
+                quote_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                    repliant_username=username_two,
+                    reply=super().aaq_question_test_data['valid_firefox_question']
+                    ['updated_reply'],
+                    quoted_reply=True,
+                    reply_for_id=question_id
+                )
 
-        self.logger.info("Verifying that the new reply text is also displayed")
-        check.equal(
-            super().aaq_question_test_data['valid_firefox_question']['updated_reply'],
-            self.sumo_pages.question_page._get_posted_reply_text(quote_id).strip()
-        )
-
-        self.logger.info("Clicking on the 'said' link")
-        self.sumo_pages.question_page._click_posted_reply_said_link(quote_id)
+        with check, allure.step("Verifying that the original repliant is displayed inside the "
+                                "quote"):
+            assert (posted_question['username_one'] in self.sumo_pages.question_page
+                    ._get_posted_quote_reply_username_text(quote_id))
 
         if quote_on == "reply":
-            self.logger.info("Verifying that the correct url is displayed")
-            expect(
-                self.page
-            ).to_have_url(
-                posted_question['question_details']['question_page_url'] + "#" + reply_id
-            )
+            with check, allure.step("Verifying that the original reply is displayed inside the "
+                                    "quote"):
+                assert (super().aaq_question_test_data['valid_firefox_question']
+                        ['question_reply'] == self.sumo_pages.question_page
+                        ._get_blockquote_reply_text(quote_id).strip())
         else:
-            self.logger.info("Verifying that the correct url is displayed")
-            expect(
-                self.page
-            ).to_have_url(
-                posted_question['question_details']['question_page_url'] + "#" + question_id
-            )
+            with check, allure.step("Verifying that the question is displayed inside the quote"):
+                assert (super().aaq_question_test_data['valid_firefox_question']
+                        ['simple_body_text'] == self.sumo_pages.question_page
+                        ._get_blockquote_reply_text(quote_id).strip())
 
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with check, allure.step("Verifying that the new reply text is also displayed"):
+            assert (super().aaq_question_test_data['valid_firefox_question']
+                    ['updated_reply'] == self.sumo_pages.question_page
+                    ._get_posted_reply_text(quote_id).strip())
+
+        with allure.step("Clicking on the 'said' link"):
+            self.sumo_pages.question_page._click_posted_reply_said_link(quote_id)
+
+        if quote_on == "reply":
+            with allure.step("Verifying that the correct url is displayed"):
+                expect(
+                    self.page
+                ).to_have_url(
+                    posted_question['question_details']['question_page_url'] + "#" + reply_id
+                )
+        else:
+            with allure.step("Verifying that the correct url is displayed"):
+                expect(
+                    self.page
+                ).to_have_url(
+                    posted_question['question_details']['question_page_url'] + "#" + question_id
+                )
+
+        with allure.step("Deleting the posted question"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # To add tests for "I have this problem, too" option
     # C2191117, C2191223, C2191226
     @pytest.mark.postedQuestions
     def test_quote_reply_functionality_signed_out(self):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
         question_id = self.sumo_pages.question_page._get_question_id()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with allure.step("Deleting user session, clicking on the 'Quote' option for the question "
+                         "and verifying that the url has updated to contain the correct fragment"
+                         " identifier"):
+            self.delete_cookies()
+            self.sumo_pages.question_page._click_on_reply_more_options_button(question_id)
+            self.sumo_pages.question_page._click_on_quote_for_a_certain_reply(question_id)
+            expect(
+                self.page
+            ).to_have_url(
+                posted_question['question_details']['question_page_url'] + "#question-reply")
 
-        self.logger.info("Clicking on the more options for the question")
-        self.sumo_pages.question_page._click_on_reply_more_options_button(question_id)
+        with allure.step("Verifying that the reply textarea field is not displayed"):
+            expect(
+                self.sumo_pages.question_page._get_post_a_reply_textarea_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on 'Quote' option for the question")
-        self.sumo_pages.question_page._click_on_quote_for_a_certain_reply(question_id)
+        with allure.step("Verifying that the 'Ask a question' signed out card is not displayed"):
+            expect(
+                self.sumo_pages.question_page._ask_a_question_signed_out_card_option_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the url has updated to contain the correct fragment "
-                         "identifier")
-        expect(
-            self.page
-        ).to_have_url(
-            posted_question['question_details']['question_page_url'] + "#question-reply")
+        with allure.step("Verifying that the 'I have this problem, too' option is not displayed"):
+            expect(
+                self.sumo_pages.question_page._get_i_have_this_problem_too_signed_out_card_locator(
+                )
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the reply textarea field is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_post_a_reply_textarea_locator()
-        ).to_be_hidden()
+        with allure.step("Clicking on the 'start a new question' signed out card link and "
+                         "verifying that we are redirected to the Contact Support page"):
+            self.sumo_pages.question_page._click_on_start_a_new_question_signed_out_card_link()
+            expect(
+                self.page
+            ).to_have_url(ContactSupportMessages.PAGE_URL)
 
-        self.logger.info("Verifying that the 'Ask a question' signed out card is not displayed")
-        expect(
-            self.sumo_pages.question_page._ask_a_question_signed_out_card_option_locator()
-        ).to_be_hidden()
+        with allure.step("Navigating back to the question page,signing in back with the op and "
+                         "leaving a question reply"):
+            self.navigate_back()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
+            reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                repliant_username=posted_question['username_one'],
+                reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
+            )
 
-        self.logger.info("Verifying that the 'I have this problem, too' option is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_i_have_this_problem_too_signed_out_card_locator()
-        ).to_be_hidden()
+        with allure.step("Deleting user session, clicking on the quote option fro the reply and "
+                         "verifying that the url has updated to contain the correct fragment "
+                         "identifier"):
+            self.delete_cookies()
+            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
+            self.sumo_pages.question_page._click_on_quote_for_a_certain_reply(reply_id)
+            expect(
+                self.page
+            ).to_have_url(
+                posted_question['question_details']['question_page_url'] + "#question-reply"
+            )
 
-        self.logger.info("Clicking on the 'start a new question' signed out card link")
-        self.sumo_pages.question_page._click_on_start_a_new_question_signed_out_card_link()
+        with allure.step("Verifying that the reply textarea field is not displayed"):
+            expect(
+                self.sumo_pages.question_page._get_post_a_reply_textarea_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that we are redirected to the Contact Support page")
-        expect(
-            self.page
-        ).to_have_url(ContactSupportMessages.PAGE_URL)
+        with allure.step("Verifying that the 'Ask a question' signed out card is displayed"):
+            expect(
+                self.sumo_pages.question_page._ask_a_question_signed_out_card_option_locator()
+            ).to_be_visible()
 
-        self.logger.info("Navigating back to the question page")
-        self.navigate_back()
+        with allure.step("Verifying that the 'I have this problem, too' option is displayed"):
+            expect(
+                self.sumo_pages.question_page._get_i_have_this_problem_too_signed_out_card_locator(
+                )
+            ).to_be_visible()
 
-        self.logger.info("Signing in back with the OP")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Clicking on the 'Ask a question' and verifying that we are redirected "
+                         "to the contact support page"):
+            self.sumo_pages.question_page._click_on_ask_a_question_signed_out_card_option()
+            expect(
+                self.page
+            ).to_have_url(ContactSupportMessages.PAGE_URL)
 
-        reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-            repliant_username=posted_question['username_one'],
-            reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
+        with allure.step("Navigating back to the question page, clicking on the 'log in to your "
+                         "account' link and proceeding with the auth flow with an admin account"):
+            self.navigate_back()
+            self.sumo_pages.question_page._click_on_log_in_to_your_account_signed_out_card_link()
+            self.sumo_pages.auth_flow_page.sign_in_flow(
+                username=super().user_special_chars,
+                account_password=super().user_secrets_pass,
+            )
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with allure.step("Verifying that we are redirected back to the question page"):
+            expect(
+                self.page
+            ).to_have_url(posted_question['question_details']['question_page_url'])
 
-        self.logger.info("Clicking on the more options for the question")
-        self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
+        with allure.step("Verifying that the textarea field is displayed"):
+            expect(
+                self.sumo_pages.question_page._get_post_a_reply_textarea_locator()
+            ).to_be_visible()
 
-        self.logger.info("Clicking on 'Quote' option for the reply")
-        self.sumo_pages.question_page._click_on_quote_for_a_certain_reply(reply_id)
-
-        self.logger.info("Verifying that the url has updated to contain the correct fragment "
-                         "identifier")
-        expect(
-            self.page
-        ).to_have_url(
-            posted_question['question_details']['question_page_url'] + "#question-reply"
-        )
-
-        self.logger.info("Verifying that the reply textarea field is not displayed")
-        expect(
-            self.sumo_pages.question_page._get_post_a_reply_textarea_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'Ask a question' signed out card is displayed")
-        expect(
-            self.sumo_pages.question_page._ask_a_question_signed_out_card_option_locator()
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the 'I have this problem, too' option is displayed")
-        expect(
-            self.sumo_pages.question_page._get_i_have_this_problem_too_signed_out_card_locator()
-        ).to_be_visible()
-
-        self.logger.info("Clicking on the 'Ask a question' signed out option")
-        self.sumo_pages.question_page._click_on_ask_a_question_signed_out_card_option()
-
-        self.logger.info("Verifying that we are redirected to the Contact Support page")
-        expect(
-            self.page
-        ).to_have_url(ContactSupportMessages.PAGE_URL)
-
-        self.logger.info("Navigating back to the question page")
-        self.navigate_back()
-
-        self.logger.info("Clicking on the 'log in to your account' link")
-        self.sumo_pages.question_page._click_on_log_in_to_your_account_signed_out_card_link()
-
-        self.logger.info("Proceeding with the auth flow with an admin account")
-        self.sumo_pages.auth_flow_page.sign_in_flow(
-            username=super().user_special_chars,
-            account_password=super().user_secrets_pass,
-        )
-
-        self.logger.info("Verifying that we are redirected back to the question page")
-        expect(
-            self.page
-        ).to_have_url(posted_question['question_details']['question_page_url'])
-
-        self.logger.info("Verifying that the textarea field is displayed")
-        expect(
-            self.sumo_pages.question_page._get_post_a_reply_textarea_locator()
-        ).to_be_visible()
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
-        ))
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Signing in with an admin account and deleting the posted question"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
+            ))
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191227
     # Currently fails due to https://github.com/mozilla/sumo/issues/1216
@@ -1987,125 +1719,111 @@ class TestPostedQuestions(TestUtilities):
         number_of_thumbs_up_votes = 0
         number_of_thumbs_down_votes = 0
 
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
         self.sumo_pages.question_page._get_question_id()
 
-        self.logger.info("Posting a reply to the question")
-        self.sumo_pages.question_page._add_text_to_post_a_reply_textarea(
-            super().aaq_question_test_data['valid_firefox_question']['question_reply']
-        )
-        reply_id = self.sumo_pages.question_page._click_on_post_reply_button(
-            posted_question['username_one']
-        )
+        with allure.step("Posting a reply to the question"):
+            self.sumo_pages.question_page._add_text_to_post_a_reply_textarea(
+                super().aaq_question_test_data['valid_firefox_question']['question_reply']
+            )
+            reply_id = self.sumo_pages.question_page._click_on_post_reply_button(
+                posted_question['username_one']
+            )
 
-        self.logger.info("Verifying the vote reply is not available for self posted questions")
-        expect(
-            self.sumo_pages.question_page._get_reply_votes_section_locator(reply_id)
-        ).to_be_hidden()
+        with allure.step("Verifying the vote reply is not available for self posted questions"):
+            expect(
+                self.sumo_pages.question_page._get_reply_votes_section_locator(reply_id)
+            ).to_be_hidden()
 
-        self.logger.info("Signing in a different user")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_13']
-        ))
+        with check, allure.step("Signing in a different user and verifying that the correct vote "
+                                "header is displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_13']
+            ))
+            assert self.sumo_pages.question_page._get_reply_vote_heading(
+                reply_id
+            ) == QuestionPageMessages.HELPFUL_VOTE_HEADER
 
-        self.logger.info("Verifying that the correct vote header is displayed")
-        check.equal(
-            self.sumo_pages.question_page._get_reply_vote_heading(reply_id),
-            QuestionPageMessages.HELPFUL_VOTE_HEADER
-        )
+        with allure.step("Clicking on the 'thumbs up' button and verifying that the correct "
+                         "message is displayed"):
+            self.sumo_pages.question_page._click_reply_vote_thumbs_up_button(reply_id)
+            number_of_thumbs_up_votes += 1
+            assert self.sumo_pages.question_page._get_thumbs_up_vote_message(
+                reply_id
+            ) == QuestionPageMessages.THUMBS_UP_VOTE_MESSAGE
 
-        self.logger.info("Clicking on the 'thumbs up' button")
-        self.sumo_pages.question_page._click_reply_vote_thumbs_up_button(reply_id)
-        number_of_thumbs_up_votes += 1
+        with check, allure.step("Refreshing the page and verifying that the correct number of "
+                                "thumbs up votes is displayed"):
+            self.refresh_page()
+            assert int(self.sumo_pages.question_page._get_helpful_count(
+                reply_id
+            )) == number_of_thumbs_up_votes
 
-        self.logger.info("Verifying that the correct message is displayed")
-        check.equal(
-            self.sumo_pages.question_page._get_thumbs_up_vote_message(reply_id),
-            QuestionPageMessages.THUMBS_UP_VOTE_MESSAGE
-        )
+        with check, allure.step("Verifying that the correct number of thumbs down votes is "
+                                "displayed"):
+            assert int(self.sumo_pages.question_page._get_not_helpful_count(
+                reply_id
+            )) == number_of_thumbs_down_votes
 
-        self.logger.info("Refreshing the page")
-        self.refresh_page()
+        with allure.step("Verifying that the thumbs up button contains the disabled attribute"):
+            expect(
+                self.sumo_pages.question_page._get_thumbs_up_button_locator(reply_id)
+            ).to_have_attribute("disabled", "")
 
-        self.logger.info("Verifying that the correct number of thumbs up votes is displayed")
-        check.equal(
-            int(self.sumo_pages.question_page._get_helpful_count(reply_id)),
-            number_of_thumbs_up_votes
-        )
+        with allure.step("Verifying that the thumbs down button contains the disabled attribute"):
+            expect(
+                self.sumo_pages.question_page._get_thumbs_down_button_locator(reply_id)
+            ).to_have_attribute("disabled", "")
 
-        self.logger.info("Verifying that the correct number of thumbs down votes is displayed")
-        check.equal(
-            int(self.sumo_pages.question_page._get_not_helpful_count(reply_id)),
-            number_of_thumbs_down_votes
-        )
+        with check, allure.step("Refreshing the page and verifying that the correct number of "
+                                "thumbs up votes is displayed"):
+            self.refresh_page()
+            assert int(self.sumo_pages.question_page._get_helpful_count(
+                reply_id
+            )) == number_of_thumbs_up_votes
 
-        self.logger.info("Verifying that the thumbs up button contains the disabled attribute")
-        expect(
-            self.sumo_pages.question_page._get_thumbs_up_button_locator(reply_id)
-        ).to_have_attribute("disabled", "")
+        with check, allure.step("Verifying that the correct number of thumbs down votes is "
+                                "displayed"):
+            assert int(self.sumo_pages.question_page._get_not_helpful_count(
+                reply_id
+            )) == number_of_thumbs_down_votes
 
-        self.logger.info("Verifying that the thumbs down button contains the disabled attribute")
-        expect(
-            self.sumo_pages.question_page._get_thumbs_down_button_locator(reply_id)
-        ).to_have_attribute("disabled", "")
+        with allure.step("Deleting the user session and clicking on the 'thumbs up' button"):
+            self.delete_cookies()
+            self.sumo_pages.question_page._click_reply_vote_thumbs_up_button(reply_id)
+            number_of_thumbs_up_votes += 1
 
-        self.logger.info("Refreshing the page")
-        self.refresh_page()
+        with check, allure.step("Refreshing the page and verifying that the correct number of "
+                                "thumbs up votes is displayed"):
+            self.refresh_page()
+            assert int(self.sumo_pages.question_page._get_helpful_count(
+                reply_id
+            )) == number_of_thumbs_up_votes
 
-        self.logger.info("Verifying that the correct number of thumbs up votes is displayed")
-        check.equal(
-            int(self.sumo_pages.question_page._get_helpful_count(reply_id)),
-            number_of_thumbs_up_votes
-        )
+        with check, allure.step("Verifying that the correct number of thumbs down votes is "
+                                "displayed"):
+            assert int(self.sumo_pages.question_page._get_not_helpful_count(
+                reply_id
+            )) == number_of_thumbs_down_votes
 
-        self.logger.info("Verifying that the correct number of thumbs down votes is displayed")
-        check.equal(
-            int(self.sumo_pages.question_page._get_not_helpful_count(reply_id)),
-            number_of_thumbs_down_votes
-        )
+        with allure.step("Verifying that the thumbs up button contains the disabled attribute"):
+            expect(
+                self.sumo_pages.question_page._get_thumbs_up_button_locator(reply_id)
+            ).to_have_attribute("disabled", "")
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with allure.step("Verifying that the thumbs down button contains the disabled attribute"):
+            expect(
+                self.sumo_pages.question_page._get_thumbs_down_button_locator(reply_id)
+            ).to_have_attribute("disabled", "")
 
-        self.logger.info("Clicking on the 'thumbs up' button")
-        self.sumo_pages.question_page._click_reply_vote_thumbs_up_button(reply_id)
-        number_of_thumbs_up_votes += 1
-
-        self.logger.info("Refreshing the page")
-        self.refresh_page()
-
-        self.logger.info("Verifying that the correct number of thumbs up votes is displayed")
-        check.equal(
-            int(self.sumo_pages.question_page._get_helpful_count(reply_id)),
-            number_of_thumbs_up_votes
-        )
-
-        self.logger.info("Verifying that the correct number of thumbs down votes is displayed")
-        check.equal(
-            int(self.sumo_pages.question_page._get_not_helpful_count(reply_id)),
-            number_of_thumbs_down_votes
-        )
-
-        self.logger.info("Verifying that the thumbs up button contains the disabled attribute")
-        expect(
-            self.sumo_pages.question_page._get_thumbs_up_button_locator(reply_id)
-        ).to_have_attribute("disabled", "")
-
-        self.logger.info("Verifying that the thumbs down button contains the disabled attribute")
-        expect(
-            self.sumo_pages.question_page._get_thumbs_down_button_locator(reply_id)
-        ).to_have_attribute("disabled", "")
-
-        self.logger.info("Refreshing the page")
-        self.refresh_page()
-
-        self.logger.info("Verifying that the correct number of thumbs up votes is displayed")
-        check.equal(
-            int(self.sumo_pages.question_page._get_helpful_count(reply_id)),
-            number_of_thumbs_up_votes
-        )
+        with check, allure.step("Refreshing the page and verifying that the correct number of "
+                                "thumbs up votes is displayed"):
+            self.refresh_page()
+            assert int(self.sumo_pages.question_page._get_helpful_count(
+                reply_id
+            )) == number_of_thumbs_up_votes
 
         self.logger.info("Verifying that the correct number of thumbs down votes is displayed")
         check.equal(
@@ -2113,38 +1831,33 @@ class TestPostedQuestions(TestUtilities):
             number_of_thumbs_down_votes
         )
 
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
-        ))
+        with allure.step("Signing in with an admin account and clicking on the vote down button"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
+            ))
+            self.sumo_pages.question_page._click_reply_vote_thumbs_down_button(reply_id)
+            number_of_thumbs_down_votes += 1
 
-        self.logger.info("Clicking on the vote down button")
-        self.sumo_pages.question_page._click_reply_vote_thumbs_down_button(reply_id)
-        number_of_thumbs_down_votes += 1
+        with check, allure.step("Verifying that the correct message is displayed"):
+            assert self.sumo_pages.question_page._get_thumbs_up_vote_message(
+                reply_id
+            ) == QuestionPageMessages.THUMBS_DOWN_VOTE_MESSAGE
 
-        self.logger.info("Verifying that the correct message is displayed")
-        check.equal(
-            self.sumo_pages.question_page._get_thumbs_up_vote_message(reply_id),
-            QuestionPageMessages.THUMBS_DOWN_VOTE_MESSAGE
-        )
+        with check, allure.step("Refreshing the page and verifying that the correct number of "
+                                "thumbs up votes is displayed"):
+            self.refresh_page()
+            assert int(self.sumo_pages.question_page._get_helpful_count(
+                reply_id
+            )) == number_of_thumbs_up_votes
 
-        self.logger.info("Refreshing the page")
-        self.refresh_page()
+        with check, allure.step("Verifying that the correct number of thumbs down votes is "
+                                "displayed"):
+            assert int(self.sumo_pages.question_page._get_not_helpful_count(
+                reply_id
+            )) == number_of_thumbs_down_votes
 
-        self.logger.info("Verifying that the correct number of thumbs up votes is displayed")
-        check.equal(
-            int(self.sumo_pages.question_page._get_helpful_count(reply_id)),
-            number_of_thumbs_up_votes
-        )
-
-        self.logger.info("Verifying that the correct number of thumbs down votes is displayed")
-        check.equal(
-            int(self.sumo_pages.question_page._get_not_helpful_count(reply_id)),
-            number_of_thumbs_down_votes
-        )
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Deleting the posted question"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2260449, C2260450, C2191243, C2191245
     @pytest.mark.postedQuestions
@@ -2154,239 +1867,207 @@ class TestPostedQuestions(TestUtilities):
                               ('question_reply', 'TEST_ACCOUNT_13'),
                               ('question_reply', 'TEST_ACCOUNT_MODERATOR')])
     def test_report_abuse(self, flagged_content, username):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            posted_question = self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
         if flagged_content == "question_reply":
-            self.logger.info("Posting a reply to the question")
-            reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
-                repliant_username=posted_question['username_one'],
-                reply=super().aaq_question_test_data['valid_firefox_question']['question_reply']
-            )
+            with allure.step("Posting a reply to the question"):
+                reply_id = self.sumo_pages.aaq_flow.post_question_reply_flow(
+                    repliant_username=posted_question['username_one'],
+                    reply=super().aaq_question_test_data['valid_firefox_question']
+                    ['question_reply']
+                )
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with allure.step("Deleting user session"):
+            self.delete_cookies()
 
         if flagged_content == "question_content":
-            self.logger.info("Clicking on the more options for the question and verifying that "
-                             "the report abuse option is not displayed for signed out users")
-            self.sumo_pages.question_page._click_on_reply_more_options_button(
-                self.sumo_pages.question_page._get_question_id()
-            )
-            expect(
-                self.sumo_pages.question_page._get_click_on_report_abuse_reply_locator(
+            with allure.step("Clicking on the more options for the question and verifying that "
+                             "the report abuse option is not displayed for signed out users"):
+                self.sumo_pages.question_page._click_on_reply_more_options_button(
                     self.sumo_pages.question_page._get_question_id()
+                )
+                expect(
+                    self.sumo_pages.question_page._get_click_on_report_abuse_reply_locator(
+                        self.sumo_pages.question_page._get_question_id()
+                    )
+                ).to_be_hidden()
+
+        else:
+            with allure.step("Clicking on the more options for the reply and verifying that the "
+                             "report abuse options is not displayed for signed out users"):
+                self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
+                expect(
+                    self.sumo_pages.question_page._get_click_on_report_abuse_reply_locator(
+                        reply_id
+                    )
+                ).to_be_hidden()
+
+        if username == "TEST_ACCOUNT_MODERATOR":
+            with allure.step("Signing in with an admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
+                ))
+        else:
+            with allure.step("Signing in with an admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_13']
+                ))
+
+        if flagged_content == "question_content":
+            with allure.step("Reporting the question as abusive"):
+                self.sumo_pages.aaq_flow.report_question_abuse(
+                    answer_id=self.sumo_pages.question_page._get_question_id(),
+                    text=super().aaq_question_test_data['valid_firefox_question']
+                    ['report_abuse_text']
+                )
+        else:
+            with allure.step("Reporting the question reply as abusive"):
+                self.sumo_pages.aaq_flow.report_question_abuse(
+                    answer_id=reply_id,
+                    text=super().aaq_question_test_data['valid_firefox_question']
+                    ['report_abuse_text']
+                )
+
+        if username == "TEST_ACCOUNT_13":
+            with allure.step("Signing in with a admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
+                ))
+
+        with allure.step("Navigating to 'Moderate forum content page' and verifying that the "
+                         "question exists inside the moderate forum content page"):
+            self.sumo_pages.top_navbar._click_on_moderate_forum_content_option()
+            expect(
+                self.sumo_pages.moderate_forum_content_page._get_flagged_question_locator(
+                    posted_question['question_details']['aaq_subject']
+                )
+            ).to_be_visible()
+
+        with allure.step("Selecting an option from the update status and clicking on the update "
+                         "button"):
+            self.sumo_pages.moderate_forum_content_page._select_update_status_option(
+                posted_question['question_details']['aaq_subject'],
+                ModerateForumContentPageMessages.UPDATE_STATUS_FIRST_VALUE
+            )
+            self.sumo_pages.moderate_forum_content_page._click_on_the_update_button(
+                posted_question['question_details']['aaq_subject']
+            )
+
+        with allure.step("Verifying that the question no longer exists inside the moderate forum "
+                         "content page"):
+            expect(
+                self.sumo_pages.moderate_forum_content_page._get_flagged_question_locator(
+                    posted_question['question_details']['aaq_subject']
                 )
             ).to_be_hidden()
 
-        else:
-            self.logger.info("Clicking on the more options for the reply and verifying that the "
-                             "report abuse options is not displayed for signed out users")
-            self.sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
-            expect(
-                self.sumo_pages.question_page._get_click_on_report_abuse_reply_locator(reply_id)
-            ).to_be_hidden()
-
-        if username == "TEST_ACCOUNT_MODERATOR":
-            self.logger.info("Signing in with an admin account")
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
-            ))
-        else:
-            self.logger.info("Signing in with an admin account")
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts['TEST_ACCOUNT_13']
-            ))
-
-        if flagged_content == "question_content":
-            self.sumo_pages.aaq_flow.report_question_abuse(
-                answer_id=self.sumo_pages.question_page._get_question_id(),
-                text=super().aaq_question_test_data['valid_firefox_question']['report_abuse_text']
-            )
-        else:
-            self.sumo_pages.aaq_flow.report_question_abuse(
-                answer_id=reply_id,
-                text=super().aaq_question_test_data['valid_firefox_question']['report_abuse_text']
-            )
-
-        if username == "TEST_ACCOUNT_13":
-            self.logger.info("Signing in with a admin account")
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
-            ))
-
-        self.logger.info("Navigating to 'Moderate forum content page'")
-        self.sumo_pages.top_navbar._click_on_moderate_forum_content_option()
-
-        self.logger.info("Verifying that the question exists inside the moderate forum content "
-                         "page")
-        expect(
-            self.sumo_pages.moderate_forum_content_page._get_flagged_question_locator(
-                posted_question['question_details']['aaq_subject']
-            )
-        ).to_be_visible()
-
-        self.logger.info("Selecting an option from the update status and clicking on the update "
-                         "button")
-        self.sumo_pages.moderate_forum_content_page._select_update_status_option(
-            posted_question['question_details']['aaq_subject'],
-            ModerateForumContentPageMessages.UPDATE_STATUS_FIRST_VALUE
-        )
-
-        self.logger.info("Clicking on the update button")
-        self.sumo_pages.moderate_forum_content_page._click_on_the_update_button(
-            posted_question['question_details']['aaq_subject']
-        )
-
-        self.logger.info("Verifying that the question no longer exists inside the moderate forum "
-                         "content page")
-        expect(
-            self.sumo_pages.moderate_forum_content_page._get_flagged_question_locator(
-                posted_question['question_details']['aaq_subject']
-            )
-        ).to_be_hidden()
-
-        self.logger.info("Navigating back to the posted question")
-        self.navigate_to_link(posted_question['question_details']['question_page_url'])
-
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Navigating back to the posted question and deleting it"):
+            self.navigate_to_link(posted_question['question_details']['question_page_url'])
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     # C2191261
     @pytest.mark.postedQuestions
     def test_common_responses(self):
-        self.logger.info("Signing in with a non admin user account and posting a Firefox product "
-                         "question")
-        self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
+        with allure.step("Signing in with a non admin user account and posting a Firefox product "
+                         "question"):
+            self.post_firefox_product_question_flow('TEST_ACCOUNT_12')
 
-        self.logger.info("Signing in with a different account")
-        username = self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_13']
-        ))
+        with allure.step("Signing in with a different account, clicking on the 'Common "
+                         "Responses' option and selecting one from the list"):
+            username = self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_13']
+            ))
+            self.sumo_pages.question_page._click_on_common_responses_option()
+            self.wait_for_networkidle()
+            self.sumo_pages.question_page._click_on_a_particular_category_option(
+                super().aaq_question_test_data["valid_firefox_question"]
+                ["common_responses_category"]
+            )
+            self.sumo_pages.question_page._type_into_common_responses_search_field(
+                super().aaq_question_test_data["valid_firefox_question"]
+                ["common_responses_response"]
+            )
+            self.wait_for_networkidle()
 
-        self.logger.info("Clicking on the 'Common Responses' option")
-        self.sumo_pages.question_page._click_on_common_responses_option()
+        with allure.step("Verifying that the only item in the category field is the searched "
+                         "option"):
+            response_options = self.sumo_pages.question_page._get_list_of_responses()
+            assert (
+                len(response_options) == 1 and response_options[0] == super().
+                aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
+            )
 
-        self.logger.info("Waiting for Network Idle")
-        self.wait_for_networkidle()
+        with allure.step("Clicking on the response option and on the 'Cancel' panel button"):
+            self.sumo_pages.question_page._click_on_a_particular_response_option(
+                super().aaq_question_test_data["valid_firefox_question"]
+                ["common_responses_response"]
+            )
+            self.wait_for_networkidle()
+            self.sumo_pages.question_page._click_on_common_responses_cancel_button()
 
-        self.logger.info("Click on a category")
-        self.sumo_pages.question_page._click_on_a_particular_category_option(
-            super().aaq_question_test_data["valid_firefox_question"]["common_responses_category"]
-        )
+        with check, allure.step("Verifying that the form textarea does not contain the common "
+                                "response"):
+            assert self.sumo_pages.question_page._get_post_a_reply_textarea_value() == ""
 
-        self.logger.info("Searching for a response")
-        self.sumo_pages.question_page._type_into_common_responses_search_field(
-            super().aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
-        )
+        with allure.step("Clicking on the 'Common Responses' option and selecting a response "
+                         "from the list"):
+            self.sumo_pages.question_page._click_on_common_responses_option()
+            self.wait_for_networkidle()
+            self.sumo_pages.question_page._click_on_a_particular_category_option(
+                super().aaq_question_test_data["valid_firefox_question"]
+                ["common_responses_category"]
+            )
+            self.sumo_pages.question_page._type_into_common_responses_search_field(
+                super().aaq_question_test_data["valid_firefox_question"]
+                ["common_responses_response"]
+            )
+            self.wait_for_networkidle()
 
-        self.logger.info("Waiting for Network Idle")
-        self.wait_for_networkidle()
+        with allure.step("Verifying that the only item in the category field is the searched "
+                         "option"):
+            response_options = self.sumo_pages.question_page._get_list_of_responses()
+            assert (
+                len(response_options) == 1 and response_options[0] == super()
+                .aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
+            )
 
-        self.logger.info("Verifying that the only item in the category field is the search option")
-        response_options = self.sumo_pages.question_page._get_list_of_responses()
-        self.logger.info(response_options)
-        self.logger.info(self.sumo_pages.question_page._get_list_of_responses())
-        assert (
-            len(response_options) == 1 and response_options[0] == super().aaq_question_test_data
-            ["valid_firefox_question"]["common_responses_response"]
-        )
+        with allure.step("Clicking on the response option"):
+            self.sumo_pages.question_page._click_on_a_particular_response_option(
+                super().aaq_question_test_data["valid_firefox_question"]
+                ["common_responses_response"]
+            )
+            self.wait_for_networkidle()
+            self.sumo_pages.question_page._click_on_switch_to_mode()
+            self.wait_for_networkidle()
+            response = self.sumo_pages.question_page._get_text_of_response_preview()
 
-        self.logger.info("Clicking on the response option")
-        self.sumo_pages.question_page._click_on_a_particular_response_option(
-            super().aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
-        )
+        with check, allure.step("Clicking on the Insert Response, post reply and verifying that "
+                                "the reply was successfully posted and contains the correct data"):
+            self.sumo_pages.question_page._click_on_common_responses_insert_response_button()
+            reply_id = self.sumo_pages.question_page._click_on_post_reply_button(username)
+            assert self.sumo_pages.question_page._get_text_content_of_reply(reply_id) in response
 
-        self.logger.info("Waiting for Networkidle")
-        self.wait_for_networkidle()
-
-        self.logger.info("Clicking on the 'Cancel button'")
-        self.sumo_pages.question_page._click_on_common_responses_cancel_button()
-
-        self.logger.info("Verifying that the form textarea does not contain the common response")
-
-        check.equal(
-            self.sumo_pages.question_page._get_post_a_reply_textarea_value(),
-            "",
-            f"Expected to be empty "
-            f"Received: {self.sumo_pages.question_page._get_post_a_reply_textarea_value()}"
-        )
-
-        self.logger.info("Clicking on the 'Common Responses' option")
-        self.sumo_pages.question_page._click_on_common_responses_option()
-
-        self.logger.info("Waiting for NetworkIdle")
-        self.wait_for_networkidle()
-
-        self.logger.info("Click on a category")
-        self.sumo_pages.question_page._click_on_a_particular_category_option(
-            super().aaq_question_test_data["valid_firefox_question"]["common_responses_category"]
-        )
-
-        self.logger.info("Searching for a response")
-        self.sumo_pages.question_page._type_into_common_responses_search_field(
-            super().aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
-        )
-
-        self.logger.info("Waiting for NetworkIdle")
-        self.wait_for_networkidle()
-
-        self.logger.info("Verifying that the only item in the category field is the search option")
-        response_options = self.sumo_pages.question_page._get_list_of_responses()
-        assert (
-            len(response_options) == 1 and response_options[0] == super().aaq_question_test_data
-            ["valid_firefox_question"]["common_responses_response"]
-        )
-
-        self.logger.info("Clicking on the response option")
-        self.sumo_pages.question_page._click_on_a_particular_response_option(
-            super().aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
-        )
-
-        self.logger.info("Waiting for Networkidle")
-        self.wait_for_networkidle()
-
-        self.sumo_pages.question_page._click_on_switch_to_mode()
-        self.logger.info("Waiting for Networkidle")
-        self.wait_for_networkidle()
-
-        response = self.sumo_pages.question_page._get_text_of_response_preview()
-
-        self.logger.info("Clicking on the Insert Response button")
-        self.sumo_pages.question_page._click_on_common_responses_insert_response_button()
-
-        self.logger.info("Clicking on the post reply button")
-        reply_id = self.sumo_pages.question_page._click_on_post_reply_button(username)
-
-        self.logger.info("Verifying that the reply was successfully posted and contains the "
-                         "correct data")
-        check.is_in(
-            self.sumo_pages.question_page._get_text_content_of_reply(reply_id),
-            response,
-            f"Expected: {self.sumo_pages.question_page._get_text_content_of_reply(reply_id)} "
-            f"Received: {response}"
-        )
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.aaq_flow.deleting_question_flow()
+        with allure.step("Signing in  with an admin account and deleting the posted question"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.aaq_flow.deleting_question_flow()
 
     def post_firefox_product_question_flow(self, username: str):
         username_one = self.start_existing_session(super().username_extraction_from_email(
             self.user_secrets_accounts[username]
         ))
 
-        self.logger.info("Posting a Firefox product question")
-        self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
+        with allure.step("Posting a Firefox product question"):
+            self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]["Firefox"])
 
-        question_details = self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-            subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
-            body=super().aaq_question_test_data["valid_firefox_question"]["simple_body_text"],
-            attach_image=False
-        )
+            question_details = self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
+                topic_name=self.sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                body=super().aaq_question_test_data["valid_firefox_question"]["simple_body_text"],
+                attach_image=False
+            )
 
-        return {"username_one": username_one, "question_details": question_details}
+            return {"username_one": username_one, "question_details": question_details}

--- a/playwright_tests/tests/ask_a_question_tests/contact_support_page_tests/test_contact_support_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/contact_support_page_tests/test_contact_support_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 from playwright.sync_api import expect
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -15,90 +16,60 @@ class TestContactSupportPage(TestUtilities):
     # C890363
     @pytest.mark.contactSupportPage
     def test_contact_support_page_content(self):
-        self.logger.info("Accessing the contact support page via the top navbar Get Help > Ask a "
-                         "Question")
-        self.sumo_pages.top_navbar._click_on_ask_a_question_option()
+        with allure.step("Accessing the contact support page via the top navbar Get Help > Ask a "
+                         "Question"):
+            self.sumo_pages.top_navbar._click_on_ask_a_question_option()
 
-        self.logger.info("Verifying that the current milestone is the correct one")
-        check.equal(
-            self.sumo_pages.contact_support_page._get_text_of_current_milestone(),
-            ContactSupportMessages.CURRENT_MILESTONE,
-            f"Incorrect current milestone displayed. "
-            f"Expected: {ContactSupportMessages.CURRENT_MILESTONE}"
-            f"Received: {self.sumo_pages.contact_support_page._get_text_of_current_milestone()}"
-        )
+        with check, allure.step("Verifying that the current milestone is the correct one"):
+            assert self.sumo_pages.contact_support_page._get_text_of_current_milestone(
+            ) == ContactSupportMessages.CURRENT_MILESTONE
 
-        self.logger.info("Verifying that the correct page header is displayed")
-        check.equal(
-            self.sumo_pages.contact_support_page._get_contact_support_main_heading(),
-            ContactSupportMessages.MAIN_HEADER,
-            f"Incorrect page header displayed. "
-            f"Expected: {ContactSupportMessages.MAIN_HEADER} "
-            f"Received: {self.sumo_pages.contact_support_page._get_contact_support_main_heading()}"
-        )
+        with check, allure.step("Verifying that the correct page header is displayed"):
+            assert self.sumo_pages.contact_support_page._get_contact_support_main_heading(
+            ) == ContactSupportMessages.MAIN_HEADER
 
-        self.logger.info("Verifying that the correct page subheading is displayed")
-        check.equal(
-            self.sumo_pages.contact_support_page._get_contact_support_subheading_text(),
-            ContactSupportMessages.SUBHEADING,
-            f"Incorrect page subheading displayed. "
-            f"Expected: {ContactSupportMessages.SUBHEADING} "
-            f"Actual:{self.sumo_pages.contact_support_page._get_contact_support_subheading_text()}"
-        )
+        with check, allure.step("Verifying that the correct page subheading is displayed"):
+            assert self.sumo_pages.contact_support_page._get_contact_support_subheading_text(
+            ) == ContactSupportMessages.SUBHEADING
 
-        self.logger.info("Verifying that each product card has the correct subheading")
-        for card in self.sumo_pages.contact_support_page._get_all_product_card_titles():
-            check.equal(
-                ContactSupportMessages.PRODUCT_CARDS_SUBHEADING[card],
-                self.sumo_pages.contact_support_page._get_product_card_subtitle(card),
-                f"Incorrect card subheading displayed "
-                f"Expected: {ContactSupportMessages.PRODUCT_CARDS_SUBHEADING[card]} "
-                f"Actual: {self.sumo_pages.contact_support_page._get_product_card_subtitle(card)}"
-            )
+        with allure.step("Verifying that each product card has the correct subheading"):
+            for card in self.sumo_pages.contact_support_page._get_all_product_card_titles():
+                with check, allure.step(f"Verifying {card} card has the correct subheading"):
+                    assert (ContactSupportMessages.
+                            PRODUCT_CARDS_SUBHEADING[card] == self.sumo_pages.
+                            contact_support_page._get_product_card_subtitle(card))
 
     # C890368, C890387, C890388
     @pytest.mark.contactSupportPage
     def test_contact_support_page_cards_redirect(self):
-        self.logger.info("Accessing the contact support page via the top navbar Get Help > "
-                         "Browse All products")
-        self.sumo_pages.top_navbar._click_on_browse_all_products_option()
-
-        self.logger.info("Clicking on all product cards")
+        with allure.step("Accessing the contact support page via the top navbar Get Help > "
+                         "Browse All products"):
+            self.sumo_pages.top_navbar._click_on_browse_all_products_option()
 
         for card in self.sumo_pages.contact_support_page._get_all_product_card_titles():
-            self.sumo_pages.contact_support_page._click_on_a_particular_card(card)
+            with allure.step(f"Clicking on {card}"):
+                self.sumo_pages.contact_support_page._click_on_a_particular_card(card)
 
-            self.logger.info("Verifying that we are on the correct product solutions page")
-            check.equal(
-                self.sumo_pages.product_solutions_page._get_product_solutions_heading(),
-                card + ProductSolutionsMessages.PAGE_HEADER,
-                f"Incorrect product solutions page displayed: "
-                f"Expected: {card + ProductSolutionsMessages.PAGE_HEADER} "
-                f"Actual:{self.sumo_pages.product_solutions_page._get_product_solutions_heading()}"
-            )
+            with check, allure.step("Verifying that we are on the correct product solutions page"):
+                assert self.sumo_pages.product_solutions_page._get_product_solutions_heading(
+                ) == card + ProductSolutionsMessages.PAGE_HEADER
 
-            self.logger.info("Verifying that we are on the correct milestone")
-            check.equal(
-                self.sumo_pages.product_solutions_page._get_current_milestone_text(),
-                ProductSolutionsMessages.CURRENT_MILESTONE_TEXT,
-                f"Incorrect current milestone displayed "
-                f"Expected: {ProductSolutionsMessages.CURRENT_MILESTONE_TEXT} "
-                f"Received: {self.sumo_pages.product_solutions_page._get_current_milestone_text()}"
-            )
+            with check, allure.step("Verifying that we are on the correct milestone"):
+                assert self.sumo_pages.product_solutions_page._get_current_milestone_text(
+                ) == ProductSolutionsMessages.CURRENT_MILESTONE_TEXT
 
-            self.logger.info("Click on the 'Change Product' milestone")
-            self.sumo_pages.product_solutions_page._click_on_the_completed_milestone()
+            with allure.step("Click on the 'Change Product' milestone"):
+                self.sumo_pages.product_solutions_page._click_on_the_completed_milestone()
 
     @pytest.mark.contactSupportPage
     def test_browse_all_product_forums_button_redirect(self):
-        self.logger.info("Accessing the contact support page via the top navbar Get Help > Ask a "
-                         "Question")
-        self.sumo_pages.top_navbar._click_on_ask_a_question_option()
+        with allure.step("Accessing the contact support page via the top navbar Get Help > Ask a "
+                         "Question"):
+            self.sumo_pages.top_navbar._click_on_ask_a_question_option()
 
-        self.sumo_pages.contact_support_page._click_on_browse_all_product_forums_button()
-
-        self.logger.info("Verifying that we are redirected to the correct page url")
-
-        expect(
-            self.page
-        ).to_have_url(SupportForumsPageMessages.PAGE_URL)
+        with allure.step("Clicking on browse all product forums button and verifying that we are "
+                         "redirected to the correct page"):
+            self.sumo_pages.contact_support_page._click_on_browse_all_product_forums_button()
+            expect(
+                self.page
+            ).to_have_url(SupportForumsPageMessages.PAGE_URL)

--- a/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 
 from playwright.sync_api import TimeoutError, expect, Error
 from playwright_tests.core.testutilities import TestUtilities
@@ -17,109 +18,90 @@ class TestPopularTopicsPage(TestUtilities):
     # C890379
     @pytest.mark.productTopicsPage
     def test_popular_topics_navbar(self):
-        self.logger.info("Navigating to product topics pages")
-        for product_topic in super().general_test_data["product_topics"]:
-            topic_url = super().general_test_data["product_topics"][product_topic]
-            self.page.wait_for_timeout(400)
-            self.navigate_to_link(topic_url)
-            self.wait_for_url_to_be(topic_url)
+        with allure.step("Navigating to product topics pages"):
+            for product_topic in super().general_test_data["product_topics"]:
+                topic_url = super().general_test_data["product_topics"][product_topic]
+                self.page.wait_for_timeout(400)
+                self.navigate_to_link(topic_url)
+                self.wait_for_url_to_be(topic_url)
 
-            for option in self.sumo_pages.product_topics_page._get_navbar_links_text():
-                self.logger.info(f"Clicking on {option} navbar option")
-                option_url = (HomepageMessages.STAGE_HOMEPAGE_URL + self.sumo_pages.
-                              product_topics_page._get_navbar_option_link(option))
-                self.sumo_pages.product_topics_page._click_on_a_navbar_option(option)
-                try:
-                    self.wait_for_url_to_be(option_url)
-                except (TimeoutError, Error):
-                    self.logger.info("Failed click, retrying")
-                    self.sumo_pages.product_topics_page._click_on_a_navbar_option(option)
-                    self.wait_for_url_to_be(option_url)
+                for option in self.sumo_pages.product_topics_page._get_navbar_links_text():
+                    with allure.step(f"Clicking on {option} navbar option"):
+                        option_url = (HomepageMessages.STAGE_HOMEPAGE_URL + self.sumo_pages.
+                                      product_topics_page._get_navbar_option_link(option))
+                        self.sumo_pages.product_topics_page._click_on_a_navbar_option(option)
+                        try:
+                            self.wait_for_url_to_be(option_url)
+                        except (TimeoutError, Error):
+                            self.logger.info("Failed click, retrying")
+                            self.sumo_pages.product_topics_page._click_on_a_navbar_option(option)
+                            self.wait_for_url_to_be(option_url)
 
-                self.logger.info("Verifying that the correct option is displayed")
-                check.equal(
-                    self.sumo_pages.product_topics_page._get_page_title(),
-                    option,
-                    f"Incorrect topic: "
-                    f"Expected: {option} "
-                    f"Received: {self.sumo_pages.product_topics_page._get_page_title()}"
-                )
+                    with check, allure.step("Verifying that the correct option is displayed"):
+                        assert self.sumo_pages.product_topics_page._get_page_title() == option
 
-                self.logger.info("Verifying that the correct navbar option is selected")
-                check.equal(
-                    self.sumo_pages.product_topics_page._get_selected_navbar_option(),
-                    option,
-                    f"Incorrect selected navbar option "
-                    f"Expected: {option} "
-                    f"Actual: {self.sumo_pages.product_topics_page._get_selected_navbar_option()}"
-                )
+                    with check, allure.step("Verifying that the correct nav option is selected"):
+                        assert self.sumo_pages.product_topics_page._get_selected_navbar_option(
+                        ) == option
 
     #  C2428991
     @pytest.mark.productTopicsPage
     def test_learn_more_redirect(self):
-        self.logger.info("Navigating to product topics pages")
-        for product_topic in super().general_test_data["product_topics"]:
-            topic_url = super().general_test_data["product_topics"][product_topic]
-            self.navigate_to_link(topic_url)
-            self.wait_for_url_to_be(topic_url)
+        with allure.step("Navigating to product topics pages"):
+            for product_topic in super().general_test_data["product_topics"]:
+                topic_url = super().general_test_data["product_topics"][product_topic]
+                self.navigate_to_link(topic_url)
+                self.wait_for_url_to_be(topic_url)
 
-            self.logger.info("Clicking on the 'Learn More' button")
-            self.sumo_pages.product_topics_page._click_on_learn_more_button()
+                with allure.step("Clicking on the 'Learn More' button"):
+                    self.sumo_pages.product_topics_page._click_on_learn_more_button()
 
-            self.logger.info("Verifying that we are redirected to the contribute_messages page")
-            expect(
-                self.page
-            ).to_have_url(ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL)
+                with allure.step("Verifying that the user is redirected to the contribute "
+                                 "messages page"):
+                    expect(
+                        self.page
+                    ).to_have_url(ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL)
 
     # C2188690
     @pytest.mark.productTopicsPage
     def test_aaq_redirect(self):
-        self.logger.info("Navigating to product topics pages")
-        for product_topic in super().general_test_data["product_topics"]:
-            topic_url = super().general_test_data["product_topics"][product_topic]
-            self.navigate_to_link(topic_url)
-            self.wait_for_url_to_be(topic_url)
+        with allure.step("Navigating to product topics pages"):
+            for product_topic in super().general_test_data["product_topics"]:
+                topic_url = super().general_test_data["product_topics"][product_topic]
+                self.navigate_to_link(topic_url)
+                self.wait_for_url_to_be(topic_url)
 
-            self.logger.info("Verifying the subheading text")
-            if product_topic in super().general_test_data["premium_products"]:
-                check.equal(
-                    self.sumo_pages.product_topics_page._get_aaq_subheading_text(),
-                    AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT,
-                    f"Incorrect aaq subheading "
-                    f"Expected: {AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT} "
-                    f"Received: {self.sumo_pages.product_topics_page._get_aaq_subheading_text()}"
-                )
-                self.logger.info("Clicking on the AAQ button")
-                self.sumo_pages.product_topics_page._click_on_aaq_button()
+                self.logger.info("Verifying the subheading text")
+                if product_topic in super().general_test_data["premium_products"]:
+                    with check, allure.step(f"Verifying that the correct subheading page for "
+                                            f"{product_topic} is displayed"):
+                        assert self.sumo_pages.product_topics_page._get_aaq_subheading_text(
+                        ) == AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT
 
-                self.logger.info("Signing in to SUMO")
-                self.sumo_pages.auth_flow_page.sign_in_flow(
-                    username=super().user_special_chars,
-                    account_password=super().user_secrets_pass
-                )
+                    with allure.step("Clicking on the AAQ button"):
+                        self.sumo_pages.product_topics_page._click_on_aaq_button()
 
-                self.logger.info("Verifying that we are on the correct AAQ form page")
+                    with allure.step("Signing in to SUMO and verifying that we are on the "
+                                     "correct AAQ form page"):
+                        self.sumo_pages.auth_flow_page.sign_in_flow(
+                            username=super().user_special_chars,
+                            account_password=super().user_secrets_pass
+                        )
+                        expect(
+                            self.page
+                        ).to_have_url(super(
+                        ).aaq_question_test_data["products_aaq_url"][product_topic], timeout=30000)
 
-                expect(
-                    self.page
-                ).to_have_url(super().aaq_question_test_data["products_aaq_url"][product_topic],
-                              timeout=30000)
+                    with allure.step("Signing out from SUMO"):
+                        self.sumo_pages.top_navbar._click_on_sign_out_button()
 
-                self.logger.info("Signing out")
-                self.sumo_pages.top_navbar._click_on_sign_out_button()
+                else:
+                    assert self.sumo_pages.product_topics_page._get_aaq_subheading_text(
+                    ) == AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
 
-            else:
-                check.equal(
-                    self.sumo_pages.product_topics_page._get_aaq_subheading_text(),
-                    AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT,
-                    f"Incorrect aaq subheading "
-                    f"Expected: {AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT} "
-                    f"Received: {self.sumo_pages.product_topics_page._get_aaq_subheading_text()}"
-                )
-                self.logger.info("Clicking on the AAQ button")
-                self.sumo_pages.product_topics_page._click_on_aaq_button()
-
-                self.logger.info("Verifying that we are on the 'Get community support article'")
-                expect(
-                    self.page
-                ).to_have_url(KBArticlePageMessages.GET_COMMUNITY_SUPPORT_ARTICLE_LINK)
+                    with allure.step("Clicking on the AAQ button and verifying that we are on "
+                                     "the 'Get community support article'"):
+                        self.sumo_pages.product_topics_page._click_on_aaq_button()
+                        expect(
+                            self.page
+                        ).to_have_url(KBArticlePageMessages.GET_COMMUNITY_SUPPORT_ARTICLE_LINK)

--- a/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 
 from playwright.sync_api import expect, TimeoutError
 from playwright_tests.core.testutilities import TestUtilities
@@ -15,93 +16,73 @@ class TestProductSolutionsPage(TestUtilities):
     #  C890370
     @pytest.mark.skip
     def test_featured_articles_redirect(self):
-        self.logger.info("Accessing the contact support page via the top navbar Get Help > "
-                         "Browse All products")
-        self.sumo_pages.top_navbar._click_on_browse_all_products_option()
+        with allure.step("Accessing the contact support page via the top navbar Get Help > "
+                         "Browse All products"):
+            self.sumo_pages.top_navbar._click_on_browse_all_products_option()
 
-        self.logger.info("Clicking on all product cards")
+        with allure.step("Clicking on all product cards"):
+            for card in self.sumo_pages.contact_support_page._get_all_product_card_titles():
+                with check, allure.step(f"Clicking on the {card} and verifying that the correct "
+                                        f"product solutions page header is displayed"):
+                    self.sumo_pages.contact_support_page._click_on_a_particular_card(card)
+                    assert self.sumo_pages.product_solutions_page._get_product_solutions_heading(
+                    ) == card + ProductSolutionsMessages.PAGE_HEADER
 
-        for card in self.sumo_pages.contact_support_page._get_all_product_card_titles():
-            self.sumo_pages.contact_support_page._click_on_a_particular_card(card)
-
-            check.equal(
-                self.sumo_pages.product_solutions_page._get_product_solutions_heading(),
-                card + ProductSolutionsMessages.PAGE_HEADER,
-                f"Incorrect product solutions page displayed: "
-                f"Expected: {card + ProductSolutionsMessages.PAGE_HEADER} "
-                f"Actual:{self.sumo_pages.product_solutions_page._get_product_solutions_heading()}"
-            )
-
-            if self.sumo_pages.product_solutions_page._is_featured_article_section_displayed():
-                for featured_article_card in (self.sumo_pages.product_solutions_page
-                                              ._get_all_featured_articles_titles()):
-                    self.sumo_pages.product_solutions_page._click_on_a_featured_article_card(
-                        featured_article_card)
-                    with self.page.context.expect_page() as tab:
-                        feature_article_page = tab.value
-                        print("Tab open")
-
-                    article_text = (feature_article_page.
-                                    locator("//h1[@class='sumo-page-heading']").inner_text())
-                    check.equal(
-                        article_text,
-                        featured_article_card,
-                        f"Incorrect article page title. "
-                        f"Expected: {featured_article_card} "
-                        f"Received: {article_text}"
-                    )
-                    feature_article_page.close()
-            else:
-                self.logger.info(f"{card} has no featured articles displayed!!!")
-
-            self.navigate_back()
+                if self.sumo_pages.product_solutions_page._is_featured_article_section_displayed():
+                    for featured_article_card in (self.sumo_pages.product_solutions_page
+                                                  ._get_all_featured_articles_titles()):
+                        self.sumo_pages.product_solutions_page._click_on_a_featured_article_card(
+                            featured_article_card)
+                        with check, allure.step(f"Clicking on the {featured_article_card} and "
+                                                f"verifying that the correct article page title "
+                                                f"is displayed"):
+                            with self.page.context.expect_page() as tab:
+                                feature_article_page = tab.value
+                            article_text = (feature_article_page.
+                                            locator("//h1[@class='sumo-page-heading']").inner_text(
+                                            ))
+                            assert article_text == featured_article_card
+                            feature_article_page.close()
+                else:
+                    self.logger.info(f"{card} has no featured articles displayed!!!")
+                self.navigate_back()
 
     #  C890375, C890379
     @pytest.mark.productSolutionsPage
     def test_popular_topics_redirect(self):
-        self.logger.info("Accessing the contact support page via the top navbar Get Help > "
-                         "Browse All products")
-        self.sumo_pages.top_navbar._click_on_browse_all_products_option()
-
-        self.logger.info("Clicking on all product cards")
+        with allure.step("Accessing the contact support page via the top navbar Get Help > "
+                         "Browse All products"):
+            self.sumo_pages.top_navbar._click_on_browse_all_products_option()
 
         for card in self.sumo_pages.contact_support_page._get_all_product_card_titles():
             self.sumo_pages.contact_support_page._click_on_a_particular_card(card)
-
-            check.equal(
-                self.sumo_pages.product_solutions_page._get_product_solutions_heading(),
-                card + ProductSolutionsMessages.PAGE_HEADER,
-                f"Incorrect product solutions page displayed: "
-                f"Expected: {card + ProductSolutionsMessages.PAGE_HEADER} "
-                f"Actual:{self.sumo_pages.product_solutions_page._get_product_solutions_heading()}"
-            )
+            with check, allure.step(f"Clicking on the {card} card and verifying that the correct "
+                                    f"product solutions page is displayed"):
+                assert self.sumo_pages.product_solutions_page._get_product_solutions_heading(
+                ) == card + ProductSolutionsMessages.PAGE_HEADER
 
             if self.sumo_pages.product_solutions_page._is_popular_topics_section_displayed:
                 for topic in self.sumo_pages.product_solutions_page._get_popular_topics():
                     self.sumo_pages.product_solutions_page._click_on_a_popular_topic_card(topic)
-                    try:
-                        with self.page.context.expect_page() as tab:
-                            feature_article_page = tab.value
-                            print(f"Tab open for topic: {topic}")
-                    except TimeoutError:
-                        print("Trying to click on the popular topic again")
-                        self.sumo_pages.product_solutions_page._click_on_a_popular_topic_card(
-                            topic)
-                        with self.page.context.expect_page() as tab:
-                            feature_article_page = tab.value
-                            print(f"Tab open for topic: {topic}")
+                    with check, allure.step(f"Clicking on the {topic} topic and verifying if "
+                                            f"correct topic page title is displayed"):
+                        try:
+                            with self.page.context.expect_page() as tab:
+                                feature_article_page = tab.value
+                                print(f"Tab open for topic: {topic}")
+                        except TimeoutError:
+                            print("Trying to click on the popular topic again")
+                            self.sumo_pages.product_solutions_page._click_on_a_popular_topic_card(
+                                topic)
+                            with self.page.context.expect_page() as tab:
+                                feature_article_page = tab.value
+                                print(f"Tab open for topic: {topic}")
 
-                    popular_topic = (feature_article_page
-                                     .locator("//h1[@class='topic-title sumo-page-heading']")
-                                     .inner_text())
-                    check.equal(
-                        popular_topic,
-                        topic,
-                        f"Incorrect topic page title. "
-                        f"Expected: {topic} "
-                        f"Received: {popular_topic}"
-                    )
-                    feature_article_page.close()
+                        popular_topic = (feature_article_page
+                                         .locator("//h1[@class='topic-title sumo-page-heading']")
+                                         .inner_text())
+                        assert popular_topic == topic
+                        feature_article_page.close()
             else:
                 self.logger.info(f"{card} has no featured articles displayed!!!")
 
@@ -110,107 +91,79 @@ class TestProductSolutionsPage(TestUtilities):
     # C890382
     @pytest.mark.productSolutionsPage
     def test_ask_now_widget_redirect(self):
-        self.logger.info("Accessing the contact support page via the top navbar Get Help > "
-                         "Browse All products")
-        self.sumo_pages.top_navbar._click_on_browse_all_products_option()
-
-        self.logger.info("Clicking on all product cards")
+        with allure.step("Accessing the contact support page via the top navbar Get Help > "
+                         "Browse All products"):
+            self.sumo_pages.top_navbar._click_on_browse_all_products_option()
 
         for freemium_product in super().general_test_data["freemium_products"]:
-            self.sumo_pages.contact_support_page._click_on_a_particular_card(freemium_product)
+            with allure.step(f"Clicking on the {freemium_product} card "):
+                self.sumo_pages.contact_support_page._click_on_a_particular_card(freemium_product)
+            with check, allure.step("verifying that the correct 'Still need help' subtext is "
+                                    "displayed"):
+                assert self.sumo_pages.product_solutions_page._get_aaq_subheading_text(
+                ) == AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
 
-            self.logger.info("Verifying that the correct 'Still need help' subtext is displayed")
-            check.equal(
-                self.sumo_pages.product_solutions_page._get_aaq_subheading_text(),
-                AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT,
-                f"Incorrect AAQ widget displayed: "
-                f"Expected: {AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT} "
-                f"Received: {self.sumo_pages.product_solutions_page._get_aaq_subheading_text()}"
-            )
+            with check, allure.step("Verifying that the correct AAQ button text is displayed"):
+                assert self.sumo_pages.product_solutions_page._get_aaq_widget_button_name(
+                ) == AAQWidgetMessages.FREEMIUM_PRODUCTS_AAQ_WIDGET_BUTTON_TEXT
 
-            self.logger.info("Verifying that the correct AAQ button text is displayed")
-            check.equal(
-                self.sumo_pages.product_solutions_page._get_aaq_widget_button_name(),
-                AAQWidgetMessages.FREEMIUM_PRODUCTS_AAQ_WIDGET_BUTTON_TEXT,
-                f"Incorrect AAQ button name. "
-                f"Expected: {self.sumo_pages.product_solutions_page._get_aaq_widget_button_name()}"
-                f" Actual: {AAQWidgetMessages.FREEMIUM_PRODUCTS_AAQ_WIDGET_BUTTON_TEXT}"
-            )
+            with allure.step("Clicking on the AAQ button and verifying that the auth page is "
+                             "displayed"):
+                self.sumo_pages.product_solutions_page._click_ask_now_button()
+                self.logger.info("Signing in to SUMO")
+                self.sumo_pages.auth_flow_page.sign_in_flow(
+                    username=super().user_special_chars,
+                    account_password=super().user_secrets_pass,
+                )
 
-            self.logger.info("Clicking on the AAQ button and verifying that the auth page is "
-                             "displayed")
-            self.sumo_pages.product_solutions_page._click_ask_now_button()
+            with allure.step("Verifying that we are on the correct AAQ form page"):
+                expect(
+                    self.page
+                ).to_have_url(super().aaq_question_test_data["products_aaq_url"][freemium_product],
+                              timeout=30000)
 
-            self.logger.info("Signing in to SUMO")
-            self.sumo_pages.auth_flow_page.sign_in_flow(
-                username=super().user_special_chars,
-                account_password=super().user_secrets_pass,
-            )
-
-            self.logger.info("Verifying that we are on the correct AAQ form page")
-
-            expect(
-                self.page
-            ).to_have_url(super().aaq_question_test_data["products_aaq_url"][freemium_product],
-                          timeout=30000)
-
-            self.logger.info("Signing out")
-            self.sumo_pages.top_navbar._click_on_sign_out_button()
-
-            self.logger.info("Accessing the contact support page via the top navbar Get Help > "
-                             "Browse All products")
-            self.sumo_pages.top_navbar._click_on_browse_all_products_option()
+            with allure.step("Signing out and accessing the contact support page via the top "
+                             "navbar Get Help > Browse All products"):
+                self.sumo_pages.top_navbar._click_on_sign_out_button()
+                self.sumo_pages.top_navbar._click_on_browse_all_products_option()
 
     # C890382
     @pytest.mark.productSolutionsPage
     def test_contact_support_widget_redirect(self):
-        self.logger.info("Accessing the contact support page via the top navbar Get Help > "
-                         "Browse All products")
-        self.sumo_pages.top_navbar._click_on_browse_all_products_option()
-
-        self.logger.info("Clicking on all product cards")
+        with allure.step("Accessing the contact support page via the top navbar Get Help > "
+                         "Browse All products"):
+            self.sumo_pages.top_navbar._click_on_browse_all_products_option()
 
         for premium_product in super().general_test_data["premium_products"]:
-            self.sumo_pages.contact_support_page._click_on_a_particular_card(premium_product)
+            with allure.step(f"Clicking on the {premium_product} card"):
+                self.sumo_pages.contact_support_page._click_on_a_particular_card(premium_product)
 
-            self.logger.info("Verifying that the correct 'Still need help' subtext is displayed")
-            check.equal(
-                self.sumo_pages.product_solutions_page._get_aaq_subheading_text(),
-                AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT,
-                f"Incorrect AAQ widget displayed: "
-                f"Expected: {AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT} "
-                f"Received: {self.sumo_pages.product_solutions_page._get_aaq_subheading_text()}"
-            )
+            with check, allure.step("Verifying that the correct 'Still need help' subtext is "
+                                    "displayed"):
+                assert self.sumo_pages.product_solutions_page._get_aaq_subheading_text(
+                ) == AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT
 
-            self.logger.info("Verifying that the correct AAQ button text is displayed")
-            check.equal(
-                self.sumo_pages.product_solutions_page._get_aaq_widget_button_name(),
-                AAQWidgetMessages.PREMIUM_PRODUCTS_AAQ_WIDGET_BUTTON_TEXT,
-                f"Incorrect AAQ button name. "
-                f"Expected: {self.sumo_pages.product_solutions_page._get_aaq_widget_button_name()}"
-                f" Actual: {AAQWidgetMessages.FREEMIUM_PRODUCTS_AAQ_WIDGET_BUTTON_TEXT}"
-            )
+            with check, allure.step("Verifying that the correct AAQ button text is displayed"):
+                assert self.sumo_pages.product_solutions_page._get_aaq_widget_button_name(
+                ) == AAQWidgetMessages.PREMIUM_PRODUCTS_AAQ_WIDGET_BUTTON_TEXT
 
-            self.logger.info("Clicking on the AAQ button and verifying that the auth page is "
-                             "displayed")
-            self.sumo_pages.product_solutions_page._click_ask_now_button()
+            with allure.step("Clicking on the AAQ button, verifying that the auth page is "
+                             "displayed and signing in to SUMO"):
+                self.sumo_pages.product_solutions_page._click_ask_now_button()
 
-            self.logger.info("Signing in to SUMO")
-            self.sumo_pages.auth_flow_page.sign_in_flow(
-                username=super().user_special_chars,
-                account_password=super().user_secrets_pass,
-            )
+                self.logger.info("Signing in to SUMO")
+                self.sumo_pages.auth_flow_page.sign_in_flow(
+                    username=super().user_special_chars,
+                    account_password=super().user_secrets_pass,
+                )
 
-            self.logger.info("Verifying that we are on the correct AAQ form page")
+            with allure.step("Verifying that we are on the correct AAQ form page"):
+                expect(
+                    self.page
+                ).to_have_url(super().aaq_question_test_data["products_aaq_url"][premium_product],
+                              timeout=30000)
 
-            expect(
-                self.page
-            ).to_have_url(super().aaq_question_test_data["products_aaq_url"][premium_product],
-                          timeout=30000)
-
-            self.logger.info("Signing out")
-            self.sumo_pages.top_navbar._click_on_sign_out_button()
-
-            self.logger.info("Accessing the contact support page via the top navbar Get Help > "
-                             "Browse All products")
-            self.sumo_pages.top_navbar._click_on_browse_all_products_option()
+            with allure.step("Signing out and access the contact support page via the top navbar "
+                             "Get Help > Browse All products"):
+                self.sumo_pages.top_navbar._click_on_sign_out_button()
+                self.sumo_pages.top_navbar._click_on_browse_all_products_option()

--- a/playwright_tests/tests/conftest.py
+++ b/playwright_tests/tests/conftest.py
@@ -1,8 +1,6 @@
-import os
-
+import allure
 import pytest
 from playwright.sync_api import sync_playwright
-
 from playwright_tests.core.testutilities import TestUtilities
 from playwright_tests.messages.homepage_messages import HomepageMessages
 from playwright_tests.pages.sumo_pages import SumoPages
@@ -17,11 +15,11 @@ def setup(request, browser, logger_setup):
     with sync_playwright() as playwright:
         if requested_browser == "chrome":
             browser = playwright.chromium.launch()
-            context = browser.new_context()
+            context = browser.new_context(record_video_dir="reports/videos")
             page = context.new_page()
         else:
             browser = playwright.firefox.launch()
-            context = browser.new_context()
+            context = browser.new_context(record_video_dir="reports/videos")
             page = context.new_page()
 
         sumo_pages = SumoPages(page)
@@ -33,7 +31,8 @@ def setup(request, browser, logger_setup):
         request.cls.requested_browser = requested_browser
         request.cls.logger = logger
         yield
-        context.close()
+        page.context.close()
+        page.video.delete()
 
 
 def pytest_addoption(parser):
@@ -62,27 +61,17 @@ def logger_setup():
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item):
+def pytest_runtest_makereport():
     try:
-        pytest_html = item.config.pluginmanager.getplugin("html")
         outcome = yield
         report = outcome.get_result()
-        extra = getattr(report, "extra", [])
         if report.when == "call":
             xfail = hasattr(report, "wasxfail")
             if (report.skipped and xfail) or (report.failed and not xfail):
-                report_directory = "reports/"
-                file_name_edit = report.nodeid.split("::")
-                file_name = file_name_edit[2] + ".png"
-                destination_file = os.path.join(report_directory, file_name)
-                page.screenshot(path=destination_file, full_page=True)
-                if file_name:
-                    html = (
-                        '<div><img src="%s" alt="screenshot" style="width:300px; height=200px"'
-                        'onclick="window.open(this.src)" align="right"/></div>' % file_name
-                    )
-
-                    extra.append(pytest_html.extras.html(html))
-            report.extra = extra
+                allure.attach.file(
+                    page.video.path(),
+                    name="Video",
+                    attachment_type=allure.attachment_type.WEBM
+                )
     except Exception as e:
         print(e)

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_article_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_article_page.py
@@ -1,6 +1,7 @@
+import allure
 import pytest
 import requests
-import pytest_check as check
+from pytest_check import check
 
 from playwright_tests.core.testutilities import TestUtilities
 from playwright_tests.messages.contribute_messages.con_pages.con_forum_messages import (
@@ -22,55 +23,30 @@ class TestContributeArticlePage(TestUtilities):
     # C2165414
     @pytest.mark.contributePagesTests
     def test_contribute_article_page_text(self):
-        self.logger.info("Accessing the Contribute with help Article page")
-        self.navigate_to_link(
-            ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute with help Article page"):
+            self.navigate_to_link(
+                ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL
+            )
 
-        self.logger.info(
-            "Verifying that the page header is successfully displayed "
-            "and contains the correct strings "
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(),
-            ContributeHelpArticlesMessages.HERO_PAGE_TITLE,
-            f"Actual: {self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text()}"
-            f"Expected: {ContributeHelpArticlesMessages.HERO_PAGE_TITLE}",
-        )
+        with check, allure.step("Verifying that the page header is successfully displayed and "
+                                "contains the correct strings"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+            ) == ContributeHelpArticlesMessages.HERO_PAGE_TITLE
 
-        self.logger.info(
-            "Verifying that the h2 is successfully displayed and contains the correct strings"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(),
-            ContributeHelpArticlesMessages.HERO_SECOND_TITLE,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_hero_second_header()}"
-            f"Expected: {ContributeHelpArticlesMessages.HERO_SECOND_TITLE}",
-        )
+        with check, allure.step("Verifying that the h2 is successfully displayed and contains "
+                                "the correct strings"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+            ) == ContributeHelpArticlesMessages.HERO_SECOND_TITLE
 
-        self.logger.info(
-            "Verifying tha the paragraph under h2 is successfully "
-            "displayed and contains the correct strings"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_text(),
-            ContributeHelpArticlesMessages.HERO_TEXT,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_hero_text()}"
-            f"Expected: {ContributeHelpArticlesMessages.HERO_TEXT}",
-        )
+        with check, allure.step("Verifying tha the paragraph under h2 is successfully displayed "
+                                "and contains the correct strings"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_text(
+            ) == ContributeHelpArticlesMessages.HERO_TEXT
 
-        self.logger.info(
-            "Verifying that the 'How you can contribute_messages' header is successfully "
-            "displayed and contains the correct strings"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(),
-            ContributeHelpArticlesMessages.HOW_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text()}"
-            f"Expected is: {ContributeHelpArticlesMessages.HOW_TO_CONTRIBUTE_HEADER}",
-        )
+        with check, allure.step("Verifying that the 'How you can contribute_messages' header is "
+                                "successfully displayed and contains the correct strings"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+            ) == ContributeHelpArticlesMessages.HOW_TO_CONTRIBUTE_HEADER
 
         # Need to add a check for the logged in state as well.
         # Excluding option four from the list since we are using a different locator
@@ -82,71 +58,33 @@ class TestContributeArticlePage(TestUtilities):
             ContributeHelpArticlesMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
         ]
 
-        self.logger.info(
-            "Verifying that the 'How you can contribute_messages' cards are successfully expected"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options_text(),
-            card_titles,
-            "How you can contribute_messages steps are incorrect!",
-        )
+        with check, allure.step("Verifying that the 'How you can contribute_messages' cards are "
+                                "successfully expected"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+            ) == card_titles
 
-        self.logger.info("Signing up with a FxA contributor account")
+        with check, allure.step("Signing up with a FxA contributor account and Verifying that "
+                                "the step 4 option is successfully displayed and the text "
+                                "contains the expected string"):
+            # We need to add here the check for when the user is signed in with a contributor
+            # account
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+            ) == ContributeHelpArticlesMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
 
-        # We need to add here the check for when the user is signed in with a contributor account
+        with check, allure.step("Verifying that the first line from the fact text is "
+                                "successfully displayed and contains the expected string"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+            ) == ContributeHelpArticlesMessages.FACT_FIRST_LINE
 
-        self.logger.info(
-            "Verifying that the step 4 option is successfully displayed and the text contains "
-            "the expected string"
-        )
+        with check, allure.step("Verifying that the second line from the fact section text is "
+                                "successfully displayed and contains the expected string"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+            ) == ContributeHelpArticlesMessages.FACT_SECOND_LINE
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text(),
-            ContributeHelpArticlesMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text()}"
-            f"Expected is: "
-            f"{ContributeHelpArticlesMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR}",
-        )
-
-        self.logger.info(
-            "Verifying that the first line from the fact text is successfully displayed and "
-            "contains the expected string"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(),
-            ContributeHelpArticlesMessages.FACT_FIRST_LINE,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_first_fact_text()}"
-            f"Expected is: "
-            f"{ContributeHelpArticlesMessages.FACT_FIRST_LINE}",
-        )
-
-        self.logger.info(
-            "Verifying that the second line from the fact section text is successfully displayed "
-            "and contains the expected string "
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(),
-            ContributeHelpArticlesMessages.FACT_SECOND_LINE,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_second_fact_text()}"
-            f"Expected is: "
-            f"{ContributeHelpArticlesMessages.FACT_SECOND_LINE}",
-        )
-
-        self.logger.info(
-            "Verifying that the 'Other ways to contribute_messages' header is successfully "
-            "displayed and contains the expected string"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(),
-            ContributeHelpArticlesMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header()}"
-            f"Expected is: "
-            f"{ContributeHelpArticlesMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER}",
-        )
+        with check, allure.step("Verifying that the 'Other ways to contribute_messages' header "
+                                "is successfully displayed and contains the expected string"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+            ) == ContributeHelpArticlesMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
         other_ways_to_contribute_card_titles = [
             ContributeHelpArticlesMessages.ANSWER_QUESTIONS_IN_SUPPORT_FORUM_TITLE,
@@ -155,53 +93,42 @@ class TestContributeArticlePage(TestUtilities):
             ContributeHelpArticlesMessages.RESPOND_TO_MOBILE_STORE_REVIEWS_CARD_TITLE,
         ]
 
-        self.logger.info(
-            "Verifying that the 'Other ways to contribute_messages' are successfully displayed "
-            "and in the correct order"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_title(),
-            other_ways_to_contribute_card_titles,
-            "Other ways to contribute_messages card titles are not the correct ones!",
-        )
+        with check, allure.step("Verifying that the 'Other ways to contribute_messages' are "
+                                "successfully displayed and in the correct order"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+            ) == other_ways_to_contribute_card_titles
 
     # C2165414
     @pytest.mark.contributePagesTests
     def test_contribute_article_page_images_are_not_broken(self):
-        self.logger.info("Accessing the Contribute with help Article page")
-        self.navigate_to_link(
-            ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL
-        )
-
-        self.logger.info("Verifying that the Contribute forum page images are not broken")
+        with allure.step("Accessing the Contribute with help Article page"):
+            self.navigate_to_link(
+                ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL
+            )
 
         for link in self.sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
             image_link = link.get_attribute("src")
             response = requests.get(image_link, stream=True)
-            check.is_true(response.status_code < 400, f"The {image_link} image is broken")
+            with check, allure.step(f"Verifying that {image_link} is not broken"):
+                assert response.status_code < 400
 
     # C2165415
     @pytest.mark.contributePagesTests
     def test_contribute_article_page_breadcrumbs(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL
+            )
 
-        self.logger.info("Verifying that the correct breadcrumbs are displayed")
         breadcrumbs = [
             ContributeHelpArticlesMessages.FIRST_BREADCRUMB,
             ContributeHelpArticlesMessages.SECOND_BREADCRUMB,
             ContributeHelpArticlesMessages.THIRD_BREADCRUMB,
         ]
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(),
-            breadcrumbs,
-            f"Breadcrumbs are: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs()}"
-            f"Expected: {breadcrumbs}",
-        )
+        with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(
+            ) == breadcrumbs
 
         counter = 1
         for breadcrumb in self.sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
@@ -211,41 +138,24 @@ class TestContributeArticlePage(TestUtilities):
             self.sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
 
             if counter == 1:
-                self.logger.info(
-                    "Verifying that the Contribute breadcrumb redirects to the Contribute page"
-                )
-                check.equal(
-                    self.get_page_url(),
-                    ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL,
-                    f"Expected to be on {ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL}"
-                    f"We are actual on {self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
+                                        "the Contribute page"):
+                    assert self.get_page_url() == ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL
                 self.navigate_forward()
                 counter -= 1
             elif counter == 0:
-                self.logger.info("Verifying that the Home breadcrumb redirects to the Homepage")
-                check.equal(
-                    self.get_page_url(),
-                    HomepageMessages.STAGE_HOMEPAGE_URL_EN_US,
-                    f"Expected to be on: "
-                    f"{HomepageMessages.STAGE_HOMEPAGE_URL_EN_US}"
-                    f"We are actual on: "
-                    f"{self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Home breadcrumb redirects to the "
+                                        "Homepage"):
+                    assert self.get_page_url() == HomepageMessages.STAGE_HOMEPAGE_URL_EN_US
 
     # Need to add tests for "How you can contribute_messages" section
     # C2165418
     @pytest.mark.contributePagesTests
     def test_contribute_article_other_ways_to_contribute_redirect_to_the_correct_page(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL
-        )
-
-        self.logger.info(
-            "Verifying that the 'other ways to contribute_messages' cards are "
-            "redirecting to the correct SUMO page"
-        )
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL
+            )
 
         ways_to_contribute_links = [
             ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL,
@@ -264,11 +174,8 @@ class TestContributeArticlePage(TestUtilities):
                 ]
             )
             self.sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
-            check.equal(
-                ways_to_contribute_links[counter],
-                self.get_page_url(),
-                f"Expected the following URL: {ways_to_contribute_links[counter]}"
-                f"Received: {self.get_page_url()}",
-            )
+            with check, allure.step(f"Verifying that the {ways_to_contribute_links[counter]} "
+                                    f"redirects to the correct page"):
+                assert ways_to_contribute_links[counter] == self.get_page_url()
             self.navigate_back()
             counter += 1

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_forum_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_forum_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 import requests
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -22,140 +23,85 @@ class TestContributeForumPage(TestUtilities):
     # C2165414
     @pytest.mark.contributePagesTests
     def test_contribute_forum_page_text(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL
+            )
+        with check, allure.step("Verifying that the Contribute Forum page contains the correct "
+                                "strings"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+            ) == ContributeForumMessages.HERO_PAGE_TITLE
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+            ) == ContributeForumMessages.HERO_SECOND_TITLE
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_text(
+            ) == ContributeForumMessages.HERO_TEXT
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+            ) == ContributeForumMessages.HOW_TO_CONTRIBUTE_HEADER
 
-        self.logger.info("Verifying that the Contribute Forum page contains the correct strings")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(),
-            ContributeForumMessages.HERO_PAGE_TITLE,
-            f"Actual: {self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text()}"
-            f"Expected: {ContributeForumMessages.HERO_PAGE_TITLE}",
-        )
+            # Need to add a check for the logged in state as well.
+            # Excluding option four from the list since we are using a different locator
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(),
-            ContributeForumMessages.HERO_SECOND_TITLE,
-            f"Actual: {self.sumo_pages.ways_to_contribute_pages._get_hero_second_header()}"
-            f"Expected: {ContributeForumMessages.HERO_PAGE_TITLE}",
-        )
+            card_titles = [
+                ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_ONE_SIGNED_OUT,
+                ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_TWO,
+                ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_THREE,
+                ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
+            ]
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_text(),
-            ContributeForumMessages.HERO_TEXT,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_hero_text()}"
-            f"Expected: {ContributeForumMessages.HERO_TEXT}",
-        )
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+            ) == card_titles
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(),
-            ContributeForumMessages.HOW_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text()}"
-            f"Expected is: {ContributeForumMessages.HOW_TO_CONTRIBUTE_HEADER}",
-        )
+            # We need to add here the check for when the user is signed in with a contributor
+            # account
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+            ) == ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
+            assert self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+            ) == ContributeForumMessages.FACT_FIRST_LINE
+            assert self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+            ) == ContributeForumMessages.FACT_SECOND_LINE
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+            ) == ContributeForumMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
-        # Need to add a check for the logged in state as well.
-        # Excluding option four from the list since we are using a different locator
-
-        card_titles = [
-            ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_ONE_SIGNED_OUT,
-            ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_TWO,
-            ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_THREE,
-            ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
-        ]
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options_text(),
-            card_titles,
-            "How you can contribute_messages steps are incorrect!",
-        )
-
-        # We need to add here the check for when the user is signed in with a contributor account
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text(),
-            ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text()}"
-            f"Expected is: "
-            f"{ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR}",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(),
-            ContributeForumMessages.FACT_FIRST_LINE,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_first_fact_text()}"
-            f"Expected is: {ContributeForumMessages.FACT_FIRST_LINE}",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(),
-            ContributeForumMessages.FACT_SECOND_LINE,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_second_fact_text()}"
-            f"Expected is: {ContributeForumMessages.FACT_SECOND_LINE}",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(),
-            ContributeForumMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header()}"
-            f"Expected is: "
-            f"{ContributeForumMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER}",
-        )
-
-        other_ways_to_contribute_card_titles = [
-            ContributeForumMessages.WRITE_ARTICLES_CARD_TITLE,
-            ContributeForumMessages.LOCALIZE_CONTENT_CARD_TITLE,
-            ContributeForumMessages.PROVIDE_SUPPORT_ON_SOCIAL_CHANNELS_CARD_TITLE,
-            ContributeForumMessages.RESPOND_TO_MOBILE_STORE_REVIEWS_CARD_TITLE,
-        ]
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_title(),
-            other_ways_to_contribute_card_titles,
-            "Other ways to contribute_messages card titles are not the correct ones!",
-        )
+            other_ways_to_contribute_card_titles = [
+                ContributeForumMessages.WRITE_ARTICLES_CARD_TITLE,
+                ContributeForumMessages.LOCALIZE_CONTENT_CARD_TITLE,
+                ContributeForumMessages.PROVIDE_SUPPORT_ON_SOCIAL_CHANNELS_CARD_TITLE,
+                ContributeForumMessages.RESPOND_TO_MOBILE_STORE_REVIEWS_CARD_TITLE,
+            ]
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+            ) == other_ways_to_contribute_card_titles
 
     # C2165414
     @pytest.mark.contributePagesTests
     def test_contribute_forum_page_images_are_not_broken(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL
+            )
 
-        self.logger.info("Verifying that the Contribute forum page images are not broken")
         for link in self.sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
             image_link = link.get_attribute("src")
             response = requests.get(image_link, stream=True)
-            check.is_true(response.status_code < 400, f"The {image_link} image is broken")
+            with check, allure.step(f"Verifying that the {image_link} link is not broken"):
+                assert response.status_code < 400
 
     # C2165415
     @pytest.mark.contributePagesTests
     def test_contribute_forum_page_breadcrumbs(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL
+            )
 
-        self.logger.info("Verifying that the correct breadcrumbs are displayed")
         breadcrumbs = [
             ContributeForumMessages.FIRST_BREADCRUMB,
             ContributeForumMessages.SECOND_BREADCRUMB,
             ContributeForumMessages.THIRD_BREADCRUMB,
         ]
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(),
-            breadcrumbs,
-            f"Breadcrumbs are: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs()}"
-            f"Expected: {breadcrumbs}",
-        )
+        with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(
+            ) == breadcrumbs
 
         counter = 1
         for breadcrumb in self.sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
@@ -165,40 +111,27 @@ class TestContributeForumPage(TestUtilities):
             self.sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
 
             if counter == 1:
-                self.logger.info(
-                    "Verifying that the Contribute breadcrumb redirects to the Contribute page"
-                )
-                check.equal(
-                    self.get_page_url(),
-                    ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL,
-                    f"Expected to be on {ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL}"
-                    f"We are actual on {self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
+                                        "the Contribute page"):
+                    assert self.get_page_url() == ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL
+
                 self.navigate_forward()
                 counter -= 1
             elif counter == 0:
-                self.logger.info("Verifying that the Home breadcrumb redirects to the Homepage")
-                check.equal(
-                    self.get_page_url(),
-                    HomepageMessages.STAGE_HOMEPAGE_URL_EN_US,
-                    f"Expected to be on {HomepageMessages.STAGE_HOMEPAGE_URL_EN_US}"
-                    f"We are actual on {self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Home breadcrumb redirects to the "
+                                        "Homepage"):
+                    assert self.get_page_url() == HomepageMessages.STAGE_HOMEPAGE_URL_EN_US
 
     # Need to add tests for "How you can contribute_messages" section
 
     # C2165418
     @pytest.mark.contributePagesTests
     def test_contribute_forum_other_ways_to_contribute_redirect_to_the_correct_page(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL
+            )
 
-        self.logger.info(
-            "Verifying that the 'other ways to contribute_messages'"
-            " cards are redirecting to the correct SUMO page"
-        )
         ways_to_contribute_links = [
             ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL,
             ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL,
@@ -216,11 +149,8 @@ class TestContributeForumPage(TestUtilities):
                 ]
             )
             self.sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
-            check.equal(
-                ways_to_contribute_links[counter],
-                self.get_page_url(),
-                f"Expected the following URL: {ways_to_contribute_links[counter]}"
-                f"Received: {self.get_page_url()}",
-            )
+            with check, allure.step("Verifying that the 'other ways to contribute_messages' "
+                                    "cards are redirecting to the correct SUMO page"):
+                assert ways_to_contribute_links[counter] == self.get_page_url()
             self.navigate_back()
             counter += 1

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_localization_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_localization_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 import requests
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -22,141 +23,81 @@ class TestContributeLocalizationPage(TestUtilities):
     # C2176356
     @pytest.mark.contributePagesTests
     def test_contribute_localization_page_text(self):
-        self.logger.info("Accessing the Contribute localization page")
-        self.navigate_to_link(
-            ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute localization page"):
+            self.navigate_to_link(
+                ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL
+            )
 
-        self.logger.info(
-            "Verifying that the Contribute localization page contains the correct strings"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(),
-            ContributeLocalizationMessages.HERO_PAGE_TITLE,
-            f"Actual {self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text()}"
-            f"Expected: {ContributeLocalizationMessages.HERO_PAGE_TITLE}",
-        )
+        with check, allure.step("Verifying that the Contribute localization page contains the "
+                                "correct strings"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+            ) == ContributeLocalizationMessages.HERO_PAGE_TITLE
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+            ) == ContributeLocalizationMessages.HERO_SECOND_TITLE
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_text(
+            ) == ContributeLocalizationMessages.HERO_TEXT
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+            ) == ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_HEADER
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(),
-            ContributeLocalizationMessages.HERO_SECOND_TITLE,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_hero_second_header()}"
-            f"Expected: {ContributeLocalizationMessages.HERO_SECOND_TITLE}",
-        )
+            # Need to add a check for the logged in state as well.
+            # Excluding option four from the list since we are using a different locator
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_text(),
-            ContributeLocalizationMessages.HERO_TEXT,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_hero_text()}"
-            f"Expected: {ContributeLocalizationMessages.HERO_TEXT}",
-        )
+            card_titles = [
+                ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_ONE_SIGNED_OUT,
+                ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_TWO,
+                ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_THREE,
+                ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
+            ]
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+            ) == card_titles
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+            ) == ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
+            assert self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+            ) == ContributeLocalizationMessages.FACT_FIRST_LINE
+            assert self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+            ) == ContributeLocalizationMessages.FACT_SECOND_LINE
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+            ) == ContributeLocalizationMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(),
-            ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text()}"
-            f"Expected is: {ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_HEADER}",
-        )
-
-        # Need to add a check for the logged in state as well.
-        # Excluding option four from the list since we are using a different locator
-
-        card_titles = [
-            ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_ONE_SIGNED_OUT,
-            ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_TWO,
-            ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_THREE,
-            ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
-        ]
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options_text(),
-            card_titles,
-            "How you can contribute_messages steps are incorrect!",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text(),
-            ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text()}"
-            f"Expected is: "
-            f"{ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR}",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(),
-            ContributeLocalizationMessages.FACT_FIRST_LINE,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_first_fact_text()}"
-            f"Expected is: {ContributeLocalizationMessages.FACT_FIRST_LINE}",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(),
-            ContributeLocalizationMessages.FACT_SECOND_LINE,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_second_fact_text()}"
-            f"Expected is: {ContributeLocalizationMessages.FACT_SECOND_LINE}",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(),
-            ContributeLocalizationMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header()}"
-            f"Expected is: "
-            f"{ContributeLocalizationMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER}",
-        )
-
-        other_ways_to_contribute_card_titles = [
-            ContributeLocalizationMessages.ANSWER_QUESTIONS_IN_SUPPORT_FORUM_TITLE,
-            ContributeLocalizationMessages.WRITE_ARTICLES_CARD_TITLE,
-            ContributeLocalizationMessages.PROVIDE_SUPPORT_ON_SOCIAL_CHANNELS_CARD_TITLE,
-            ContributeLocalizationMessages.RESPOND_TO_MOBILE_STORE_REVIEWS_CARD_TITLE,
-        ]
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_title(),
-            other_ways_to_contribute_card_titles,
-            "Other ways to contribute_messages card titles are not the correct ones!",
-        )
+            other_ways_to_contribute_card_titles = [
+                ContributeLocalizationMessages.ANSWER_QUESTIONS_IN_SUPPORT_FORUM_TITLE,
+                ContributeLocalizationMessages.WRITE_ARTICLES_CARD_TITLE,
+                ContributeLocalizationMessages.PROVIDE_SUPPORT_ON_SOCIAL_CHANNELS_CARD_TITLE,
+                ContributeLocalizationMessages.RESPOND_TO_MOBILE_STORE_REVIEWS_CARD_TITLE,
+            ]
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+            ) == other_ways_to_contribute_card_titles
 
     # C2176356
     @pytest.mark.contributePagesTests
     def test_contribute_localization_page_images_are_not_broken(self):
-        self.logger.info("Accessing the Contribute localization page")
-        self.navigate_to_link(
-            ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute localization page"):
+            self.navigate_to_link(
+                ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL
+            )
 
-        self.logger.info("Verifying that the Contribute localization page images are not broken")
         for link in self.sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
             image_link = link.get_attribute("src")
             response = requests.get(image_link, stream=True)
-            check.is_true(response.status_code < 400, f"The {image_link} image is broken")
+            with check, allure.step(f"Verifying that the {image_link} is not broken"):
+                assert response.status_code < 400
 
     # C2176357
     @pytest.mark.contributePagesTests
     def test_contribute_localization_page_breadcrumbs(self):
-        self.logger.info("Accessing the Contribute localization page")
-        self.navigate_to_link(
-            ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute localization page"):
+            self.navigate_to_link(
+                ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL
+            )
 
-        self.logger.info("Verifying that the correct breadcrumbs are displayed")
-        breadcrumbs = [
-            ContributeLocalizationMessages.FIRST_BREADCRUMB,
-            ContributeLocalizationMessages.SECOND_BREADCRUMB,
-            ContributeLocalizationMessages.THIRD_BREADCRUMB,
-        ]
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(),
-            breadcrumbs,
-            f"Breadcrumbs are: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs()}"
-            f"Expected: {breadcrumbs}",
-        )
+        with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
+            breadcrumbs = [
+                ContributeLocalizationMessages.FIRST_BREADCRUMB,
+                ContributeLocalizationMessages.SECOND_BREADCRUMB,
+                ContributeLocalizationMessages.THIRD_BREADCRUMB,
+            ]
+            assert self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(
+            ) == breadcrumbs
 
         counter = 1
         for breadcrumb in self.sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
@@ -166,40 +107,27 @@ class TestContributeLocalizationPage(TestUtilities):
             self.sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
 
             if counter == 1:
-                self.logger.info(
-                    "Verifying that the Contribute breadcrumb redirects to the Contribute page"
-                )
-                check.equal(
-                    self.get_page_url(),
-                    ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL,
-                    f"Expected to be on {ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL}"
-                    f"We are actual on {self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
+                                        "the Contribute page"):
+                    assert self.get_page_url() == ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL
+
                 self.navigate_forward()
                 counter -= 1
             elif counter == 0:
-                self.logger.info("Verifying that the Home breadcrumb redirects to the Homepage")
-                check.equal(
-                    self.get_page_url(),
-                    HomepageMessages.STAGE_HOMEPAGE_URL_EN_US,
-                    f"Expected to be on {HomepageMessages.STAGE_HOMEPAGE_URL_EN_US}"
-                    f"We are actual on {self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Home breadcrumb redirects to the "
+                                        "Homepage"):
+                    assert self.get_page_url() == HomepageMessages.STAGE_HOMEPAGE_URL_EN_US
 
     # Need to add tests for "How you can contribute_messages" section
 
     # C2176360
     @pytest.mark.contributePagesTests
     def test_contribute_localization_other_ways_to_contribute_redirect_to_the_correct_page(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL
+            )
 
-        self.logger.info(
-            "Verifying that the 'other ways to contribute_messages' "
-            "cards are redirecting to the correct SUMO page"
-        )
         ways_to_contribute_links = [
             ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL,
             ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL,
@@ -217,11 +145,8 @@ class TestContributeLocalizationPage(TestUtilities):
                 ]
             )
             self.sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
-            check.equal(
-                ways_to_contribute_links[counter],
-                self.get_page_url(),
-                f"Expected the following URL: {ways_to_contribute_links[counter]}"
-                f"Received: {self.get_page_url()}",
-            )
+            with check, allure.step("Verifying that the 'other ways to contribute_messages' "
+                                    "cards are redirecting to the correct SUMO page"):
+                assert ways_to_contribute_links[counter] == self.get_page_url()
             self.navigate_back()
             counter += 1

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_mobile_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_mobile_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 import requests
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -22,141 +23,82 @@ class TestContributeMobilePage(TestUtilities):
     #  C2176366
     @pytest.mark.contributePagesTests
     def test_contribute_mobile_page_text(self):
-        self.logger.info("Accessing the Contribute Mobile Store page")
-        self.navigate_to_link(
-            ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Mobile Store page"):
+            self.navigate_to_link(
+                ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL
+            )
 
-        self.logger.info(
-            "Verifying that the Contribute Mobile Store page contains the correct strings"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(),
-            ContributeMobileSupportMessages.HERO_PAGE_TITLE,
-            f"Actual {self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text()}"
-            f"Expected: {ContributeMobileSupportMessages.HERO_PAGE_TITLE}",
-        )
+        with check, allure.step("Verifying that the Contribute Mobile Store page contains the "
+                                "correct strings"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+            ) == ContributeMobileSupportMessages.HERO_PAGE_TITLE
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+            ) == ContributeMobileSupportMessages.HERO_SECOND_TITLE
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_text(
+            ) == ContributeMobileSupportMessages.HERO_TEXT
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+            ) == ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_HEADER
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(),
-            ContributeMobileSupportMessages.HERO_SECOND_TITLE,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_hero_second_header()}"
-            f"Expected: {ContributeMobileSupportMessages.HERO_SECOND_TITLE}",
-        )
+            # Need to add a check for the logged in state as well.
+            # Excluding option four from the list since we are using a different locator
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_text(),
-            ContributeMobileSupportMessages.HERO_TEXT,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_hero_text()}"
-            f"Expected: {ContributeMobileSupportMessages.HERO_TEXT}",
-        )
+            card_titles = [
+                ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_ONE_SIGNED_OUT,
+                ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_TWO,
+                ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_THREE,
+                ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
+            ]
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+            ) == card_titles
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+            ) == ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
+            assert self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+            ) == ContributeMobileSupportMessages.FACT_FIRST_LINE
+            assert self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+            ) == ContributeMobileSupportMessages.FACT_SECOND_LINE
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+            ) == ContributeMobileSupportMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(),
-            ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text()}"
-            f"Expected is: {ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_HEADER}",
-        )
-
-        # Need to add a check for the logged in state as well.
-        # Excluding option four from the list since we are using a different locator
-
-        card_titles = [
-            ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_ONE_SIGNED_OUT,
-            ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_TWO,
-            ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_THREE,
-            ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
-        ]
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options_text(),
-            card_titles,
-            "How you can contribute_messages steps are incorrect!",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text(),
-            ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text()}"
-            f"Expected is: "
-            f"{ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR}",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(),
-            ContributeMobileSupportMessages.FACT_FIRST_LINE,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_first_fact_text()}"
-            f"Expected is: {ContributeMobileSupportMessages.FACT_FIRST_LINE}",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(),
-            ContributeMobileSupportMessages.FACT_SECOND_LINE,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_second_fact_text()}"
-            f"Expected is: {ContributeMobileSupportMessages.FACT_SECOND_LINE}",
-        )
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(),
-            ContributeMobileSupportMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header()}"
-            f"Expected is: "
-            f"{ContributeMobileSupportMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER}",
-        )
-
-        other_ways_to_contribute_card_titles = [
-            ContributeMobileSupportMessages.ANSWER_QUESTIONS_IN_SUPPORT_FORUM_TITLE_CARD_TITLE,
-            ContributeMobileSupportMessages.WRITE_HELP_ARTICLES_CARD_TITLE,
-            ContributeMobileSupportMessages.LOCALIZE_CONTENT_CARD_TITLE,
-            ContributeMobileSupportMessages.PROVIDE_SUPPORT_ON_SOCIAL_CHANNELS_CARD_TITLE,
-        ]
-
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_title(),
-            other_ways_to_contribute_card_titles,
-            "Other ways to contribute_messages card titles are not the correct ones!",
-        )
+            other_ways_to_contribute_card_titles = [
+                ContributeMobileSupportMessages.ANSWER_QUESTIONS_IN_SUPPORT_FORUM_TITLE_CARD_TITLE,
+                ContributeMobileSupportMessages.WRITE_HELP_ARTICLES_CARD_TITLE,
+                ContributeMobileSupportMessages.LOCALIZE_CONTENT_CARD_TITLE,
+                ContributeMobileSupportMessages.PROVIDE_SUPPORT_ON_SOCIAL_CHANNELS_CARD_TITLE,
+            ]
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+            ) == other_ways_to_contribute_card_titles
 
     # C2176366
     @pytest.mark.contributePagesTests
     def test_contribute_mobile_page_images_are_not_broken(self):
-        self.logger.info("Accessing the Contribute Mobile store page")
-        self.navigate_to_link(
-            ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Mobile store page"):
+            self.navigate_to_link(
+                ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL
+            )
 
-        self.logger.info("Verifying that the Contribute Mobile store page images are not broken")
         for link in self.sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
             image_link = link.get_attribute("src")
             response = requests.get(image_link, stream=True)
-            check.is_true(response.status_code < 400, f"The {image_link} image is broken")
+            with check, allure.step(f"Verifying that the {image_link} image is not broken"):
+                assert response.status_code < 400
 
     # C2176367
     @pytest.mark.contributePagesTests
     def test_contribute_mobile_page_breadcrumbs(self):
-        self.logger.info("Accessing the Contribute Mobile Store page")
-        self.navigate_to_link(
-            ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Mobile Store page"):
+            self.navigate_to_link(
+                ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL
+            )
 
-        self.logger.info("Verifying that the correct breadcrumbs are displayed")
         breadcrumbs = [
             ContributeMobileSupportMessages.FIRST_BREADCRUMB,
             ContributeMobileSupportMessages.SECOND_BREADCRUMB,
             ContributeMobileSupportMessages.THIRD_BREADCRUMB,
         ]
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(),
-            breadcrumbs,
-            f"Breadcrumbs are: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs()}"
-            f"Expected: {breadcrumbs}",
-        )
+        with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(
+            ) == breadcrumbs
 
         counter = 1
         for breadcrumb in self.sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
@@ -166,40 +108,26 @@ class TestContributeMobilePage(TestUtilities):
             self.sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
 
             if counter == 1:
-                self.logger.info(
-                    "Verifying that the Contribute breadcrumb redirects to the Contribute page"
-                )
-                check.equal(
-                    self.get_page_url(),
-                    ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL,
-                    f"Expected to be on {ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL}"
-                    f"We are actual on {self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
+                                        "the Contribute page"):
+                    assert self.get_page_url() == ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL
                 self.navigate_forward()
                 counter -= 1
             elif counter == 0:
-                self.logger.info("Verifying that the Home breadcrumb redirects to the Homepage")
-                check.equal(
-                    self.get_page_url(),
-                    HomepageMessages.STAGE_HOMEPAGE_URL_EN_US,
-                    f"Expected to be on {HomepageMessages.STAGE_HOMEPAGE_URL_EN_US}"
-                    f"We are actual on {self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Home breadcrumb redirects to the "
+                                        "Homepage"):
+                    assert self.get_page_url() == HomepageMessages.STAGE_HOMEPAGE_URL_EN_US
 
     # Need to add tests for "How you can contribute_messages" section
 
     # C2176370
     @pytest.mark.contributePagesTests
     def test_contribute_mobile_other_ways_to_contribute_redirect_to_the_correct_page(self):
-        self.logger.info("Accessing the Contribute Mobile Store page")
-        self.navigate_to_link(
-            ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Mobile Store page"):
+            self.navigate_to_link(
+                ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL
+            )
 
-        self.logger.info(
-            "Verifying that the 'other ways to contribute_messages' "
-            "cards are redirecting to the correct SUMO page"
-        )
         ways_to_contribute_links = [
             ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL,
             ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL,
@@ -209,7 +137,7 @@ class TestContributeMobilePage(TestUtilities):
 
         counter = 0
         for (
-                element
+            element
         ) in self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list():
             card = (
                 self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list()[
@@ -217,11 +145,8 @@ class TestContributeMobilePage(TestUtilities):
                 ]
             )
             self.sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
-            check.equal(
-                ways_to_contribute_links[counter],
-                self.get_page_url(),
-                f"Expected the following URL: {ways_to_contribute_links[counter]}"
-                f"Received: {self.get_page_url()}",
-            )
+            with check, allure.step("Verifying that the 'other ways to contribute_messages' "
+                                    "cards are redirecting to the correct SUMO page"):
+                assert ways_to_contribute_links[counter] == self.get_page_url()
             self.navigate_back()
             counter += 1

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 import requests
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -23,50 +24,30 @@ class TestContributePage(TestUtilities):
     # C2165413
     @pytest.mark.contributePagesTests
     def test_contribute_page_text(self):
-        self.logger.info("Clicking on the Contribute top-navbar option")
-        self.sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
+        with allure.step("Clicking on the Contribute top-navbar option"):
+            self.sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
 
-        self.logger.info("Verifying that the correct page hero header text is displayed")
-        check.equal(
-            self.sumo_pages.contribute_page._get_page_hero_main_header_text(),
-            ContributePageMessages.HERO_MAIN_PAGE_TITLE,
-            f"Text is: {self.sumo_pages.contribute_page._get_page_hero_main_header_text()} "
-            f"Expected: {ContributePageMessages.HERO_MAIN_PAGE_TITLE}"
-        )
+        with check, allure.step("Verifying that the correct page hero header text is displayed"):
+            assert self.sumo_pages.contribute_page._get_page_hero_main_header_text(
+            ) == ContributePageMessages.HERO_MAIN_PAGE_TITLE
 
-        self.logger.info("Verifying that the correct page hero need help subtext is displayed")
-        check.equal(
-            self.sumo_pages.contribute_page._get_page_hero_main_subtext(),
-            ContributePageMessages.HERO_HELP_MILLION_OF_USERS_TEXT,
-            f"Text is: {self.sumo_pages.contribute_page._get_page_hero_main_subtext()} "
-            f"Expected: {ContributePageMessages.HERO_HELP_MILLION_OF_USERS_TEXT}",
-        )
+        with check, allure.step("Verifying that the correct page hero need help subtext is "
+                                "displayed"):
+            assert self.sumo_pages.contribute_page._get_page_hero_main_subtext(
+            ) == ContributePageMessages.HERO_HELP_MILLION_OF_USERS_TEXT
 
-        self.logger.info("Verifying that the correct need help header text is displayed")
-        check.equal(
-            self.sumo_pages.contribute_page._get_page_hero_need_help_header_text(),
-            ContributePageMessages.HERO_NEED_YOUR_HELP_TITLE,
-            f"Text is: "
-            f"{self.sumo_pages.contribute_page._get_page_hero_need_help_header_text()}"
-            f" Expected: {ContributePageMessages.HERO_NEED_YOUR_HELP_TITLE}",
-        )
+        with check, allure.step("Verifying that the correct need help header text is displayed"):
+            assert self.sumo_pages.contribute_page._get_page_hero_need_help_header_text(
+            ) == ContributePageMessages.HERO_NEED_YOUR_HELP_TITLE
 
-        self.logger.info("Verifying that the correct need help subtext is displayed")
-        check.equal(
-            self.sumo_pages.contribute_page._get_page_hero_need_help_subtext(),
-            ContributePageMessages.HERO_NEED_YOUR_HELP_PARAGRAPH,
-            f"Text is: {self.sumo_pages.contribute_page._get_page_hero_need_help_subtext()}."
-            f"Expected: {ContributePageMessages.HERO_NEED_YOUR_HELP_PARAGRAPH}",
-        )
+        with check, allure.step("Verifying that the correct need help subtext is displayed"):
+            assert self.sumo_pages.contribute_page._get_page_hero_need_help_subtext(
+            ) == ContributePageMessages.HERO_NEED_YOUR_HELP_PARAGRAPH
 
-        self.logger.info("Verifying that the correct get way to contribute_messages header is "
-                         "displayed")
-        check.equal(
-            self.sumo_pages.contribute_page._get_way_to_contribute_header_text(),
-            ContributePageMessages.PICK_A_WAY_TO_CONTRIBUTE_HEADER,
-            f"Text is: {self.sumo_pages.contribute_page._get_way_to_contribute_header_text()}"
-            f"Expected: {ContributePageMessages.PICK_A_WAY_TO_CONTRIBUTE_HEADER}",
-        )
+        with check, allure.step("Verifying that the correct get way to contribute_messages "
+                                "header is displayed"):
+            assert self.sumo_pages.contribute_page._get_way_to_contribute_header_text(
+            ) == ContributePageMessages.PICK_A_WAY_TO_CONTRIBUTE_HEADER
 
         card_titles = [
             ContributePageMessages.ANSWER_QUESTIONS_CARD_TITLE,
@@ -76,75 +57,53 @@ class TestContributePage(TestUtilities):
             ContributePageMessages.RESPOND_TO_MOBILE_STORE_REVIEWS_CARD_TITLE,
         ]
 
-        self.logger.info("Verifying that the correct list of ways to contribute_messages card "
-                         "titles is displayed")
-        check.equal(
-            card_titles,
-            self.sumo_pages.contribute_page._get_way_to_contribute_card_titles_text(),
-            "Pick a way to contribute_messages card titles are not the correct ones",
-        )
+        with check, allure.step("Verifying that the correct list of ways to contribute_messages "
+                                "card titles is displayed"):
+            assert card_titles == self.sumo_pages.contribute_page._get_way_to_contribute_cards()
 
-        self.logger.info("Verifying that the correct about us header text is displayed")
-        check.equal(
-            self.sumo_pages.contribute_page._get_about_us_header_text(),
-            ContributePageMessages.ABOUT_US_HEADER,
-            f"Text is: {self.sumo_pages.contribute_page._get_about_us_header_text()}"
-            f"Expected: {ContributePageMessages.ABOUT_US_HEADER}",
-        )
+        with check, allure.step("Verifying that the correct about us header text is displayed"):
+            assert self.sumo_pages.contribute_page._get_about_us_header_text(
+            ) == ContributePageMessages.ABOUT_US_HEADER
 
-        self.logger.info("Verifying that the correct about us subtext is displayed")
-        check.equal(
-            self.sumo_pages.contribute_page._get_about_us_subtext(),
-            ContributePageMessages.ABOUT_US_CONTENT,
-            f"Text is: {self.sumo_pages.contribute_page._get_about_us_subtext()}"
-            f"Expected: {ContributePageMessages.ABOUT_US_CONTENT}",
-        )
+        with check, allure.step("Verifying that the correct about us subtext is displayed"):
+            assert self.sumo_pages.contribute_page._get_about_us_subtext(
+            ) == ContributePageMessages.ABOUT_US_CONTENT
 
     # C2165413
     @pytest.mark.contributePagesTests
     def test_contribute_page_images_are_not_broken(self):
-        self.logger.info("Clicking on the 'Contribute' top-navbar option")
-        self.sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
-
-        self.logger.info("Verifying that the contribute_messages page images are not broken")
+        with allure.step("Clicking on the 'Contribute' top-navbar option"):
+            self.sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
 
         for link in self.sumo_pages.contribute_page._get_all_page_links():
             image_link = link.get_attribute("src")
             response = requests.get(image_link, stream=True)
-            check.is_true(response.status_code < 400, f'The {image_link} image is broken!')
+            with check, allure.step(f"Verifying that the {image_link} image is not broken"):
+                assert response.status_code < 400
 
     # C1949333
     @pytest.mark.contributePagesTests
     def test_contribute_page_breadcrumbs(self):
-        self.logger.info("Clicking on the Contribute top-navbar option")
-        self.sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
+        with allure.step("Clicking on the Contribute top-navbar option"):
+            self.sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
 
         breadcrumbs = [
             ContributePageMessages.FIRST_BREADCRUMB,
             ContributePageMessages.SECOND_BREADCRUMB,
         ]
 
-        self.logger.info("Verifying that the correct breadcrumbs are displayed")
-        check.equal(
-            self.sumo_pages.contribute_page._get_breadcrumbs_text(),
-            breadcrumbs,
-            f"Breadcrumbs are: {self.sumo_pages.contribute_page._get_breadcrumbs_text()}"
-            f"Expected to be: {breadcrumbs}",
-        )
+        with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
+            assert self.sumo_pages.contribute_page._get_breadcrumbs_text() == breadcrumbs
 
-        self.logger.info("Verifying that the home breadcrumb redirects to the homepage")
-        self.sumo_pages.contribute_page._click_on_home_breadcrumb()
-
-        assert self.get_page_url() == HomepageMessages.STAGE_HOMEPAGE_URL_EN_US, (
-            f"{HomepageMessages.STAGE_HOMEPAGE_URL_EN_US} page was expected to be displayed"
-            f"{self.get_page_url()} is displayed instead"
-        )
+        with allure.step("Verifying that the home breadcrumb redirects to the homepage"):
+            self.sumo_pages.contribute_page._click_on_home_breadcrumb()
+            assert self.get_page_url() == HomepageMessages.STAGE_HOMEPAGE_URL_EN_US
 
     # C1949335,C1949336,C1949337,C1949338,C1949339,C1949355
     @pytest.mark.contributePagesTests
     def test_way_to_contribute_redirects_to_correct_page(self):
-        self.logger.info("Clicking on the Contribute top-navbar option")
-        self.sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
+        with allure.step("Clicking on the Contribute top-navbar option"):
+            self.sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
 
         ways_to_contribute_links = [
             ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL,
@@ -154,20 +113,12 @@ class TestContributePage(TestUtilities):
             ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL,
         ]
 
-        self.logger.info(
-            "Verifying that the 'way to contribute_messages' cards are redirecting to the "
-            "correct SUMO page"
-        )
-
         counter = 0
         for element in self.sumo_pages.contribute_page._get_list_of_contribute_cards():
             card = self.sumo_pages.contribute_page._get_list_of_contribute_cards()[counter]
             self.sumo_pages.contribute_page._click_on_way_to_contribute_card(card)
-            check.equal(
-                ways_to_contribute_links[counter],
-                self.get_page_url(),
-                f"Expected the following URL: {ways_to_contribute_links[counter]}"
-                f"Received: {self.get_page_url()}",
-            )
+            with check, allure.step("Verifying that the 'way to contribute_messages' cards are "
+                                    "redirecting to the correct SUMO page"):
+                assert ways_to_contribute_links[counter] == self.get_page_url()
             self.navigate_back()
             counter += 1

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_social_media_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_social_media_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 import requests
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -22,47 +23,27 @@ class TestContributeSocialMediaPage(TestUtilities):
     # C2176361
     @pytest.mark.contributePagesTests
     def test_contribute_social_page_text(self):
-        self.logger.info("Accessing the Contribute Social Channels page")
-        self.navigate_to_link(
-            ContributeSocialSupportMessages.STAGE_CONTRIBUTE_SOCIAL_SUPPORT_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Social Channels page"):
+            self.navigate_to_link(
+                ContributeSocialSupportMessages.STAGE_CONTRIBUTE_SOCIAL_SUPPORT_PAGE_URL
+            )
 
-        self.logger.info(
-            "Verifying that the correct hero main header is displayed"
-        )
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(),
-            ContributeSocialSupportMessages.HERO_PAGE_TITLE,
-            f"Actual: {self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text()}"
-            f"Expected: {ContributeSocialSupportMessages.HERO_PAGE_TITLE}",
-        )
+        with check, allure.step("Verifying that the correct hero main header is displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+            ) == ContributeSocialSupportMessages.HERO_PAGE_TITLE
 
-        self.logger.info("Verifying that the correct hero second header is displayed")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(),
-            ContributeSocialSupportMessages.HERO_SECOND_TITLE,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_hero_second_header()}"
-            f"Expected: {ContributeSocialSupportMessages.HERO_SECOND_TITLE}",
-        )
+        with check, allure.step("Verifying that the correct hero second header is displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+            ) == ContributeSocialSupportMessages.HERO_SECOND_TITLE
 
-        self.logger.info("Verifying that the correct get hero text is displayed")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_hero_text(),
-            ContributeSocialSupportMessages.HERO_TEXT,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_hero_text()}"
-            f"Expected: {ContributeSocialSupportMessages.HERO_TEXT}",
-        )
+        with check, allure.step("Verifying that the correct get hero text is displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_hero_text(
+            ) == ContributeSocialSupportMessages.HERO_TEXT
 
-        self.logger.info("Verifying that the correct how to contribute_messages header text is "
-                         "displayed")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(),
-            ContributeSocialSupportMessages.HOW_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text()}"
-            f"Expected is: {ContributeSocialSupportMessages.HOW_TO_CONTRIBUTE_HEADER}",
-        )
+        with check, allure.step("Verifying that the correct how to contribute_messages header "
+                                "text is displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+            ) == ContributeSocialSupportMessages.HOW_TO_CONTRIBUTE_HEADER
 
         # Need to add a check for the logged in state as well.
         # Excluding option four from the list since we are using a different locator
@@ -74,50 +55,27 @@ class TestContributeSocialMediaPage(TestUtilities):
             ContributeSocialSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
         ]
 
-        self.logger.info("Verifying that the correct how to contribute_messages link option are "
-                         "displayed")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options_text(),
-            card_titles,
-            "How you can contribute_messages steps are incorrect!",
-        )
+        with check, allure.step("Verifying that the correct how to contribute_messages link "
+                                "option are displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+            ) == card_titles
 
-        self.logger.info("Verifying that the correct option four text is displayed")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text(),
-            ContributeSocialSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four_text()}"
-            f"Expected is: "
-            f"{ContributeSocialSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR}",
-        )
+        with check, allure.step("Verifying that the correct option four text is displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+            ) == ContributeSocialSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
 
-        self.logger.info("Verifying that the correct page first fact text is displayed")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(),
-            ContributeSocialSupportMessages.FACT_FIRST_LINE,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_first_fact_text()}"
-            f"Expected is: {ContributeSocialSupportMessages.FACT_FIRST_LINE}",
-        )
+        with check, allure.step("Verifying that the correct page first fact text is displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+            ) == ContributeSocialSupportMessages.FACT_FIRST_LINE
 
-        self.logger.info("Verifying that the correct second fact text is displayed")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(),
-            ContributeSocialSupportMessages.FACT_SECOND_LINE,
-            f"Text is: {self.sumo_pages.ways_to_contribute_pages._get_second_fact_text()}"
-            f"Expected is: {ContributeSocialSupportMessages.FACT_SECOND_LINE}",
-        )
+        with check, allure.step("Verifying that the correct second fact text is displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+            ) == ContributeSocialSupportMessages.FACT_SECOND_LINE
 
-        self.logger.info("Verifying that the correct get other ways to contribute_messages "
-                         "header is displayed")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(),
-            ContributeSocialSupportMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER,
-            f"Text is: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header()}"
-            f"Expected is: "
-            f"{ContributeSocialSupportMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER}",
-        )
+        with check, allure.step("Verifying that the correct get other ways to "
+                                "contribute_messages header is displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+            ) == ContributeSocialSupportMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
         other_ways_to_contribute_card_titles = [
             ContributeSocialSupportMessages.ANSWER_QUESTIONS_IN_SUPPORT_FORUM_TITLE,
@@ -126,51 +84,42 @@ class TestContributeSocialMediaPage(TestUtilities):
             ContributeSocialSupportMessages.RESPOND_TO_MOBILE_STORE_REVIEWS_CARD_TITLE,
         ]
 
-        self.logger.info("Verifying that the other ways to contribute_messages card titles are "
-                         "the correct ones")
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_title(),
-            other_ways_to_contribute_card_titles,
-            "Other ways to contribute_messages card titles are not the correct ones!",
-        )
+        with check, allure.step("Verifying that the other ways to contribute_messages card "
+                                "titles are the correct ones"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+            ) == other_ways_to_contribute_card_titles
 
     # C2176361
     @pytest.mark.contributePagesTests
     def test_contribute_social_page_images_are_not_broken(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeSocialSupportMessages.STAGE_CONTRIBUTE_SOCIAL_SUPPORT_PAGE_URL
-        )
-
-        self.logger.info("Verifying that the Contribute forum page images are not broken")
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeSocialSupportMessages.STAGE_CONTRIBUTE_SOCIAL_SUPPORT_PAGE_URL
+            )
 
         for link in self.sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
             image_link = link.get_attribute("src")
             response = requests.get(image_link, stream=True)
-            check.is_true(response.status_code < 400, f"The {image_link} image is broken")
+            with check, allure.step(f"Verifying that the {image_link} image is not broken"):
+                assert response.status_code < 400
 
     # C2176362
     @pytest.mark.contributePagesTests
     def test_contribute_social_page_breadcrumbs(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeSocialSupportMessages.STAGE_CONTRIBUTE_SOCIAL_SUPPORT_PAGE_URL
-        )
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeSocialSupportMessages.STAGE_CONTRIBUTE_SOCIAL_SUPPORT_PAGE_URL
+            )
 
-        self.logger.info("Verifying that the correct breadcrumbs are displayed")
         breadcrumbs = [
             ContributeSocialSupportMessages.FIRST_BREADCRUMB,
             ContributeSocialSupportMessages.SECOND_BREADCRUMB,
             ContributeSocialSupportMessages.THIRD_BREADCRUMB,
         ]
 
-        check.equal(
-            self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(),
-            breadcrumbs,
-            f"Breadcrumbs are: "
-            f"{self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs()}"
-            f"Expected: {breadcrumbs}",
-        )
+        with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
+            assert self.sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(
+            ) == breadcrumbs
 
         counter = 1
         for breadcrumb in self.sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
@@ -180,40 +129,25 @@ class TestContributeSocialMediaPage(TestUtilities):
             self.sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
 
             if counter == 1:
-                self.logger.info(
-                    "Verifying that the Contribute breadcrumb redirects to the Contribute page"
-                )
-                check.equal(
-                    self.get_page_url(),
-                    ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL,
-                    f"Expected to be on {ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL}"
-                    f"We are actual on {self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
+                                        "the Contribute page"):
+                    assert self.get_page_url() == ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL
                 self.navigate_forward()
                 counter -= 1
             elif counter == 0:
-                self.logger.info("Verifying that the Home breadcrumb redirects to the Homepage")
-                check.equal(
-                    self.get_page_url(),
-                    HomepageMessages.STAGE_HOMEPAGE_URL_EN_US,
-                    f"Expected to be on {HomepageMessages.STAGE_HOMEPAGE_URL_EN_US}"
-                    f"We are actual on {self.get_page_url()}",
-                )
+                with check, allure.step("Verifying that the Home breadcrumb redirects to the "
+                                        "Homepage"):
+                    assert self.get_page_url() == HomepageMessages.STAGE_HOMEPAGE_URL_EN_US
 
     # Need to add tests for "How you can contribute_messages" section
 
     # C2176364
     @pytest.mark.contributePagesTests
     def test_contribute_social_other_ways_to_contribute_redirect_to_the_correct_page(self):
-        self.logger.info("Accessing the Contribute Forum page")
-        self.navigate_to_link(
-            ContributeSocialSupportMessages.STAGE_CONTRIBUTE_SOCIAL_SUPPORT_PAGE_URL
-        )
-
-        self.logger.info(
-            "Verifying that the 'other ways to contribute_messages' "
-            "cards are redirecting to the correct SUMO page"
-        )
+        with allure.step("Accessing the Contribute Forum page"):
+            self.navigate_to_link(
+                ContributeSocialSupportMessages.STAGE_CONTRIBUTE_SOCIAL_SUPPORT_PAGE_URL
+            )
 
         ways_to_contribute_links = [
             ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL,
@@ -224,7 +158,7 @@ class TestContributeSocialMediaPage(TestUtilities):
 
         counter = 0
         for (
-                element
+            element
         ) in self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list():
             card = (
                 self.sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list()[
@@ -232,11 +166,8 @@ class TestContributeSocialMediaPage(TestUtilities):
                 ]
             )
             self.sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
-            check.equal(
-                ways_to_contribute_links[counter],
-                self.get_page_url(),
-                f"Expected the following URL: {ways_to_contribute_links[counter]}"
-                f"Received: {self.get_page_url()}",
-            )
+            with check, allure.step("Verifying that the 'other ways to contribute_messages'n "
+                                    "cards are redirecting to the correct SUMO page"):
+                assert ways_to_contribute_links[counter] == self.get_page_url()
             self.navigate_back()
             counter += 1

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 from playwright.sync_api import expect
 from playwright_tests.core.testutilities import TestUtilities
 from playwright_tests.messages.contribute_messages.con_tools.kb_dashboard_messages import (
@@ -11,639 +12,523 @@ class TestKBDashboard(TestUtilities, KBDashboardPageMessages):
     # C891357
     @pytest.mark.kbDashboard
     def test_unreviewed_articles_visibility_in_kb_dashboard(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            article_url = self.get_page_url()
 
-        self.sumo_pages.kb_article_page._click_on_article_option()
-        article_url = self.get_page_url()
+        with allure.step("Navigating to the kb dashboards and clicking on the 'Complete "
+                         "overview' option"):
+            self.sumo_pages.top_navbar._click_on_dashboards_option()
+            self.sumo_pages.kb_dashboard_page._click_on_the_complete_overview_link()
 
-        self.logger.info("Navigating to the kb dashboards")
-        self.sumo_pages.top_navbar._click_on_dashboards_option()
+        with allure.step("Verifying that we are redirected to the correct page"):
+            expect(
+                self.page
+            ).to_have_url(super().general_test_data['dashboard_links']['kb_overview'])
 
-        self.logger.info("Clicking on the 'Complete overview' option")
-        self.sumo_pages.kb_dashboard_page._click_on_the_complete_overview_link()
-
-        self.logger.info("Verifying that we are redirected to the correct page")
-        expect(
-            self.page
-        ).to_have_url(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct live status is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
+        with check, allure.step("Verifying that the correct live status is displayed"):
+            assert self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
                 article_details['article_title']
-            ).strip(),
-            self.get_kb_not_live_status(
+            ).strip() == self.get_kb_not_live_status(
                 revision_note=article_details['article_review_description']
             )
-        )
 
-        self.logger.info("Signing out and verifying that the article is not displayed since it "
-                         "is not live yet")
-        self.delete_cookies()
-        expect(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+        with allure.step("Signing out and verifying that the article is not displayed since it "
+                         "is not live yet"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_details['article_title']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Navigating to the homepage and performing the sign in step since the "
+                         "kb overview takes quite a bit to refresh/load"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+
+        with allure.step("Navigating to the kb overview verifying that the article is not "
+                         "displayed since it is not live yet"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_details['article_title']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Signing in with an admin account"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        with allure.step("Navigating to the kb overview page and clicking on the article title"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            self.sumo_pages.kb_dashboard_page._click_on_article_title(
                 article_details['article_title']
             )
-        ).to_be_hidden()
 
-        self.logger.info("Navigating to the homepage and performing the sign in step since the "
-                         "kb overview takes quite a bit to refresh/load")
-        self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        with allure.step("Verifying that the user is redirected to the correct kb page"):
+            expect(
+                self.page
+            ).to_have_url(article_url)
 
-        self.logger.info("Signing in with a non-admin account and verifying that the article is "
-                         "not displayed since it is not live yet")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with allure.step("Approving the article revision"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Navigating to the kb overview")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-        expect(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+        with check, allure.step("Navigating back to the kb overview page and verifying that the "
+                                "correct live status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
+                article_details['article_title']
+            ).strip() == self.KB_LIVE_STATUS
+
+        with allure.step("Signing out and verifying that the article is visible"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_details['article_title']
+                )
+            ).to_be_visible()
+
+        with allure.step("Signing in with a non-admin user"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+
+        with allure.step("Navigating to the kb overview and verifying that the article is "
+                         "visible"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_details['article_title']
+                )
+            ).to_be_visible()
+
+        with allure.step("Signing back with an admin account and deleting the article"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            self.sumo_pages.kb_dashboard_page._click_on_article_title(
                 article_details['article_title']
             )
-        ).to_be_hidden()
-
-        self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
-        self.logger.info("Signing back in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Navigating to the kb overview")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Clicking on the article title")
-        self.sumo_pages.kb_dashboard_page._click_on_article_title(
-            article_details['article_title']
-        )
-
-        self.logger.info("Verifying that the user is redirected to the correct kb page")
-        expect(
-            self.page
-        ).to_have_url(article_url)
-
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
-
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
-
-        self.logger.info("Navigating to the kb overview")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct status is displayed")
-
-        self.logger.info("Verifying that the correct live status is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
-                article_details['article_title']
-            ).strip(),
-            self.KB_LIVE_STATUS
-        )
-
-        self.logger.info("Signing out and verifying that the article is visible")
-        self.delete_cookies()
-        expect(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
-                article_details['article_title']
-            )
-        ).to_be_visible()
-
-        self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
-        self.logger.info("Signing in with a non-admin user and verifying that the article is "
-                         "visible")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.logger.info("Navigating to the kb overview")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        expect(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
-                article_details['article_title']
-            )
-        ).to_be_visible()
-
-        self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
-
-        self.logger.info("Signing back with an admin account and deleting the article")
-        self.logger.info("Signing back in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Navigating to the kb overview")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Clicking on the article title")
-        self.sumo_pages.kb_dashboard_page._click_on_article_title(
-            article_details['article_title']
-        )
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2266376
     @pytest.mark.kbDashboard
     def test_kb_dashboard_articles_status(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with the admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+        with allure.step("Approving the first article revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Creating a new revision for the document")
-        second_revision_details = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
+        with allure.step("Creating a anew revision for the document"):
+            second_revision = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
 
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct status is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
+        with check, allure.step("Navigating to the kb overview dashboard and verifying that the "
+                                "correct status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
                 article_details['article_title']
-            ).strip(),
-            self.get_kb_not_live_status(
-                revision_note=second_revision_details['changes_description']
+            ).strip() == self.get_kb_not_live_status(
+                revision_note=second_revision['changes_description']
             )
-        )
 
-        self.logger.info("Navigating back to the article history and deleting the revision")
-        self.navigate_to_link(article_url)
+        with allure.step("Navigating back to the article history and deleting the revision"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(
+                second_revision['revision_id']
+            )
+            self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
 
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(
-            second_revision_details['revision_id']
-        )
-
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
-
-        self.logger.info("Navigating back to the kb dashboard and verifying that the live status "
-                         "is displayed")
-
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
+        with check, allure.step("Navigating back to the kb dashboard and verifying that the live "
+                                "status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
                 article_details['article_title']
-            ).strip(),
-            self.KB_LIVE_STATUS
-        )
+            ).strip() == self.KB_LIVE_STATUS
 
-        self.logger.info("Clicking on the article title")
-        self.sumo_pages.kb_dashboard_page._click_on_article_title(
-            article_details['article_title']
-        )
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Clicking on the article title and deleting it"):
+            self.sumo_pages.kb_dashboard_page._click_on_article_title(
+                article_details['article_title']
+            )
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     @pytest.mark.kbDashboard
     def test_kb_dashboard_revision_deferred_status(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+        with allure.step("Approving the first article revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Creating a new revision for the document")
-        second_revision_details = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
+        with allure.step("Creating a new revision for the document"):
+            second_revision = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
 
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct status is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
+        with check, allure.step("Navigating to the kb overview page and verifying that the "
+                                "correct kb status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
                 article_details['article_title']
-            ),
-            self.get_kb_not_live_status(second_revision_details['changes_description'])
-        )
+            ) == self.get_kb_not_live_status(second_revision['changes_description'])
 
-        self.logger.info("Navigating back to the article history page")
-        self.navigate_to_link(article_url)
+        with allure.step("Navigating back to the article history page and deferring the revision"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
+                second_revision['revision_id']
+            )
+            self.sumo_pages.kb_article_review_revision_page._click_on_defer_revision_button()
+            self.sumo_pages.kb_article_review_revision_page._click_on_defer_confirm_button()
 
-        self.logger.info("Deferring the revision")
-        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
-            second_revision_details['revision_id']
-        )
-
-        self.sumo_pages.kb_article_review_revision_page._click_on_defer_revision_button()
-        self.sumo_pages.kb_article_review_revision_page._click_on_defer_confirm_button()
-
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
+        with check, allure.step("Navigating back to the kb overview page and verifying that the "
+                                "correct status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_a_particular_article_status(
                 article_details['article_title']
-            ),
-            self.KB_LIVE_STATUS
-        )
+            ) == self.KB_LIVE_STATUS
 
-        self.logger.info("Navigating back to the article page")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the article"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     @pytest.mark.kbDashboard
     def test_kb_dashboard_needs_update_when_reviewing_a_revision(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+        with allure.step("Approving the first article revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Creating a new revision for the document")
-        second_revision_details = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision(
-        )
+        with allure.step("Creating an new article revision for the document"):
+            second_revision = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision(
+            )
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+                second_revision['revision_id'], revision_needs_change=True
+            )
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
-            second_revision_details['revision_id'], revision_needs_change=True
-        )
-
-        self.logger.info("Navigating to the kb dashboard overview")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_needs_update_status(
+        with check, allure.step("Navigating to the kb dashboard overview page and verifying that "
+                                "the correct article status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_needs_update_status(
                 article_details['article_title']
-            ).strip(),
-            super().kb_revision_test_data['needs_change_message']
-        )
+            ).strip() == super().kb_revision_test_data['needs_change_message']
 
-        self.logger.info("Navigating back to the article page")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the article"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2266377
     @pytest.mark.kbDashboard
     def test_kb_dashboard_needs_update_edit_metadata(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with the admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+        with allure.step("Approving the first article revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Clicking on the 'Edit Article Metadata' option")
-        self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+        with allure.step("Clicking on the 'Edit Article Metadata' option and enabling the 'Needs "
+                         "change with comment' option"):
+            self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(
+                needs_change=True, needs_change_comment=True
+            )
 
-        self.logger.info("Enabling Needs Change with comment")
-        self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(
-            needs_change=True, needs_change_comment=True
-        )
-
-        self.logger.info("Navigating to the complete dashboard list")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct needs change status is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_needs_update_status(
+        with check, allure.step("Navigating to the kb dashboard and verifying that the correct "
+                                "needs change status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_needs_update_status(
                 article_details['article_title']
-            ).strip(),
-            super().kb_revision_test_data['needs_change_message']
-        )
+            ).strip() == super().kb_revision_test_data['needs_change_message']
 
-        self.logger.info("Navigating back to the article")
-        self.navigate_to_link(article_url)
+        with allure.step("Navigating back to the article's 'Edit Article Metadata' page and "
+                         "removing the comment from the needs change textarea"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(needs_change=True)
 
-        self.logger.info("Clicking on the 'Edit Article Metadata' option")
-        self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
-
-        self.logger.info("Removing the comment from the needs change comment")
-        self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(needs_change=True)
-
-        self.logger.info("Navigating to the complete dashboard list")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct needs change status is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_needs_update_status(
+        with allure.step("Navigating to the complete dashboard list and verifying that the "
+                         "correct needs change status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_needs_update_status(
                 article_details['article_title']
-            ).strip(),
-            KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
-        )
+            ).strip() == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
-        self.logger.info("Navigating back to the article")
-        self.navigate_to_link(article_url)
+        with allure.step("Navigating back to the article's 'Edit Article Metadata' page and "
+                         "removing the needs change updates"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            self.sumo_pages.edit_article_metadata_flow.edit_article_metadata()
 
-        self.logger.info("Clicking on the 'Edit Article Metadata' option")
-        self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
-
-        self.logger.info("Editing the article metadata by removing the needs change updates")
-        self.sumo_pages.edit_article_metadata_flow.edit_article_metadata()
-
-        self.logger.info("Navigating to the complete dashboard list")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        check.is_true(
-            self.sumo_pages.kb_dashboard_page._is_needs_change_empty(
+        with check, allure.step("Navigating to the kb overview page and verifying that the "
+                                "correct needs change status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._is_needs_change_empty(
                 article_details['article_title']
             )
-        )
 
-        self.logger.info("Deleting the article")
-        self.navigate_to_link(article_url)
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the article"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2266378
     @pytest.mark.kbDashboard
     def test_ready_for_l10n_kb_dashboard_revision_approval(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with the admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision and marking it as ready for l10n")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
-            revision_id=revision_id, ready_for_l10n=True)
+        with allure.step("Approving the first revision and marking it as ready for l10n"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+                revision_id=revision_id, ready_for_l10n=True)
 
-        self.logger.info("Navigating to the kb dashboard overview page")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct l10n status is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_ready_for_l10n_status(
+        with check, allure.step("Navigating to the kb dashboard overview page and verifying that "
+                                "the correct l10n status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_ready_for_l10n_status(
                 article_details['article_title']
-            ),
-            KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
-        )
+            ) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
-        self.logger.info("Navigating back to the article")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Deleting the article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the article"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2266378
     @pytest.mark.kbDashboard
     def test_ready_for_l10n_kb_dashboard_revision_l10n_status(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with the admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new kb article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id=revision_id)
+        with allure.step("Approving the first kb revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id=revision_id)
 
-        self.logger.info("Navigating to the kb dashboard overview page")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct l10n status displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_ready_for_l10n_status(
+        with check, allure.step("Navigating to the kb dashboard overview page and verifying that "
+                                "the correct l10n status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_ready_for_l10n_status(
                 article_details['article_title']
-            ),
-            KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
-        )
+            ) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
-        self.logger.info("Navigating back to the article page")
-        self.navigate_to_link(article_url)
+        with allure.step("Navigating back to the article page and marking the revision as ready "
+                         "for l10n"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_show_history_page._click_on_ready_for_l10n_option(
+                revision_id
+            )
+            self.sumo_pages.kb_article_show_history_page._click_on_submit_l10n_readiness_button()
 
-        self.logger.info("Mark the revision as ready for l10n")
-        self.sumo_pages.kb_article_show_history_page._click_on_ready_for_l10n_option(revision_id)
-        self.sumo_pages.kb_article_show_history_page._click_on_submit_l10n_readiness_button()
-
-        self.logger.info("Navigating to the kb dashboard overview page")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct l10n status is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_ready_for_l10n_status(
+        with allure.step("Navigating to the kb dashboard overview page and verifying that the "
+                         "correct l10n status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_ready_for_l10n_status(
                 article_details['article_title']
-            ),
-            KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
-        )
+            ) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
-        self.logger.info("Navigating to the article")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Deleting the article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Navigating to the article and deleting it"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2266378
     @pytest.mark.kbDashboard
     def test_article_translation_not_allowed_kb_dashboard(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with the admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            allow_translations=False
-        )
+        with allure.step("Creating a new simple article & unchecking the allow translations"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                allow_translations=False
+            )
 
         article_url = self.get_page_url()
 
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id=revision_id)
+        with allure.step("Approving the first revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id=revision_id)
 
-        self.logger.info("Navigating to the kb dashboard overview page")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct l10n status displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_ready_for_l10n_status(
+        with allure.step("Navigating to the kb dashboard overview page and verifying that the "
+                         "correct l10n status is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_ready_for_l10n_status(
                 article_details['article_title']
-            ),
-            KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
-        )
+            ) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
-        self.logger.info("Navigating to the article")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Deleting the article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the article"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2266379, C2266380
     @pytest.mark.kbDashboard
     def test_article_stale_kb_dashboard(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with the admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article by adding an old expiry date")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            expiry_date=self.kb_article_test_data['old_expiry_date']
-        )
+        with allure.step("Create a new simple article & adding an old expiry date"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                expiry_date=self.kb_article_test_data['old_expiry_date']
+            )
 
         article_url = self.get_page_url()
 
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+        with allure.step("Approving the first kb article revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Navigating to the kb dashboard overview page")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct stale status displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_stale_status(
+        with check, allure.step("Navigating to the kb dashboard overview page and verifying that "
+                                "the correct stale status and date is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._get_stale_status(
                 article_details['article_title']
-            ),
-            KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
-        )
-
-        self.logger.info("Verifying that the correct date is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_existing_expiry_date(
+            ) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
+            assert self.sumo_pages.kb_dashboard_page._get_existing_expiry_date(
                 article_details['article_title']
-            ),
-            self.convert_string_to_datetime(
+            ) == self.convert_string_to_datetime(
                 self.kb_article_test_data['old_expiry_date']
             )
-        )
 
-        self.logger.info("Navigating back to the article")
-        self.navigate_to_link(article_url)
+        with allure.step("Navigating back to the article and creating a new revision with a "
+                         "non-stale expiry date"):
+            self.navigate_to_link(article_url)
+            second_revision = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision(
+                expiry_date=self.kb_article_test_data['expiry_date']
+            )
 
-        self.logger.info("Creating a new revision with non-stale expiry date")
-        second_revision_details = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision(
-            expiry_date=self.kb_article_test_data['expiry_date']
-        )
+        with allure.step("Approving the revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+                second_revision['revision_id']
+            )
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
-            second_revision_details['revision_id']
-        )
-
-        self.logger.info("Navigating to the complete dashboard list")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct stale status is displayed")
-        check.is_true(
-            self.sumo_pages.kb_dashboard_page._is_stale_status_empty(
+        with check, allure.step("Navigating to the kb dashboard and verifying that the correct "
+                                "stale status and date is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            assert self.sumo_pages.kb_dashboard_page._is_stale_status_empty(
                 article_details['article_title']
             )
-        )
-
-        self.logger.info("Verifying that the correct date is displayed")
-        check.equal(
-            self.sumo_pages.kb_dashboard_page._get_existing_expiry_date(
+            assert self.sumo_pages.kb_dashboard_page._get_existing_expiry_date(
                 article_details['article_title']
-            ),
-            self.convert_string_to_datetime(
+            ) == self.convert_string_to_datetime(
                 self.kb_article_test_data['expiry_date']
             )
-        )
 
-        self.logger.info("Navigating to the article")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Deleting the article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the article"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     @pytest.mark.kbDashboard
     def test_article_title_update(self):
-        self.logger.info("Signing in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with the admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new kb article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id=revision_id)
+        with allure.step("Approving the first kb article revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id=revision_id)
 
-        self.logger.info("Navigating to the kb dashboard overview page")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+        with allure.step("Navigating to the kb dashboard overview page and verifying that the "
+                         "correct title is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_details['article_title']
+                )
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the correct title is displayed")
-        expect(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
-                article_details['article_title']
+        with allure.step("Navigating to the article's 'Edit Metadata page' page and changing the "
+                         "title"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            new_article_title = "Updated " + article_details['article_title']
+            self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(
+                title=new_article_title
             )
-        ).to_be_visible()
 
-        self.logger.info("Navigating back to the article")
-        self.navigate_to_link(article_url)
+        with allure.step("Navigating back to the kb dashboard page and verifying that the "
+                         "correct title is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    new_article_title
+                )
+            ).to_be_visible()
 
-        self.logger.info("Editing the article metadata by changing the title")
-        self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
-
-        new_article_title = "Updated " + article_details['article_title']
-        self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(title=new_article_title)
-
-        self.logger.info("Navigating back to the kb dashboard")
-        self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
-
-        self.logger.info("Verifying that the correct title is displayed")
-        expect(
-            self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
-                new_article_title
-            )
-        ).to_be_visible()
-
-        self.logger.info("Navigating to the article")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Deleting the article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the kb article"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 from playwright.sync_api import expect
 from playwright_tests.core.testutilities import TestUtilities
 from playwright_tests.messages.explore_help_articles.kb_article_revision_page_messages import (
@@ -13,576 +14,450 @@ class TestRecentRevisionsDashboard(TestUtilities):
     # C2499112
     @pytest.mark.recentRevisionsDashboard
     def test_recent_revisions_revision_availability(self):
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
         username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new kb article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
-        self.logger.info("Navigating to the recent revisions dashboard")
-        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+        with allure.step("Navigating to the recent revisions dashboard and verifying that the "
+                         "posted article is displayed for admin accounts"):
+            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_details['article_title']
+                )
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the posted article is displayed for admin accounts")
-        expect(
-            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
-                article_details['article_title']
+        with allure.step("Deleting the user session and verifying that the revision is not "
+                         "displayed for signed out users"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_details['article_title']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Typing the article creator username inside the 'Users' field and "
+                         "verifying that the article is not displayed"):
+            self.sumo_pages.recent_revisions_page._fill_in_users_field(username)
+            self.wait_for_given_timeout(2000)
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_details['article_title']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Clearing the user search field and signing in with a different "
+                         "non-admin account"):
+            self.sumo_pages.recent_revisions_page._clearing_the_user_field()
+            self.username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
             )
-        ).to_be_visible()
 
-        self.logger.info("Deleting user session and verifying that the revision is not displayed")
-        self.delete_cookies()
+        with allure.step("Verifying that the revision is not displayed for non-admin accounts"):
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_details['article_title']
+                )
+            ).to_be_hidden()
 
-        expect(
-            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
-                article_details['article_title']
-            )
-        ).to_be_hidden()
+        with allure.step("Typing the article creator username inside the 'Users' field and "
+                         "verifying that the article is not displayed"):
+            self.sumo_pages.recent_revisions_page._fill_in_users_field(username)
+            self.wait_for_given_timeout(2000)
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_details['article_title']
+                )
+            ).to_be_hidden()
 
-        self.logger.info("Typing the article creator username inside the 'Users' field and "
-                         "verifying that the article is not displayed")
-        self.sumo_pages.recent_revisions_page._fill_in_users_field(username)
+        with allure.step("Clearing the user search field and signing in back with the admin "
+                         "account"):
+            self.sumo_pages.recent_revisions_page._clearing_the_user_field()
+            self.logger.info("Signing back in with the admin account")
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.wait_for_given_timeout(2000)
+        with allure.step("Navigating to the article page and deleting it"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
-        expect(
-            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
-                article_details['article_title']
-            )
-        ).to_be_hidden()
-
-        self.logger.info("Clearing the user search field")
-        self.sumo_pages.recent_revisions_page._clearing_the_user_field()
-
-        self.logger.info("Signing in with a different user account")
-        self.username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
-        )
-
-        self.logger.info("Verifying that the revision is not displayed")
-        expect(
-            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
-                article_details['article_title']
-            )
-        ).to_be_hidden()
-
-        self.logger.info("Typing the article creator username inside the 'Users' field and "
-                         "verifying that the article is not displayed")
-        self.sumo_pages.recent_revisions_page._fill_in_users_field(username)
-        self.wait_for_given_timeout(2000)
-
-        expect(
-            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
-                article_details['article_title']
-            )
-        ).to_be_hidden()
-
-        self.logger.info("Clearing the user search field")
-        self.sumo_pages.recent_revisions_page._clearing_the_user_field()
-
-        self.logger.info("Signing back in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Navigating to the article page and deleting it")
-        self.navigate_to_link(article_url)
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
-
-        self.logger.info("Navigating back to the recent revisions page and verifying that the "
-                         "article is no longer displayed")
-
-        self.logger.info("Navigating to the recent revisions dashboard")
-        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
-
-        self.logger.info("Verifying that the posted article is no longer displayed for admin "
-                         "accounts")
-        expect(
-            self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article_locator(
-                article_details['article_title']
-            )
-        ).to_be_hidden()
+        with allure.step("Navigating back to the recent revisions page and verifying that the "
+                         "article is no longer displayed"):
+            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_details['article_title']
+                )
+            ).to_be_hidden()
 
     # C2266240
     @pytest.mark.recentRevisionsDashboard
     def test_second_revisions_availability(self):
-        self.logger.info("Signing back in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing back in with the admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new kb article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Clicking on the 'Review' option")
-        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
-            revision_id
-        )
+        with allure.step("Approving the article revision"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Click on 'Approve Revision' button")
-        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
-
-        self.logger.info("Clicking on the 'Accept' button")
-        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
-
-        self.logger.info("Signing in with a non admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.logger.info("Signing in with a non admin account")
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
 
         username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Creating a new revision for the article")
-        second_revision_details = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
+        with allure.step("Creating a new revision for the article"):
+            second_revision = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
 
-        self.logger.info("Navigating to the Recent Revisions dashboard and verifying that own "
-                         "revision is visible")
-        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
-        expect(
-            self.sumo_pages.recent_revisions_page.
-            _get_recent_revision_based_on_article_title_and_user(
-                article_details['article_title'], username
+        with allure.step("Navigating to the Recent Revisions dashboard and verifying that own "
+                         "revision is visible"):
+            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            expect(
+                self.sumo_pages.recent_revisions_page.
+                _get_recent_revision_based_on_article_title_and_user(
+                    article_details['article_title'], username
+                )
+            ).to_be_visible()
+
+        with allure.step("Deleting user session and verifying that the recent revision is "
+                         "displayed"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.recent_revisions_page.
+                _get_recent_revision_based_on_article_title_and_user(
+                    article_details['article_title'], username
+                )
+            ).to_be_visible()
+
+        with allure.step("Signing in with a different non-admin user and verifying that the "
+                         "revision is displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+            ))
+            expect(
+                self.sumo_pages.recent_revisions_page.
+                _get_recent_revision_based_on_article_title_and_user(
+                    article_details['article_title'], username
+                )
+            ).to_be_visible()
+
+        with allure.step("Signing in with an admin account and verifying that the revision is "
+                         "displayed"):
+            self.delete_cookies()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            expect(
+                self.sumo_pages.recent_revisions_page.
+                _get_recent_revision_based_on_article_title_and_user(
+                    article_details['article_title'], username
+                )
+            ).to_be_visible()
+
+        with allure.step("Navigating to the article and approving the revision"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+                second_revision['revision_id']
             )
-        ).to_be_visible()
+            self.wait_for_given_timeout(1000)
 
-        self.logger.info("Deleting user session and verifying that the recent revision is "
-                         "displayed")
-        self.delete_cookies()
-        expect(
-            self.sumo_pages.recent_revisions_page.
-            _get_recent_revision_based_on_article_title_and_user(
-                article_details['article_title'], username
-            )
-        ).to_be_visible()
+        with allure.step("Signing out and verifying that the revision is displayed inside the "
+                         "Recent Revisions dashboard"):
+            self.delete_cookies()
+            self.navigate_to_link(self.general_test_data['dashboard_links']['recent_revisions'])
+            expect(
+                self.sumo_pages.recent_revisions_page.
+                _get_recent_revision_based_on_article_title_and_user(
+                    article_details['article_title'], username
+                )
+            ).to_be_visible()
 
-        self.logger.info("Signing in with a different non-admin user and verifying that the "
-                         "revision is displayed")
-        self.username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
-        )
-        expect(
-            self.sumo_pages.recent_revisions_page.
-            _get_recent_revision_based_on_article_title_and_user(
-                article_details['article_title'], username
-            )
-        ).to_be_visible()
+        with allure.step("Signing in with a different non-admin user account and verifying that "
+                         "the revision is visible"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+            ))
+            expect(
+                self.sumo_pages.recent_revisions_page.
+                _get_recent_revision_based_on_article_title_and_user(
+                    article_details['article_title'], username
+                )
+            ).to_be_visible()
 
-        self.logger.info("Signing in with an admin account and verifying that the revision is "
-                         "displayed")
+        with allure.step("Signing back in with an admin account an deleting the article"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        expect(
-            self.sumo_pages.recent_revisions_page.
-            _get_recent_revision_based_on_article_title_and_user(
-                article_details['article_title'], username
-            )
-        ).to_be_visible()
+        with allure.step("Navigating back to the recent revision dashboard, signing out and "
+                         "verifying that the revision is no longer displayed for the deleted kb "
+                         "article"):
+            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            self.wait_for_given_timeout(1000)
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.recent_revisions_page.
+                _get_recent_revision_based_on_article_title_and_user(
+                    article_details['article_title'], username
+                )
+            ).to_be_hidden()
 
-        self.logger.info("Navigating to the article and approving the revision")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Clicking on the 'Review' option")
-        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
-            second_revision_details['revision_id']
-        )
-
-        self.logger.info("Click on 'Approve Revision' button")
-        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
-
-        self.logger.info("Clicking on the 'Accept' button")
-        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
-        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
-
-        expect(
-            self.page
-        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
-
-        self.logger.info("Signing out and verifying that the revision is displayed inside the "
-                         "Recent Revisions dashboard")
-        self.delete_cookies()
-        expect(
-            self.sumo_pages.recent_revisions_page.
-            _get_recent_revision_based_on_article_title_and_user(
-                article_details['article_title'], username
-            )
-        ).to_be_visible()
-
-        self.logger.info("Signing in with a different non-admin user account and verifying that "
-                         "the revision is visible")
-        self.username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
-        )
-        expect(
-            self.sumo_pages.recent_revisions_page.
-            _get_recent_revision_based_on_article_title_and_user(
-                article_details['article_title'], username
-            )
-        ).to_be_visible()
-
-        self.logger.info("Signing back in with an admin account and deleting the article")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Navigating to the article page and deleting it")
-        self.navigate_to_link(article_url)
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
-        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
-
-        expect(
-            self.page
-        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
-
-        self.logger.info("Signing out and and verifying that the revision is no longer displayed "
-                         "inside the Recent Revisions dashboard")
-        self.delete_cookies()
-        expect(
-            self.sumo_pages.recent_revisions_page.
-            _get_recent_revision_based_on_article_title_and_user(
-                article_details['article_title'], username
-            )
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with a different non-admin user account and verifying that "
-                         "the revision is not visible")
-        self.username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
-        )
-        expect(
-            self.sumo_pages.recent_revisions_page.
-            _get_recent_revision_based_on_article_title_and_user(
-                article_details['article_title'], username
-            )
-        ).to_be_hidden()
+        with allure.step("Signing in with a different non-admin account and verifying that the "
+                         "revision is no longer displayed for the deleted kb article"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+            ))
+            expect(
+                self.sumo_pages.recent_revisions_page.
+                _get_recent_revision_based_on_article_title_and_user(
+                    article_details['article_title'], username
+                )
+            ).to_be_hidden()
 
     # C2266240
     @pytest.mark.recentRevisionsDashboard
     def test_recent_revisions_dashboard_links(self):
-        self.logger.info("Signing back in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
         first_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new kb article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         self.sumo_pages.kb_article_page._click_on_article_option()
         article_url = self.get_page_url()
 
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
+        with allure.step("Approving the first revision"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        with allure.step("Navigating to the recent revisions dahsboard and verifying that the "
+                         "'Show Diff' option is not available for first revisions"):
+            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            self.wait_for_given_timeout(3000)
+            expect(
+                self.sumo_pages.recent_revisions_page._get_show_diff_article_locator(
+                    article_title=article_details['article_title'], creator=first_username
+                )
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on the 'Review' option")
-        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
-            revision_id
-        )
-
-        self.logger.info("Click on 'Approve Revision' button")
-        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
-
-        self.logger.info("Clicking on the 'Accept' button")
-        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
-
-        self.logger.info("Navigating to the recent revisions dashboard")
-        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
-
-        expect(
-            self.page
-        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
-
-        self.logger.info("Verifying that the Show Diff option is not available for first revision")
-        expect(
-            self.sumo_pages.recent_revisions_page._get_show_diff_article_locator(
-                article_title=article_details['article_title'], creator=first_username
-            )
-        ).to_be_hidden()
-
-        self.navigate_to_link(article_url)
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-        username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
-
-        self.logger.info("Creating a new revision for the article")
-        second_revision_details = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
-
-        self.logger.info("Navigating to the Recent Revisions dashboard")
-        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
-
-        expect(
-            self.page
-        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
-
-        self.logger.info("Signing out from SUMO")
-        self.delete_cookies()
-
-        self.logger.info("Clicking on the revision date link")
-        self.sumo_pages.recent_revisions_page._click_on_revision_date_for_article(
-            article_title=article_details['article_title'], username=username
-        )
-
-        self.logger.info("Verifying that the user is redirected to the correct page")
-        expect(
-            self.page
-        ).to_have_url(
-            article_url + KBArticleRevision.
-            KB_REVISION_PREVIEW + str(self.number_extraction_from_string(
-                second_revision_details['revision_id']
+        with allure.step("Navigating to the article page, signing in with a non-admin user and "
+                         "creating a new revision for the article"):
+            self.navigate_to_link(article_url)
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
             ))
-        )
+            username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+            second_revision = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
 
-        self.logger.info("Verifying that the revision id is the correct one")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_id_text(),
-            str(self.number_extraction_from_string(second_revision_details['revision_id']))
-        )
-
-        self.logger.info("Navigating back")
-        self.navigate_back()
-
-        self.logger.info("Clicking on the revision title")
-        self.sumo_pages.recent_revisions_page._click_on_article_title(
-            article_title=article_details['article_title'], creator=username
-        )
-
-        self.logger.info("Verifying that the user is redirected to the article title")
-        expect(
-            self.page
-        ).to_have_url(article_url)
-
-        self.logger.info("Navigating back")
-        self.navigate_back()
-
-        self.logger.info("Verifying that the correct comment is displayed")
-        check.equal(
-            self.sumo_pages.recent_revisions_page._get_revision_comment(
+        with allure.step("Navigating to the recent revisions dashboard, signing out and clicking "
+                         "on the revision date link and verifying that the user is redirected to"
+                         "the correct page"):
+            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            self.wait_for_given_timeout(3000)
+            self.delete_cookies()
+            self.sumo_pages.recent_revisions_page._click_on_revision_date_for_article(
                 article_title=article_details['article_title'], username=username
-            ),
-            self.kb_article_test_data['changes_description']
-        )
+            )
+            expect(
+                self.page
+            ).to_have_url(
+                article_url + KBArticleRevision.
+                KB_REVISION_PREVIEW + str(self.number_extraction_from_string(
+                    second_revision['revision_id']
+                ))
+            )
 
-        self.logger.info("Clicking on the editor")
-        self.sumo_pages.recent_revisions_page._click_article_creator_link(
-            article_title=article_details['article_title'], creator=username
-        )
+        with check, allure.step("Verifying that the revision id is the correct one"):
+            assert self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_id_text(
+            ) == str(self.number_extraction_from_string(second_revision['revision_id']))
 
-        self.logger.info("Verifying that the user was redirected to the correct user page")
-        expect(
-            self.page
-        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username))
+        with allure.step("Navigating back, clicking on the revision title and verifying that the "
+                         "user is redirected to the article page"):
+            self.navigate_back()
+            self.sumo_pages.recent_revisions_page._click_on_article_title(
+                article_title=article_details['article_title'], creator=username
+            )
+            expect(
+                self.page
+            ).to_have_url(article_url)
 
-        self.logger.info("Navigating back")
-        self.navigate_back()
+        with check, allure.step("Navigating back and verifying that the correct comment is "
+                                "displayed"):
+            self.navigate_back()
+            assert self.sumo_pages.recent_revisions_page._get_revision_comment(
+                article_title=article_details['article_title'], username=username
+            ) == self.kb_article_test_data['changes_description']
 
-        self.logger.info("Clicking on show diff option")
-        self.sumo_pages.recent_revisions_page._click_on_show_diff_for_article(
-            article_title=article_details['article_title'], creator=username
-        )
+        with allure.step("Clicking on the editor and verifying that the user was redirected to "
+                         "the correct page"):
+            self.sumo_pages.recent_revisions_page._click_article_creator_link(
+                article_title=article_details['article_title'], creator=username
+            )
+            expect(
+                self.page
+            ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username))
 
-        self.logger.info("Verifying that the diff section is displayed")
-        expect(
-            self.sumo_pages.recent_revisions_page._get_diff_section_locator()
-        ).to_be_visible()
+        with allure.step("Navigating back, clicking on the show diff option and verifying that"
+                         "diff section is displayed"):
+            self.navigate_back()
+            self.sumo_pages.recent_revisions_page._click_on_show_diff_for_article(
+                article_title=article_details['article_title'], creator=username
+            )
+            expect(
+                self.sumo_pages.recent_revisions_page._get_diff_section_locator()
+            ).to_be_visible()
 
-        self.logger.info("Hiding the diff")
-        self.sumo_pages.recent_revisions_page._click_on_hide_diff_for_article(
-            article_title=article_details['article_title'], creator=username
-        )
+        with allure.step("Hiding the diff and verifying that the diff section is not displayed"):
+            self.sumo_pages.recent_revisions_page._click_on_hide_diff_for_article(
+                article_title=article_details['article_title'], creator=username
+            )
+            expect(
+                self.sumo_pages.recent_revisions_page._get_diff_section_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the diff section is not displayed")
-        expect(
-            self.sumo_pages.recent_revisions_page._get_diff_section_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Navigating back to the article page")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.logger.info("Clicking on the 'Delete article' button")
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-
-        self.logger.info("Clicking on the 'Delete' button")
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+        with allure.step("Signing in with an admin account and deleting the article"):
+            self.logger.info("Signing in with an admin account")
+            self.delete_cookies()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.logger.info("Navigating back to the article page")
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2266240
     @pytest.mark.recentRevisionsDashboard
     def test_recent_revisions_dashboard_title_and_username_update(self):
-        self.logger.info("Signing back in with the admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing back in with the admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
         first_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new kb article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         self.sumo_pages.kb_article_page._click_on_article_option()
         article_url = self.get_page_url()
 
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
+        with allure.step("Approving the first article revision"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        with allure.step("Changing the article title via the 'Edit Article Metadata' page"):
+            self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(
+                title=self.kb_article_test_data['updated_kb_article_title'] + article_details
+                ['article_title']
+            )
 
-        self.logger.info("Clicking on the 'Review' option")
-        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
-            revision_id
-        )
-
-        self.logger.info("Click on 'Approve Revision' button")
-        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
-
-        self.logger.info("Clicking on the 'Accept' button")
-        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
-
-        self.logger.info("Clicking on the 'Edit Article Metadata' option")
-        self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
-
-        self.sumo_pages.kb_article_edit_article_metadata_page._add_text_to_title_field(
-            self.kb_article_test_data['updated_kb_article_title'] + article_details
-            ['article_title']
-        )
-
-        self.logger.info("Clicking on the 'Save' button")
-        self.sumo_pages.kb_article_edit_article_metadata_page._click_on_save_changes_button()
-
-        self.logger.info("Editing the username")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-
-        new_username = self.profile_edit_test_data['valid_user_edit']['username']
-        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(
-            new_username
-        )
-
-        self.logger.info("Clicking on the 'Update My Profile' button")
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
-
-        self.logger.info("Navigating to the recent revisions dashboard")
-        self.sumo_pages.top_navbar._click_on_recent_revisions_option()
-
-        expect(
-            self.page
-        ).to_have_url(self.general_test_data['dashboard_links']['recent_revisions'])
-
-        expect(
-            self.sumo_pages.recent_revisions_page._get_revision_and_username_locator(
-                self.kb_article_test_data['updated_kb_article_title'] + article_details
-                ['article_title'],
+        with allure.step("Editing the username"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            new_username = self.profile_edit_test_data['valid_user_edit']['username']
+            self.sumo_pages.edit_my_profile_page._send_text_to_username_field(
                 new_username
             )
-        ).to_be_visible()
+            self.logger.info("Clicking on the 'Update My Profile' button")
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Editing the username back")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Navigating to the recent revisions dashboard and verifying that the "
+                         "correct new username and article title arte displayed"):
+            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            self.wait_for_given_timeout(3000)
+            expect(
+                self.sumo_pages.recent_revisions_page._get_revision_and_username_locator(
+                    article_title=self.kb_article_test_data
+                    ['updated_kb_article_title'] + article_details['article_title'],
+                    username=new_username
+                )
+            ).to_be_visible()
 
-        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(
-            first_username
-        )
+        with allure.step("Changing the username back"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._send_text_to_username_field(
+                first_username
+            )
+            self.logger.info("Clicking on the 'Update My Profile' button")
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Clicking on the 'Update My Profile' button")
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
-
-        self.logger.info("Deleting the article")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.logger.info("Clicking on the 'Delete article' button")
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-
-        self.logger.info("Clicking on the 'Delete' button")
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+        with allure.step("Deleting the article"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2266241
     @pytest.mark.recentRevisionsDashboard
     def test_recent_revisions_dashboard_filters(self):
         start_date = "04052023"
         end_date = "05012023"
-        self.logger.info("Navigating to the 'Recent Revisions' dashboard")
-        self.navigate_to_link(
-            self.general_test_data['dashboard_links']['recent_revisions']
-        )
-
-        self.logger.info("Selecting the ro locale from the locale filter")
-        self.sumo_pages.recent_revisions_page._select_locale_option("ro")
-
-        self.wait_for_given_timeout(3000)
-
-        self.logger.info("Verifying that all the displayed revisions are for the 'ro' locale")
-        for tag in self.sumo_pages.recent_revisions_page._get_list_of_all_locale_tage():
-            check.equal(
-                tag,
-                "ro"
+        with allure.step("Navigating to the 'Recent Revisions' dashboard"):
+            self.navigate_to_link(
+                self.general_test_data['dashboard_links']['recent_revisions']
             )
 
-        self.logger.info("Select the US filter")
-        self.sumo_pages.recent_revisions_page._select_locale_option("en-US")
+        with check, allure.step("Selecting the ro locale from the locale filter and verifying "
+                                "that all the displayed revisions are for the 'ro' locale"):
+            self.sumo_pages.recent_revisions_page._select_locale_option("ro")
+            self.wait_for_given_timeout(3000)
+            for tag in self.sumo_pages.recent_revisions_page._get_list_of_all_locale_tage():
+                assert tag == "ro"
 
-        self.wait_for_given_timeout(3000)
-
-        self.logger.info("Typing a username inside the 'Users' filter")
-        username = self.username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        )
-
-        self.sumo_pages.recent_revisions_page._fill_in_users_field(username)
-
-        self.wait_for_given_timeout(2000)
-
-        self.logger.info("Verifying that all the displayed revisions are for the posted user")
-        for user in self.sumo_pages.recent_revisions_page._get_list_of_all_editors():
-            check.equal(
-                user,
-                username
+        with check, allure.step("Selecting the US filter, typing a username inside the 'Users' "
+                                "filter and verifying that all the displayed revisions are for "
+                                "the posted user"):
+            self.sumo_pages.recent_revisions_page._select_locale_option("en-US")
+            self.wait_for_given_timeout(3000)
+            username = self.username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
             )
+            self.sumo_pages.recent_revisions_page._fill_in_users_field(username)
+            self.wait_for_given_timeout(2000)
+            for user in self.sumo_pages.recent_revisions_page._get_list_of_all_editors():
+                assert user == username
 
-        self.sumo_pages.recent_revisions_page._clearing_the_user_field()
-        self.wait_for_given_timeout(2000)
+        with allure.step("Clearing the user filter, adding data inside the start and end fields"):
+            self.sumo_pages.recent_revisions_page._clearing_the_user_field()
+            self.wait_for_given_timeout(2000)
 
-        self.logger.info("Adding date inside the start field")
-        self.sumo_pages.recent_revisions_page._add_start_date("04052023")
+            self.logger.info("Adding date inside the start field")
+            self.sumo_pages.recent_revisions_page._add_start_date("04052023")
 
-        self.logger.info("Adding date inside the end field")
-        self.sumo_pages.recent_revisions_page._add_end_date("05012023")
+            self.logger.info("Adding date inside the end field")
+            self.sumo_pages.recent_revisions_page._add_end_date("05012023")
+            self.wait_for_given_timeout(2000)
 
-        self.wait_for_given_timeout(2000)
+        with check, allure.step("Verifying that the displayed revision dates are between ("
+                                "inclusive) the set start and end date filters"):
+            extracted_date = []
+            date_filters = [int(start_date), int(end_date)]
+            for date in self.sumo_pages.recent_revisions_page._get_all_revision_dates():
+                extracted_date.append(self.extract_date_to_digit_format(
+                    self.extract_month_day_year_from_string(date)
+                ))
 
-        self.logger.info("Verifying that the displayed revision dates are between (inclusive) "
-                         "the set start and end date filters")
-        extracted_date = []
-        date_filters = [int(start_date), int(end_date)]
-        for date in self.sumo_pages.recent_revisions_page._get_all_revision_dates():
-            extracted_date.append(self.extract_date_to_digit_format(
-                self.extract_month_day_year_from_string(date)
-            ))
-
-        for date in extracted_date:
-            check.between_equal(
-                date,
-                date_filters[0],
-                date_filters[1]
-            )
+            for date in extracted_date:
+                assert date_filters[0] <= date <= date_filters[1]

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
@@ -1,4 +1,5 @@
-import pytest_check as check
+import allure
+from pytest_check import check
 import pytest
 from playwright_tests.core.testutilities import TestUtilities
 from playwright.sync_api import expect
@@ -21,13 +22,13 @@ class TestKBArticleShowHistory(TestUtilities, KBArticleShowHistoryPageMessages):
     # C891309, C2102170,  C2102168, C2489545
     @pytest.mark.kbArticleShowHistory
     def test_kb_article_removal(self):
-        self.logger.info("Signing in with a normal account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
@@ -35,254 +36,216 @@ class TestKBArticleShowHistory(TestUtilities, KBArticleShowHistoryPageMessages):
         revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
         revision_id_number = self.number_extraction_from_string(revision_id)
 
-        self.logger.info("Verifying that the delete button is not available for the only revision")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
-                revision_id
-            )
-        ).to_be_hidden()
+        with allure.step("Verifying that the delete button is not available for the only kb "
+                         "revision"):
+            expect(
+                self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
+                    revision_id
+                )
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that manually navigating to the delete revision endpoint "
-                         "returns 403")
-        with self.page.expect_navigation() as navigation_info:
+        with check, allure.step("Verifying that manually navigating to the delete revision "
+                                "endpoint returns 403"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(super().get_delete_revision_endpoint(
+                    article_details["article_slug"], revision_id_number
+                ))
+                response = navigation_info.value
+                assert response.status == 403
+
+        with allure.step("Navigating back and verifying that the delete button for the article "
+                         "is not displayed"):
+            self.navigate_to_link(article_url)
+            expect(
+                self.sumo_pages.kb_article_show_history_page
+                ._get_delete_this_document_button_locator()
+            ).to_be_hidden()
+
+        with check, allure.step("Verifying that manually navigating to the delete endpoint "
+                                "returns 403"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    KBArticlePageMessages
+                    .KB_ARTICLE_PAGE_URL + article_details['article_slug'] + QuestionPageMessages
+                    .DELETE_QUESTION_URL_ENDPOINT
+                )
+                response = navigation_info.value
+                assert response.status == 403
+
+        with allure.step("Navigating back and deleting the user session"):
+            self.navigate_to_link(article_url)
+            self.delete_cookies()
+
+        with check, allure.step("Manually navigating to the delete revision endpoint and "
+                                "verifying that the auth page is returned"):
             self.navigate_to_link(super().get_delete_revision_endpoint(
                 article_details["article_slug"], revision_id_number
             ))
-            response = navigation_info.value
-            check.equal(
-                response.status,
-                403
-            )
+            assert FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
 
-        self.logger.info("Navigating back")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Verifying that the delete button for the article is not displayed")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that manually navigating to the delete endpoint returns 403")
-        with self.page.expect_navigation() as navigation_info:
+        with check, allure.step("Navigating back and verifying that manually navigating to the "
+                                "delete endpoint returns the auth page"):
+            self.navigate_to_link(article_url)
             self.navigate_to_link(
                 KBArticlePageMessages
                 .KB_ARTICLE_PAGE_URL + article_details['article_slug'] + QuestionPageMessages
                 .DELETE_QUESTION_URL_ENDPOINT
             )
-            response = navigation_info.value
-            check.equal(
-                response.status,
-                403
-            )
+            assert FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
 
-        self.logger.info("Navigating back")
-        self.navigate_to_link(article_url)
+        with allure.step("Navigating back and verifying that the delete button is not available "
+                         "for the only revision"):
+            self.navigate_to_link(article_url)
+            expect(
+                self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
+                    revision_id
+                )
+            ).to_be_hidden()
 
-        self.logger.info("Delete user session")
-        self.delete_cookies()
+        with allure.step("Verifying that the delete button for the article is not displayed"):
+            expect(
+                self.sumo_pages.kb_article_show_history_page
+                ._get_delete_this_document_button_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Manually navigating to the delete revision endpoint and verifying that "
-                         "the auth page is returned")
-        self.navigate_to_link(super().get_delete_revision_endpoint(
-            article_details["article_slug"], revision_id_number
-        ))
+        with allure.step("Signing in with an admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        check.is_true(
-            FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
-        )
-        self.logger.info("Navigating back")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Verifying that manually navigating to the delete endpoint returns the "
-                         "auth page")
-        self.navigate_to_link(
-            KBArticlePageMessages
-            .KB_ARTICLE_PAGE_URL + article_details['article_slug'] + QuestionPageMessages
-            .DELETE_QUESTION_URL_ENDPOINT
-        )
-
-        check.is_true(
-            FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
-        )
-
-        self.logger.info("Navigating back")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Verifying that the delete button is not available for the only revision")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
+        with check, allure.step("Clicking on the delete revision button for the only available "
+                                "revision and verifying that the correct 'Unable to delete the "
+                                "revision' page header"):
+            self.sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(
                 revision_id
             )
-        ).to_be_hidden()
+            assert (self.sumo_pages.kb_article_show_history_page
+                    ._get_unable_to_delete_revision_header(
+                    ) == KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER)
 
-        self.logger.info("Verifying that the delete button for the article is not displayed")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator()
-        ).to_be_hidden()
+        with check, allure.step("Verifying that the correct 'Unable to delete the revision' page "
+                                "sub-header is displayed"):
+            assert (self.sumo_pages.kb_article_show_history_page
+                    ._get_unable_to_delete_revision_subheader() == KBArticleRevision.
+                    KB_REVISION_CANNOT_DELETE_ONLY_REVISION_SUBHEADER)
 
-        self.logger.info("Signing in with a admin user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the delete revision button for the only available revision")
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(revision_id)
-
-        self.logger.info("Verifying that the correct 'Unable to delete the revision' page header")
-        check.equal(
-            self.sumo_pages.kb_article_show_history_page._get_unable_to_delete_revision_header(),
-            KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER
-        )
-
-        self.logger.info("Verifying that the correct 'Unable to delete the revision' page "
-                         "subheader")
-        check.equal(
-            self.sumo_pages.kb_article_show_history_page.
-            _get_unable_to_delete_revision_subheader(),
-            KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_SUBHEADER
-        )
-
-        self.logger.info("Clicking on the 'Go back to document history button'")
-        self.sumo_pages.kb_article_show_history_page._click_go_back_to_document_history_option()
-
-        self.logger.info("Verifying that we are redirected to the document history page")
-        expect(
-            self.page
-        ).to_have_url(
-            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
-            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the 'Delete article' button")
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-
-        self.logger.info("Clicking on the cancel button")
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_cancel_button()
-
-        self.logger.info("Verifying that we are back on the show history page for the article")
-        expect(
-            self.page
-        ).to_have_url(
-            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
-            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
-        )
-
-        self.logger.info("Deleting the article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
-
-        self.logger.info("Verifying that the article was successfully deleted by navigating to "
-                         "the article")
-
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details['article_slug'] + "/"
+        with allure.step("Clicking on the 'Go back to document history button' and verifying "
+                         "that we are redirected to the document history page"):
+            self.sumo_pages.kb_article_show_history_page._click_go_back_to_document_history_option(
             )
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            404
-        )
+            expect(
+                self.page
+            ).to_have_url(
+                KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
+                ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
+            )
+
+        with allure.step("Clicking on the 'Delete article' button, canceling the confirmation "
+                         "modal and verifying that we are back on the show history page for the "
+                         "article"):
+            self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
+            self.sumo_pages.kb_article_show_history_page._click_on_confirmation_cancel_button()
+            expect(
+                self.page
+            ).to_have_url(
+                KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
+                ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
+            )
+
+        with check, allure.step("Deleting the article, navigating to the article and verifying "
+                                "that the article was successfully deleted"):
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    KBArticlePageMessages.
+                    KB_ARTICLE_PAGE_URL + article_details['article_slug'] + "/"
+                )
+            response = navigation_info.value
+            assert response.status == 404
 
     # C2490047, C2490048
     @pytest.mark.kbArticleShowHistory
     def test_kb_article_category_link_and_header(self):
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
         for category in self.general_test_data["kb_article_categories"]:
 
             if category != "Templates":
-                self.logger.info("Create a new article")
-                article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-                    article_category=category
-                )
+                with allure.step("Creating a new article"):
+                    article_info = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                        article_category=category
+                    )
             else:
-                self.logger.info("Create a new article")
-                article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-                    article_category=category,
-                    is_template=True
-                )
+                with allure.step("Creating a new template article"):
+                    article_info = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                        article_category=category,
+                        is_template=True
+                    )
 
-            self.logger.info("Verifying that the correct page header is displayed")
-            check.equal(
-                self.sumo_pages.kb_article_show_history_page._get_show_history_page_title(),
-                KBArticleShowHistoryPageMessages.PAGE_TITLE + article_details["article_title"]
-            )
+            with check, allure.step("Verifying that the correct page header is displayed"):
+                assert self.sumo_pages.kb_article_show_history_page._get_show_history_page_title(
+                ) == KBArticleShowHistoryPageMessages.PAGE_TITLE + article_info["article_title"]
 
-            self.logger.info("Verifying that the correct category is displayed inside the 'Show "
-                             "History' page")
-            check.equal(
-                self.sumo_pages.kb_article_show_history_page._get_show_history_category_text(),
-                category
-            )
+            with check, allure.step("Verifying that the correct category is displayed inside the "
+                                    "'Show History' page"):
+                assert (self.sumo_pages.kb_article_show_history_page
+                        ._get_show_history_category_text() == category)
 
-            self.logger.info("Verifying that the correct revision history for locale is displayed")
-            check.equal(
-                self.sumo_pages.kb_article_show_history_page.
-                _get_show_history_revision_for_locale_text(),
-                KBArticleShowHistoryPageMessages.DEFAULT_REVISION_FOR_LOCALE
-            )
+            with check, allure.step("Verifying that the correct revision history for locale is "
+                                    "displayed"):
+                assert (self.sumo_pages.
+                        kb_article_show_history_page._get_show_history_revision_for_locale_text(
+                        ) == KBArticleShowHistoryPageMessages.DEFAULT_REVISION_FOR_LOCALE)
 
-            self.logger.info("Clicking on the 'Category' link")
-            self.sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+            with allure.step("Clicking on the 'Category' link and verifying that the user is "
+                             "redirected to the correct page"):
+                self.sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+                expect(
+                    self.page
+                ).to_have_url(self.different_endpoints['kb_categories_links'][category])
 
-            self.logger.info("Verifying that the user is redirected to the correct page")
-            expect(
-                self.page
-            ).to_have_url(self.different_endpoints['kb_categories_links'][category])
-
-            self.logger.info("Navigating back")
-            self.navigate_back()
-
-            self.logger.info("Deleting the article")
-            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+            with allure.step("Navigating back and deleting the article"):
+                self.navigate_back()
+                self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2101637, C2489543, C2102169
     @pytest.mark.kbArticleShowHistory
     def test_kb_article_contributor_removal(self):
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Create a new simple article")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         article_url = self.get_page_url()
 
-        self.logger.info("Verifying that no users are added inside the contributors list")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_all_contributors_locator()
-        ).to_be_hidden()
+        with allure.step("Verifying that no users are added inside the contributors list"):
+            expect(
+                self.sumo_pages.kb_article_show_history_page._get_all_contributors_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on the Article menu option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
+        with check, allure.step("Clicking on the Article menu option and verifying that the user "
+                                "is not displayed inside the article contributors section"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            assert (username_one not in self.sumo_pages.kb_article_page
+                    ._get_list_of_kb_article_contributors())
 
-        self.logger.info("Verifying that the user is not displayed inside the article "
-                         "contributors section")
-        check.is_not_in(
-            username_one,
-            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
-        )
+        with allure.step("Navigating back to the 'Show History page and approving the revision"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Navigating back to the 'Show History page'")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
-
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
-
-        self.logger.info("Verifying that the username which created the revision is added inside "
-                         "the 'Contributors' list")
-        check.is_in(
-            username_one,
-            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors(),
-        )
+        with check, allure.step("Verifying that the username which created the revision is added "
+                                "inside the 'Contributors' list"):
+            assert (username_one in self.sumo_pages.kb_article_show_history_page
+                    ._get_list_of_all_contributors())
 
         self.logger.info("Fetching the contributor id")
         self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
@@ -290,674 +253,538 @@ class TestKBArticleShowHistory(TestUtilities, KBArticleShowHistoryPageMessages):
          _click_on_delete_button_for_a_particular_contributor(username_one))
         deletion_link = self.get_page_url()
 
-        self.logger.info("Navigating back by hitting the cancel button")
-        (self.sumo_pages.kb_article_show_history_page.
-         _click_on_delete_contributor_confirmation_page_cancel_button())
+        with check, allure.step("Navigating back by hitting the cancel button. clicking on the "
+                                "Article menu option and verifying that the user is displayed "
+                                "inside the article contributors section"):
+            (self.sumo_pages.kb_article_show_history_page.
+             _click_on_delete_contributor_confirmation_page_cancel_button())
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            assert (username_one in self.sumo_pages.kb_article_page
+                    ._get_list_of_kb_article_contributors())
 
-        self.logger.info("Clicking on the Article menu option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
-
-        self.logger.info("Verifying that the user is displayed inside the article "
-                         "contributors section")
-        check.is_in(
-            username_one,
-            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
-        )
-
-        self.logger.info("Navigating back to the 'Show History page'")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Navigating back to the 'Show History page' and signing in with a "
+                         "non-admin account"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_two = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Creating a new revision for the document")
-        second_revision_details = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision(
-        )
-
-        self.logger.info("Verifying that the 'Edit Contributors' option is not displayed for "
-                         "users which don't have the necessary permissions")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_edit_contributors_option_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Manually navigating to the deletion link and verifying that 403 is "
-                         "returned")
-
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                deletion_link
+        with allure.step("Creating a new revision for the document and verifying that the 'Edit "
+                         "Contributors' option is not displayed for users which don't have the "
+                         "necessary permissions"):
+            second_revision_info = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision(
             )
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            403
-        )
+            expect(
+                self.sumo_pages.kb_article_show_history_page._get_edit_contributors_option_locator(
+                )).to_be_hidden()
 
-        self.logger.info("Navigating back")
-        self.navigate_to_link(article_url)
+        with check, allure.step("Manually navigating to the deletion link and verifying that 403 "
+                                "is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    deletion_link
+                )
+            response = navigation_info.value
+            assert response.status == 403
 
-        self.logger.info("Clicking on the Article menu option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
+        with check, allure.step("Navigating back, clicking on the Article menu and verifying "
+                                "that the user is not displayed inside the article contributors "
+                                "section"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            assert (username_two not in self.sumo_pages.kb_article_page.
+                    _get_list_of_kb_article_contributors())
 
-        self.logger.info("Verifying that the user is not displayed inside the article "
-                         "contributors section")
-        check.is_not_in(
-            username_two,
-            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
-        )
+        with allure.step("Navigating back to the 'Show History page', deleting the user session "
+                         "and verifying that the 'Edit Contributors' options is not displayed"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_article_show_history_page._get_edit_contributors_option_locator(
+                )).to_be_hidden()
 
-        self.logger.info("Navigating back to the 'Show History page'")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
+        with check, allure.step("Manually navigating to the deletion link and the user is "
+                                "redirected to the auth page"):
+            self.navigate_to_link(deletion_link)
+            assert FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with check, allure.step("Navigating back, signing in with a non-admin account and "
+                                "verifying that the username two is not displayed inside the "
+                                "Contributors list"):
+            self.navigate_to_link(article_url)
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            assert (username_two not in self.sumo_pages.kb_article_show_history_page
+                    ._get_list_of_all_contributors())
 
-        self.logger.info("Verifying that the 'Edit Contributors' option is not displayed for "
-                         "signed out users")
-        expect(
-            self.sumo_pages.kb_article_show_history_page._get_edit_contributors_option_locator()
-        ).to_be_hidden()
+        with check, allure.step("Approving the revision and verifying that the second username "
+                                "is displayed inside the Contributors list"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+                second_revision_info['revision_id']
+            )
+            assert (username_two in self.sumo_pages.kb_article_show_history_page
+                    ._get_list_of_all_contributors())
 
-        self.logger.info("Manually navigating to the deletion link and the user is redirected to "
-                         "the auth page")
+        with check, allure.step("Clicking on the Article menu and verifying that the user is "
+                                "displayed inside the article contributors section"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            assert (username_one in self.sumo_pages.kb_article_page
+                    ._get_list_of_kb_article_contributors())
 
-        self.navigate_to_link(deletion_link)
-        check.is_true(
-            FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
-        )
+        with allure.step("Clicking on the delete button for user two"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+            (self.sumo_pages.kb_article_show_history_page.
+             _click_on_delete_button_for_a_particular_contributor(username_two))
 
-        self.logger.info("Navigating back")
-        self.navigate_to_link(article_url)
+        with check, allure.step("Verifying that the correct delete contributor page header is "
+                                "displayed"):
+            assert (self.sumo_pages.kb_article_show_history_page
+                    ._get_delete_contributor_confirmation_page_header() == self
+                    .get_remove_contributor_page_header(username_two))
 
-        self.logger.info("Signing in with a normal account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with check, allure.step("Clicking on the 'Cancel' button and verifying that the second "
+                                "username is displayed inside the Contributors list"):
+            (self.sumo_pages.kb_article_show_history_page.
+             _click_on_delete_contributor_confirmation_page_cancel_button())
+            assert (username_two in self.sumo_pages.kb_article_show_history_page
+                    ._get_list_of_all_contributors())
 
-        self.logger.info("Verifying that the username two is not displayed inside the "
-                         "Contributors list")
-        check.is_not_in(
-            username_two,
-            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors()
-        )
+        with check, allure.step("Clicking on the Article menu option and verifying that the user "
+                                "is displayed inside the article contributors section"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            assert (username_one in self.sumo_pages.kb_article_page
+                    ._get_list_of_kb_article_contributors())
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
-            second_revision_details['revision_id']
-        )
+        with allure.step("Navigating back to the 'Show History' page and deleting the the second "
+                         "contributor"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+            (self.sumo_pages.kb_article_show_history_page.
+             _click_on_delete_button_for_a_particular_contributor(username_two))
+            (self.sumo_pages.kb_article_show_history_page.
+             _click_on_delete_contributor_confirmation_page_confirm_button())
 
-        self.logger.info("Verifying that second username is displayed inside the 'Contributors' "
-                         "list")
-        check.is_in(
-            username_two,
-            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors()
-        )
+        with check, allure.step("Verifying that the correct banner is displayed"):
+            assert self.sumo_pages.kb_article_show_history_page._get_show_history_page_banner(
+            ) == super().get_contributor_removed_message(username_two)
 
-        self.logger.info("Clicking on the Article menu option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
+        with check, allure.step("Verifying that second username is not displayed inside the "
+                                "'Contributors' list"):
+            assert (username_two not in self.sumo_pages.kb_article_show_history_page
+                    ._get_list_of_all_contributors())
 
-        self.logger.info("Verifying that the user is displayed inside the article "
-                         "contributors section")
-        check.is_in(
-            username_one,
-            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
-        )
+        with check, allure.step("Clicking on the Article menu and verifying that the user is not "
+                                "displayed inside the contributors section"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            assert (username_two not in self.sumo_pages.kb_article_page
+                    ._get_list_of_kb_article_contributors())
 
-        self.logger.info("Navigating back to the 'Show History page'")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.logger.info("Clicking on the 'Edit contributors' option")
-        self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
-
-        self.logger.info("Clicking on the delete button for user two")
-        (self.sumo_pages.kb_article_show_history_page.
-         _click_on_delete_button_for_a_particular_contributor(username_two))
-
-        self.logger.info("Verifying that the correct delete contributor page header is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_show_history_page.
-            _get_delete_contributor_confirmation_page_header(),
-            self.get_remove_contributor_page_header(username_two)
-        )
-
-        self.logger.info("Clicking on the 'Cancel' button")
-        (self.sumo_pages.kb_article_show_history_page.
-         _click_on_delete_contributor_confirmation_page_cancel_button())
-
-        self.logger.info("Verifying that second username is displayed inside the 'Contributors' "
-                         "list")
-        check.is_in(
-            username_two,
-            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors()
-        )
-
-        self.logger.info("Clicking on the Article menu option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
-
-        self.logger.info("Verifying that the user is displayed inside the article "
-                         "contributors section")
-        check.is_in(
-            username_one,
-            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
-        )
-
-        self.logger.info("Navigating back to the 'Show History page'")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.logger.info("Clicking on the 'Edit contributors' option")
-        self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
-
-        self.logger.info("Clicking on the delete button for user two")
-        (self.sumo_pages.kb_article_show_history_page.
-         _click_on_delete_button_for_a_particular_contributor(username_two))
-
-        self.logger.info("Clicking on the 'Remove contributor' button")
-        (self.sumo_pages.kb_article_show_history_page.
-         _click_on_delete_contributor_confirmation_page_confirm_button())
-
-        self.logger.info("Verifying that the correct banner is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_show_history_page._get_show_history_page_banner(),
-            super().get_contributor_removed_message(username_two)
-        )
-
-        self.logger.info("Verifying that second username is not displayed inside the "
-                         "'Contributors' list")
-        check.is_not_in(
-            username_two,
-            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors()
-        )
-
-        self.logger.info("Clicking on the Article menu option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
-
-        self.logger.info("Verifying that the user is not displayed inside the article "
-                         "contributors section")
-        check.is_not_in(
-            username_two,
-            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
-        )
-
-        self.logger.info("Deleting the article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the article"):
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2101638
     @pytest.mark.kbArticleShowHistory
     def test_contributors_can_be_manually_added(self):
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
         self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Create a new simple article")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Creating a new simple article"):
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
-        self.logger.info("Clicking on the 'Edit contributors' option")
-        self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+        with allure.step("Clicking on the 'Edit Contributors' option, adding and selecting the "
+                         "username from the search field"):
+            self.sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+            new_contributor = super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            )
+            (self.sumo_pages.kb_article_show_history_page.
+             _add_a_new_contributor_inside_the_contributor_field(new_contributor))
+            (self.sumo_pages.kb_article_show_history_page.
+             _click_on_new_contributor_search_result(new_contributor))
 
-        new_contributor = super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        )
+        with check, allure.step("Clicking on the 'Add Contributor' option and verifying that the "
+                                "correct banner is displayed"):
+            self.sumo_pages.kb_article_show_history_page._click_on_add_contributor_button()
+            assert self.sumo_pages.kb_article_show_history_page._get_show_history_page_banner(
+            ) == super().get_contributor_added_message(new_contributor)
 
-        self.logger.info("Adding and selecting the username from the search field")
-        (self.sumo_pages.kb_article_show_history_page.
-         _add_a_new_contributor_inside_the_contributor_field(new_contributor))
+        with check, allure.step("Verifying that the user was successfully added inside the "
+                                "contributors list"):
+            assert (new_contributor in self.sumo_pages.kb_article_show_history_page
+                    ._get_list_of_all_contributors())
 
-        (self.sumo_pages.kb_article_show_history_page.
-         _click_on_new_contributor_search_result(new_contributor))
+        with check, allure.step("Clicking on the Article menu option and verifying that the user "
+                                "is displayed inside the article contributors section"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            assert (new_contributor in self.sumo_pages.kb_article_page
+                    ._get_list_of_kb_article_contributors())
 
-        self.logger.info("Clicking on the 'Add Contributor' option")
-        self.sumo_pages.kb_article_show_history_page._click_on_add_contributor_button()
+        with allure.step("Deleting the created article"):
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
-        self.logger.info("Verifying that the correct banner is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_show_history_page._get_show_history_page_banner(),
-            super().get_contributor_added_message(new_contributor)
-        )
-
-        self.logger.info("Verifying that the user was successfully added inside the contributors "
-                         "list")
-        check.is_in(
-            new_contributor,
-            self.sumo_pages.kb_article_show_history_page._get_list_of_all_contributors(),
-        )
-
-        self.logger.info("Clicking on the Article menu option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
-
-        self.logger.info("Verifying that the user is displayed inside the article "
-                         "contributors section")
-        check.is_in(
-            new_contributor,
-            self.sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
-        )
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
-
-    # C2101634, C2489553
+    # C2101634, C2489553, C2102186
     @pytest.mark.kbArticleShowHistory
     def test_kb_article_contributor_profile_access(self):
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
         self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Create a new simple article")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
         self.sumo_pages.kb_article_page._click_on_article_option()
         article_url = self.get_page_url()
 
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
+        with allure.step("Approving the article revision"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
 
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-Admin account amd creating a new revision"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        username_two = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
+            username_two = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Creating a new revision for the document")
-        second_revision_details = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision(
-        )
+            second_revision_info = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision(
+            )
 
-        self.logger.info("Signing in with a normal account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
-            second_revision_details['revision_id']
-        )
+        with allure.step("Approving the revision and deleting the user session"):
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+                second_revision_info['revision_id']
+            )
+            self.delete_cookies()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
+        with allure.step("Clicking on the second contributor and verifying that we are "
+                         "redirected to it's profile page"):
+            (self.sumo_pages.kb_article_show_history_page._click_on_a_particular_contributor
+             (username_two)
+             )
+            expect(
+                self.page
+            ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
-        self.logger.info("Clicking on the second contributor and verifying that we are "
-                         "redirected to it's profile page")
-        (self.sumo_pages.kb_article_show_history_page._click_on_a_particular_contributor
-         (username_two)
-         )
+        with allure.step("Navigating back, clicking on the revision editor and verifying that we "
+                         "are redirected to the editor homepage"):
+            self.navigate_back()
+            self.sumo_pages.kb_article_show_history_page._click_on_a_particular_revision_editor(
+                second_revision_info['revision_id'], username_two
+            )
+            expect(
+                self.page
+            ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
-        expect(
-            self.page
-        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
+        with allure.step("Navigating back to the article main menu"):
+            self.navigate_to_link(
+                article_url
+            )
 
-        self.logger.info("Navigating back")
-        self.navigate_back()
+        with allure.step("Clicking on the contributor listed inside the article page and "
+                         "verifying that we are redirected to the editor homepage"):
+            self.sumo_pages.kb_article_page._click_on_a_particular_article_contributor(
+                username_two
+            )
+            expect(
+                self.page
+            ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
-        self.logger.info("Clicking on the revision editor")
-        self.sumo_pages.kb_article_show_history_page._click_on_a_particular_revision_editor(
-            second_revision_details['revision_id'], username_two
-        )
+        with allure.step("Navigating back and signin in with an admin account"):
+            self.navigate_back()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Verifying that we are redirected to the editor homepage")
-        expect(
-            self.page
-        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
+        with allure.step("Clicking on the Article menu option, clicking on the contributor "
+                         "listed inside the article page and verifying that we are redirected to "
+                         "the editor homepage"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            self.sumo_pages.kb_article_page._click_on_a_particular_article_contributor(
+                username_two
+            )
+            expect(
+                self.page
+            ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
-        self.logger.info("Navigating back")
-        self.navigate_back()
+        with allure.step("Navigating back to the article history, clicking on the second "
+                         "contributor and verifying that we are redirected to it's profile page"):
+            self.navigate_back()
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            (self.sumo_pages.kb_article_show_history_page._click_on_a_particular_contributor
+             (username_two)
+             )
+            expect(
+                self.page
+            ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
-        self.logger.info("Navigating to the article main menu")
-        self.navigate_to_link(
-            article_url
-        )
+        with allure.step("Navigating back and clicking on the revision editor"):
+            self.navigate_back()
+            self.sumo_pages.kb_article_show_history_page._click_on_a_particular_revision_editor(
+                second_revision_info['revision_id'], username_two
+            )
 
-        self.logger.info("Clicking on the contributor listed inside the article page")
-        self.sumo_pages.kb_article_page._click_on_a_particular_article_contributor(username_two)
+        with allure.step("Verifying that we are redirected to the editor homepage"):
+            expect(
+                self.page
+            ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
-        self.logger.info("Verifying that we are redirected to the editor homepage")
-        expect(
-            self.page
-        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
-
-        self.logger.info("Navigating back")
-        self.navigate_back()
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the Article menu option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
-
-        self.logger.info("Clicking on the contributor listed inside the article page")
-        self.sumo_pages.kb_article_page._click_on_a_particular_article_contributor(username_two)
-
-        self.logger.info("Verifying that we are redirected to the editor homepage")
-        expect(
-            self.page
-        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
-
-        self.logger.info("Navigating back")
-        self.navigate_back()
-
-        self.logger.info("Navigating to the show history page")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.logger.info("Clicking on the second contributor and verifying that we are "
-                         "redirected to it's profile page")
-        (self.sumo_pages.kb_article_show_history_page._click_on_a_particular_contributor
-         (username_two)
-         )
-
-        expect(
-            self.page
-        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
-
-        self.logger.info("Navigating back")
-        self.navigate_back()
-
-        self.logger.info("Clicking on the revision editor")
-        self.sumo_pages.kb_article_show_history_page._click_on_a_particular_revision_editor(
-            second_revision_details['revision_id'], username_two
-        )
-
-        self.logger.info("Verifying that we are redirected to the editor homepage")
-        expect(
-            self.page
-        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
-
-        self.logger.info("Navigating back")
-        self.navigate_back()
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Navigating back and deleting the created article"):
+            self.navigate_back()
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2499415
     @pytest.mark.kbArticleShowHistory
     def test_kb_article_revision_date_functionality(self):
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
         main_user = super().username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         )
 
-        self.logger.info("Create a new simple article")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article, clicking on the 'Show History' option and "
+                         "approving the revision"):
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            article_url = self.get_page_url()
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.sumo_pages.kb_article_page._click_on_article_option()
-        article_url = self.get_page_url()
+        with allure.step("Signing in with a non-admin account"):
+            creator_username = self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
+        with allure.step("Submitting a new revision"):
+            second_revision_info = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision(
+            )
 
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        with allure.step("Deleting the user session and clicking on the first revision"):
+            self.delete_cookies()
+            revision_time = self.sumo_pages.kb_article_show_history_page._get_revision_time(
+                second_revision_info['revision_id']
+            )
+            self.sumo_pages.kb_article_show_history_page._click_on_a_revision_date(revision_id)
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+        with check, allure.step("Verifying that the correct 'Is current revision?' text is "
+                                "displayed"):
+            assert self.sumo_pages.kb_article_preview_revision_page._get_is_current_revision_text(
+            ) == KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
 
-        self.logger.info("Signing in with a non-admin account")
-        creator_username = self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Navigating back and clicking on the revision time"):
+            self.navigate_back()
+            self.sumo_pages.kb_article_show_history_page._click_on_a_revision_date(
+                second_revision_info['revision_id']
+            )
 
-        self.logger.info("Submitting a new revision")
-        second_revision_details = self.sumo_pages.kb_article_revision_flow.submit_new_kb_revision()
+        with allure.step("Verifying that the revision information content is expanded by default"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page.
+                _get_revision_information_content_locator()
+            ).to_be_visible()
 
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-        revision_time = self.sumo_pages.kb_article_show_history_page._get_revision_time(
-            second_revision_details['revision_id']
-        )
+        with allure.step("Clicking on the 'Revision Information' foldout section and Verifying "
+                         "that the revision information content is collapsed/no longer displayed"):
+            (self.sumo_pages.kb_article_preview_revision_page.
+             _click_on_revision_information_foldout_section())
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page.
+                _get_revision_information_content_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on the first revision")
-        self.sumo_pages.kb_article_show_history_page._click_on_a_revision_date(revision_id)
+        with allure.step("Clicking on the 'Revision Information' foldout section"):
+            (self.sumo_pages.kb_article_preview_revision_page.
+             _click_on_revision_information_foldout_section())
 
-        self.logger.info("Verifying that the correct 'Is current revision?' text is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_is_current_revision_text(),
-            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
-        )
+        with allure.step("Verifying that the revision information content is displayed"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page.
+                _get_revision_information_content_locator()
+            ).to_be_visible()
 
-        self.logger.info("Navigating back")
-        self.navigate_back()
+        with check, allure.step("Verifying that the revision id is the correct one"):
+            assert self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_id_text(
+            ) == str(self.number_extraction_from_string(second_revision_info['revision_id']))
 
-        self.logger.info("Clicking on the revision time")
-        self.sumo_pages.kb_article_show_history_page._click_on_a_revision_date(
-            second_revision_details['revision_id']
-        )
+        with check, allure.step("Verifying that the correct revision time is displayed"):
+            assert (self.sumo_pages.kb_article_preview_revision_page
+                    ._get_preview_revision_created_date_text() == revision_time)
 
-        self.logger.info("Verifying that the revision information content is expanded by default")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_revision_information_content_locator()
-        ).to_be_visible()
+        with check, allure.step("Verifying that the correct creator is displayed"):
+            assert (self.sumo_pages.kb_article_preview_revision_page
+                    ._get_preview_revision_creator_text() == creator_username)
 
-        self.logger.info("Clicking on the 'Revision Information' foldout section")
-        (self.sumo_pages.kb_article_preview_revision_page.
-         _click_on_revision_information_foldout_section())
+        with allure.step("Clicking on the creator link and verifying that we are redirected to "
+                         "the username page"):
+            self.sumo_pages.kb_article_preview_revision_page._click_on_creator_link()
+            expect(
+                self.page
+            ).to_have_url(MyProfileMessages.get_my_profile_stage_url(creator_username))
 
-        self.logger.info("Verifying that the revision information content is collapsed/no longer "
-                         "displayed")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_revision_information_content_locator()
-        ).to_be_hidden()
+        with check, allure.step("Navigating back to the revision preview page and verifying that "
+                                "the correct review comment is displayed"):
+            self.navigate_back()
+            assert (self.sumo_pages.kb_article_preview_revision_page
+                    ._get_preview_revision_comment_text() == self
+                    .kb_article_test_data['changes_description'])
 
-        self.logger.info("Clicking on the 'Revision Information' foldout section")
-        (self.sumo_pages.kb_article_preview_revision_page.
-         _click_on_revision_information_foldout_section())
+        with check, allure.step("Verifying that the correct reviewed status is displayed"):
+            assert (self.sumo_pages.kb_article_preview_revision_page
+                    ._get_preview_revision_reviewed_text() == KBArticleRevision.
+                    KB_ARTICLE_REVISION_NO_STATUS)
 
-        self.logger.info("Verifying that the revision information content is displayed")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_revision_information_content_locator()
-        ).to_be_visible()
+        with allure.step("Verifying that the reviewed by locator is hidden"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page._get_reviewed_by_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the preview revision page contains the correct info "
-                         "inside the 'revision information' section")
+        with allure.step("Verifying that the is approved locator is hidden"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page._get_is_approved_text_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the revision id is the correct one")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_id_text(),
-            str(self.number_extraction_from_string(second_revision_details['revision_id']))
-        )
+        with allure.step("Verifying that the is current revision locator is hidden"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page._is_current_revision_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the correct revision time is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_preview_revision_created_date_text(),
-            revision_time
-        )
+        with check, allure.step("Verifying that the correct ready for localization locator is "
+                                "displayed"):
+            assert (self.sumo_pages.kb_article_preview_revision_page
+                    ._get_preview_revision_ready_for_localization_text() == KBArticleRevision.
+                    KB_ARTICLE_REVISION_NO_STATUS)
 
-        self.logger.info("Verifying that the correct creator is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_creator_text(),
-            creator_username
-        )
+        with allure.step("Verifying that the readied for localization by is hidden"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page
+                ._readied_for_localization_by_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on the creator link and verifying that we are redirected to "
-                         "the username page")
-        self.sumo_pages.kb_article_preview_revision_page._click_on_creator_link()
+        with allure.step("Verifying that the 'Edit article based on this revision' is not "
+                         "displayed"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page.
+                _get_edit_article_based_on_this_revision_link_locator()
+            ).to_be_hidden()
 
-        expect(
-            self.page
-        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(creator_username))
+        with allure.step("Verifying that the 'Revision Source' section is hidden by default"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page.
+                _get_preview_revision_source_textarea_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Navigating back to the revision preview page")
-        self.navigate_back()
+        with check, allure.step("Clicking on the 'Revision Source' foldout section option and "
+                                "verifying that the 'Revision Source' textarea contains the "
+                                "correct details"):
+            (self.sumo_pages.kb_article_preview_revision_page.
+             _click_on_revision_source_foldout_section())
+            assert (self.sumo_pages.kb_article_preview_revision_page
+                    ._get_preview_revision_source_textarea_content() == self.
+                    kb_article_test_data['updated_article_content'])
 
-        self.logger.info("Verifying that the correct review comment is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_comment_text(),
-            self.kb_article_test_data['changes_description']
-        )
+        with allure.step("Verifying that the 'Revision Content' section is hidden by default"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page
+                ._get_revision_content_html_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the correct reviewed status is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_reviewed_text(),
-            KBArticleRevision.KB_ARTICLE_REVISION_NO_STATUS
-        )
+        with allure.step("Clicking on the 'Revision Content' foldout option and verifying that "
+                         "the 'Revision Content' section is visible"):
+            (self.sumo_pages.kb_article_preview_revision_page.
+             _click_on_revision_content_foldout_section())
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page
+                ._get_revision_content_html_locator()
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the reviewed by locator is hidden")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page._get_reviewed_by_locator()
-        ).to_be_hidden()
+        with allure.step("Signing in with an admin account and approving the revision"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Verifying that the is approved locator is hidden")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page._get_is_approved_text_locator()
-        ).to_be_hidden()
+        with allure.step("Clicking on show history option and approving the second revision"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+                second_revision_info['revision_id'], ready_for_l10n=True)
 
-        self.logger.info("Verifying that the is current revision locator is hidden")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page._is_current_revision_locator()
-        ).to_be_hidden()
+        with check, allure.step("Deleting the user session, clicking on the revision time and "
+                                "verifying that the correct reviewed status is displayed"):
+            self.delete_cookies()
+            self.sumo_pages.kb_article_show_history_page._click_on_a_revision_date(
+                second_revision_info['revision_id']
+            )
+            assert (self.sumo_pages.kb_article_preview_revision_page
+                    ._get_preview_revision_reviewed_text() == KBArticleRevision
+                    .KB_ARTICLE_REVISION_YES_STATUS)
 
-        self.logger.info("Verifying that the correct ready for localization locator is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_preview_revision_ready_for_localization_text(),
-            KBArticleRevision.KB_ARTICLE_REVISION_NO_STATUS
-        )
+        with allure.step("Verifying that the reviewed by date is displayed"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page.
+                _get_preview_revision_reviewed_date_locator()
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the readied for localization by is hidden")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page._readied_for_localization_by_locator()
-        ).to_be_hidden()
+        with check, allure.step("Verifying that the correct 'Reviewed by' text is displayed"):
+            assert self.sumo_pages.kb_article_preview_revision_page._get_reviewed_by_text(
+            ) == main_user
 
-        self.logger.info("Verifying that the 'Edit article based on this revision' is not "
-                         "displayed")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_edit_article_based_on_this_revision_link_locator()
-        ).to_be_hidden()
+        with check, allure.step("Verifying that the correct is approved status displayed"):
+            assert self.sumo_pages.kb_article_preview_revision_page._get_is_approved_text(
+            ) == KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
 
-        self.logger.info("Verifying that the 'Revision Source' section is hidden by default")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_preview_revision_source_textarea_locator()
-        ).to_be_hidden()
+        with check, allure.step("Verifying that the correct is current revision status displayed"):
+            assert self.sumo_pages.kb_article_preview_revision_page._get_is_current_revision_text(
+            ) == KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
 
-        self.logger.info("Clicking on the 'Revision Source' foldout section option")
-        (self.sumo_pages.kb_article_preview_revision_page.
-         _click_on_revision_source_foldout_section())
+        with check, allure.step("Verifying that the correct is ready for localization status "
+                                "displayed"):
+            assert (self.sumo_pages.kb_article_preview_revision_page
+                    ._get_preview_revision_ready_for_localization_text() == KBArticleRevision.
+                    KB_ARTICLE_REVISION_YES_STATUS)
 
-        self.logger.info("Verifying that the 'Revision Source' textarea contains the correct "
-                         "details")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_preview_revision_source_textarea_content(),
-            self.kb_article_test_data['updated_article_content']
-        )
+        with allure.step("Verifying that the 'Readied for localization' date is displayed"):
+            expect(
+                self.sumo_pages.kb_article_preview_revision_page._ready_for_localization_date()
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the 'Revision Content' section is hidden by default")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page._get_revision_content_html_locator()
-        ).to_be_hidden()
+        with check, allure.step("Verifying that the correct localization by text is displayed"):
+            assert (self.sumo_pages.kb_article_preview_revision_page
+                    ._readied_for_localization_by_text() == main_user)
 
-        self.logger.info("Clicking on the 'Revision Content' foldout option")
-        (self.sumo_pages.kb_article_preview_revision_page.
-         _click_on_revision_content_foldout_section())
+        with allure.step("Signing in with an admin account and deleting the article"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Verifying that the 'Revision Content' section is visible")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page._get_revision_content_html_locator()
-        ).to_be_visible()
+        with allure.step("Clicking on the 'Edit article based on this revision option' and "
+                         "verifying that the correct link is displayed"):
+            (self.sumo_pages.kb_article_preview_revision_page.
+             _click_on_edit_article_based_on_this_revision_link())
+            expect(
+                self.page
+            ).to_have_url(
+                article_url + QuestionPageMessages.EDIT_QUESTION_URL_ENDPOINT + "/" + str(
+                    self.number_extraction_from_string(second_revision_info['revision_id']))
+            )
 
-        self.logger.info("Signing in with an admin account and approving the revision")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
-            second_revision_details['revision_id'], ready_for_l10n=True)
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
-        self.logger.info("Clicking on the revision time")
-        self.sumo_pages.kb_article_show_history_page._click_on_a_revision_date(
-            second_revision_details['revision_id']
-        )
-
-        self.logger.info("Verifying that the correct reviewed status is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_preview_revision_reviewed_text(),
-            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
-        )
-
-        self.logger.info("Verifying that the reviewed by date is displayed")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_preview_revision_reviewed_date_locator()
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the correct 'Reviewed by' text is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_reviewed_by_text(),
-            main_user
-        )
-
-        self.logger.info("Verifying that the correct is approved status displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_is_approved_text(),
-            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
-        )
-
-        self.logger.info("Verifying that the correct is current revision status displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._get_is_current_revision_text(),
-            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
-        )
-
-        self.logger.info("Verifying that the correct is ready for localization status displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page.
-            _get_preview_revision_ready_for_localization_text(),
-            KBArticleRevision.KB_ARTICLE_REVISION_YES_STATUS
-        )
-
-        self.logger.info("Verifying that the 'Readied for localization' date is displayed")
-        expect(
-            self.sumo_pages.kb_article_preview_revision_page._ready_for_localization_date()
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the correct localization by text is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_preview_revision_page._readied_for_localization_by_text(),
-            main_user
-        )
-
-        self.logger.info("Signing in with an admin account and deleting the article")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the 'Edit article based on this revision option'")
-        (self.sumo_pages.kb_article_preview_revision_page.
-         _click_on_edit_article_based_on_this_revision_link())
-
-        self.logger.info("Verifying that the correct link is displayed")
-        expect(
-            self.page
-        ).to_have_url(
-            article_url + QuestionPageMessages.EDIT_QUESTION_URL_ENDPOINT + "/" + str(
-                self.number_extraction_from_string(second_revision_details['revision_id']))
-        )
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the created article"):
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
@@ -1,6 +1,7 @@
+import allure
 import pytest
 from playwright.sync_api import expect
-import pytest_check as check
+from pytest_check import check
 from playwright_tests.core.testutilities import TestUtilities
 from playwright_tests.messages.explore_help_articles.kb_article_page_messages import (
     KBArticlePageMessages)
@@ -13,1201 +14,1103 @@ class TestArticleThreads(TestUtilities):
     # C2188031
     @pytest.mark.articleThreads
     def test_article_thread_field_validation(self):
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Manually navigating to the article endpoint")
-        self.navigate_to_link(TestArticleThreads.article_url)
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+        with allure.step("Manually navigating to the article endpoint and clicking on the "
+                         "'Discussion' editing tools navbar option"):
+            self.navigate_to_link(TestArticleThreads.article_url)
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
 
-        self.logger.info("Clicking on the 'Post Thread' button without adding any data in the "
-                         "form fields")
-        self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
+        with allure.step("Clicking on the 'Post a new thread button' and clicking on the 'Post "
+                         "Thread' button without adding any data in the form fields"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
 
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(
-            TestArticleThreads.article_url + KBArticlePageMessages.
-            KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
+        with allure.step("Verifying that we are on the same page"):
+            expect(
+                self.page
+            ).to_have_url(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
 
-        self.logger.info("Adding one character inside the 'Title' field and clicking the 'Post "
-                         "Thread' button")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_title_field("t")
-        self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
+        with allure.step("Adding one character inside the 'Title' field, clicking the 'Post "
+                         "Thread' button and verifying that we are on the same page"):
+            self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_title_field("t")
+            self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
 
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(TestArticleThreads.article_url + KBArticlePageMessages.
-                      KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
+            self.logger.info("Verifying that we are on the same page")
+            expect(
+                self.page
+            ).to_have_url(TestArticleThreads.article_url + KBArticlePageMessages.
+                          KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
 
-        self.logger.info("Clearing the input field")
-        self.sumo_pages.kb_article_discussion_page._clear_new_thread_title_field()
-
-        self.logger.info("Adding input with 5 characters inside the title field")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_title_field(
-            super().kb_new_thread_test_data['new_thread_reduced_title']
-        )
-
-        self.logger.info("Clicking on the 'Post Thread' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
-
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(TestArticleThreads.article_url + KBArticlePageMessages.
-                      KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
-
-        self.logger.info("Adding one character inside the content field")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_body_input_field("a")
-
-        self.logger.info("Clicking on the 'Post Thread' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
-
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(TestArticleThreads.article_url + KBArticlePageMessages.
-                      KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
-
-        self.logger.info("Clearing the content field")
-        self.sumo_pages.kb_article_discussion_page._clear_new_thread_body_field()
-
-        self.logger.info("Clearing both title and content fields")
-        self.sumo_pages.kb_article_discussion_page._clear_new_thread_title_field()
-        self.sumo_pages.kb_article_discussion_page._clear_new_thread_body_field()
-
-        self.logger.info("Adding 5 characters inside the thread content field")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_body_input_field(
-            super().kb_new_thread_test_data['new_thread_reduced_body']
-        )
-
-        self.logger.info("Clicking on the 'Post Thread' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
-
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(TestArticleThreads.article_url + KBArticlePageMessages.
-                      KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
-
-        self.logger.info("Adding 5 characters inside the thread title field")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_title_field(
-            super().kb_new_thread_test_data['new_thread_reduced_title']
-        )
-
-        self.logger.info("Clicking on the 'Cancel' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_cancel_new_thread_button()
-
-        self.logger.info("Verifying that the article is not displayed inside the discussion "
-                         "thread list")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_thread_by_title_locator(
+        with allure.step("Clearing the input field and adding 5 characters inside the title "
+                         "input field"):
+            self.sumo_pages.kb_article_discussion_page._clear_new_thread_title_field()
+            self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_title_field(
                 super().kb_new_thread_test_data['new_thread_reduced_title']
             )
-        ).to_be_hidden()
 
-        self.logger.info("Clicking on the 'Post a new thread' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+        with allure.step("Clicking on the 'Post Thread' button and verifying that we are on the "
+                         "same page"):
+            self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
+            expect(
+                self.page
+            ).to_have_url(TestArticleThreads.article_url + KBArticlePageMessages.
+                          KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
 
-        self.logger.info("Adding the minimum required characters inside both title and content "
-                         "fields")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_title_field(
-            super().kb_new_thread_test_data['new_thread_reduced_title']
-        )
-        self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_body_input_field(
-            super().kb_new_thread_test_data['new_thread_reduced_body']
-        )
-
-        self.logger.info("Clicking on the 'Post Thread' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
-
-        thread_url = self.get_page_url()
-        thread_id = str(super().number_extraction_from_string_endpoint(
-            KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT, thread_url)
-        )
-
-        self.logger.info("Manually navigating to the discuss endpoint")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the posted thread is successfully displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_posted_thread_locator(
-                thread_id
+        with allure.step("Adding one character inside the content field, clicking on the 'Post "
+                         "Thread' button and verifying that we are on the same page"):
+            self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_body_input_field(
+                "a"
             )
-        ).to_be_visible()
+            self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
+            expect(
+                self.page
+            ).to_have_url(TestArticleThreads.article_url + KBArticlePageMessages.
+                          KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
 
-        self.__clearing_newly_created_thread(thread_id)
+        with allure.step("Clearing both title and content fields and adding 5 characters inside "
+                         "the thread content field"):
+            self.sumo_pages.kb_article_discussion_page._clear_new_thread_body_field()
+            self.sumo_pages.kb_article_discussion_page._clear_new_thread_title_field()
+            self.sumo_pages.kb_article_discussion_page._clear_new_thread_body_field()
+            self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_body_input_field(
+                super().kb_new_thread_test_data['new_thread_reduced_body']
+            )
+
+        with allure.step("Clicking on the 'Post Thread' button and verifying that we are on the "
+                         "same page"):
+            self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
+            expect(
+                self.page
+            ).to_have_url(TestArticleThreads.article_url + KBArticlePageMessages.
+                          KB_ARTICLE_DISCUSSIONS_NEW_ENDPOINT)
+
+        with allure.step("Adding 5 characters inside the thread title field, clicking on the "
+                         "'Cancel' button and verifying that the article is not displayed inside "
+                         "the discussion thread list"):
+            self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_title_field(
+                super().kb_new_thread_test_data['new_thread_reduced_title']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_cancel_new_thread_button()
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_thread_by_title_locator(
+                    super().kb_new_thread_test_data['new_thread_reduced_title']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Clicking on the 'Post a new thread' button and adding the minimum "
+                         "required characters inside both title and content fields"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_title_field(
+                super().kb_new_thread_test_data['new_thread_reduced_title']
+            )
+            self.sumo_pages.kb_article_discussion_page._add_text_to_new_thread_body_input_field(
+                super().kb_new_thread_test_data['new_thread_reduced_body']
+            )
+
+        with allure.step("Clicking on the 'Post Thread' button, manually navigating to the "
+                         "discuss endpoint and verifying that the posted thread is successfully "
+                         "displayed"):
+            self.sumo_pages.kb_article_discussion_page._click_on_submit_new_thread_button()
+            thread_url = self.get_page_url()
+            thread_id = str(super().number_extraction_from_string_endpoint(
+                KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT, thread_url)
+            )
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_posted_thread_locator(
+                    thread_id
+                )
+            ).to_be_visible()
+
+        with allure.step("Clearing the newly created thread"):
+            self.__clearing_newly_created_thread(thread_id)
 
     # C2260840
     @pytest.mark.articleThreads
     def test_thread_replies_counter_increment(self):
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Manually navigating to the article endpoint")
-        self.navigate_to_link(TestArticleThreads.article_url)
-        self.logger.info("Clicking on the article option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+        with allure.step("Manually navigating to the article endpoint and clicking on the "
+                         "article option"):
+            self.navigate_to_link(TestArticleThreads.article_url)
+            self.sumo_pages.kb_article_page._click_on_article_option()
 
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+        with allure.step("Clicking on the 'Discussion' editing tools navbar option"):
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
 
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info = (self.sumo_pages.post_kb_discussion_thread_flow.
-                       add_new_kb_discussion_thread())
+        with check, allure.step("Clicking on the 'Post a new thread button', posting a new kb "
+                                "article discussion thread and verifying that the thread counter"
+                                " is not 0"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info = (self.sumo_pages.post_kb_discussion_thread_flow.
+                           add_new_kb_discussion_thread())
+            assert (self.number_extraction_from_string(
+                self.sumo_pages.kb_article_discussion_page._get_thread_page_counter_replies_text(
+                ))) == 0
 
-        self.logger.info("Verifying that the thread counter is not 0")
-        check.equal(
-            self.number_extraction_from_string(
-                self.sumo_pages.kb_article_discussion_page._get_thread_page_counter_replies_text()
-            ),
-            0,
-            "Thread counter is not 0!"
-        )
-
-        self.logger.info("Manually navigating to the discuss endpoint")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the reply counter for the posted thread has incremented "
-                         "successfully")
-        check.equal(
-            self.number_extraction_from_string(
+        with check, allure.step("Manually navigating to the discuss endpoint "
+                                "and verifying that the reply counter for the posted thread has "
+                                "incremented successfully"):
+            self.navigate_to_link(TestArticleThreads.article_url + KBArticlePageMessages
+                                  .KB_ARTICLE_DISCUSSIONS_ENDPOINT)
+            assert (self.number_extraction_from_string(
                 self.sumo_pages.kb_article_discussion_page._get_article_discussions_thread_counter(
-                    thread_info['thread_id']
-                )
-            ),
-            0,
-            "Incorrect number of replies!"
-        )
+                    thread_info['thread_id']))) == 0
 
-        self.logger.info("Navigating back to the thread")
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info['thread_id']
-        )
+        with allure.step("Navigating back to the thread and posting a new reply with the same "
+                         "user"):
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info['thread_id']
+            )
+            self.sumo_pages.kb_article_discussion_page._fill_the_thread_post_a_reply_textarea(
+                self.kb_new_thread_test_data['thread_reply_body']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_thread_post_reply_button()
 
-        self.logger.info("Posting a new reply with the same user")
-        self.sumo_pages.kb_article_discussion_page._fill_the_thread_post_a_reply_textarea_field(
-            self.kb_new_thread_test_data['thread_reply_body']
-        )
-        self.sumo_pages.kb_article_discussion_page._click_on_thread_post_reply_button()
+        with check, allure.step("Verifying that the thread counter is 1"):
+            assert (self.number_extraction_from_string(
+                self.sumo_pages.kb_article_discussion_page
+                ._get_thread_page_counter_replies_text())) == 1
 
-        self.logger.info("Verifying that the thread counter is 1")
-        check.equal(
-            self.number_extraction_from_string(
-                self.sumo_pages.kb_article_discussion_page._get_thread_page_counter_replies_text()
-            ),
-            1,
-            "Thread counter is not 0!"
-        )
-
-        self.logger.info("Manually navigating to the discuss endpoint")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the reply counter for the posted thread has incremented "
-                         "successfully")
-        check.equal(
-            self.number_extraction_from_string(
+        with check, allure.step("Manually navigating to the discuss endpoint and verifying that "
+                                "the reply counter for the posted thread has incremented "
+                                "successfully"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            assert (self.number_extraction_from_string(
                 self.sumo_pages.kb_article_discussion_page._get_article_discussions_thread_counter(
-                    thread_info['thread_id']
-                )
-            ),
-            1,
-            "Incorrect number of replies!"
-        )
+                    thread_info['thread_id']))) == 1
 
-        self.__clearing_newly_created_thread(thread_info['thread_id'])
+        with allure.step("Clearing the newly created thread"):
+            self.__clearing_newly_created_thread(thread_info['thread_id'])
 
     # C2260840, C2260809
     @pytest.mark.articleThreads
     def test_thread_replies_counter_decrement(self):
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Manually navigating to the article endpoint")
-        self.navigate_to_link(TestArticleThreads.article_url)
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Signing in with a normal account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Manually navigating to the article endpoint and clicking on the "
+                         "'Discussion' editing tool navbar option"):
+            self.navigate_to_link(TestArticleThreads.article_url)
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
 
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+        with allure.step("Signing in with a normal account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info = (self.sumo_pages.post_kb_discussion_thread_flow.
-                       add_new_kb_discussion_thread())
+        with allure.step("Clicking on the 'Post a new thread button' and posting a new kb "
+                         "article discussion thread"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info = (self.sumo_pages.post_kb_discussion_thread_flow.
+                           add_new_kb_discussion_thread())
 
-        self.logger.info("Posting a new reply with the same user")
-        self.sumo_pages.kb_article_discussion_page._fill_the_thread_post_a_reply_textarea_field(
-            self.kb_new_thread_test_data['thread_reply_body']
-        )
-        self.sumo_pages.kb_article_discussion_page._click_on_thread_post_reply_button()
+        with allure.step("Posting a new reply with the same user"):
+            self.sumo_pages.kb_article_discussion_page._fill_the_thread_post_a_reply_textarea(
+                self.kb_new_thread_test_data['thread_reply_body']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_thread_post_reply_button()
 
-        thread_reply_id = self.sumo_pages.kb_article_discussion_page._get_thread_reply_id(
-            self.get_page_url()
-        )
+            thread_reply_id = self.sumo_pages.kb_article_discussion_page._get_thread_reply_id(
+                self.get_page_url()
+            )
 
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
+            ))
 
-        self.logger.info("Posting a new reply with the same user")
-        self.sumo_pages.kb_article_discussion_page._fill_the_thread_post_a_reply_textarea_field(
-            self.kb_new_thread_test_data['thread_reply_body']
-        )
-        self.sumo_pages.kb_article_discussion_page._click_on_thread_post_reply_button()
-
-        self.logger.info("Verifying that the reply counter for the posted thread has incremented "
-                         "successfully")
-        check.equal(
-            self.number_extraction_from_string(
+        with check, allure.step("Posting a new reply with the same user and verifying that the "
+                                "reply counter for the posted thread has incremented "
+                                "successfully"):
+            self.sumo_pages.kb_article_discussion_page._fill_the_thread_post_a_reply_textarea(
+                self.kb_new_thread_test_data['thread_reply_body']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_thread_post_reply_button()
+            assert (self.number_extraction_from_string(
                 self.sumo_pages.kb_article_discussion_page._get_thread_page_counter_replies_text()
-            ),
-            2,
-            "Incorrect number of replies!"
-        )
+            ) == 2)
 
-        self.logger.info("Manually navigating to the discuss endpoint")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the reply counter for the posted thread has incremented "
-                         "successfully")
-        check.equal(
-            self.number_extraction_from_string(
+        with allure.step("Manually navigating to the discuss endpoint and verifying that the "
+                         "reply counter for the posted thread has incremented successfully"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages
+                .KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            assert (self.number_extraction_from_string(
                 self.sumo_pages.kb_article_discussion_page._get_article_discussions_thread_counter(
-                    thread_info['thread_id']
-                )
-            ),
-            2,
-            "Incorrect number of replies!"
-        )
+                    thread_info['thread_id'])) == 2)
 
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info['thread_id']
-        )
+        with allure.step("Clicking on the 3 dotted menu for a posted thread reply"):
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info['thread_id']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_dotted_menu_for_a_certain_reply(
+                thread_reply_id
+            )
 
-        self.logger.info("Clicking on the 3 dotted menu for the posted reply")
-        self.sumo_pages.kb_article_discussion_page._click_on_dotted_menu_for_a_certain_reply(
-            thread_reply_id
-        )
+        with check, allure.step("Clicking on the 'Delete this post' option and verifying that "
+                                "the reply counter for the posted thread has incremented "
+                                "successfully"):
+            self.sumo_pages.kb_article_discussion_page._click_on_delete_this_thread_reply(
+                thread_reply_id
+            )
+            (self.sumo_pages.kb_article_discussion_page
+             ._click_on_delete_this_thread_reply_confirmation_button())
+            assert (self.number_extraction_from_string(
+                self.sumo_pages.kb_article_discussion_page._get_thread_page_counter_replies_text(
+                )) == 1)
 
-        self.logger.info("Clicking on the 'Delete this post' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_delete_this_thread_reply(
-            thread_reply_id
-        )
-        (self.sumo_pages.kb_article_discussion_page
-         ._click_on_delete_this_thread_reply_confirmation_button())
-
-        self.logger.info("Verifying that the reply counter for the posted thread has incremented "
-                         "successfully")
-        check.equal(
-            self.number_extraction_from_string(
-                self.sumo_pages.kb_article_discussion_page._get_thread_page_counter_replies_text()
-            ),
-            1,
-            "Incorrect number of replies!"
-        )
-
-        self.logger.info("Manually navigating to the discuss endpoint")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the reply counter for the posted thread has incremented "
-                         "successfully")
-        check.equal(
-            self.number_extraction_from_string(
+        with check, allure.step("Manually navigating to the discuss endpoint and verifying that "
+                                "the reply counter for the posted thread has incremented "
+                                "successfully"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            assert (self.number_extraction_from_string(
                 self.sumo_pages.kb_article_discussion_page._get_article_discussions_thread_counter(
-                    thread_info['thread_id']
-                )
-            ),
-            1,
-            "Incorrect number of replies!"
-        )
+                    thread_info['thread_id'])) == 1)
 
-        self.__clearing_newly_created_thread(thread_info['thread_id'])
+        with allure.step("Clearing the newly created thread"):
+            self.__clearing_newly_created_thread(thread_info['thread_id'])
 
     @pytest.mark.articleThreads
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_12', 'TEST_ACCOUNT_MODERATOR', ''])
     def test_article_thread_author_filter(self, username):
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Manually navigating to the article endpoint")
-        self.navigate_to_link(TestArticleThreads.article_url)
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info = self.sumo_pages.post_kb_discussion_thread_flow.add_new_kb_discussion_thread()
-
-        self.logger.info("Navigating back to the article discussion page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.
-            KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
-
-        self.logger.info("Navigating back to the article discussion page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        if username == 'TEST_ACCOUNT_MODERATOR':
+        with allure.step("Signing in with an admin account"):
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
+
+        with allure.step("Manually navigating to the article endpoint and clicking on the "
+                         "'Discussion' editing tools navbar option"):
+            self.navigate_to_link(TestArticleThreads.article_url)
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+
+        with allure.step("Posting a new kb article discussion thread"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info = (self.sumo_pages.post_kb_discussion_thread_flow
+                           .add_new_kb_discussion_thread())
+
+        with allure.step("Navigating back to the article discussion page and signing in with a "
+                         "non-admin account"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+
+        with allure.step("Posting a new kb article discussion thread"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
+
+        with allure.step("Navigating back to the article discussion page"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+
+        if username == 'TEST_ACCOUNT_MODERATOR':
+            with allure.step("Signing in with an admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
         elif username != 'TEST_ACCOUNT_12':
-            self.delete_cookies()
+            with allure.step("Signing out from SUMO"):
+                self.delete_cookies()
 
-        self.logger.info("Clicking on the 'Author' filter")
-        self.sumo_pages.kb_article_discussion_page._click_on_article_thread_author_replies_filter()
-
-        self.logger.info("Verifying that the authors are in reverse alphabetical order")
-        check.not_equal(
-            self.sumo_pages.kb_article_discussion_page._get_all_article_threads_authors(),
-            sorted(
+        with check, allure.step("Clicking on the 'Author' filter and verifying that the authors "
+                                "are in reverse alphabetical order"):
+            (self.sumo_pages.kb_article_discussion_page
+             ._click_on_article_thread_author_replies_filter())
+            assert self.sumo_pages.kb_article_discussion_page._get_all_article_threads_authors(
+            ) != sorted(
                 self.sumo_pages.kb_article_discussion_page._get_all_article_threads_authors()
             )
-        )
 
-        self.logger.info("Clicking on the 'Author' filter again")
-        self.sumo_pages.kb_article_discussion_page._click_on_article_thread_author_replies_filter()
+        with check, allure.step("Clicking on the 'Author' filter again and verifying that the "
+                                "authors are in alphabetical order"):
+            (self.sumo_pages.kb_article_discussion_page
+             ._click_on_article_thread_author_replies_filter())
+            assert self.sumo_pages.kb_article_discussion_page._get_all_article_threads_authors(
+            ) == sorted(
+                self.sumo_pages.kb_article_discussion_page._get_all_article_threads_authors()
+            )
 
-        self.logger.info("Verifying that the authors are in alphabetical order")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_all_article_threads_authors(),
-            sorted(self.sumo_pages.kb_article_discussion_page._get_all_article_threads_authors())
-        )
-
-        self.__clearing_newly_created_thread(thread_info['thread_id'])
-        self.__clearing_newly_created_thread(thread_info_two['thread_id'])
+        with allure.step("Clearing both created threads"):
+            self.__clearing_newly_created_thread(thread_info['thread_id'])
+            self.__clearing_newly_created_thread(thread_info_two['thread_id'])
 
     @pytest.mark.articleThreads
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_12', 'TEST_ACCOUNT_MODERATOR', ''])
     def test_article_thread_replies_filter(self, username):
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Manually navigating to the article endpoint")
-        self.navigate_to_link(TestArticleThreads.article_url)
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+        with allure.step("Manually navigating to the article endpoint and clicking on the "
+                         "'Discussion' editing tools navbar option"):
+            self.navigate_to_link(TestArticleThreads.article_url)
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
 
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info = self.sumo_pages.post_kb_discussion_thread_flow.add_new_kb_discussion_thread()
-
-        self.logger.info("Posting a new reply with the same user")
-        self.sumo_pages.kb_article_discussion_page._fill_the_thread_post_a_reply_textarea_field(
-            self.kb_new_thread_test_data['thread_reply_body']
-        )
-        self.sumo_pages.kb_article_discussion_page._click_on_thread_post_reply_button()
-
-        self.logger.info("Navigating back to the article discussion page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
+        with allure.step("Clicking on the 'Post a new thread button' and posting a new kb "
+                         "article discussion thread"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info = (self.sumo_pages.post_kb_discussion_thread_flow.
                            add_new_kb_discussion_thread())
 
-        self.logger.info("Navigating back to the article discussion page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
+        with allure.step("Posting a new reply with the same user"):
+            self.sumo_pages.kb_article_discussion_page._fill_the_thread_post_a_reply_textarea(
+                self.kb_new_thread_test_data['thread_reply_body']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_thread_post_reply_button()
+
+        with allure.step("Navigating back to the article discussion page and posting a new kb "
+                         "article discussion thread"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
+
+        with allure.step("Navigating back to the article discussion page"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
 
         if username == "TEST_ACCOUNT_12":
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_12"]
-            ))
+            with allure.step("Signing in with a non admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_12"]
+                ))
         elif username == '':
-            self.delete_cookies()
+            with allure.step("Deleting user session"):
+                self.delete_cookies()
 
-        self.logger.info("Clicking on the 'Replies' filter")
-        self.sumo_pages.kb_article_discussion_page._click_on_article_thread_replies_filter()
-
-        self.logger.info("Verifying that the replies is in descending order")
-        check.is_true(
-            self.is_descending(
+        with allure.step("Clicking on the 'Replies' filter and verifying that the replies is in "
+                         "descending order"):
+            self.sumo_pages.kb_article_discussion_page._click_on_article_thread_replies_filter()
+            assert self.is_descending(
                 self.sumo_pages.kb_article_discussion_page._get_all_article_threads_replies()
             )
-        )
 
-        self.logger.info("Clicking on the 'Replies' filter again")
-        self.sumo_pages.kb_article_discussion_page._click_on_article_thread_replies_filter()
-
-        self.logger.info("Verifying that the replies is in descending order")
-        check.is_false(
-            self.is_descending(
+        with check, allure.step("Clicking on the 'Replies' filter again and verifying that the "
+                                "replies is in ascending order"):
+            self.sumo_pages.kb_article_discussion_page._click_on_article_thread_replies_filter()
+            assert not self.is_descending(
                 self.sumo_pages.kb_article_discussion_page._get_all_article_threads_replies()
             )
-        )
 
-        self.__clearing_newly_created_thread(thread_info['thread_id'])
-        self.__clearing_newly_created_thread(thread_info_two['thread_id'])
+        with allure.step("Clearing both created threads"):
+            self.__clearing_newly_created_thread(thread_info['thread_id'])
+            self.__clearing_newly_created_thread(thread_info_two['thread_id'])
 
     @pytest.mark.articleThreads
     def test_article_lock_thread_non_admin_users(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin account and creating an article"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
         kb_url = self.__posting_a_new_test_article_manually(approve_it=False,
                                                             post_it=True)
 
-        self.logger.info("Signing in with an admin account and approving the article")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account and approving the article"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.__posting_a_new_test_article_manually(approve_it=True, post_it=False)
 
-        self.__posting_a_new_test_article_manually(approve_it=True, post_it=False)
+        with allure.step("Clicking on the 'Discussion' editing tools navbar option and posting a "
+                         "new kb article discussion thread"):
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
 
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+        with allure.step("Navigating back to the discussions page and posting a new kb article "
+                         "discussion thread"):
+            self.navigate_to_link(
+                kb_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
 
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
+        with allure.step("Navigating back to the discussions page, clicking on the thread posted "
+                         "by another user and verifying that the 'Lock thread' option is not "
+                         "available"):
+            self.navigate_to_link(
+                kb_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info_one['thread_id']
+            )
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Navigating back to the article discussions page, clicking on the "
+                         "thread posted by self and verifying that the 'Lock thread' option is "
+                         "not available"):
+            self.navigate_to_link(
+                kb_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info_two['thread_id']
+            )
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            kb_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
+        with allure.step("Deleting user sessions and verifying that the 'Lock thread' options is "
+                         "not available"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            kb_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the thread posted by another user")
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info_one['thread_id']
-        )
-
-        self.logger.info("Verifying that the 'Lock thread' option is not available'")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Navigating back to the article discussions page")
-        self.navigate_to_link(
-            kb_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the thread posted by self")
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info_two['thread_id']
-        )
-
-        self.logger.info("Verifying that the 'Lock thread' option is not available'")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Deleting user sessions")
-        self.delete_cookies()
-
-        self.logger.info("Verifying that the 'Lock thread' option is not available")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Navigating to the article and deleting it")
-        self.navigate_to_link(kb_url)
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+        with allure.step("Signing in with an admin account and deleting the kb article"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.navigate_to_link(kb_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     #  C2260810
     @pytest.mark.articleThreads
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_MODERATOR', 'TEST_ACCOUNT_12', ''])
     def test_article_lock_thread_functionality(self, username):
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Manually navigating to the article endpoint")
-        self.navigate_to_link(TestArticleThreads.article_url)
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
-
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the thread posted by self user")
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info_one['thread_id']
-        )
-
-        self.logger.info("Clicking on 'Lock this thread' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
-
-        if username == 'TEST_ACCOUNT_12':
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts['TEST_ACCOUNT_12']
-            ))
-
-            self.logger.info("Verifying that the correct thread locked message is displayed")
-            check.equal(
-                self.sumo_pages.kb_article_discussion_page.
-                _get_text_of_locked_article_thread_text(),
-                KBArticlePageMessages.KB_ARTICLE_LOCKED_THREAD_MESSAGE
-            )
-        elif username == '':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
-
-        self.logger.info("Verifying that the 'Post a reply' textarea field is not displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_thread_post_a_reply_textarea_field()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'Locked' status is displayed under article header")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_locked_article_status()
-        ).to_be_visible()
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        if username != 'TEST_ACCOUNT_MODERATOR':
+        with allure.step("Signing in with an admin account"):
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
 
-        self.logger.info("Clicking on the thread posted by the other user")
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info_two['thread_id']
-        )
+        with allure.step("Manually navigating to the article endpoint and clicking on the "
+                         "'Discussion' editing tools navbar option"):
+            self.navigate_to_link(TestArticleThreads.article_url)
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
 
-        self.logger.info("Clicking on 'Lock this thread' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
+        with allure.step("Posting a new kb article discussion thread"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
 
-        if username == 'TEST_ACCOUNT_12':
+        with allure.step("Signing in with a non-admin user account"):
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
-            self.logger.info("Verifying that the correct thread locked message is displayed")
-            check.equal(
-                self.sumo_pages.kb_article_discussion_page.
-                _get_text_of_locked_article_thread_text(),
-                KBArticlePageMessages.KB_ARTICLE_LOCKED_THREAD_MESSAGE
+
+        with allure.step("Navigating back to the discussions page and posting a new discussion "
+                         "thread"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
             )
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
+
+        with allure.step("Navigating back to the discussions page"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        with allure.step("Clicking on the thread posted by self user and locking the thread"):
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info_one['thread_id']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
+
+        if username == 'TEST_ACCOUNT_12':
+            with check, allure.step("Signing in with a non-admin account and verifying that the "
+                                    "correct thread locked message is displayed"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_12']
+                ))
+                assert (self.sumo_pages.kb_article_discussion_page
+                        ._get_text_of_locked_article_thread_text() == KBArticlePageMessages
+                        .KB_ARTICLE_LOCKED_THREAD_MESSAGE)
+
         elif username == '':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
+            with allure.step("Deleting user session"):
+                self.delete_cookies()
 
-        self.logger.info("Verifying that the 'Locked' status is displayed under article header")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_locked_article_status()
-        ).to_be_visible()
+        with allure.step("Verifying that the 'Post a reply' textarea field is not displayed"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_thread_post_a_reply_textarea_field(
+                )
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'Post a reply' textarea field is not displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_thread_post_a_reply_textarea_field()
-        ).to_be_hidden()
+        with allure.step("Verifying that the 'Locked' status is displayed under article header"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_locked_article_status()
+            ).to_be_visible()
 
-        self.__clearing_newly_created_thread(thread_info_one['thread_id'])
-        self.__clearing_newly_created_thread(thread_info_two['thread_id'])
+        with allure.step("Navigating back to the discussions page"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages
+                .KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+
+        if username != 'TEST_ACCOUNT_MODERATOR':
+            with allure.step("Signing in with an admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
+
+        with allure.step("Clicking on the thread posted by the other user and clicking on the "
+                         "'Lock this thread' option"):
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info_two['thread_id']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
+
+        if username == 'TEST_ACCOUNT_12':
+            with check, allure.step("Signing in with a non-admin account and verifying that the "
+                                    "correct thread locked message is displayed"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_12']
+                ))
+                assert (self.sumo_pages.kb_article_discussion_page
+                        ._get_text_of_locked_article_thread_text() == KBArticlePageMessages
+                        .KB_ARTICLE_LOCKED_THREAD_MESSAGE)
+        elif username == '':
+            with allure.step("Deleting user session"):
+                self.delete_cookies()
+
+        with allure.step("Verifying that the 'Locked' status is displayed under article header"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_locked_article_status()
+            ).to_be_visible()
+
+        with allure.step("Verifying that the 'Post a reply' textarea field is not displayed"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_thread_post_a_reply_textarea_field(
+                )
+            ).to_be_hidden()
+
+        with allure.step("Clearing both created threads"):
+            self.__clearing_newly_created_thread(thread_info_one['thread_id'])
+            self.__clearing_newly_created_thread(thread_info_two['thread_id'])
 
     # C2260810
     @pytest.mark.articleThreads
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_MODERATOR', 'TEST_ACCOUNT_12', ''])
     def test_article_unlock_thread_functionality(self, username):
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Manually navigating to the article endpoint")
-        self.navigate_to_link(TestArticleThreads.article_url)
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
-
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the thread posted by self user")
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info_one['thread_id']
-        )
-
-        self.logger.info("Verifying that the correct 'Lock this thread' option text is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_option_text(),
-            KBArticlePageMessages.KB_ARTICLE_LOCK_THIS_THREAD_OPTION
-        )
-
-        self.logger.info("Clicking on 'Lock this thread' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
-
-        self.logger.info("Verifying that the correct 'Unlock this thread' text is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_option_text(),
-            KBArticlePageMessages.KB_ARTICLE_UNLOCK_THIS_THREAD_OPTION
-        )
-
-        if username == 'TEST_ACCOUNT_12':
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts['TEST_ACCOUNT_12']
-            ))
-            self.logger.info("Verifying that the 'Unlock this thread' option is no displayed")
-            expect(
-                self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
-            ).to_be_hidden()
-        if username == '':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
-            self.logger.info("Verifying that the 'Unlock this thread' option is no displayed")
-            expect(
-                self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
-            ).to_be_hidden()
-
-        if username != 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Signing in with an admin account")
+        with allure.step("Signing in with an admin account"):
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
 
-        self.logger.info("Clicking on the 'Unlock this thread'")
-        self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
+        with allure.step("Navigating to the article endpoint"):
+            self.navigate_to_link(TestArticleThreads.article_url)
 
-        if username == 'TEST_ACCOUNT_12':
+        with allure.step("Posting a new kb article discussion thread"):
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
+
+        with allure.step("Signing in with a normal user account"):
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
-            self.logger.info("Verifying that the textarea field is available")
-            expect(
-                self.sumo_pages.kb_article_discussion_page._get_thread_post_a_reply_textarea_field(
-                )
-            ).to_be_visible()
+
+        with allure.step("Navigating back to the discussions page"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+
+        with allure.step("Posting a new kb article discussion thread"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
+
+        with allure.step("Navigating back to the discussions page"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        with check, allure.step("Clicking on the thread posted by self user and verifying that "
+                                "the correct 'Lock this thread' option text is displayed"):
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info_one['thread_id']
+            )
+            assert (self.sumo_pages.kb_article_discussion_page
+                    ._get_lock_this_article_thread_option_text() == KBArticlePageMessages
+                    .KB_ARTICLE_LOCK_THIS_THREAD_OPTION)
+
+        with check, allure.step("Clicking on 'Lock this thread' option and verifying that the "
+                                "correct 'Unlock this thread' text is displayed"):
+            self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
+            assert (self.sumo_pages.kb_article_discussion_page
+                    ._get_lock_this_article_thread_option_text() == KBArticlePageMessages.
+                    KB_ARTICLE_UNLOCK_THIS_THREAD_OPTION)
+
+        if username == 'TEST_ACCOUNT_12':
+            with allure.step("Signing in with a non-admin account and verifying that the 'Unlock "
+                             "this thread' option is not displayed"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_12']
+                ))
+                expect(
+                    self.sumo_pages.kb_article_discussion_page.
+                    _get_lock_this_article_thread_locator()
+                ).to_be_hidden()
         if username == '':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
-            self.logger.info("Verifying that the textarea field is not available")
+            with allure.step("Deleting user session and verifying that the 'Unlock this thread' "
+                             "option is no displayed"):
+                self.delete_cookies()
+                expect(
+                    self.sumo_pages.kb_article_discussion_page.
+                    _get_lock_this_article_thread_locator()
+                ).to_be_hidden()
+
+        if username != 'TEST_ACCOUNT_MODERATOR':
+            with allure.step("Signing in with an admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
+
+        with allure.step("Clicking on the 'Unlock this thread'"):
+            self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
+
+        if username == 'TEST_ACCOUNT_12':
+            with allure.step("Signing in with a non-admin account and verifying that the "
+                             "textarea field is available"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_12']
+                ))
+                expect(
+                    self.sumo_pages.kb_article_discussion_page
+                    ._get_thread_post_a_reply_textarea_field(
+                    )
+                ).to_be_visible()
+        if username == '':
+            with allure.step("Deleting user session and verifying that the textarea field is not "
+                             "available"):
+                self.delete_cookies()
+                expect(
+                    self.sumo_pages.kb_article_discussion_page
+                    ._get_thread_post_a_reply_textarea_field(
+                    )
+                ).to_be_hidden()
+
+        with allure.step("Verifying that the 'Locked' header text is not displayed"):
             expect(
-                self.sumo_pages.kb_article_discussion_page._get_thread_post_a_reply_textarea_field(
-                )
+                self.sumo_pages.kb_article_discussion_page._get_locked_article_status()
             ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'Locked' header text is not displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_locked_article_status()
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'Thread locked' thread page message is not displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_text_of_locked_article_thread_locator()
-        ).to_be_hidden()
+        with allure.step("Verifying that the 'Thread locked' page message is not displayed"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page
+                ._get_text_of_locked_article_thread_locator()
+            ).to_be_hidden()
 
         if username != "TEST_ACCOUNT_MODERATOR":
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-            ))
+            with allure.step("Signing in with an admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
 
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
+        with allure.step("Navigating back the article page and clicking on the thread posted by "
+                         "another user"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages
+                .KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info_two['thread_id']
+            )
 
-        self.logger.info("Clicking on the thread posted by another user")
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info_two['thread_id']
-        )
+        with check, allure.step("Verifying that the correct 'Lock this thread' option text is "
+                                "displayed"):
+            assert (self.sumo_pages.kb_article_discussion_page
+                    ._get_lock_this_article_thread_option_text() == KBArticlePageMessages
+                    .KB_ARTICLE_LOCK_THIS_THREAD_OPTION)
 
-        self.logger.info("Verifying that the correct 'Lock this thread' option text is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_option_text(),
-            KBArticlePageMessages.KB_ARTICLE_LOCK_THIS_THREAD_OPTION
-        )
-
-        self.logger.info("Clicking on 'Lock this thread' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
-
-        self.logger.info("Verifying that the correct 'Unlock this thread' text is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_option_text(),
-            KBArticlePageMessages.KB_ARTICLE_UNLOCK_THIS_THREAD_OPTION
-        )
+        with check, allure.step("Clicking on 'Lock this thread' option and verifying that the "
+                                "correct 'Unlock this thread' text is displayed"):
+            self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
+            assert (self.sumo_pages.kb_article_discussion_page
+                    ._get_lock_this_article_thread_option_text() == KBArticlePageMessages
+                    .KB_ARTICLE_UNLOCK_THIS_THREAD_OPTION)
 
         if username == 'TEST_ACCOUNT_12':
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts['TEST_ACCOUNT_12']
-            ))
-            self.logger.info("Verifying that the 'Unlock this thread' option is no displayed")
-            expect(
-                self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
-            ).to_be_hidden()
+            with allure.step("Signing in with a non-admin account and verifying that the 'Unlock "
+                             "this thread' option is displayed"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_12']
+                ))
+                expect(
+                    self.sumo_pages.kb_article_discussion_page
+                    ._get_lock_this_article_thread_locator()
+                ).to_be_hidden()
         if username == '':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
-            self.logger.info("Verifying that the 'Unlock this thread' option is no displayed")
-            expect(
-                self.sumo_pages.kb_article_discussion_page._get_lock_this_article_thread_locator()
-            ).to_be_hidden()
+            with allure.step("Deleting the user session and verifying that the 'Unlock this "
+                             "thread' option is not displayed"):
+                self.delete_cookies()
+                expect(
+                    self.sumo_pages.kb_article_discussion_page
+                    ._get_lock_this_article_thread_locator()
+                ).to_be_hidden()
 
         if username != 'TEST_ACCOUNT_MODERATOR':
-            self.logger.info("Signing in with an admin account")
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-            ))
-
-        self.logger.info("Clicking on the 'Unlock this thread'")
+            with allure.step("Signing in with an admin account and clicking on the 'Unlock this "
+                             "thread' option"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
         self.sumo_pages.kb_article_discussion_page._click_on_lock_this_article_thread_option()
 
         if username == 'TEST_ACCOUNT_12':
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts['TEST_ACCOUNT_12']
-            ))
-            self.logger.info("Verifying that the textarea field is available")
-            expect(
-                self.sumo_pages.kb_article_discussion_page._get_thread_post_a_reply_textarea_field(
-                )
-            ).to_be_visible()
+            with allure.step("Signing in with a non-admin account and verifying that the "
+                             "textarea field is available"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_12']
+                ))
+                expect(
+                    self.sumo_pages.kb_article_discussion_page
+                    ._get_thread_post_a_reply_textarea_field(
+                    )
+                ).to_be_visible()
         if username == '':
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
-            self.logger.info("Verifying that the textarea field is not available")
+            with allure.step("Deleting user session and verifying that the textarea field is not "
+                             "available"):
+                self.delete_cookies()
+                expect(
+                    self.sumo_pages.kb_article_discussion_page
+                    ._get_thread_post_a_reply_textarea_field(
+                    )
+                ).to_be_hidden()
+
+        with allure.step("Verifying that the 'Locked' header text is not displayed"):
             expect(
-                self.sumo_pages.kb_article_discussion_page._get_thread_post_a_reply_textarea_field(
-                )
+                self.sumo_pages.kb_article_discussion_page._get_locked_article_status()
             ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'Locked' header text is not displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_locked_article_status()
-        ).to_be_hidden()
+        with allure.step("Verifying that the 'Thread locked' page message is not displayed"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page
+                ._get_text_of_locked_article_thread_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'Thread locked' thread page message is not displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_text_of_locked_article_thread_locator()
-        ).to_be_hidden()
-
-        self.__clearing_newly_created_thread(thread_info_one['thread_id'])
-        self.__clearing_newly_created_thread(thread_info_two['thread_id'])
+        with allure.step("Clearing the newly created thread"):
+            self.__clearing_newly_created_thread(thread_info_one['thread_id'])
+            self.__clearing_newly_created_thread(thread_info_two['thread_id'])
 
     # C2260811
     @pytest.mark.articleThreads
     @pytest.mark.parametrize("username", ['TEST_ACCOUNT_MODERATOR', 'TEST_ACCOUNT_12', ''])
     def test_article_thread_sticky(self, username):
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        kb_article_url = self.__posting_a_new_test_article_manually(post_it=True, approve_it=True)
-
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
-
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            kb_article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread(title='Other test thread'))
-
-        self.logger.info("Verifying that the 'Sticky this thread' option is not displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            kb_article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the thread self posted thread")
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info_one['thread_id']
-        )
-
-        self.logger.info("Clicking on the sticky this thread option")
-        self.sumo_pages.kb_article_discussion_page._click_on_sticky_this_thread_option()
-
-        self.logger.info("Verifying that the text changed to 'Unsticky this thread'")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_text_of_sticky_this_thread_option(),
-            KBArticlePageMessages.KB_ARTICLE_UNSTICKY_OPTION
-        )
-
-        if username == 'TEST_ACCOUNT_12':
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts['TEST_ACCOUNT_12']
-            ))
-            self.logger.info("Verifying that the unsitcky this thread option is not available")
-            expect(
-                self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_locator()
-            ).to_be_hidden()
-        if username == '':
-            self.delete_cookies()
-            self.logger.info("Verifying that the unsitcky this thread option is not available")
-            expect(
-                self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_locator()
-            ).to_be_hidden()
-
-        self.logger.info("Verifying that the 'Sticky' status is displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_status_locator()
-        ).to_be_visible()
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            kb_article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the sticky article is displayed in top of the list")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_all_article_threads_titles()[0],
-            thread_info_one['thread_title']
-        )
-
-        if username != 'TEST_ACCOUNT_MODERATOR':
+        with allure.step("Signing in with an admin account"):
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
 
-        self.logger.info("Clicking on the thread self posted thread")
-        self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-            thread_info_one['thread_id']
-        )
+        with allure.step("Posting a new kb article"):
+            kb_article_url = self.__posting_a_new_test_article_manually(
+                post_it=True, approve_it=True
+            )
 
-        self.logger.info("Clicking on the unsticky this thread option")
-        self.sumo_pages.kb_article_discussion_page._click_on_sticky_this_thread_option()
+        with allure.step("Posting a new kb article discussion thread"):
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
 
-        self.logger.info("Verifying that the text changed to 'Sticky this thread'")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_text_of_sticky_this_thread_option(),
-            KBArticlePageMessages.KB_ARTICLE_STICKY_THIS_THREAD_OPTION
-        )
-
-        if username == 'TEST_ACCOUNT_12':
+        with allure.step("Signing in with a normal user account"):
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts['TEST_ACCOUNT_12']
             ))
+
+        with allure.step("Navigating back to the discussions page"):
+            self.navigate_to_link(
+                kb_article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+
+        with allure.step("Posting a new kb article discussion thread"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread(title='Other test thread'))
+
+        with allure.step("Verifying that the 'Sticky this thread' option is not displayed"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_locator()
+            ).to_be_hidden()
+
+        with allure.step("Navigating back to the discussions page"):
+            self.navigate_to_link(
+                kb_article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        with allure.step("Clicking on the thread posted by self and clicking on the 'sticky this "
+                         "thread' option"):
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info_one['thread_id']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_sticky_this_thread_option()
+
+        with check, allure.step("Verifying that the text changed to 'Unsticky this thread'"):
+            assert (self.sumo_pages.kb_article_discussion_page
+                    ._get_text_of_sticky_this_thread_option() == KBArticlePageMessages
+                    .KB_ARTICLE_UNSTICKY_OPTION)
+
+        if username == 'TEST_ACCOUNT_12':
+            with allure.step("Signing in with a non-admin account and verifying that the "
+                             "unsticky this thread option is not available"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_12']
+                ))
+                expect(
+                    self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_locator()
+                ).to_be_hidden()
         if username == '':
-            self.delete_cookies()
+            with allure.step("Deleting user session and verifying that the unsticky this thread "
+                             "option is not available"):
+                self.delete_cookies()
+                expect(
+                    self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_locator()
+                ).to_be_hidden()
 
-        self.logger.info("Verifying that the 'Sticky' status is not displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_status_locator()
-        ).to_be_hidden()
+        with allure.step("Verifying that the 'Sticky' status is displayed"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_status_locator()
+            ).to_be_visible()
 
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            kb_article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
+        with check, allure.step("Navigating back to the discussions page and verifying that the "
+                                "sticky article is displayed in top of the list"):
+            self.navigate_to_link(
+                kb_article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            assert self.sumo_pages.kb_article_discussion_page._get_all_article_threads_titles(
+            )[0] == thread_info_one['thread_title']
 
-        self.logger.info("Verifying that the sticky article is not displayed in top of the list")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_all_article_threads_titles()[0],
-            thread_info_two['thread_title']
-        )
+        if username != 'TEST_ACCOUNT_MODERATOR':
+            with allure.step("Signing in with an admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
 
-        self.start_existing_session(self.username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.navigate_to_link(kb_article_url)
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+        with check, allure.step("Clicking on the unsitcky this thread and verifying that the "
+                                "text changed to 'Sticky this thread'"):
+            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                thread_info_one['thread_id']
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_sticky_this_thread_option()
+            assert (self.sumo_pages.kb_article_discussion_page
+                    ._get_text_of_sticky_this_thread_option() == KBArticlePageMessages.
+                    KB_ARTICLE_STICKY_THIS_THREAD_OPTION)
+
+        if username == 'TEST_ACCOUNT_12':
+            with allure.step("Signing in with a non-admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts['TEST_ACCOUNT_12']
+                ))
+        if username == '':
+            with allure.step("Deleting user session"):
+                self.delete_cookies()
+
+        with allure.step("Verifying that the 'Sticky' status is not displayed"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_sticky_this_thread_status_locator()
+            ).to_be_hidden()
+
+        with check, allure.step("Navigating back to the discussions page and verifying that the "
+                                "sticky article is not displayed in top of the list"):
+            self.navigate_to_link(
+                kb_article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            assert self.sumo_pages.kb_article_discussion_page._get_all_article_threads_titles(
+            )[0] == thread_info_two['thread_title']
+
+        with allure.step("Signing in with an admin account and deleting the kb article"):
+            self.start_existing_session(self.username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.navigate_to_link(kb_article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     #  C2260808, C2260823
     @pytest.mark.articleThreads
     @pytest.mark.parametrize("thread_author", ['self', 'other'])
     def test_article_thread_content_edit(self, thread_author):
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-        self.logger.info("Manually navigating to the article endpoint")
-        self.navigate_to_link(TestArticleThreads.article_url)
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+        with allure.step("Manually navigating to the article endpoint and posting a new kb "
+                         "article discussion thread"):
+            self.navigate_to_link(TestArticleThreads.article_url)
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
 
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_one = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Navigating back to the discussions page and posting a new kb article "
+                         "discussion thread"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
+                               add_new_kb_discussion_thread())
 
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
+        with allure.step("Adding data inside the edit this thread title field and clicking on "
+                         "the cancel button"):
+            self.sumo_pages.kb_article_discussion_page._click_on_edit_this_thread_option()
+            (self.sumo_pages.kb_article_discussion_page
+                ._add_text_to_edit_article_thread_title_field(
+                    self.kb_new_thread_test_data['updated_thread_title']))
+            self.sumo_pages.kb_article_discussion_page._click_on_edit_article_thread_cancel_button(
+            )
 
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+        with check, allure.step("Verifying that the thread title was not changed"):
+            assert self.sumo_pages.kb_article_discussion_page._get_thread_title_text(
+            ) == thread_info_two['thread_title']
 
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info_two = (self.sumo_pages.post_kb_discussion_thread_flow.
-                           add_new_kb_discussion_thread())
+        with allure.step("Adding data inside the edit this thread title field and clicking on "
+                         "the update button"):
+            self.sumo_pages.kb_article_discussion_page._click_on_edit_this_thread_option()
+            (self.sumo_pages.kb_article_discussion_page
+                ._add_text_to_edit_article_thread_title_field(
+                    self.kb_new_thread_test_data['updated_thread_title']))
+            self.sumo_pages.kb_article_discussion_page._click_on_edit_article_thread_update_button(
+            )
 
-        self.logger.info("Clicking on the 'Edit this thread' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_edit_this_thread_option()
+        with check, allure.step("Verifying that the thread title was changed"):
+            assert self.sumo_pages.kb_article_discussion_page._get_thread_title_text(
+            ) == self.kb_new_thread_test_data['updated_thread_title']
 
-        self.logger.info("Adding data inside the title field")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_edit_article_thread_title_field(
-            self.kb_new_thread_test_data['updated_thread_title']
-        )
+        with allure.step("Deleting user session adn verifying that the edit this thread option "
+                         "is not displayed"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_edit_this_thread_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Clicking on the 'Cancel' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_edit_article_thread_cancel_button()
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Verifying that the thread title was not changed")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_thread_title_text(),
-            thread_info_two['thread_title']
-        )
-
-        self.logger.info("Clicking on the 'Edit this thread' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_edit_this_thread_option()
-
-        self.logger.info("Adding data inside the title field")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_edit_article_thread_title_field(
-            self.kb_new_thread_test_data['updated_thread_title']
-        )
-
-        self.logger.info("Clicking on the 'Update' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_edit_article_thread_update_button()
-
-        self.logger.info("Verifying that the thread title was changed")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_thread_title_text(),
-            self.kb_new_thread_test_data['updated_thread_title']
-        )
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_edit_this_thread_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with an Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
+        with allure.step("Navigating back to the discussions page"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
 
         if thread_author == 'self':
-            self.logger.info("Clicking on the self posted thread")
-            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-                thread_info_one["thread_id"]
-            )
+            with allure.step("Clicking on the self posted thread"):
+                self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                    thread_info_one["thread_id"]
+                )
         else:
-            self.logger.info("Clicking on the other user posted thread")
-            self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
-                thread_info_two["thread_id"])
+            with allure.step("Clicking on the other user posted thread"):
+                self.sumo_pages.kb_article_discussion_page._click_on_a_particular_thread(
+                    thread_info_two["thread_id"])
 
-        self.logger.info("Clicking on the 'Edit this thread' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_edit_this_thread_option()
-
-        self.logger.info("Adding data inside the title field")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_edit_article_thread_title_field(
-            self.kb_new_thread_test_data['second_thread_updated_title']
-        )
-
-        self.logger.info("Clicking on the 'Cancel' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_edit_article_thread_cancel_button()
+        with allure.step("Clicking on the 'Edit this thread', adding data inside the title field "
+                         "and clicking on the cancel button"):
+            self.sumo_pages.kb_article_discussion_page._click_on_edit_this_thread_option()
+            (self.sumo_pages.kb_article_discussion_page
+                ._add_text_to_edit_article_thread_title_field(
+                    self.kb_new_thread_test_data['second_thread_updated_title']))
+            self.sumo_pages.kb_article_discussion_page._click_on_edit_article_thread_cancel_button(
+            )
 
         if thread_author == 'self':
-            self.logger.info("Verifying that the thread title was not changed")
-            check.equal(
-                self.sumo_pages.kb_article_discussion_page._get_thread_title_text(),
-                thread_info_one['thread_title']
-            )
+            with check, allure.step("Verifying that the thread title was not changed"):
+                assert self.sumo_pages.kb_article_discussion_page._get_thread_title_text(
+                ) == thread_info_one['thread_title']
         else:
-            self.logger.info("Verifying that the thread title was not changed")
-            check.equal(
-                self.sumo_pages.kb_article_discussion_page._get_thread_title_text(),
-                self.kb_new_thread_test_data['updated_thread_title']
+            with check, allure.step("Verifying that the thread title was not changed"):
+                assert self.sumo_pages.kb_article_discussion_page._get_thread_title_text(
+                ) == self.kb_new_thread_test_data['updated_thread_title']
+
+        with allure.step("Adding data inside the edit this thread title field and clicking on "
+                         "the update button"):
+            self.sumo_pages.kb_article_discussion_page._click_on_edit_this_thread_option()
+            (self.sumo_pages.kb_article_discussion_page
+                ._add_text_to_edit_article_thread_title_field(
+                    self.kb_new_thread_test_data['second_thread_updated_title']))
+            self.sumo_pages.kb_article_discussion_page._click_on_edit_article_thread_update_button(
             )
 
-        self.logger.info("Clicking on the 'Edit this thread' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_edit_this_thread_option()
+        with check, allure.step("Verifying that the thread title was changed"):
+            assert self.sumo_pages.kb_article_discussion_page._get_thread_title_text(
+            ) == self.kb_new_thread_test_data['second_thread_updated_title']
 
-        self.logger.info("Adding data inside the title field")
-        self.sumo_pages.kb_article_discussion_page._add_text_to_edit_article_thread_title_field(
-            self.kb_new_thread_test_data['second_thread_updated_title']
-        )
+        with allure.step("Navigating back to the discussions page"):
+            self.navigate_to_link(
+                TestArticleThreads.article_url + KBArticlePageMessages.
+                KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
 
-        self.logger.info("Clicking on the 'Update' button")
-        self.sumo_pages.kb_article_discussion_page._click_on_edit_article_thread_update_button()
+        with check, allure.step("Verifying that the updated thread title is displayed inside the "
+                                "threads list"):
+            assert (self.kb_new_thread_test_data['second_thread_updated_title'] in self.sumo_pages
+                    .kb_article_discussion_page._get_all_article_threads_titles())
 
-        self.logger.info("Verifying that the thread title was changed")
-        check.equal(
-            self.sumo_pages.kb_article_discussion_page._get_thread_title_text(),
-            self.kb_new_thread_test_data['second_thread_updated_title']
-        )
-
-        self.logger.info("Navigating back to the discussions page")
-        self.navigate_to_link(
-            TestArticleThreads.article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the updated thread title is displayed inside the "
-                         "threads list")
-        check.is_in(
-            self.kb_new_thread_test_data['second_thread_updated_title'],
-            self.sumo_pages.kb_article_discussion_page._get_all_article_threads_titles()
-        )
-
-        self.__clearing_newly_created_thread(thread_info_one['thread_id'])
-        self.__clearing_newly_created_thread(thread_info_two['thread_id'])
+        with allure.step("Clearing all the created threads"):
+            self.__clearing_newly_created_thread(thread_info_one['thread_id'])
+            self.__clearing_newly_created_thread(thread_info_two['thread_id'])
 
     # To be used in specific tests
     def __posting_a_new_test_article_manually(self, approve_it: bool,

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_explore_articles_products_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_explore_articles_products_page.py
@@ -1,6 +1,8 @@
+import allure
+
 from playwright_tests.core.testutilities import TestUtilities
 from playwright.sync_api import expect
-import pytest_check as check
+from pytest_check import check
 import pytest
 
 from playwright_tests.messages.homepage_messages import HomepageMessages
@@ -13,46 +15,42 @@ class TestPostedQuestions(TestUtilities):
     # C890834, C890833
     @pytest.mark.kbProductsPage
     def test_products_page_content(self):
-        self.logger.info("Navigating to products page via top-navbar")
-        self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
+        with check, allure.step("Navigating to products page via top-navbar and verifying that "
+                                "the correct page header is displayed"):
+            self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
+            assert self.sumo_pages.products_page._get_page_header(
+            ) == ProductsPageMessages.PRODUCTS_PAGE_HEADER
 
-        self.logger.info("Verifying that the correct page header is displayed")
-        check.equal(
-            self.sumo_pages.products_page._get_page_header(),
-            ProductsPageMessages.PRODUCTS_PAGE_HEADER
-        )
+        with allure.step("Clicking on the first 'Home' breadcrumb and verifying the redirect"):
+            self.sumo_pages.products_page._click_on_first_breadcrumb()
+            expect(
+                self.page
+            ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
 
-        self.logger.info("Clicking on the first 'Home' breadcrumb and verifying the redirect")
-        self.sumo_pages.products_page._click_on_first_breadcrumb()
-        expect(
-            self.page
-        ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
-
-        self.logger.info("Navigating back to the 'Products' page")
-        self.navigate_back()
+        with allure.step("Navigating back to the 'Products' page"):
+            self.navigate_back()
 
         for card in self.sumo_pages.products_page._get_all_product_support_titles():
-            self.logger.info(f"Verifying that the {card} card contains the correct subheading")
-            if card in ProductsPageMessages.PRODUCT_CARDS_SUBHEADING:
-                check.equal(
-                    self.sumo_pages.products_page._get_subheading_of_card(card),
-                    ProductsPageMessages.PRODUCT_CARDS_SUBHEADING[card]
-                )
+            with check, allure.step(f"Verifying that the {card} card contains the correct "
+                                    f"subheading"):
+                if card in ProductsPageMessages.PRODUCT_CARDS_SUBHEADING:
+                    assert self.sumo_pages.products_page._get_subheading_of_card(
+                        card) == ProductsPageMessages.PRODUCT_CARDS_SUBHEADING[card]
 
     # C890846
     @pytest.mark.kbProductsPage
     def test_products_page_card_redirect(self):
-        self.logger.info("Navigating to products page via top-navbar")
-        self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
+        with allure.step("Navigating to products page via top-navbar"):
+            self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
 
         for card in self.sumo_pages.products_page._get_all_product_support_titles():
             if card in self.general_test_data['product_support']:
-                self.logger.info(f"Clicking on {card} card and verifying that we are redirected "
-                                 f"to the correct product url")
-                self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
-                expect(
-                    self.page
-                ).to_have_url(self.general_test_data['product_support'][card])
+                with allure.step(f"Clicking on {card} card and verifying that we are redirected "
+                                 f"to the correct product url"):
+                    self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
+                    expect(
+                        self.page
+                    ).to_have_url(self.general_test_data['product_support'][card])
 
-                self.logger.info("Navigating back to the products page")
-                self.navigate_back()
+                with allure.step("Navigating back to the products page"):
+                    self.navigate_back()

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
@@ -1,4 +1,5 @@
-import pytest_check as check
+import allure
+from pytest_check import check
 import pytest
 import re
 from playwright.sync_api import expect
@@ -15,527 +16,431 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
     # C891308, C2081444
     @pytest.mark.kbArticleCreationAndAccess
     def test_non_admin_users_kb_article_submission(self):
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-Admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
-        self.logger.info("Verifying that the user is redirected to the article's show history "
-                         "page after submission")
-        expect(
-            self.page
-        ).to_have_url(
-            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
-            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT)
+        with allure.step("Verifying that the user is redirected to the article's show history "
+                         "page after submission"):
+            expect(
+                self.page
+            ).to_have_url(
+                KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
+                ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT)
 
-        self.logger.info("Verifying that the revision contains the correct status")
-        status = self.sumo_pages.kb_article_show_history_page._get_revision_status(
-            self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
-        )
+        with check, allure.step("Verifying that the revision contains the correct status"):
+            status = self.sumo_pages.kb_article_show_history_page._get_revision_status(
+                self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            )
+            assert KBArticlePageMessages.UNREVIEWED_REVISION_STATUS == status
 
-        check.equal(
-            KBArticlePageMessages.UNREVIEWED_REVISION_STATUS,
-            status
-        )
+        with check, allure.step("Clicking on the 'Article' navbar menu and verifying that the "
+                                "doc content contains the correct string"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            assert self.sumo_pages.kb_article_page._get_text_of_kb_article_content(
+            ) == KBArticlePageMessages.KB_ARTICLE_NOT_APPROVED_CONTENT
 
-        self.logger.info("Clicking on the 'Article' navbar menu")
-        self.sumo_pages.kb_article_page._click_on_article_option()
+        with check, allure.step("Deleting user session and verifying that the 404 page is "
+                                "received"):
+            with self.page.expect_navigation() as navigation_info:
+                self.delete_cookies()
+            response = navigation_info.value
+            assert response.status == 404
 
-        self.logger.info("Verifying that the doc content contains the correct string")
-        check.equal(
-            self.sumo_pages.kb_article_page._get_text_of_kb_article_content(),
-            KBArticlePageMessages.KB_ARTICLE_NOT_APPROVED_CONTENT
-        )
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Deleting user session and verifying that the 404 page is received")
-        with self.page.expect_navigation() as navigation_info:
-            self.delete_cookies()
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            404
-        )
+        with check, allure.step("Clicking on the 'Show History' option and verifying that the "
+                                "revision contains the correct status"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            status = (
+                self.sumo_pages.kb_article_show_history_page._get_status_of_reviewable_revision(
+                    self.sumo_pages.kb_article_show_history_page._get_last_revision_id()))
+            assert KBArticlePageMessages.REVIEW_REVISION_STATUS == status
 
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.logger.info("Verifying that the revision contains the correct status")
-        status = self.sumo_pages.kb_article_show_history_page._get_status_of_reviewable_revision(
-            self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
-        )
-
-        check.equal(
-            KBArticlePageMessages.REVIEW_REVISION_STATUS,
-            status
-        )
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the created article"):
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2081446, # C2081447
     @pytest.mark.kbArticleCreationAndAccess
     def test_articles_revision_page_and_revision_approval(self):
-        self.logger.info("Signing in with a non-Admin account")
-        username = self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            username = self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
-        self.logger.info("Signing in with an Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
-        self.logger.info("Clicking on the 'Review' option")
-        self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
-            revision_id
-        )
-
-        self.logger.info("Verifying that the correct revision header is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_review_revision_page._get_revision_header(),
-            KBArticleRevision.KB_ARTICLE_REVISION_HEADER + article_details['article_title'],
-        )
-
-        self.logger.info("Verifying that the correct subtext is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_review_revision_page._get_reviewing_revision_text()
-            .replace("\n", "").strip(),
-            self.get_kb_article_revision_details(
-                revision_id=re.findall(r'\d+', revision_id)[0],
-                username=username,
-                revision_comment=article_details['article_review_description']
-            ).strip()
-        )
-
-        self.logger.info("Click on the 'Back to History' option and verifying that the user is "
-                         "redirected to the article history page")
-        self.sumo_pages.kb_article_review_revision_page._click_on_back_to_history_option()
-        expect(
-            self.page
-        ).to_have_url(
-            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
-            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
-        )
-
-        self.logger.info("Navigate back")
-        self.navigate_back()
-
-        self.logger.info("Verifying that the 'Keywords:' header is displayed")
-        check.is_true(
-            self.sumo_pages.kb_article_review_revision_page._is_keywords_header_visible()
-        )
-
-        self.logger.info("Verifying that the correct keyword is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_review_revision_page._get_keywords_content(),
-            article_details['keyword']
-        )
-
-        self.logger.info("Verifying that the 'Search results summary:' header is displayed")
-        check.is_true(
-            self.sumo_pages.kb_article_review_revision_page._is_search_results_summary_visible()
-        )
-
-        self.logger.info("Verifying that the correct search result summary is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_review_revision_page._get_search_results_summary_content(),
-            article_details['search_results_summary']
-        )
-
-        self.logger.info("Verifying that the 'Revision source:' header is displayed")
-        check.is_true(
-            self.sumo_pages.kb_article_review_revision_page._is_revision_source_visible()
-        )
-
-        self.logger.info("Verifying that the correct revision source content is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_review_revision_page._revision_source_content(),
-            article_details['article_content']
-        )
-
-        self.logger.info("Verifying that the 'Revision rendered html:' header is displayed")
-        check.is_true(
-            self.sumo_pages.kb_article_review_revision_page.
-            _is_revision_rendered_html_header_visible()
-        )
-
-        self.logger.info("Verifying that the correct 'Revision rendered html:' content is "
-                         "displayed")
-        check.equal(
-            self.sumo_pages.kb_article_review_revision_page._get_revision_rendered_html_content(),
-            article_details['article_content_html']
-        )
-
-        self.logger.info("Click on 'Approve Revision' button")
-        self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
-
-        self.logger.info("Clicking on the 'Accept' button")
-        self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
-
-        self.logger.info("Verifying that the review status updates to 'Current'")
-        check.equal(
-            self.sumo_pages.kb_article_show_history_page._get_revision_status(
+        with check, allure.step("Clicking on the first review and verifying that the correct "
+                                "revision header is displayed"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            self.logger.info("Clicking on the 'Review' option")
+            self.sumo_pages.kb_article_show_history_page._click_on_review_revision(
                 revision_id
-            ),
-            KBArticlePageMessages.CURRENT_REVISION_STATUS
-        )
+            )
+            assert self.sumo_pages.kb_article_review_revision_page._get_revision_header(
+            ) == KBArticleRevision.KB_ARTICLE_REVISION_HEADER + article_details['article_title']
 
-        self.logger.info("Clicking on the 'Article' editing tools option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
+        with check, allure.step("Verifying that the correct subtext is displayed"):
+            assert (self.sumo_pages.kb_article_review_revision_page._get_reviewing_revision_text()
+                    .replace("\n", "").strip() == self.get_kb_article_revision_details(
+                    revision_id=re.findall(r'\d+', revision_id)[0],
+                    username=username,
+                    revision_comment=article_details['article_review_description']
+                    ).strip())
 
-        self.logger.info("Verifying that the correct html article content is displayed")
-        check.equal(
-            self.sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(),
-            article_details['article_content_html']
-        )
+        with allure.step("Click on the 'Back to History' option and verifying that the user is "
+                         "redirected to the article history page"):
+            self.sumo_pages.kb_article_review_revision_page._click_on_back_to_history_option()
+            expect(
+                self.page
+            ).to_have_url(
+                KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
+                ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
+            )
 
-        self.logger.info("Signing out and verifying that the correct article content is displayed")
-        self.delete_cookies()
+        with check, allure.step("Navigate back and verifying that the 'Keywords:' header is "
+                                "displayed"):
+            self.navigate_back()
+            assert self.sumo_pages.kb_article_review_revision_page._is_keywords_header_visible()
 
-        check.equal(
-            self.sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(),
-            article_details['article_content_html']
-        )
+        with check, allure.step("Verifying that the correct keyword is displayed"):
+            assert self.sumo_pages.kb_article_review_revision_page._get_keywords_content(
+            ) == article_details['keyword']
 
-        self.logger.info("Signing in with a non admin account and verifying that the correct "
-                         "content is displayed")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with check, allure.step("Verifying that the correct header is displayed"):
+            assert (self.sumo_pages.kb_article_review_revision_page
+                    ._is_search_results_summary_visible())
 
-        check.equal(
-            self.sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(),
-            article_details['article_content_html']
-        )
+        with check, allure.step("Verifying that the correct search result summary is displayed"):
+            assert (self.sumo_pages.kb_article_review_revision_page
+                    ._get_search_results_summary_content(
+                    ) == article_details['search_results_summary'])
 
-        self.logger.info("Signing in with an admin account and deleting the article")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with check, allure.step("Verifying that the 'Revision source:' header is displayed"):
+            assert self.sumo_pages.kb_article_review_revision_page._is_revision_source_visible()
 
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with check, allure.step("Verifying that the correct revision source content is displayed"):
+            assert self.sumo_pages.kb_article_review_revision_page._revision_source_content(
+            ) == article_details['article_content']
+
+        with check, allure.step("Verifying that the correct header is displayed"):
+            assert (self.sumo_pages.kb_article_review_revision_page
+                    ._is_revision_rendered_html_header_visible())
+
+        with check, allure.step("Verifying that the correct 'Revision rendered html:' content is "
+                                "displayed"):
+            assert (self.sumo_pages.kb_article_review_revision_page
+                    ._get_revision_rendered_html_content(
+                    ) == article_details['article_content_html'])
+
+        with allure.step("Approving the revision"):
+            self.sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
+            self.sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+
+        with check, allure.step("Verifying that the review status updates to 'Current'"):
+            assert self.sumo_pages.kb_article_show_history_page._get_revision_status(
+                revision_id
+            ) == KBArticlePageMessages.CURRENT_REVISION_STATUS
+
+        with allure.step("Clicking on the 'Article' editing tools option"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+
+        with check, allure.step("Verifying that the correct html article content is displayed"):
+            assert self.sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(
+            ) == article_details['article_content_html']
+
+        with check, allure.step("Signing out and verifying that the correct article content is "
+                                "displayed"):
+            self.delete_cookies()
+            assert self.sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(
+            ) == article_details['article_content_html']
+
+        with check, allure.step("Signing in with a non admin account and verifying if the "
+                                "correct content is displayed"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            assert self.sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(
+            ) == article_details['article_content_html']
+
+        with allure.step("Signing in with an admin account and deleting the article"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2091580, C954321
     @pytest.mark.kbArticleCreationAndAccess
     def test_articles_discussions_allowed(self):
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
-        self.logger.info("Clicking on the article option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
-        article_url = self.get_page_url()
+        with allure.step("Clicking on the article option and posting a new article thread"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            article_url = self.get_page_url()
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread_info = (self.sumo_pages.post_kb_discussion_thread_flow.
+                           add_new_kb_discussion_thread())
 
-        self.logger.info("Clicking on the 'Discussion' editing tools navbar option")
-        self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
-
-        self.logger.info("Clicking on the 'Post a new thread button'")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info = (self.sumo_pages.post_kb_discussion_thread_flow.
-                       add_new_kb_discussion_thread())
-
-        self.logger.info("Manually navigating to the discuss endpoint")
-        self.navigate_to_link(
-            article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the posted thread is successfully displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_posted_thread_locator(
-                thread_info['thread_id']
+        with allure.step("Manually navigating to the discuss endpoint"):
+            self.navigate_to_link(
+                article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
             )
-        ).to_be_visible()
 
-        self.logger.info("Navigating to the article page")
-        self.navigate_to_link(article_url)
+        with allure.step("Verifying that the posted thread is successfully displayed"):
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_posted_thread_locator(
+                    thread_info['thread_id']
+                )
+            ).to_be_visible()
 
-        expect(
-            self.page
-        ).to_have_url(article_url)
+        with allure.step("Navigating to the article page"):
+            self.navigate_to_link(article_url)
+            expect(
+                self.page
+            ).to_have_url(article_url)
 
-        self.logger.info("Signing in with an Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        with allure.step("Approving the article revision"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+        with allure.step("Navigating to the article page"):
+            self.navigate_to_link(article_url)
+            expect(
+                self.page
+            ).to_have_url(article_url)
 
-        self.logger.info("Navigating to the article page")
-        self.navigate_to_link(article_url)
+        with allure.step("Deleting user session and verifying that the discussion editing tools "
+                         "option is not available"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_article_page._editing_tools_discussion_locator()
+            ).to_be_hidden()
 
-        expect(
-            self.page
-        ).to_have_url(article_url)
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
-        self.logger.info("Verifying that the discussion editing tools option is not available")
-        expect(
-            self.sumo_pages.kb_article_page._editing_tools_discussion_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Manually navigating to the discuss endpoint")
-        self.navigate_to_link(
-            article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the posted thread is successfully displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_posted_thread_locator(
-                thread_info['thread_id']
+        with allure.step("Manually navigating to the discuss endpoint and verifying that the "
+                         "posted thread is successfully displayed"):
+            self.navigate_to_link(
+                article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
             )
-        ).to_be_visible()
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_posted_thread_locator(
+                    thread_info['thread_id']
+                )
+            ).to_be_visible()
 
-        self.logger.info("Manually navigating to the discuss endpoint")
-        self.navigate_to_link(
-            article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Clicking on the 'Post a new thread' option")
-        self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
-
-        self.logger.info("Verifying that the user is to the auth page")
-        assert (
-            FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
-        )
-
-        self.logger.info("Signing in")
-        self.sumo_pages.auth_flow_page.sign_in_flow(
-            username=super().user_special_chars,
-            account_password=super().user_secrets_pass,
-        )
-
-        self.logger.info("Posting a new kb article discussion thread")
-        thread_info = (self.sumo_pages.post_kb_discussion_thread_flow.
-                       add_new_kb_discussion_thread())
-
-        self.logger.info("Manually navigating to the discuss endpoint")
-        self.navigate_to_link(
-            article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-        )
-
-        self.logger.info("Verifying that the posted thread is successfully displayed")
-        expect(
-            self.sumo_pages.kb_article_discussion_page._get_posted_thread_locator(
-                thread_info['thread_id']
+        with allure.step("Manually navigating to the discuss endpoint"):
+            self.navigate_to_link(
+                article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
             )
-        ).to_be_visible()
 
-        self.logger.info("Signing in with an admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Clicking on the 'Post a new thread' option and verifying that the user "
+                         "is redirected to the auth page"):
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            assert (
+                FxAPageMessages.AUTH_PAGE_URL in self.get_page_url()
+            )
 
-        self.logger.info("Navigating to the article and deleting it")
-        self.navigate_to_link(article_url)
+        with allure.step("Signing in with a different account and posting a new kb article "
+                         "discussion thread"):
+            self.sumo_pages.auth_flow_page.sign_in_flow(
+                username=super().user_special_chars,
+                account_password=super().user_secrets_pass,
+            )
+            thread_info = (self.sumo_pages.post_kb_discussion_thread_flow.
+                           add_new_kb_discussion_thread())
 
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Manually navigating to the discuss endpoint and verifying that the "
+                         "posted thread is successfully displayed"):
+            self.navigate_to_link(
+                article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+            )
+            expect(
+                self.sumo_pages.kb_article_discussion_page._get_posted_thread_locator(
+                    thread_info['thread_id']
+                )
+            ).to_be_visible()
+
+        with allure.step("Signing in with an admin account and deleting the article"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2091581
     @pytest.mark.kbArticleCreationAndAccess
     def test_articles_discussions_not_allowed(self):
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(allow_discussion=False)
+        with allure.step("Create a new simple article"):
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(allow_discussion=False)
 
-        self.logger.info("Clicking on the article option")
-        self.sumo_pages.kb_article_page._click_on_article_option()
+        with allure.step("Clicking on the article option and verifying that the 'Discussion' "
+                         "option is not displayed"):
+            self.sumo_pages.kb_article_page._click_on_article_option()
+            article_url = self.get_page_url()
+            expect(
+                self.sumo_pages.kb_article_page._editing_tools_discussion_locator()
+            ).to_be_hidden()
 
-        article_url = self.get_page_url()
+        with check, allure.step("Manually navigating to the 'Discuss' endpoint and verifying "
+                                "that the 404 is displayed"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+                )
+            response = navigation_info.value
+            assert response.status == 404
 
-        self.logger.info("Verifying that the 'Discussion' option is not displayed")
-        expect(
-            self.sumo_pages.kb_article_page._editing_tools_discussion_locator()
-        ).to_be_hidden()
+        with allure.step("Navigating back to the article page and signing in with admin"):
+            self.navigate_to_link(article_url)
+            expect(
+                self.page
+            ).to_have_url(article_url)
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Manually navigating to the 'Discuss' endpoint")
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-            )
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            404
-        )
+        with allure.step("Approving the revision"):
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
 
-        self.logger.info("Navigating back to the article page and signing in with admin")
-        self.navigate_to_link(article_url)
+        with allure.step("Navigating back to the article page and verifying that the "
+                         "'Discussion' option is not displayed"):
+            self.navigate_to_link(article_url)
+            expect(
+                self.sumo_pages.kb_article_page._editing_tools_discussion_locator()
+            ).to_be_hidden()
 
-        expect(
-            self.page
-        ).to_have_url(article_url)
+        with check, allure.step("Manually navigating to the 'Discuss' endpoint and verifying "
+                                "that the 404 page is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+                )
+            response = navigation_info.value
+            assert response.status == 404
 
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Navigating back and deleting the user session"):
+            self.navigate_to_link(article_url)
+            expect(
+                self.page
+            ).to_have_url(article_url)
+            self.delete_cookies()
 
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        with allure.step("Verifying that the 'Discussion' option is not displayed"):
+            expect(
+                self.sumo_pages.kb_article_page._editing_tools_discussion_locator()
+            ).to_be_hidden()
 
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+        with check, allure.step("Manually navigating to the 'Discuss' endpoint and verifying "
+                                "that the 404 page is displayed"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
+                )
+            response = navigation_info.value
+            assert response.status == 404
 
-        self.logger.info("Navigating back to the article page")
-        self.navigate_to_link(article_url)
-
-        self.logger.info("Verifying that the 'Discussion' option is not displayed")
-        expect(
-            self.sumo_pages.kb_article_page._editing_tools_discussion_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Manually navigating to the 'Discuss' endpoint")
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-            )
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            404
-        )
-
-        self.logger.info("Navigating back")
-        self.navigate_to_link(article_url)
-
-        expect(
-            self.page
-        ).to_have_url(article_url)
-
-        self.logger.info("Deleting user session")
-        self.delete_cookies()
-
-        self.logger.info("Verifying that the 'Discussion' option is not displayed")
-        expect(
-            self.sumo_pages.kb_article_page._editing_tools_discussion_locator()
-        ).to_be_hidden()
-
-        self.logger.info("Manually navigating to the 'Discuss' endpoint")
-        with self.page.expect_navigation() as navigation_info:
-            self.navigate_to_link(
-                article_url + KBArticlePageMessages.KB_ARTICLE_DISCUSSIONS_ENDPOINT
-            )
-        response = navigation_info.value
-        check.equal(
-            response.status,
-            404
-        )
-
-        self.logger.info("Navigating back to the article page")
-        self.navigate_to_link(article_url)
-
-        expect(
-            self.page
-        ).to_have_url(article_url)
-
-        self.logger.info("Signing in with an admin account and deleting the article")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Navigating back to the article page and deleting the article"):
+            self.navigate_to_link(article_url)
+            expect(
+                self.page
+            ).to_have_url(article_url)
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2091665
     @pytest.mark.kbArticleCreationAndAccess
     def test_kb_article_title_and_slug_validations(self):
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        with allure.step("Create a new simple article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
-        self.logger.info("Verifying that the article slug was pre-populated successfully")
-        check.equal(
-            article_details['article_slug'],
-            self.create_slug_from_title(article_details['article_title'])
-        )
+        with check, allure.step("Verifying that the article slug was pre-populated successfully"):
+            assert article_details['article_slug'] == self.create_slug_from_title(
+                article_details['article_title'])
 
-        self.logger.info("Navigating to the create kb article form")
-        self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+        with allure.step("Navigating to the create kb article form and submitting the form "
+                         "without adding a title & slug"):
+            self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                article_title="",
+                article_slug="",
+            )
 
-        self.logger.info("Submitting the form without adding a title & slug")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            article_title="",
-            article_slug="",
-        )
+        with allure.step("Verifying that we are on the same page"):
+            expect(
+                self.page
+            ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+        with allure.step("Navigating to the create kb article form, submitting the form without "
+                         "adding a slug and verifying that we are on the same page"):
+            self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                article_slug="",
+            )
+            expect(
+                self.page
+            ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
-        self.logger.info("Navigating to the create kb article form")
-        self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+        with allure.step("Navigating to the create kb article form and submitting the form "
+                         "without adding a title"):
+            self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                article_title="",
+                article_slug=self.kb_article_test_data['different_slug']
+            )
 
-        self.logger.info("Submitting the form without adding a slug")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            article_slug="",
-        )
+        with allure.step("Verifying that we are on the same page"):
+            expect(
+                self.page
+            ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-
-        self.logger.info("Navigating to the create kb article form")
-        self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-
-        self.logger.info("Submitting the form without adding a title")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            article_title="",
-            article_slug=self.kb_article_test_data['different_slug']
-        )
-
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-
-        self.logger.info("Navigating to the create kb article form")
-        self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-
-        self.logger.info("Adding the same title and slug inside article form")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            article_title=article_details['article_title'],
-            article_slug=article_details['article_slug'],
-            submit_article=False
-        )
+        with allure.step("Navigating to the create kb article form and adding the same title and "
+                         "slug inside article form"):
+            self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                article_title=article_details['article_title'],
+                article_slug=article_details['article_slug'],
+                submit_article=False
+            )
 
         # Currently fails due to https://github.com/mozilla/sumo/issues/1641
         # self.logger.info("Verifying that the correct errors are displayed")
@@ -549,30 +454,25 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         #     KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS[1]
         # )
 
-        self.logger.info("Submitting the form")
-        self.sumo_pages.kb_submit_kb_article_form_page._click_on_submit_for_review_button()
-        self.sumo_pages.kb_submit_kb_article_form_page._add_text_to_changes_description_field(
-            self.kb_article_test_data["changes_description"]
-        )
-        self.sumo_pages.kb_submit_kb_article_form_page._click_on_changes_submit_button()
-
-        self.logger.info("Verifying that both title and slug errors are displayed")
-        for error in (self.sumo_pages.kb_submit_kb_article_form_page.
-                      get_all_kb_errors()):
-            check.is_in(
-                error,
-                KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS
+        with check, allure.step("Submitting the form and verifying that both title and slug "
+                                "errors are displayed"):
+            self.sumo_pages.kb_submit_kb_article_form_page._click_on_submit_for_review_button()
+            self.sumo_pages.kb_submit_kb_article_form_page._add_text_to_changes_description_field(
+                self.kb_article_test_data["changes_description"]
             )
+            self.sumo_pages.kb_submit_kb_article_form_page._click_on_changes_submit_button()
+            for error in (self.sumo_pages.kb_submit_kb_article_form_page.
+                          get_all_kb_errors()):
+                assert error in KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS
 
-        self.logger.info("Navigate to the kb submission page")
-        self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-
-        self.logger.info("Adding same title and a different slug")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            article_title=article_details['article_title'],
-            article_slug=self.kb_article_test_data['different_slug'],
-            submit_article=False
-        )
+        with allure.step("Navigate to the kb submission page and adding same title and a "
+                         "different slug"):
+            self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                article_title=article_details['article_title'],
+                article_slug=self.kb_article_test_data['different_slug'],
+                submit_article=False
+            )
 
         # # Currently fails due to https://github.com/mozilla/sumo/issues/1641
         # self.logger.info("Verifying that the title error is displayed")
@@ -585,26 +485,23 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         #     self.sumo_pages.kb_submit_kb_article_form_page.get_kb_slug_error()
         # ).to_be_hidden()
 
-        self.logger.info("Submitting the form")
-        self.sumo_pages.kb_submit_kb_article_form_page._click_on_submit_for_review_button()
-        self.sumo_pages.kb_submit_kb_article_form_page._add_text_to_changes_description_field(
-            self.kb_article_test_data["changes_description"]
-        )
-        self.sumo_pages.kb_submit_kb_article_form_page._click_on_changes_submit_button()
+        with check, allure.step("Submitting the form and verifying that the correct error is "
+                                "displayed"):
+            self.sumo_pages.kb_submit_kb_article_form_page._click_on_submit_for_review_button()
+            self.sumo_pages.kb_submit_kb_article_form_page._add_text_to_changes_description_field(
+                self.kb_article_test_data["changes_description"]
+            )
+            self.sumo_pages.kb_submit_kb_article_form_page._click_on_changes_submit_button()
+            assert self.sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors(
+            )[0] == KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS[0]
 
-        check.equal(
-            self.sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors()[0],
-            KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS[0]
-        )
-
-        self.logger.info("Navigate to the kb submission page")
-        self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-
-        self.logger.info("Adding different title but same slug")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            article_slug=article_details['article_slug'],
-            submit_article=False
-        )
+        with allure.step("Navigate to the kb submission page and adding different title but same "
+                         "slug"):
+            self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                article_slug=article_details['article_slug'],
+                submit_article=False
+            )
 
         # # Currently fails due to https://github.com/mozilla/sumo/issues/1641
         # self.logger.info("Verifying that the title error is not displayed")
@@ -617,186 +514,161 @@ class TestKBArticleCreationAndAccess(TestUtilities, KBArticleRevision):
         #     self.sumo_pages.kb_submit_kb_article_form_page.get_kb_slug_error()
         # ).to_be_visible()
 
-        self.logger.info("Submitting the form")
-        self.sumo_pages.kb_submit_kb_article_form_page._click_on_submit_for_review_button()
-        self.sumo_pages.kb_submit_kb_article_form_page._add_text_to_changes_description_field(
-            self.kb_article_test_data["changes_description"]
-        )
-        self.sumo_pages.kb_submit_kb_article_form_page._click_on_changes_submit_button()
+        with check, allure.step("Submitting the form and verifying that the correct error "
+                                "message is displayed"):
+            self.sumo_pages.kb_submit_kb_article_form_page._click_on_submit_for_review_button()
+            self.sumo_pages.kb_submit_kb_article_form_page._add_text_to_changes_description_field(
+                self.kb_article_test_data["changes_description"]
+            )
+            self.sumo_pages.kb_submit_kb_article_form_page._click_on_changes_submit_button()
+            assert self.sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors(
+            )[0] == KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS[1]
 
-        check.equal(
-            self.sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors()[0],
-            KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS[1]
-        )
-
-        self.logger.info("Deleting the created article")
-        self.navigate_to_link(
-            KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
-            ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT)
-
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Deleting the created article"):
+            self.navigate_to_link(
+                KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
+                ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C2091665
     @pytest.mark.kbArticleCreationAndAccess
     def test_kb_article_relevancy_validations(self):
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(selected_relevancy=False)
+        with allure.step("Create a new simple article and verifying that we are on the same page"):
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                selected_relevancy=False
+            )
+            expect(
+                self.page
+            ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-
-        self.logger.info("Verifying that the correct error message is displayed")
-        check.equal(
-            self.sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors()[0],
-            KBArticlePageMessages.KB_ARTICLE_RELEVANCY_ERROR
-        )
+        with check, allure.step("Verifying that the correct error message is displayed"):
+            assert self.sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors(
+            )[0] == KBArticlePageMessages.KB_ARTICLE_RELEVANCY_ERROR
 
     # C2091665
     @pytest.mark.kbArticleCreationAndAccess
     def test_kb_article_topic_validation(self):
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(selected_topics=False)
+        with allure.step("Create a new simple article and verifying that we are on the same page"):
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                selected_topics=False
+            )
+            expect(
+                self.page
+            ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-
-        self.logger.info("Verifying that the correct error message is displayed")
-        check.equal(
-            self.sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors()[0],
-            KBArticlePageMessages.KB_ARTICLE_TOPIC_ERROR
-        )
+        with check, allure.step("Verifying that the correct error message is displayed"):
+            assert self.sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors(
+            )[0] == KBArticlePageMessages.KB_ARTICLE_TOPIC_ERROR
 
     # C2091665
     @pytest.mark.kbArticleCreationAndAccess
     def test_kb_article_summary_and_content_validation(self):
-        self.logger.info("Signing in with a non-Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Create a new simple article by leaving out the search summary")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(search_summary="")
+        with allure.step("Create a new simple article by leaving out the search summary"):
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(search_summary="")
 
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+        with allure.step("Verifying that we are on the same page"):
+            expect(
+                self.page
+            ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
-        self.logger.info("Navigating to the create kb article form")
-        self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-
-        self.logger.info("Create a new simple article by leaving out the article content")
-        self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(article_content="")
-
-        self.logger.info("Verifying that we are on the same page")
-        expect(
-            self.page
-        ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+        with allure.step("Create a new simple article by leaving out the article content and "
+                         "verifying that we are on the same page"):
+            self.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
+            self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(article_content="")
+            expect(
+                self.page
+            ).to_have_url(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
     # C2091583, C2091584
     @pytest.mark.kbArticleCreationAndAccess
     @pytest.mark.parametrize("username", ['admin', 'simple_user', 'no_user'])
     def test_kb_article_keywords_and_summary(self, username):
-        self.logger.info("Signing in with an Admin account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
-
-        self.logger.info("Clicking on the 'Show History' option")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-        revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
-
-        self.logger.info("Approving the revision")
-        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
-
-        self.logger.info("Clicking on the top navbar sumo nav logo")
-        self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
-
-        self.logger.info("Wait for ~1 minute until the kb article is available in search")
-        self.wait_for_given_timeout(65000)
-
-        if username == 'simple_user':
-            self.start_existing_session(super().username_extraction_from_email(
-                self.user_secrets_accounts["TEST_ACCOUNT_12"]
-            ))
-        elif username == "no_user":
-            self.logger.info("Deleting user session")
-            self.delete_cookies()
-
-        self.logger.info("Typing the article keyword inside the search field")
-        self.sumo_pages.search_page._type_into_searchbar(article_details['keyword'])
-
-        self.logger.info("Verifying that the article is displayed inside the search results")
-        expect(
-            self.sumo_pages.search_page._get_locator_of_a_particular_article(
-                article_details['article_title']
-            )
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the correct kb summary is displayed inside the search "
-                         "results")
-        check.equal(
-            self.sumo_pages.search_page._get_search_result_summary_text_of_a_particular_article(
-                article_details['article_title']
-            ),
-            article_details['search_results_summary']
-        )
-
-        self.logger.info("Clearing the searchbar")
-        self.sumo_pages.search_page._clear_the_searchbar()
-
-        self.logger.info("Typing the article summary inside the search field")
-        self.sumo_pages.search_page._type_into_searchbar(article_details['search_results_summary'])
-
-        self.logger.info("Verifying that the article is displayed inside the search results")
-        expect(
-            self.sumo_pages.search_page._get_locator_of_a_particular_article(
-                article_details['article_title']
-            )
-        ).to_be_visible()
-
-        self.logger.info("Verifying that the correct kb summary is displayed inside the search "
-                         "results")
-        check.equal(
-            self.sumo_pages.search_page._get_search_result_summary_text_of_a_particular_article(
-                article_details['article_title']
-            ),
-            article_details['search_results_summary']
-        )
-
-        self.logger.info("Clicking on the article and verifying that the user is redirected to "
-                         "the kb article")
-        self.sumo_pages.search_page._click_on_a_particular_article(
-            article_details['article_title']
-        )
-        check.equal(
-            self.sumo_pages.kb_article_page._get_text_of_article_title(),
-            article_details['article_title']
-        )
-
-        self.logger.info("Deleting the created article")
-        if username != 'admin':
+        with allure.step("Signing in with an admin account"):
             self.start_existing_session(super().username_extraction_from_email(
                 self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
 
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+        with allure.step("Create a new simple article and approving the revision"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            revision_id = self.sumo_pages.kb_article_show_history_page._get_last_revision_id()
+            self.sumo_pages.kb_article_revision_flow.approve_kb_revision(revision_id)
+
+        with allure.step("Clicking on the top navbar sumo nav logo"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.wait_for_given_timeout(65000)
+
+        if username == 'simple_user':
+            with allure.step("Signing in with a non-admin account"):
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_12"]
+                ))
+        elif username == "no_user":
+            with allure.step("Deleting user session"):
+                self.delete_cookies()
+
+        with allure.step("Typing the article keyword inside the search field and verifying that "
+                         "the article is displayed inside the search results"):
+            self.sumo_pages.search_page._type_into_searchbar(article_details['keyword'])
+            expect(
+                self.sumo_pages.search_page._get_locator_of_a_particular_article(
+                    article_details['article_title']
+                )
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the correct kb summary is displayed inside the "
+                                "search results"):
+            assert (self.sumo_pages.search_page
+                    ._get_search_result_summary_text_of_a_particular_article(
+                        article_details['article_title']
+                    )) == article_details['search_results_summary']
+
+        with allure.step("Clearing the searchbar, typing the article summary inside the search "
+                         "field and verifying that the article is displayed inside the search "
+                         "results"):
+            self.sumo_pages.search_page._clear_the_searchbar()
+            self.sumo_pages.search_page._type_into_searchbar(
+                article_details['search_results_summary']
+            )
+            expect(
+                self.sumo_pages.search_page._get_locator_of_a_particular_article(
+                    article_details['article_title']
+                )
+            ).to_be_visible()
+
+        with allure.step("Verifying that the correct kb summary is displayed inside the search "
+                         "results"):
+            assert (self.sumo_pages.search_page
+                    ._get_search_result_summary_text_of_a_particular_article(
+                        article_details['article_title'])
+                    ) == article_details['search_results_summary']
+
+        with check, allure.step("Clicking on the article and verifying that the user is "
+                                "redirected to the kb article"):
+            self.sumo_pages.search_page._click_on_a_particular_article(
+                article_details['article_title']
+            )
+            assert self.sumo_pages.kb_article_page._get_text_of_article_title(
+            ) == article_details['article_title']
+
+        with allure.step("Deleting the created article"):
+            if username != 'admin':
+                self.start_existing_session(super().username_extraction_from_email(
+                    self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+                ))
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
@@ -1,4 +1,5 @@
-import pytest_check as check
+import allure
+from pytest_check import check
 import pytest
 from playwright.sync_api import expect
 from playwright_tests.core.testutilities import TestUtilities
@@ -18,236 +19,215 @@ class TestPostedQuestions(TestUtilities):
     # C890926, C890931, C2091563
     @pytest.mark.skip
     def test_product_support_page(self):
-        self.logger.info("Navigating to products page via top-navbar")
-        self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
+        with allure.step("Navigating to products page via top-navbar"):
+            self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
 
-        self.logger.info("Clicking on all product cards")
-        for card in self.sumo_pages.products_page._get_all_product_support_titles():
-            if card in self.general_test_data['product_support']:
-                self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
+        with allure.step("Clicking on all product cards"):
+            for card in self.sumo_pages.products_page._get_all_product_support_titles():
+                if card in self.general_test_data['product_support']:
+                    self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
 
-                self.logger.info("Verifying that the correct page header is displayed")
-                check.equal(
-                    self.sumo_pages.product_support_page._get_product_support_title_text(),
-                    card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
-                )
+                    with check, allure.step("Verifying that the correct page header is displayed"):
+                        assert (self.sumo_pages.product_support_page
+                                ._get_product_support_title_text()
+                                ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
 
-                self.logger.info("Verifying that the correct topics header is displayed")
-                check.equal(
-                    self.sumo_pages.product_support_page._get_frequent_topics_title_text(),
-                    ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_TITLE
-                )
+                    with check, allure.step("Verifying the correct topics header is displayed"):
+                        assert (self.sumo_pages.product_support_page
+                                ._get_frequent_topics_title_text()
+                                ) == (ProductSupportPageMessages
+                                      .PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_TITLE)
 
-                self.logger.info("Verifying that the correct topics subheader is displayed")
-                check.equal(
-                    self.sumo_pages.product_support_page._get_frequent_topics_subtitle_text(),
-                    ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_SUBTITLE
-                )
+                    with check, allure.step("Verifying that the correct topics subheader is "
+                                            "displayed"):
+                        assert (self.sumo_pages.product_support_page
+                                ._get_frequent_topics_subtitle_text()
+                                ) == (ProductSupportPageMessages
+                                      .PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_SUBTITLE)
 
-                self.logger.info("Verifying that the correct still need help title is displayed")
-                check.equal(
-                    self.sumo_pages.product_support_page._get_still_need_help_widget_title(),
-                    ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_TITLE
-                )
+                    with check, allure.step("Verifying that the correct still need help title is "
+                                            "displayed"):
+                        assert (self.sumo_pages.product_support_page
+                                ._get_still_need_help_widget_title()
+                                ) == ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_TITLE
 
-                if card in super().general_test_data['premium_products']:
-                    self.logger.info(
-                        "Verifying that the correct still need help content is displayed")
-                    check.equal(
-                        self.sumo_pages.product_support_page.
-                        _get_still_need_help_widget_content(),
-                        ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_CONTENT_PREMIUM
-                    )
+                    if card in super().general_test_data['premium_products']:
+                        with check, allure.step("Verifying that the correct still need help "
+                                                "content is displayed"):
+                            assert (self.sumo_pages.product_support_page
+                                    ._get_still_need_help_widget_content()
+                                    ) == (ProductSupportPageMessages
+                                          .STILL_NEED_HELP_WIDGET_CONTENT_PREMIUM)
 
-                    self.logger.info("Verifying that the correct still need help button text is "
-                                     "displayed")
-                    check.equal(
-                        self.sumo_pages.product_support_page
-                        ._get_still_need_help_widget_button_text(),
-                        ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_BUTTON_TEXT_PREMIUM
-                    )
-                else:
-                    self.logger.info("Verifying that the correct still need help content is "
-                                     "displayed")
-                    check.equal(
-                        self.sumo_pages.product_support_page.
-                        _get_still_need_help_widget_content(),
-                        ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_CONTENT_FREEMIUM
-                    )
+                        with check, allure.step("Verifying that the correct still need help "
+                                                "button text is displayed"):
+                            assert (self.sumo_pages.product_support_page
+                                    ._get_still_need_help_widget_button_text()
+                                    ) == (ProductSupportPageMessages
+                                          .STILL_NEED_HELP_WIDGET_BUTTON_TEXT_PREMIUM)
+                    else:
+                        with check, allure.step("Verifying that the correct still need help "
+                                                "content is displayed"):
+                            assert (self.sumo_pages.product_support_page
+                                    ._get_still_need_help_widget_content()
+                                    ) == (ProductSupportPageMessages
+                                          .STILL_NEED_HELP_WIDGET_CONTENT_FREEMIUM)
 
-                    self.logger.info("Verifying that the correct still need help button text is "
-                                     "displayed")
-                    check.equal(
-                        self.sumo_pages.product_support_page
-                        ._get_still_need_help_widget_button_text(),
-                        ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_BUTTON_TEXT_FREEMIUM
-                    )
+                        with check, allure.step("Verifying that the correct still need help "
+                                                "button text is displayed"):
+                            assert (self.sumo_pages.product_support_page
+                                    ._get_still_need_help_widget_button_text()
+                                    ) == (ProductSupportPageMessages
+                                          .STILL_NEED_HELP_WIDGET_BUTTON_TEXT_FREEMIUM)
 
-                # Firefox Focus and Thunderbird don't have frequent articles section
-                if card != "Firefox Focus" and card != "Thunderbird":
-                    self.logger.info("Verifying the correct featured articles header is displayed")
-                    check.equal(
-                        self.sumo_pages.product_support_page._get_featured_articles_header_text(),
-                        ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_FREQUENT_ARTICLES_TITLE
-                    )
+                    # Firefox Focus and Thunderbird don't have frequent articles section
+                    if card != "Firefox Focus" and card != "Thunderbird":
+                        with check, allure.step("Verifying the correct featured articles header "
+                                                "is displayed"):
+                            assert (self.sumo_pages.product_support_page
+                                    ._get_featured_articles_header_text()
+                                    ) == (ProductSupportPageMessages
+                                          .PRODUCT_SUPPORT_PAGE_FREQUENT_ARTICLES_TITLE)
 
-                self.logger.info("Verifying that the correct 'Join Our Community' section header "
-                                 "is displayed")
-                check.equal(
-                    self.sumo_pages.product_support_page._get_join_our_community_header_text(),
-                    ProductSupportPageMessages.JOIN_OUR_COMMUNITY_SECTION_HEADER
-                )
+                    with check, allure.step("Verifying that the correct 'Join Our Community' "
+                                            "section header is displayed"):
+                        assert (self.sumo_pages.product_support_page
+                                ._get_join_our_community_header_text()
+                                ) == ProductSupportPageMessages.JOIN_OUR_COMMUNITY_SECTION_HEADER
 
-                self.logger.info("Verifying that the correct 'Join Our Community section content "
-                                 "is displayed'")
-                check.equal(
-                    self.sumo_pages.product_support_page._get_join_our_community_content_text(),
-                    ProductSupportPageMessages.JOIN_OUR_COMMUNITY_SECTION_CONTENT
-                )
+                    with check, allure.step("Verifying that the correct 'Join Our Community "
+                                            "section content is displayed'"):
+                        assert (self.sumo_pages.product_support_page
+                                ._get_join_our_community_content_text()
+                                ) == ProductSupportPageMessages.JOIN_OUR_COMMUNITY_SECTION_CONTENT
 
-                self.logger.info("Clicking on the 'Learn more' option from the 'Join Our "
-                                 "Community' section")
-                self.sumo_pages.product_support_page._click_join_our_community_learn_more_link()
+                    with allure.step("Clicking on the 'Learn more' option from the 'Join Our "
+                                     "Community' section"):
+                        (self.sumo_pages.product_support_page
+                         ._click_join_our_community_learn_more_link())
 
-                self.logger.info("Verify that we are redirected to the contribute messages page")
-                expect(
-                    self.page
-                ).to_have_url(ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL)
+                    with allure.step("Verify that we are redirected to the contribute messages "
+                                     "page"):
+                        expect(
+                            self.page
+                        ).to_have_url(ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL)
 
-                self.logger.info("Navigate back")
-                self.navigate_back()
+                    with allure.step("Navigate back, clicking on the 'Home' breadcrumb and "
+                                     "verifying that we are redirected to the homepage"):
+                        self.navigate_back()
+                        (self.sumo_pages.product_support_page
+                         ._click_on_product_support_home_breadcrumb())
+                        expect(
+                            self.page
+                        ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
 
-                self.logger.info("Clicking on the 'Home' breadcrumb")
-                self.sumo_pages.product_support_page._click_on_product_support_home_breadcrumb()
-
-                self.logger.info("Verifying that we are redirected to the homepage")
-                expect(
-                    self.page
-                ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
-
-                self.logger.info("Navigating to products page via top-navbar")
-                self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
+                    with allure.step("Navigating to products page via top-navbar"):
+                        self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
 
     # C890929
     @pytest.mark.skip
     def test_product_support_page_frequent_topics_redirect(self):
-        self.logger.info("Navigating to products page via top-navbar")
-        self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
+        with allure.step("Navigating to products page via top-navbar"):
+            self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
 
-        self.logger.info("Clicking on all product cards")
+        with allure.step("Clicking on all product cards"):
 
-        for card in self.sumo_pages.products_page._get_all_product_support_titles():
-            if card in self.general_test_data['product_support']:
-                self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
+            for card in self.sumo_pages.products_page._get_all_product_support_titles():
+                if card in self.general_test_data['product_support']:
+                    self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
 
-                self.logger.info("Verifying that the correct page header is displayed")
-                check.equal(
-                    self.sumo_pages.product_support_page._get_product_support_title_text(),
-                    card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
-                )
+                    with check, allure.step("Verifying that the correct page header is displayed"):
+                        assert (self.sumo_pages.product_support_page
+                                ._get_product_support_title_text()
+                                ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
 
-                if self.sumo_pages.product_support_page._is_frequent_topics_section_displayed:
-                    for topic in (self.sumo_pages.product_support_page.
-                                  _get_all_frequent_topics_cards()):
-                        (self.sumo_pages.product_support_page
-                         ._click_on_a_particular_frequent_topic_card(topic))
-                        check.equal(
-                            self.sumo_pages.product_topics_page._get_page_title(),
-                            topic,
-                            f"Incorrect topic page title. "
-                            f"Expected: {topic} "
-                            f"Received: {self.sumo_pages.product_topics_page._get_page_title()}"
-                        )
+                    if self.sumo_pages.product_support_page._is_frequent_topics_section_displayed:
+                        for topic in (self.sumo_pages.product_support_page.
+                                      _get_all_frequent_topics_cards()):
+                            (self.sumo_pages.product_support_page
+                             ._click_on_a_particular_frequent_topic_card(topic))
+                            with check, allure.step("Clicking on a particular frequent topic "
+                                                    "card and verifying that the correct topic "
+                                                    "page title is displayed"):
+                                assert self.sumo_pages.product_topics_page._get_page_title(
+                                ) == topic
+                            self.navigate_back()
+                    else:
+                        self.logger.info(f"{card} has no frequent topics displayed!!!")
+                    with allure.step("Navigating back"):
                         self.navigate_back()
-                else:
-                    self.logger.info(f"{card} has no frequent topics displayed!!!")
-
-                self.navigate_back()
 
     @pytest.mark.skip
     def test_product_support_page_featured_articles_redirect(self):
-        self.logger.info("Navigating to products page via top-navbar")
-        self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
+        with allure.step("Navigating to products page via top-navbar"):
+            self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
 
-        self.logger.info("Clicking on all product cards")
+        with allure.step("Clicking on all product cards"):
+            for card in self.sumo_pages.products_page._get_all_product_support_titles():
+                if card in self.general_test_data['product_support']:
+                    self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
 
-        for card in self.sumo_pages.products_page._get_all_product_support_titles():
-            if card in self.general_test_data['product_support']:
-                self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
+                    with check, allure.step("Verifying that the correct page header is displayed"):
+                        assert (self.sumo_pages.product_support_page
+                                ._get_product_support_title_text()
+                                ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
 
-                self.logger.info("Verifying that the correct page header is displayed")
-                check.equal(
-                    self.sumo_pages.product_support_page._get_product_support_title_text(),
-                    card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
-                )
+                    if (self.sumo_pages.product_support_page
+                            ._is_featured_articles_section_displayed):
+                        featured_article_cards_count = (self.sumo_pages.product_support_page
+                                                        ._get_feature_articles_count())
+                        count = 1
+                        while count <= featured_article_cards_count:
+                            featured_article_names = (self.sumo_pages.product_support_page.
+                                                      _get_list_of_featured_articles_headers())
+                            # Skipping check for now because the Firefox Monitor article redirects
+                            # to a different one
+                            if featured_article_names[count - 1] == "Firefox Monitor":
+                                continue
+                            (self.sumo_pages.product_support_page.
+                                _click_on_a_particular_feature_article_card(
+                                    featured_article_names[count - 1]))
 
-                if self.sumo_pages.product_support_page._is_featured_articles_section_displayed:
-                    featured_article_cards_count = (self.sumo_pages.product_support_page
-                                                    ._get_feature_articles_count())
-                    count = 1
-                    while count <= featured_article_cards_count:
-                        featured_article_names = (self.sumo_pages.product_support_page.
-                                                  _get_list_of_featured_articles_headers())
-                        # Skipping check for now because the Firefox Monitor article redirects to
-                        # a different one
-                        if featured_article_names[count - 1] == "Firefox Monitor":
-                            continue
-                        (self.sumo_pages.product_support_page.
-                            _click_on_a_particular_feature_article_card(
-                                featured_article_names[count - 1]))
+                            with check, allure.step("Verifying the accessed article title is the "
+                                                    "correct one"):
+                                assert featured_article_names[count - 1] == (
+                                    self.sumo_pages.kb_article_page._get_text_of_article_title())
+                            count += 1
+                            self.navigate_back()
+                    else:
+                        self.logger.info(f"{card} has no featured articles displayed!!!")
 
-                        self.logger.info("Verifying the accessed article title is the correct one")
-                        check.equal(
-                            featured_article_names[count - 1],
-                            self.sumo_pages.kb_article_page._get_text_of_article_title(),
-                            f"Expected: {featured_article_names[count - 1]} "
-                            f"Received:"
-                            f" {self.sumo_pages.kb_article_page._get_text_of_article_title()}"
-                        )
-                        count += 1
+                    with allure.step("Navigating back"):
                         self.navigate_back()
-                else:
-                    self.logger.info(f"{card} has no featured articles displayed!!!")
-
-                self.navigate_back()
 
     # C890932
     @pytest.mark.skip
     def test_still_need_help_button_redirect(self):
-        self.logger.info("Navigating to products page via top-navbar")
-        self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
+        with allure.step("Navigating to products page via top-navbar"):
+            self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
 
-        self.logger.info("Clicking on all product cards")
+        with allure.step("Clicking on all product cards"):
+            for card in self.sumo_pages.products_page._get_all_product_support_titles():
+                if card in self.general_test_data['product_support']:
+                    self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
 
-        for card in self.sumo_pages.products_page._get_all_product_support_titles():
-            if card in self.general_test_data['product_support']:
-                self.sumo_pages.products_page._click_on_a_particular_product_support_card(card)
+                    with check, allure.step("Verifying that the correct page header is displayed"):
+                        assert (self.sumo_pages.product_support_page
+                                ._get_product_support_title_text()
+                                ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
+                    self.sumo_pages.product_support_page._click_still_need_help_widget_button()
 
-                self.logger.info("Verifying that the correct page header is displayed")
-                check.equal(
-                    self.sumo_pages.product_support_page._get_product_support_title_text(),
-                    card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
-                )
+                    with allure.step("Verifying that we are redirected to the correct product "
+                                     "solutions page"):
+                        expect(
+                            self.page
+                        ).to_have_url(
+                            super().general_test_data['product_solutions'][card]
+                        )
 
-                self.sumo_pages.product_support_page._click_still_need_help_widget_button()
+                    with check, allure.step("Verifying that we are on the correct milestone"):
+                        assert self.sumo_pages.product_solutions_page._get_current_milestone_text(
+                        ) == ProductSolutionsMessages.CURRENT_MILESTONE_TEXT
 
-                self.logger.info("Verifying that we are redirected to the correct product "
-                                 "solutions page")
-                expect(
-                    self.page
-                ).to_have_url(
-                    super().general_test_data['product_solutions'][card]
-                )
-
-                self.logger.info("Verifying that we are on the correct milestone")
-                check.equal(
-                    self.sumo_pages.product_solutions_page._get_current_milestone_text(),
-                    ProductSolutionsMessages.CURRENT_MILESTONE_TEXT,
-                    f"Incorrect current milestone displayed "
-                    f"Expected: {ProductSolutionsMessages.CURRENT_MILESTONE_TEXT} "
-                    f"Received: "
-                    f"{self.sumo_pages.product_solutions_page._get_current_milestone_text()}"
-                )
-
-                self.logger.info("Navigating to products page via top-navbar")
-                self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()
+                    with allure.step("Navigating to products page via top-navbar"):
+                        self.sumo_pages.top_navbar._click_on_explore_our_help_articles_option()

--- a/playwright_tests/tests/footer_tests/test_footer.py
+++ b/playwright_tests/tests/footer_tests/test_footer.py
@@ -1,6 +1,7 @@
+import allure
 import pytest
 import requests
-import pytest_check as check
+from pytest_check import check
 
 from playwright_tests.core.testutilities import TestUtilities
 from urllib.parse import urljoin
@@ -39,11 +40,5 @@ class TestFooter(TestUtilities):
 
             # Some links are returning status code 429.
             # We are currently treating them as pass cases.
-
-            check.is_true(
-                response.status_code < 400 or response.status_code == 429,
-                f"The following url is broken: "
-                f"{url}. "
-                f"Received status code: "
-                f"{response.status_code}"
-            )
+            with check, allure.step(f"Verifying that {url} is not broken are not broken"):
+                assert response.status_code < 400 or response.status_code == 429

--- a/playwright_tests/tests/homepage_tests/test_homepage.py
+++ b/playwright_tests/tests/homepage_tests/test_homepage.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 
 from playwright_tests.core.testutilities import TestUtilities
 
@@ -14,82 +15,84 @@ class TestHomepage(TestUtilities):
     # C876542
     @pytest.mark.homePageTests
     def test_join_our_community_card_learn_more_redirects_to_contribute_page(self):
-        self.logger.info("Clicking on the 'Learn More' option")
-        self.sumo_pages.homepage._click_learn_more_option()
+        with allure.step("Clicking on the 'Learn More' option"):
+            self.sumo_pages.homepage._click_learn_more_option()
 
-        self.logger.info("Verifying that we are redirected to the 'Contribute' page successfully")
-        assert (
-            self.get_page_url()
-            == ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL
-        ), "We are not on the Contribute page!"
+        with allure.step("Verifying that we are redirected to the 'Contribute' page successfully"):
+            assert (
+                self.get_page_url()
+                == ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL
+            ), "We are not on the Contribute page!"
 
     # C876542
     @pytest.mark.homePageTests
     def test_join_our_community_card_has_the_correct_content(self):
-        self.logger.info(
+        with allure.step(
             "Verifying that the 'Join Our Community' card has the correct strings applied"
-        )
-        assert (
-            self.sumo_pages.homepage._get_community_card_title()
-            == HomepageMessages.JOIN_OUR_COMMUNITY_CARD_TITLE
-            and self.sumo_pages.homepage._get_community_card_description()
-            == HomepageMessages.JOIN_OUR_COMMUNITY_CARD_DESCRIPTION
-        ), "Incorrect strings are displayed"
+        ):
+            assert (
+                self.sumo_pages.homepage._get_community_card_title()
+                == HomepageMessages.JOIN_OUR_COMMUNITY_CARD_TITLE
+                and self.sumo_pages.homepage._get_community_card_description()
+                == HomepageMessages.JOIN_OUR_COMMUNITY_CARD_DESCRIPTION
+            ), "Incorrect strings are displayed"
 
     # C876541
     @pytest.mark.homePageTests
     def test_homepage_feature_articles_are_available_and_interactable(self):
-        self.logger.info(
-            "Verifying that the correct number of featured articles are present on the homepage"
-        )
-        check.equal(
-            self.sumo_pages.homepage._get_number_of_featured_articles(),
-            HomepageMessages.EXPECTED_FEATURED_ARTICLES_COUNT,
-            "Unexpected featured article count"
-        )
+        with check, allure.step(
+            "Verifying if the correct number of featured articles are present on the homepage"
+        ):
+            assert self.sumo_pages.homepage._get_number_of_featured_articles(
 
-        self.logger.info("Clicking on each featured article card and verifying that the user is "
-                         "redirected to the correct article page.")
-        counter = 0
-        for featured_article in self.sumo_pages.homepage._get_featured_articles_titles():
-            articles_names = self.sumo_pages.homepage._get_featured_articles_titles()
+            ) is HomepageMessages.EXPECTED_FEATURED_ARTICLES_COUNT
 
-            self.logger.info(f"Clicking on: {articles_names[counter]} article card")
-            self.sumo_pages.homepage._click_on_a_featured_card(counter)
+        with allure.step("Clicking on each featured article card and verifying that the user is"
+                         " redirected to the correct article page."):
+            counter = 0
+            for featured_article in self.sumo_pages.homepage._get_featured_articles_titles():
+                articles_names = self.sumo_pages.homepage._get_featured_articles_titles()
 
-            self.logger.info("Verifying that the correct article title is displayed.")
-            assert (
-                self.sumo_pages.kb_article_page._get_text_of_article_title()
-                == articles_names[counter]
-            ), (f"Incorrect featured article displayed. Expected: {featured_article} "
-                f"Received: {self.sumo_pages.kb_article_page._get_text_of_article_title()}")
+                self.logger.info(
+                    f"Clicking on: {articles_names[counter]} article card"
+                )
+                self.sumo_pages.homepage._click_on_a_featured_card(counter)
 
-            self.logger.info("Navigating back to the previous page")
-            self.navigate_back()
-            counter += 1
+                self.logger.info(
+                    "Verifying that the correct article title is displayed."
+                )
+
+                assert (
+                    self.sumo_pages.kb_article_page._get_text_of_article_title()
+                    == articles_names[counter]
+                ), (f"Incorrect featured article displayed. Expected: {featured_article} "
+                    f"Received: {self.sumo_pages.kb_article_page._get_text_of_article_title()}")
+
+                with allure.step("Navigating back to the previous page"):
+                    self.navigate_back()
+                    counter += 1
 
     # C873774
     @pytest.mark.homePageTests
     def test_product_cards_are_functional_and_redirect_to_the_proper_support_page(self):
-        self.logger.info("Verifying that the product cards are redirecting to the correct "
-                         "support page")
-        card_titles = self.sumo_pages.homepage._get_text_of_product_card_titles()
-        counter = 0
-        for product_card in card_titles:
-            expected_product_title = card_titles[counter] + SupportPageMessages.TITLE_CONTAINS
+        with allure.step("Verifying that the product cards redirect to the correct support page"):
+            card_titles = self.sumo_pages.homepage._get_text_of_product_card_titles()
+            counter = 0
+            for product_card in card_titles:
+                expected_product_title = card_titles[counter] + SupportPageMessages.TITLE_CONTAINS
 
-            self.logger.info(expected_product_title)
-            self.logger.info(f"Clicking on the: {card_titles[counter]} card")
-            self.sumo_pages.homepage._click_on_product_card(counter)
-            self.logger.info("Verifying that the correct product support page is displayed")
-            assert (
-                expected_product_title
-                == self.sumo_pages.product_support_page._get_product_support_title_text()
-            ), (f"Incorrect support page displayed. "
-                f"Expected: {expected_product_title} "
-                f"Received: "
-                f"{self.sumo_pages.product_support_page._get_product_support_title_text()}")
+                self.logger.info(expected_product_title)
+                self.logger.info(f"Clicking on the: {card_titles[counter]} card")
+                self.sumo_pages.homepage._click_on_product_card(counter)
+                self.logger.info("Verifying that the correct product support page is displayed")
+                assert (
+                    expected_product_title
+                    == self.sumo_pages.product_support_page._get_product_support_title_text()
+                ), (f"Incorrect support page displayed. "
+                    f"Expected: {expected_product_title} "
+                    f"Received: "
+                    f"{self.sumo_pages.product_support_page._get_product_support_title_text()}")
 
-            self.logger.info("Navigating back to the previous page")
-            self.navigate_back()
-            counter += 1
+                with allure.step("Navigating back to the previous page"):
+                    self.navigate_back()
+                    counter += 1

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 from playwright.sync_api import expect
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -17,51 +18,33 @@ class TestMessagingSystem(TestUtilities):
     # C891415
     @pytest.mark.messagingSystem
     def test_there_are_no_messages_here_text_is_displayed_when_no_messages_are_available(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Navigating to the inbox page")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
+        with allure.step("Navigating to the inbox page"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
 
-        self.logger.info(
-            "Clearing the inbox if there are messages"
-        )
         if self.sumo_pages.inbox_page._are_inbox_messages_displayed():
-            self.sumo_pages.inbox_page._delete_all_inbox_messages()
-            self.logger.info("Messages found. Clearing the list")
+            with allure.step("Clearing the inbox since there are some existing messages"):
+                self.sumo_pages.inbox_page._delete_all_inbox_messages()
 
-        self.logger.info("Verifying that the correct message is displayed")
-        check.equal(
-            self.sumo_pages.inbox_page._get_text_of_inbox_no_message_header(),
-            InboxPageMessages.NO_MESSAGES_IN_INBOX_TEXT,
-            f"Incorrect message displayed. "
-            f"Expected: "
-            f"{InboxPageMessages.NO_MESSAGES_IN_INBOX_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.inbox_page._get_text_of_inbox_no_message_header()}",
-        )
+        with check, allure.step("Verifying that the correct message is displayed"):
+            assert self.sumo_pages.inbox_page._get_text_of_inbox_no_message_header(
+            ) == InboxPageMessages.NO_MESSAGES_IN_INBOX_TEXT
 
-        self.logger.info("Navigating to the 'Sent Messages' page")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_sent_messages()
+        with allure.step("Navigating to the 'Sent Messages' page"):
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_sent_messages()
 
-        self.logger.info("Verifying if there are messages displayed inside the inbox section. If "
-                         "there are, we are clearing them all")
         if self.sumo_pages.sent_message_page._are_sent_messages_displayed():
-            self.sumo_pages.sent_message_page._delete_all_displayed_sent_messages()
-            self.logger.info("Messages found. Clearing the list")
+            with allure.step("Clearing sent messages list since there are some existing messages"):
+                self.sumo_pages.sent_message_page._delete_all_displayed_sent_messages()
 
+        with check, allure.step("Verifying that the correct page message is displayed"):
+            assert self.sumo_pages.sent_message_page._get_sent_messages_no_message_text(
+            ) == SentMessagesPageMessages.NO_MESSAGES_IN_SENT_MESSAGES_TEXT
         self.logger.info("Verifying that the correct page message is displayed")
-        check.equal(
-            self.sumo_pages.sent_message_page._get_sent_messages_no_message_text(),
-            SentMessagesPageMessages.NO_MESSAGES_IN_SENT_MESSAGES_TEXT,
-            f"Incorrect message displayed. "
-            f"Expected: "
-            f"{SentMessagesPageMessages.NO_MESSAGES_IN_SENT_MESSAGES_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.sent_message_page._get_sent_messages_no_message_text()}",
-        )
 
     # C2094292
     # This test needs to be updated to fetch the username from a different place
@@ -71,106 +54,88 @@ class TestMessagingSystem(TestUtilities):
             self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_2"]
         )
 
-        self.logger.info("Signing in with a simple user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_1"]
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_1"]
+            ))
 
         user_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Navigating to the profile page for user two")
-        self.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(username=user_two)
-        )
-
-        self.logger.info("Clicking on the 'Private Message button'")
-        self.sumo_pages.my_profile_page._click_on_private_message_button()
-
-        self.logger.info("Verifying that the receiver is automatically added inside the To field")
-        # Firefox GH runner fails here. We are running this assertion only in Chrome for now
-        if self.requested_browser == "chrome":
-            assert self.sumo_pages.new_message_page._get_user_to_text() == user_two, (
-                f"Incorrect 'To' receiver. Expected: {user_two}. "
-                f"Received: {self.sumo_pages.new_message_page._get_user_to_text()}"
+        with allure.step("Navigating to the profile page for user two"):
+            self.navigate_to_link(
+                MyProfileMessages.get_my_profile_stage_url(username=user_two)
             )
 
-        self.logger.info("Sending a message to the user")
-        self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
-            message_body=self.user_message_test_data["valid_user_message"]["message"]
-        )
+        with allure.step("Clicking on the 'Private Message button'"):
+            self.sumo_pages.my_profile_page._click_on_private_message_button()
 
-        self.logger.info("Verifying that the correct message sent banner is displayed")
-        check.equal(
-            self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(),
-            InboxPageMessages.MESSAGE_SENT_BANNER_TEXT,
-            f"Incorrect banner text displayed. "
-            f"Expected: "
-            f"{InboxPageMessages.MESSAGE_SENT_BANNER_TEXT}. "
-            f"Received: "
-            f"{self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text()}",
-        )
+        with allure.step("Verifying that the receiver is automatically added inside the 'To' "
+                         "field"):
+            # Firefox GH runner fails here. We are running this assertion only in Chrome for now
+            if self.requested_browser == "chrome":
+                assert self.sumo_pages.new_message_page._get_user_to_text() == user_two, (
+                    f"Incorrect 'To' receiver. Expected: {user_two}. "
+                    f"Received: {self.sumo_pages.new_message_page._get_user_to_text()}"
+                )
 
-        self.logger.info("Clicking on the 'Sent Messages option' and verifying that the message "
-                         "was successfully sent")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_sent_messages()
+        with allure.step("Sending a message to the user"):
+            self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
+                message_body=self.user_message_test_data["valid_user_message"]["message"]
+            )
 
-        self.logger.info("Verifying that the sent message is displayed")
-        expect(self.sumo_pages.sent_message_page._sent_messages(
-            username=user_two
-        )).to_be_visible()
+        with check, allure.step("Verifying that the correct message sent banner is displayed"):
+            assert self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(
+            ) == InboxPageMessages.MESSAGE_SENT_BANNER_TEXT
 
-        self.logger.info("Deleting the message from the sent messages link and verifying that "
-                         "the message is no longer displayed")
-        self.sumo_pages.sent_message_page._click_on_sent_message_delete_button(username=user_two)
-        self.sumo_pages.sent_message_page._click_on_delete_page_delete_button()
+        with allure.step("Clicking on the 'Sent Messages option"):
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_sent_messages()
 
+        with allure.step("Verifying that the sent message is displayed"):
+            expect(self.sumo_pages.sent_message_page._sent_messages(
+                username=user_two
+            )).to_be_visible()
+
+        with allure.step("Deleting the message from the sent messages page"):
+            self.sumo_pages.messaging_system_flow.delete_message_flow(
+                username=user_two, from_sent_list=True
+            )
+
+        with check, allure.step("Verifying that the correct banner is displayed"):
+            assert self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text(
+            ) == SentMessagesPageMessages.DELETE_MESSAGE_BANNER_TEXT
         self.logger.info("Verifying that the correct banner is displayed")
-        check.equal(
-            self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text(),
-            SentMessagesPageMessages.DELETE_MESSAGE_BANNER_TEXT,
-            f"Wrong message displayed inside the banner. "
-            f"Expected: "
-            f"{SentMessagesPageMessages.DELETE_MESSAGE_BANNER_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text()}",
-        )
 
-        expect(
-            self.sumo_pages.sent_message_page._sent_messages(username=user_two)
-        ).to_be_hidden()
+        with allure.step("Verifying that messages from user two are not displayed"):
+            expect(
+                self.sumo_pages.sent_message_page._sent_messages(username=user_two)
+            ).to_be_hidden()
 
-        self.logger.info("Signing in with the user which received the message")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_2"]
-        ))
+        with allure.step("Signing in with the user which received the message"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_2"]
+            ))
 
-        self.logger.info("Accessing the Inbox section and verifying that the message was received")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
+        with allure.step("Accessing the Inbox section"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
 
-        expect(self.sumo_pages.inbox_page._inbox_message(
-            username=user_one
-        )).to_be_visible()
+        with allure.step("Verifying that the inbox contains the previously sent messages"):
+            expect(self.sumo_pages.inbox_page._inbox_message(
+                username=user_one
+            )).to_be_visible()
 
-        self.logger.info("Deleting the message and verifying that it is no longer displayed "
-                         "inside the inbox section")
-        self.sumo_pages.inbox_page._click_on_inbox_message_delete_button(username=user_one)
+        with allure.step("Deleting the messages from the inbox section"):
+            self.sumo_pages.messaging_system_flow.delete_message_flow(
+                username=user_one, from_inbox_list=True
+            )
 
-        self.sumo_pages.inbox_page._click_on_delete_page_delete_button()
+        with allure.step("Verifying that the messages are no longer displayed inside the inbox"):
+            expect(
+                self.sumo_pages.inbox_page._inbox_message(username=user_one)
+            ).to_be_hidden()
 
-        expect(
-            self.sumo_pages.inbox_page._inbox_message(username=user_one)
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the correct banner is displayed")
-        check.equal(
-            self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text(),
-            SentMessagesPageMessages.DELETE_MESSAGE_BANNER_TEXT,
-            f"Wrong message displayed inside the banner. "
-            f"Expected: "
-            f"{SentMessagesPageMessages.DELETE_MESSAGE_BANNER_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text()}",
-        )
+        with check, allure.step("Verifying that the correct banner is displayed"):
+            assert self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text(
+            ) == SentMessagesPageMessages.DELETE_MESSAGE_BANNER_TEXT
 
     # C891419
     @pytest.mark.messagingSystem
@@ -179,117 +144,102 @@ class TestMessagingSystem(TestUtilities):
             self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
         )
 
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_3"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_3"]
+            ))
 
         user_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the New Message page and sending a message to another user")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_new_message()
-        self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
-            recipient_username=test_user,
-            message_body=super().user_message_test_data["valid_user_message"]["message"],
-        )
+        with allure.step("Accessing the New Message page and sending a message to another user"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
+            self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
+                recipient_username=test_user,
+                message_body=super().user_message_test_data["valid_user_message"]["message"],
+            )
 
+        with check, allure.step("Verifying that the correct banner is displayed"):
+            assert self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(
+            ) == InboxPageMessages.MESSAGE_SENT_BANNER_TEXT
         self.logger.info("Verifying that the correct banner is displayed")
-        check.equal(
-            self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(),
-            InboxPageMessages.MESSAGE_SENT_BANNER_TEXT,
-            f"Incorrect banner text displayed. "
-            f"Expected: "
-            f"{InboxPageMessages.MESSAGE_SENT_BANNER_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text()}",
-        )
 
-        self.logger.info("Verifying that the sent message is displayed inside the 'sent "
-                         "messages' page")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_sent_messages()
+        with allure.step("Verifying that the sent message is displayed inside the sent messages "
+                         "page"):
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_sent_messages()
+            expect(self.sumo_pages.sent_message_page._sent_messages(test_user)).to_be_visible()
 
-        expect(self.sumo_pages.sent_message_page._sent_messages(test_user)).to_be_visible()
+        with allure.step("Clearing the sent messages list"):
+            self.sumo_pages.sent_message_page._delete_all_displayed_sent_messages()
 
-        self.logger.info("Clearing the sent messages list")
-        self.sumo_pages.sent_message_page._delete_all_displayed_sent_messages()
+        with allure.step("Signing in with the receiver account and verifying that the message is "
+                         "displayed inside the inbox section"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+            self.sumo_pages.top_navbar._click_on_inbox_option()
+            expect(self.sumo_pages.inbox_page._inbox_message(
+                username=user_one
+            )).to_be_visible()
 
-        self.logger.info("Signing in with the receiver account and verifying that the message is "
-                         "displayed inside the inbox section")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_inbox_option()
-
-        expect(self.sumo_pages.inbox_page._inbox_message(
-            username=user_one
-        )).to_be_visible()
-
-        self.logger.info("Clearing the inbox")
-        self.sumo_pages.inbox_page._delete_all_inbox_messages()
+        with allure.step("Clearing the inbox"):
+            self.sumo_pages.inbox_page._delete_all_inbox_messages()
 
     # C891412, C891413
     @pytest.mark.messagingSystem
     def test_navbar_options_redirect_to_the_correct_page_and_options_are_correctly_highlighted(
             self,
     ):
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Accessing the inbox section via the top-navbar"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
 
-        self.logger.info("Accessing the inbox section via the top-navbar")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
+        with allure.step("Verifying that we are on the correct page and the 'Inbox' navbar "
+                         "option is highlighted"):
+            expect(self.page).to_have_url(InboxPageMessages.INBOX_PAGE_STAGE_URL)
+            expect(
+                self.sumo_pages.mess_system_user_navbar._get_inbox_navbar_element()
+            ).to_have_css("background-color", InboxPageMessages.NAVBAR_INBOX_SELECTED_BG_COLOR)
 
-        self.logger.info("Verifying that we are on the correct page and the 'Inbox' navbar "
-                         "option is highlighted")
-        expect(self.page).to_have_url(InboxPageMessages.INBOX_PAGE_STAGE_URL)
+        with allure.step("Clicking on the sent messages navbar option"):
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_sent_messages()
 
-        expect(
-            self.sumo_pages.mess_system_user_navbar._get_inbox_navbar_element()
-        ).to_have_css("background-color", InboxPageMessages.NAVBAR_INBOX_SELECTED_BG_COLOR)
+        with allure.step("Verifying that we are on the correct page and the 'Sent Messages' "
+                         "navbar option is highlighted"):
+            expect(
+                self.page
+            ).to_have_url(SentMessagesPageMessages.SENT_MESSAGES_PAGE_URL)
+            expect(
+                self.sumo_pages.mess_system_user_navbar._get_sent_messages_navbar_element()
+            ).to_have_css("background-color",
+                          SentMessagesPageMessages.NAVBAR_SENT_MESSAGES_SELECTED_BG_COLOR)
 
-        self.logger.info("Clicking on the sent messages navbar option")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_sent_messages()
+        with allure.step("Clicking on the 'New message' navbar option"):
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
-        self.logger.info("Verifying that we are on the correct page and the 'Sent Messages' page "
-                         "is successfully displayed")
-        expect(
-            self.page
-        ).to_have_url(SentMessagesPageMessages.SENT_MESSAGES_PAGE_URL)
+        with allure.step("Verifying that we are on the correct page and the 'New Message' navbar "
+                         "option is successfully highlighted"):
+            expect(
+                self.page
+            ).to_have_url(NewMessagePageMessages.NEW_MESSAGE_PAGE_STAGE_URL)
+            expect(
+                self.sumo_pages.mess_system_user_navbar._get_new_message_navbar_element()
+            ).to_have_css("background-color",
+                          NewMessagePageMessages.NAVBAR_NEW_MESSAGE_SELECTED_BG_COLOR)
 
-        self.logger.info("Verifying that the 'Sent Messages' option is highlighted")
-        expect(
-            self.sumo_pages.mess_system_user_navbar._get_sent_messages_navbar_element()
-        ).to_have_css("background-color",
-                      SentMessagesPageMessages.NAVBAR_SENT_MESSAGES_SELECTED_BG_COLOR)
+        with allure.step("Clicking on the navbar inbox messaging system navbar option"):
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_inbox()
 
-        self.logger.info("Clicking on the 'New message' navbar option")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_new_message()
-
-        self.logger.info("Verifying that the 'New Message' page is displayed")
-        expect(
-            self.page
-        ).to_have_url(NewMessagePageMessages.NEW_MESSAGE_PAGE_STAGE_URL)
-
-        self.logger.info("Verifying that the 'New Message' navbar option is highlighted")
-        expect(
-            self.sumo_pages.mess_system_user_navbar._get_new_message_navbar_element()
-        ).to_have_css("background-color",
-                      NewMessagePageMessages.NAVBAR_NEW_MESSAGE_SELECTED_BG_COLOR)
-
-        self.logger.info("Clicking on the navbar inbox messaging system navbar option")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_inbox()
-
-        self.logger.info("Verifying that we are on the correct page and the 'Inbox' navbar "
-                         "option is highlighted")
-        expect(self.page).to_have_url(InboxPageMessages.INBOX_PAGE_STAGE_URL)
-
-        expect(
-            self.sumo_pages.mess_system_user_navbar._get_inbox_navbar_element()
-        ).to_have_css("background-color", InboxPageMessages.NAVBAR_INBOX_SELECTED_BG_COLOR)
+        with allure.step("Verifying that we are on the correct page and the 'Inbox' navbar "
+                         "option is highlighted"):
+            expect(self.page).to_have_url(InboxPageMessages.INBOX_PAGE_STAGE_URL)
+            expect(
+                self.sumo_pages.mess_system_user_navbar._get_inbox_navbar_element()
+            ).to_have_css("background-color", InboxPageMessages.NAVBAR_INBOX_SELECTED_BG_COLOR)
 
     # C891416
     @pytest.mark.messagingSystem
@@ -297,41 +247,38 @@ class TestMessagingSystem(TestUtilities):
         user_two = self.username_extraction_from_email(
             self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_1"]
         )
-        self.logger.info("Signing in with normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
 
-        self.logger.info("Accessing the New Message page")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_new_message()
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Submitting the form without any data")
-        self.sumo_pages.new_message_page._click_on_new_message_send_button()
+        with allure.step("Accessing the New Message page"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
-        self.logger.info("Verifying that we are still on the 'New Message page'")
-        expect(self.page).to_have_url(NewMessagePageMessages.NEW_MESSAGE_PAGE_STAGE_URL)
+        with allure.step("Trying to submit the form without any data and verifying that we are "
+                         "still on the 'New Message' page"):
+            self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data()
+            expect(self.page).to_have_url(NewMessagePageMessages.NEW_MESSAGE_PAGE_STAGE_URL)
 
-        self.logger.info("Sending a message and verifying that we are on the same page")
-        self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
-            recipient_username=user_two
-        )
+        with allure.step("Adding a recipient inside the 'To' field and trying to submit the form "
+                         "without any message body"):
+            self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
+                recipient_username=user_two
+            )
+            expect(self.page).to_have_url(NewMessagePageMessages.NEW_MESSAGE_PAGE_STAGE_URL)
 
-        expect(self.page).to_have_url(NewMessagePageMessages.NEW_MESSAGE_PAGE_STAGE_URL)
+        with check, allure.step("Verifying that the default remaining characters is the correct "
+                                "one"):
+            assert (self.sumo_pages.new_message_page
+                    ._get_characters_remaining_text() in NewMessagePageMessages
+                    .NEW_MESSAGE_DEFAULT_REMAINING_CHARACTERS)
 
-        self.logger.info("Verifying that the default remaining characters is the correct one")
-        check.equal(
-            self.sumo_pages.new_message_page._get_characters_remaining_text(),
-            NewMessagePageMessages.NEW_MESSAGE_DEFAULT_REMAINING_CHARACTERS,
-            f" The default character remaining string is not the correct one! "
-            f"Expected: {NewMessagePageMessages.NEW_MESSAGE_DEFAULT_REMAINING_CHARACTERS}"
-            f"Received: {self.sumo_pages.new_message_page._get_characters_remaining_text()}",
-        )
-
-        self.logger.info("Verifying that the characters remaining color is the expected one")
-        expect(
-            self.sumo_pages.new_message_page._get_characters_remaining_text_element()
-        ).to_have_css("color", NewMessagePageMessages.ENOUGH_CHARACTERS_REMAINING_COLOR)
+        with allure.step("Verifying that the characters remaining color is the expected one"):
+            expect(
+                self.sumo_pages.new_message_page._get_characters_remaining_text_element()
+            ).to_have_css("color", NewMessagePageMessages.ENOUGH_CHARACTERS_REMAINING_COLOR)
 
         # To check if firefox container crashes. If not remove this part and uncomment the if
         # clause
@@ -344,22 +291,21 @@ class TestMessagingSystem(TestUtilities):
         #             "9990_characters_long_message"
         #         ]
         #     )
-        self.logger.info("Adding 9990 characters inside the input field")
-        self.sumo_pages.new_message_page._fill_into_new_message_body_textarea(
-            text=super().user_message_test_data["valid_user_message"][
-                "9990_characters_long_message"
-            ])
-        check.equal(
-            self.sumo_pages.new_message_page._get_characters_remaining_text(),
-            NewMessagePageMessages.TEN_CHARACTERS_REMAINING_MESSAGE,
-            f"Incorrect remaining characters string displayed. "
-            f"Expected: {NewMessagePageMessages.TEN_CHARACTERS_REMAINING_MESSAGE}"
-            f"Displayed: {self.sumo_pages.new_message_page._get_characters_remaining_text()}",
-        )
 
-        self.logger.info("Verifying that the characters remaining color is the expected one")
-        expect(self.sumo_pages.new_message_page._get_characters_remaining_text_element()
-               ).to_have_css("color", NewMessagePageMessages.ENOUGH_CHARACTERS_REMAINING_COLOR)
+        with allure.step("Adding 9990 characters inside the input field"):
+            self.sumo_pages.new_message_page._fill_into_new_message_body_textarea(
+                text=super().user_message_test_data["valid_user_message"][
+                    "9990_characters_long_message"
+                ])
+
+        with check, allure.step("Verifying that the correct remaining characters left message is "
+                                "displayed"):
+            assert self.sumo_pages.new_message_page._get_characters_remaining_text(
+            ) in NewMessagePageMessages.TEN_CHARACTERS_REMAINING_MESSAGE
+
+        with allure.step("Verifying that the characters remaining color is the expected one"):
+            expect(self.sumo_pages.new_message_page._get_characters_remaining_text_element()
+                   ).to_have_css("color", NewMessagePageMessages.ENOUGH_CHARACTERS_REMAINING_COLOR)
 
         # elif self.browser == "firefox":
         #     check.equal(
@@ -370,23 +316,18 @@ class TestMessagingSystem(TestUtilities):
         #         f"Received: {self.pages.new_message_page.get_characters_remaining_text_color()}",
         #     )
 
-        self.logger.info("Adding one character inside the textarea field")
-        self.sumo_pages.new_message_page._type_into_new_message_body_textarea(
-            text=super().user_message_test_data["valid_user_message"]["one_character_message"]
-        )
+        with allure.step("Adding one character inside the textarea field"):
+            self.sumo_pages.new_message_page._type_into_new_message_body_textarea(
+                text=super().user_message_test_data["valid_user_message"]["one_character_message"]
+            )
 
-        self.logger.info("Verifying that the char remaining string is updated accordingly")
-        check.equal(
-            self.sumo_pages.new_message_page._get_characters_remaining_text(),
-            NewMessagePageMessages.NINE_CHARACTERS_REMAINING_MESSAGE,
-            f"Incorrect remaining characters string displayed. "
-            f"Expected:{NewMessagePageMessages.NINE_CHARACTERS_REMAINING_MESSAGE} "
-            f"Displayed: {self.sumo_pages.new_message_page._get_characters_remaining_text()}",
-        )
+        with check, allure.step("Verifying that the char remaining string is updated accordingly"):
+            assert self.sumo_pages.new_message_page._get_characters_remaining_text(
+            ) in NewMessagePageMessages.NINE_CHARACTERS_REMAINING_MESSAGE
 
-        self.logger.info("Verifying that the characters remaining color is the expected one")
-        expect(self.sumo_pages.new_message_page._get_characters_remaining_text_element()
-               ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
+        with allure.step("Verifying that the characters remaining color is the expected one"):
+            expect(self.sumo_pages.new_message_page._get_characters_remaining_text_element()
+                   ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
 
         # elif self.browser == "firefox":
         #     check.equal(
@@ -397,15 +338,15 @@ class TestMessagingSystem(TestUtilities):
         #         f"Received: {self.pages.new_message_page.get_characters_remaining_text_color()}",
         #     )
 
-        self.logger.info("Adding 9 characters inside the textarea field")
-        self.sumo_pages.new_message_page._type_into_new_message_body_textarea(
-            text=super().user_message_test_data["valid_user_message"]["9_characters_message"]
-        )
+        with allure.step("Adding 9 characters inside the textarea field"):
+            self.sumo_pages.new_message_page._type_into_new_message_body_textarea(
+                text=super().user_message_test_data["valid_user_message"]["9_characters_message"]
+            )
 
-        self.logger.info("Verifying that the char remaining string is updated accordingly")
-        expect(
-            self.sumo_pages.new_message_page._get_characters_remaining_text_element()
-        ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
+        with allure.step("Verifying that the char remaining string is updated accordingly"):
+            expect(
+                self.sumo_pages.new_message_page._get_characters_remaining_text_element()
+            ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
         # elif self.browser == "firefox":
         #     check.equal(
         #         self.pages.new_message_page.get_characters_remaining_text_color(),
@@ -415,10 +356,10 @@ class TestMessagingSystem(TestUtilities):
         #         f"Received: {self.pages.new_message_page.get_characters_remaining_text_color()}",
         #     )
 
-        self.logger.info("Verifying that the characters remaining color is the expected one")
-        expect(
-            self.sumo_pages.new_message_page._get_characters_remaining_text_element()
-        ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
+        with allure.step("Verifying that the characters remaining color is the expected one"):
+            expect(
+                self.sumo_pages.new_message_page._get_characters_remaining_text_element()
+            ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
 
         # elif self.browser == "firefox":
         #     check.equal(
@@ -436,52 +377,49 @@ class TestMessagingSystem(TestUtilities):
             super().user_secrets_accounts["TEST_ACCOUNT_13"]
         )
 
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+
         user_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'New Message' section")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_new_message()
+        with allure.step("Accessing the 'New Message' section"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
-        self.logger.info("Filling the new message form with data")
-        self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
-            recipient_username=user_two,
-            message_body=super().user_message_test_data["valid_user_message"]["message"],
-            submit_message=False
-        )
+        with allure.step("Filling the new message form with data"):
+            self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
+                recipient_username=user_two,
+                message_body=super().user_message_test_data["valid_user_message"]["message"],
+                submit_message=False
+            )
 
-        self.logger.info("Clicking on the 'Cancel' button")
-        self.sumo_pages.new_message_page._click_on_new_message_cancel_button()
+        with allure.step("Clicking on the 'Cancel' button and verifying that the user is "
+                         "redirected back to the inbox page"):
+            self.sumo_pages.new_message_page._click_on_new_message_cancel_button()
+            expect(
+                self.sumo_pages.mess_system_user_navbar._get_inbox_navbar_element()
+            ).to_have_css("background-color", InboxPageMessages.NAVBAR_INBOX_SELECTED_BG_COLOR)
+            expect(self.page).to_have_url(InboxPageMessages.INBOX_PAGE_STAGE_URL)
 
-        self.logger.info("Verifying that the user is redirected to the inbox page")
-        expect(
-            self.sumo_pages.mess_system_user_navbar._get_inbox_navbar_element()
-        ).to_have_css("background-color", InboxPageMessages.NAVBAR_INBOX_SELECTED_BG_COLOR)
+        with allure.step("Navigating to the 'Sent Messages' page and verifying that the message "
+                         "was not sent"):
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_sent_messages()
+            expect(self.sumo_pages.sent_message_page._sent_messages(username=user_two)
+                   ).to_be_hidden()
 
-        expect(self.page).to_have_url(InboxPageMessages.INBOX_PAGE_STAGE_URL)
+        with allure.step("Signing out and signing in with the receiver account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
 
-        self.logger.info("Navigating to the 'Sent Messages' page nad verifying that the message "
-                         "was not sent")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_sent_messages()
-
-        expect(self.sumo_pages.sent_message_page._sent_messages(username=user_two)
-               ).to_be_hidden()
-
-        self.logger.info("Signing out and signing in with the receiver account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.logger.info("Navigating to the receiver inbox and verifying that no message was "
-                         "received")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
-
-        expect(
-            self.sumo_pages.inbox_page._inbox_message(username=user_one)
-        ).to_be_hidden()
+        with allure.step("Navigating to the receiver inbox and verifying that no message was "
+                         "received"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
+            expect(
+                self.sumo_pages.inbox_page._inbox_message(username=user_one)
+            ).to_be_hidden()
 
     # C891418
     @pytest.mark.messagingSystem
@@ -490,132 +428,98 @@ class TestMessagingSystem(TestUtilities):
             self.user_secrets_accounts["TEST_ACCOUNT_13"]
         )
 
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the inbox section")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
+        with allure.step("Accessing the inbox section and navigating to the new message page"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
-        self.logger.info("Navigating to the new message page")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_new_message()
+        with allure.step("Adding text inside the message content section"):
+            self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
+                recipient_username=test_user,
+                message_body=super().user_message_test_data["valid_user_message"]["message"],
+                submit_message=False
+            )
 
-        self.logger.info("Adding text inside the message content section")
-        self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
-            recipient_username=test_user,
-            message_body=super().user_message_test_data["valid_user_message"]["message"],
-            submit_message=False
-        )
+        with allure.step("Clicking on the 'Preview' button and verifying that the preview "
+                         "section is successfully displayed"):
+            self.sumo_pages.new_message_page._click_on_new_message_preview_button()
+            expect(
+                self.sumo_pages.new_message_page._message_preview_section_element()
+            ).to_be_visible()
 
-        self.logger.info("Clicking on  the 'Preview' button")
-        self.sumo_pages.new_message_page._click_on_new_message_preview_button()
+        with check, allure.step("Verifying that all the preview items are displayed"):
+            assert self.sumo_pages.new_message_page._get_text_of_test_data_first_paragraph_text(
+            ) in NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_TEXT
 
-        self.logger.info("Verifying that the preview section is successfully displayed")
-        expect(
-            self.sumo_pages.new_message_page._message_preview_section_element()
-        ).to_be_visible()
+            assert self.sumo_pages.new_message_page._get_text_of_test_data_first_p_strong_text(
+            ) in NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_STRONG_TEXT
 
-        self.logger.info("Verifying that all the preview items are displayed")
-        check.equal(
-            self.sumo_pages.new_message_page._get_text_of_test_data_first_paragraph_text(),
-            NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_TEXT,
-            f"Wrong text displayed. "
-            f"Expected: "
-            f"{NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.new_message_page._get_text_of_test_data_first_paragraph_text()}",
-        )
+            assert self.sumo_pages.new_message_page._get_text_of_test_data_first_p_italic_text(
+            ) in NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_ITALIC_TEXT
 
-        check.equal(
-            self.sumo_pages.new_message_page._get_text_of_test_data_first_p_strong_text(),
-            NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_STRONG_TEXT,
-            f"Wrong text displayed. "
-            f"Expected:"
-            f"{NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_STRONG_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.new_message_page._get_text_of_test_data_first_p_strong_text()}",
-        )
+            numbered_list_items = [
+                NewMessagePageMessages.PREVIEW_MESSAGE_OL_LI_NUMBER_ONE,
+                NewMessagePageMessages.PREVIEW_MESSAGE_OL_LI_NUMBER_TWO,
+                NewMessagePageMessages.PREVIEW_MESSAGE_OL_LI_NUMBER_THREE,
+            ]
 
-        check.equal(
-            self.sumo_pages.new_message_page._get_text_of_test_data_first_p_italic_text(),
-            NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_ITALIC_TEXT,
-            f"Wrong text displayed. "
-            f"Expected:"
-            f"{NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_ITALIC_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.new_message_page._get_text_of_test_data_first_p_italic_text()}",
-        )
+            bulleted_list_items = [
+                NewMessagePageMessages.PREVIEW_MESSAGE_UL_LI_NUMBER_ONE,
+                NewMessagePageMessages.PREVIEW_MESSAGE_UL_LI_NUMBER_TWO,
+                NewMessagePageMessages.PREVIEW_MESSAGE_UL_LI_NUMBER_THREE,
+            ]
 
-        numbered_list_items = [
-            NewMessagePageMessages.PREVIEW_MESSAGE_OL_LI_NUMBER_ONE,
-            NewMessagePageMessages.PREVIEW_MESSAGE_OL_LI_NUMBER_TWO,
-            NewMessagePageMessages.PREVIEW_MESSAGE_OL_LI_NUMBER_THREE,
-        ]
+            assert self.sumo_pages.new_message_page._get_text_of_numbered_list_items(
+            ) == numbered_list_items
 
-        bulleted_list_items = [
-            NewMessagePageMessages.PREVIEW_MESSAGE_UL_LI_NUMBER_ONE,
-            NewMessagePageMessages.PREVIEW_MESSAGE_UL_LI_NUMBER_TWO,
-            NewMessagePageMessages.PREVIEW_MESSAGE_UL_LI_NUMBER_THREE,
-        ]
+            assert self.sumo_pages.new_message_page._get_text_of_bulleted_list_items(
+            ) == bulleted_list_items
 
-        check.equal(
-            self.sumo_pages.new_message_page._get_text_of_numbered_list_items(),
-            numbered_list_items,
-            f"Wrong data displayed in the numbered list. Expected {numbered_list_items} "
-            f"Received: {self.sumo_pages.new_message_page._get_text_of_numbered_list_items()}",
-        )
+            expect(
+                self.sumo_pages.new_message_page.
+                _new_message_preview_external_link_test_data_element()
+            ).to_be_visible()
 
-        check.equal(
-            self.sumo_pages.new_message_page._get_text_of_bulleted_list_items(),
-            bulleted_list_items,
-            f"Wrong data displayed in the numbered list. Expected {bulleted_list_items} "
-            f"Received: {self.sumo_pages.new_message_page._get_text_of_numbered_list_items()}",
-        )
-        expect(
-            self.sumo_pages.new_message_page._new_message_preview_external_link_test_data_element()
-        ).to_be_visible()
+            expect(
+                self.sumo_pages.new_message_page.
+                _new_message_preview_internal_link_test_data_element()
+            ).to_be_visible()
 
-        expect(
-            self.sumo_pages.new_message_page._new_message_preview_internal_link_test_data_element()
-        ).to_be_visible()
+        with allure.step("Clicking on the internal link and verifying that the user is "
+                         "redirected to the correct article"):
+            self.sumo_pages.new_message_page._click_on_preview_internal_link()
+            assert (
+                self.sumo_pages.kb_article_page._get_text_of_article_title()
+                == NewMessagePageMessages.PREVIEW_MESSAGE_INTERNAL_LINK_TITLE
+            ), (
+                f"Incorrect article title displayed! "
+                f"Expected: {NewMessagePageMessages.PREVIEW_MESSAGE_INTERNAL_LINK_TITLE} "
+                f"Received: {self.sumo_pages.kb_article_page._get_text_of_article_title()}"
+            )
 
-        self.logger.info("Clicking on the internal link and verifying that the user is "
-                         "redirected to the correct article")
-        self.sumo_pages.new_message_page._click_on_preview_internal_link()
+        with allure.step("Verifying that the message was no sent by checking the "
+                         "'Sent Messages page'"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_sent_messages()
+            expect(
+                self.sumo_pages.sent_message_page._sent_messages(username=test_user)
+            ).to_be_hidden()
 
-        assert (
-            self.sumo_pages.kb_article_page._get_text_of_article_title()
-            == NewMessagePageMessages.PREVIEW_MESSAGE_INTERNAL_LINK_TITLE
-        ), (
-            f"Incorrect article title displayed! "
-            f"Expected: {NewMessagePageMessages.PREVIEW_MESSAGE_INTERNAL_LINK_TITLE} "
-            f"Received: {self.sumo_pages.kb_article_page._get_text_of_article_title()}"
-        )
-
-        self.logger.info("Verifying that the message was no sent by checking the 'Sent Messages "
-                         "page'")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
-
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_sent_messages()
-
-        expect(
-            self.sumo_pages.sent_message_page._sent_messages(username=test_user)
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with the potential message receiver and verifying that no "
-                         "message was received")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_inbox_option()
-
-        expect(
-            self.sumo_pages.inbox_page._inbox_message(username=username)
-        ).to_be_hidden()
+        with allure.step("Signing in with the potential message receiver and verifying that no "
+                         "message were received"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            self.sumo_pages.top_navbar._click_on_inbox_option()
+            expect(
+                self.sumo_pages.inbox_page._inbox_message(username=username)
+            ).to_be_hidden()
 
     # C891421, C891424
     @pytest.mark.messagingSystem
@@ -624,143 +528,103 @@ class TestMessagingSystem(TestUtilities):
             self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
         )
 
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
 
         user_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'New Message' page and sending a message to a different "
-                         "user")
-        self.sumo_pages.top_navbar._click_on_inbox_option()
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_new_message()
-        self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
-            recipient_username=test_user,
-            message_body=super().user_message_test_data["valid_user_message"]["message"],
-        )
-
-        self.logger.info("Navigating to the sent messages page")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_sent_messages()
-
-        self.logger.info("Clicking on the 'Delete Selected' button")
-        self.sumo_pages.sent_message_page._click_on_delete_selected_button()
-
-        self.logger.info("Verifying that the correct message is displayed and is no longer "
-                         "displayed when dismissed")
-        check.equal(
-            self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text(),
-            SentMessagesPageMessages.NO_MESSAGES_SELECTED_BANNER_TEXT,
-            f"Incorrect banner text displayed. "
-            f"Expected: "
-            f"{SentMessagesPageMessages.NO_MESSAGES_SELECTED_BANNER_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text()}",
-        )
-
-        self.logger.info("Verifying that the message is still listed inside the sent messages "
-                         "section")
-        expect(
-            self.sumo_pages.sent_message_page._sent_messages(username=test_user)
-        ).to_be_visible()
-
-        self.logger.info("Sending another message to self twice")
-        for i in range(2):
-            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_new_message()
+        with allure.step("Accessing the 'New Message' page and sending a message to a different "
+                         "user"):
+            self.sumo_pages.top_navbar._click_on_inbox_option()
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
             self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
-                recipient_username=user_one,
+                recipient_username=test_user,
                 message_body=super().user_message_test_data["valid_user_message"]["message"],
             )
 
-        self.logger.info("Clicking on the 'delete selected' button while no messages is selected "
-                         "and verifying that the correct banner is displayed")
-        self.sumo_pages.inbox_page._click_on_inbox_delete_selected_button()
+        with allure.step("Navigating to the sent messages page"):
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_sent_messages()
 
-        check.equal(
-            self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(),
-            InboxPageMessages.NO_MESSAGES_SELECTED_BANNER_TEXT,
-            f"Incorrect messages displayed. "
-            f"Expected: {InboxPageMessages.NO_MESSAGES_SELECTED_BANNER_TEXT} "
-            f"Received: {self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text()}",
-        )
+        with allure.step("Clicking on the 'Delete Selected' button"):
+            self.sumo_pages.sent_message_page._click_on_delete_selected_button()
 
-        expect(
-            self.sumo_pages.inbox_page._inbox_message(username=user_one).first
-        ).to_be_visible()
+        with check, allure.step("Verifying that the correct message is displayed"):
+            assert self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text(
+            ) in SentMessagesPageMessages.NO_MESSAGES_SELECTED_BANNER_TEXT
 
-        self.logger.info("Selecting the messages and deleting it via the 'delete selected button'")
-        self.sumo_pages.inbox_page._delete_all_inbox_messages_via_delete_selected_button()
+        with allure.step("Verifying that the message is still listed inside the sent messages "
+                         "section"):
+            expect(
+                self.sumo_pages.sent_message_page._sent_messages(username=test_user)
+            ).to_be_visible()
 
-        self.logger.info("Verifying that the messages are no longer displayed")
+        with allure.step("Sending another message to self twice"):
+            for i in range(2):
+                self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message(
+                )
+                self.sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
+                    recipient_username=user_one,
+                    message_body=super().user_message_test_data["valid_user_message"]["message"],
+                )
 
-        expect(
-            self.sumo_pages.inbox_page._inbox_message(username=user_one)
-        ).to_be_hidden()
+        with check, allure.step("Clicking on the 'delete selected' button while no messages is "
+                                "selected and verifying that the correct banner is displayed"):
+            self.sumo_pages.inbox_page._click_on_inbox_delete_selected_button()
+            assert self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(
+            ) in InboxPageMessages.NO_MESSAGES_SELECTED_BANNER_TEXT
+            expect(
+                self.sumo_pages.inbox_page._inbox_message(username=user_one).first
+            ).to_be_visible()
 
-        check.equal(
-            self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(),
-            InboxPageMessages.MULTIPLE_MESSAGES_DELETION_BANNER_TEXT,
-            f"Incorrect message banner displayed. "
-            f"Expected: {InboxPageMessages.MULTIPLE_MESSAGES_DELETION_BANNER_TEXT} "
-            f"Received: {self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text()}",
-        )
+        with allure.step("Selecting the messages and deleting it via the delete selected button"):
+            self.sumo_pages.inbox_page._delete_all_inbox_messages_via_delete_selected_button()
 
-        self.logger.info("Navigating to the sent messages section and clearing all messages via "
-                         "the 'delete selected button'")
-        self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_navbar_sent_messages()
+        with check, allure.step("Verifying that the messages are no longer displayed"):
+            expect(
+                self.sumo_pages.inbox_page._inbox_message(username=user_one)
+            ).to_be_hidden()
+            assert self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(
+            ) in InboxPageMessages.MULTIPLE_MESSAGES_DELETION_BANNER_TEXT
 
-        self.sumo_pages.sent_message_page._delete_all_sent_messages_via_delete_selected_button()
+        with allure.step("Navigating to the sent messages section and clearing all messages via "
+                         "the 'delete selected button'"):
+            self.sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_sent_messages()
+            self.sumo_pages.sent_message_page._delete_all_sent_messages_via_delete_selected_button(
+            )
 
-        self.logger.info("Verifying that the messages are no longer displayed")
-        expect(
-            self.sumo_pages.sent_message_page._sent_messages(username=user_one)
-        ).to_be_hidden()
+        with allure.step("Verifying that the messages are no longer displayed"):
+            expect(
+                self.sumo_pages.sent_message_page._sent_messages(username=user_one)
+            ).to_be_hidden()
+            expect(
+                self.sumo_pages.sent_message_page._sent_messages(username=test_user)
+            ).to_be_hidden()
 
-        expect(
-            self.sumo_pages.sent_message_page._sent_messages(username=test_user)
-        ).to_be_hidden()
+        with check, allure.step("Verifying that the correct banner is displayed"):
+            assert self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text(
+            ) in SentMessagesPageMessages.MULTIPLE_MESSAGES_DELETION_BANNER_TEXT
 
-        self.logger.info("Verifying that the correct banner is displayed")
-        check.equal(
-            self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text(),
-            SentMessagesPageMessages.MULTIPLE_MESSAGES_DELETION_BANNER_TEXT,
-            f"Incorrect message banner displayed. "
-            f"Expected: "
-            f"{SentMessagesPageMessages.MULTIPLE_MESSAGES_DELETION_BANNER_TEXT} "
-            f"Received: "
-            f"{self.sumo_pages.sent_message_page._get_sent_messages_page_deleted_banner_text()}",
-        )
+        with allure.step("Signing in with the receiver account and navigating to the inbox"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+            ))
+            self.sumo_pages.top_navbar._click_on_inbox_option()
 
-        self.logger.info(
-            "Signing in with the receiver account and navigating to the inbox section"
-        )
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
-        ))
+        with allure.step("Verifying that the messages are displayed inside the inbox section"):
+            expect(
+                self.sumo_pages.inbox_page._inbox_message(username=user_one)
+            ).to_be_visible()
 
-        self.sumo_pages.top_navbar._click_on_inbox_option()
+        with allure.step("Deleting all messages from the inbox page via the delete selected "
+                         "button'"):
+            self.sumo_pages.inbox_page._delete_all_inbox_messages_via_delete_selected_button()
 
-        self.logger.info("Verifying that the messages are displayed inside the inbox section")
-        expect(
-            self.sumo_pages.inbox_page._inbox_message(username=user_one)
-        ).to_be_visible()
-
-        self.logger.info(
-            "Deleting all messages from the inbox page via the 'delete selected button'"
-        )
-        self.sumo_pages.inbox_page._delete_all_inbox_messages_via_delete_selected_button()
-
-        self.logger.info("Verifying that the messages are no longer displayed inside the inbox "
-                         "section")
-        expect(
-            self.sumo_pages.inbox_page._inbox_message(username=user_one)
-        ).to_be_hidden()
-
-        self.logger.info("Verifying that the correct banner is displayed")
-        check.equal(
-            self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(),
-            InboxPageMessages.MESSAGE_DELETED_BANNER_TEXT,
-            f"Incorrect message banner displayed. "
-            f"Expected: {InboxPageMessages.MESSAGE_DELETED_BANNER_TEXT} "
-            f"Received: {self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text()}",
-        )
+        with check, allure.step("Verifying that the messages are no longer displayed inside the "
+                                "inbox section and the correct banner is displayed"):
+            expect(
+                self.sumo_pages.inbox_page._inbox_message(username=user_one)
+            ).to_be_hidden()
+            assert self.sumo_pages.inbox_page._get_text_inbox_page_message_banner_text(
+            ) in InboxPageMessages.MESSAGE_DELETED_BANNER_TEXT

--- a/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
+++ b/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 import requests
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -10,70 +11,67 @@ class TestTopNavbar(TestUtilities):
     # C876534, C890961
     @pytest.mark.topNavbarTests
     def test_number_of_options_not_signed_in(self):
-        self.logger.info("Verifying that the SUMO logo is successfully displayed")
-        image = self.sumo_pages.top_navbar._get_sumo_nav_logo()
-        image_link = image.get_attribute("src")
-        response = requests.get(image_link, stream=True)
-        check.is_true(response.status_code < 400, f"The {image_link} image is broken")
+        with check, allure.step("Verifying that the SUMO logo is successfully displayed"):
+            image = self.sumo_pages.top_navbar._get_sumo_nav_logo()
+            image_link = image.get_attribute("src")
+            response = requests.get(image_link, stream=True)
+            assert response.status_code < 400
 
-        self.logger.info("Verifying that top-navbar contains only Get Help & Contribute options "
-                         "for non signed-in state")
-        top_navbar_items = self.sumo_pages.top_navbar._get_available_menu_titles()
-        expected_top_navbar_items = [
-            TopNavbarMessages.GET_HELP_OPTION_TEXT,
-            TopNavbarMessages.CONTRIBUTE_OPTION_TEXT,
-        ]
-
-        assert top_navbar_items == expected_top_navbar_items, (
-            "Incorrect elements displayed in top-navbar for signed out state"
-        )
+        with allure.step("Verifying that top-navbar contains only Get Help & Contribute options "
+                         "for non signed-in state"):
+            top_navbar_items = self.sumo_pages.top_navbar._get_available_menu_titles()
+            expected_top_navbar_items = [
+                TopNavbarMessages.GET_HELP_OPTION_TEXT,
+                TopNavbarMessages.CONTRIBUTE_OPTION_TEXT,
+            ]
+            assert top_navbar_items == expected_top_navbar_items, (
+                "Incorrect elements displayed in top-navbar for signed out state"
+            )
 
     #  C876539
     @pytest.mark.topNavbarTests
     def test_number_of_options_signed_in(self):
-        self.logger.info("Using saved user session")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in using a non-admin user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Verifying that the SUMO logo is successfully displayed")
-        image = self.sumo_pages.top_navbar._get_sumo_nav_logo()
-        image_link = image.get_attribute("src")
-        response = requests.get(image_link, stream=True)
-        check.is_true(response.status_code < 400, f"The {image_link} image is broken")
+        with check, allure.step("Verifying that the SUMO logo is successfully displayed"):
+            image = self.sumo_pages.top_navbar._get_sumo_nav_logo()
+            image_link = image.get_attribute("src")
+            response = requests.get(image_link, stream=True)
+            assert response.status_code < 400
 
-        self.logger.info("Verifying that the top-navbar contains Get Help, Contributor Tools and "
-                         "Contribute options")
-        top_navbar_items = self.sumo_pages.top_navbar._get_available_menu_titles()
-        expected_top_navbar_items = [
-            TopNavbarMessages.GET_HELP_OPTION_TEXT,
-            TopNavbarMessages.CONTRIBUTOR_TOOLS_TEXT,
-            TopNavbarMessages.CONTRIBUTE_OPTION_TEXT,
-        ]
-
-        assert top_navbar_items == expected_top_navbar_items, (
-            "Incorrect elements displayed in top-navbar for " "signed-in state"
-        )
+        with allure.step("Verifying that the top-navbar contains Get Help, Contributor Tools and "
+                         "Contribute options"):
+            top_navbar_items = self.sumo_pages.top_navbar._get_available_menu_titles()
+            expected_top_navbar_items = [
+                TopNavbarMessages.GET_HELP_OPTION_TEXT,
+                TopNavbarMessages.CONTRIBUTOR_TOOLS_TEXT,
+                TopNavbarMessages.CONTRIBUTE_OPTION_TEXT,
+            ]
+            assert top_navbar_items == expected_top_navbar_items, (
+                "Incorrect elements displayed in top-navbar for " "signed-in state"
+            )
 
     #  C876534
     @pytest.mark.topNavbarTests
     def test_contributor_tools_is_removed_after_user_signs_out(self):
-        self.logger.info("Using saved user session")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Signing the user out from SUMO by clearing session cookies")
-        self.delete_cookies()
+        with allure.step("Signing the user out from SUMO"):
+            self.delete_cookies()
 
-        self.logger.info("Verifying that top-navbar contains only Get Help & Contribute options "
-                         "for non signed-in state")
-        top_navbar_items = self.sumo_pages.top_navbar._get_available_menu_titles()
-        expected_top_navbar_items = [
-            TopNavbarMessages.GET_HELP_OPTION_TEXT,
-            TopNavbarMessages.CONTRIBUTE_OPTION_TEXT,
-        ]
-
-        assert top_navbar_items == expected_top_navbar_items, (
-            "Incorrect elements displayed in top-navbar for " "signed out state"
-        )
+        with allure.step("Verifying that top-navbar contains only Get Help & Contribute options "
+                         "for non signed-in state"):
+            top_navbar_items = self.sumo_pages.top_navbar._get_available_menu_titles()
+            expected_top_navbar_items = [
+                TopNavbarMessages.GET_HELP_OPTION_TEXT,
+                TopNavbarMessages.CONTRIBUTE_OPTION_TEXT,
+            ]
+            assert top_navbar_items == expected_top_navbar_items, (
+                "Incorrect elements displayed in top-navbar for " "signed out state"
+            )

--- a/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 from playwright.sync_api import expect
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -14,430 +15,279 @@ class TestEditMyProfile(TestUtilities):
     # C891529
     @pytest.mark.editUserProfileTests
     def test_username_field_is_automatically_populated(self):
-        self.logger.info(
-            "Signing in with a simple user account and navigating to the 'Edit Profile' page"
-        )
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin user and navigating to the 'Edit Profile' "
+                         "page"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
 
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-
-        self.logger.info(
-            "Verifying that username field is automatically populated with the correct data"
-        )
-        top_navbar_displayed_username = (
-            self.sumo_pages.top_navbar._get_text_of_logged_in_username())
-
-        assert (
-            self.sumo_pages.edit_my_profile_page._get_username_input_field_value()
-            == top_navbar_displayed_username
-        ), (
-            f"Incorrect username displayed inside the user field. "
-            f"Expected: {top_navbar_displayed_username}, "
-            f"received: {self.sumo_pages.edit_my_profile_page._get_username_input_field_value()}"
-        )
+        with allure.step("Verifying that username field is automatically populated with the "
+                         "correct data"):
+            top_navbar_displayed_username = (
+                self.sumo_pages.top_navbar._get_text_of_logged_in_username())
+            assert (
+                self.sumo_pages.edit_my_profile_page._get_username_input_field_value()
+                == top_navbar_displayed_username
+            )
 
     # C1491017
     # This test is currently covering the: my profile section, top navbar, and posted questions.
     # Might want to extend the coverage
     @pytest.mark.editUserProfileTests
     def test_edit_profile_field_validation_with_symbols(self):
-        self.logger.info("Signing in with a normal account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Navigating to the profile edit page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Navigating to the profile edit page"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
 
-        self.logger.info("Extracting the username value")
         original_username = self.sumo_pages.edit_my_profile_page._get_username_input_field_value()
 
-        self.logger.info(
-            "Clearing the username and display name fields and inserting the new username"
-        )
-        self.sumo_pages.edit_my_profile_page._clear_username_field()
-        self.sumo_pages.edit_my_profile_page._clear_display_name_field()
+        with allure.step("Clearing the username, display name fields and inserting the new one"):
+            self.sumo_pages.edit_my_profile_page._clear_username_field()
+            self.sumo_pages.edit_my_profile_page._clear_display_name_field()
+            profile_edit_data = super().profile_edit_test_data
 
-        profile_edit_data = super().profile_edit_test_data
+            if self.requested_browser == "chrome":
+                new_username = profile_edit_data["valid_user_edit_with_symbols"][
+                    "username_with_valid_symbols_chrome"
+                ]
+            elif self.requested_browser == "firefox":
+                new_username = profile_edit_data["valid_user_edit_with_symbols"][
+                    "username_with_valid_symbols_firefox"
+                ]
+            self.sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
 
-        if self.requested_browser == "chrome":
-            new_username = profile_edit_data["valid_user_edit_with_symbols"][
-                "username_with_valid_symbols_chrome"
-            ]
-        elif self.requested_browser == "firefox":
-            new_username = profile_edit_data["valid_user_edit_with_symbols"][
-                "username_with_valid_symbols_firefox"
-            ]
+        with allure.step("Clicking on the 'Update My Profile' button"):
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
+        with check, allure.step("Verify that the newly set username is successfully applied to "
+                                "the my profile section"):
+            assert self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
+            ) == new_username
 
-        self.logger.info("Clicking on the 'Update My Profile' button")
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Verify that the newly set username is displayed inside the "
+                                "top navbar"):
+            assert self.sumo_pages.top_navbar._get_text_of_logged_in_username() == new_username
 
-        self.logger.info(
-            "Verify that the newly set username is successfully applied to the my profile section"
-        )
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text(),
-            new_username,
-            f"The username displayed inside the profile section should be {new_username} "
-            f"but instead is: "
-            f"{self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()}",
-        )
+        with check, allure.step("Access a previously posted question and verify that the display"
+                                " name has changed"):
+            self.sumo_pages.my_profile_page._click_on_my_profile_questions_link()
+            self.sumo_pages.my_questions_page._click_on_a_question_by_index(1)
 
-        self.logger.info("Verify that the newly set username is displayed inside the top navbar")
-        check.equal(
-            self.sumo_pages.top_navbar._get_text_of_logged_in_username(),
-            new_username,
-            f"The username displayed inside the top navbar section should be {new_username} "
-            f"but instead is {self.sumo_pages.top_navbar._get_text_of_logged_in_username()}",
-        )
+            assert self.sumo_pages.question_page._get_question_author_name() == new_username
 
-        self.logger.info(
-            "Access a previously posted question and verify that the display name has changed"
-        )
-        self.sumo_pages.my_profile_page._click_on_my_profile_questions_link()
-        self.sumo_pages.my_questions_page._click_on_a_question_by_index(1)
+        with allure.step("Going back to the my profile page and reverting the username back to "
+                         "the original one"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_username_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_username_field(original_username)
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        check.equal(
-            self.sumo_pages.question_page._get_question_author_name(),
-            new_username,
-            "The new username should be reflected under the posted questions as well",
-        )
+        with check, allure.step("Verifying that the username was updated back to the original "
+                                "one"):
+            assert self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
+            ) == original_username
 
-        self.logger.info(
-            "Going back to the my profile page and reverting the username back to the original one"
-        )
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_username_field()
-        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(original_username)
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Verify that the newly set username is displayed inside the top "
+                                "navbar"):
+            assert self.sumo_pages.top_navbar._get_text_of_logged_in_username(
+            ) == original_username
 
-        self.logger.info("Verifying that the username was updated back to the original one")
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text(),
-            original_username,
-            f"The username displayed inside the profile section should be {original_username}"
-            f" but instead is: "
-            f"{self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()}",
-        )
-
-        self.logger.info("Verify that the newly set username is displayed inside the top navbar")
-        check.equal(
-            self.sumo_pages.top_navbar._get_text_of_logged_in_username(),
-            original_username,
-            f"The username displayed inside the top navbar section should be "
-            f"{original_username} "
-            f"but instead is {self.sumo_pages.top_navbar._get_text_of_logged_in_username()}",
-        )
-
-        self.logger.info(
-            "Access a previously posted question and verify that the display name has changed"
-        )
-        self.sumo_pages.my_profile_page._click_on_my_profile_questions_link()
-        self.sumo_pages.my_questions_page._click_on_a_question_by_index(1)
-
-        check.equal(
-            self.sumo_pages.question_page._get_question_author_name(),
-            original_username,
-            "The new username should be reflected under the posted questions as well",
-        )
+        with check, allure.step("Access a previously posted question and verify that the display "
+                                "name has changed"):
+            self.sumo_pages.my_profile_page._click_on_my_profile_questions_link()
+            self.sumo_pages.my_questions_page._click_on_a_question_by_index(1)
+            assert self.sumo_pages.question_page._get_question_author_name() == original_username
 
     # C1491017
     @pytest.mark.editUserProfileTests
     def test_username_with_invalid_symbols(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Accessing the edit profile page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the edit profile page"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
 
-        self.logger.info("Extracting the original username")
         original_username = self.sumo_pages.edit_my_profile_page._get_username_input_field_value()
 
-        self.logger.info("Clearing the username input field and adding an invalid user")
-        self.sumo_pages.edit_my_profile_page._clear_username_field()
+        with allure.step("Clearing the username input field and adding an invalid user"):
+            self.sumo_pages.edit_my_profile_page._clear_username_field()
+            profile_edit_data = super().profile_edit_test_data
+            new_username = profile_edit_data["invalid_username_with_symbols"][
+                "username_with_invalid_symbols"
+            ]
+            self.sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
 
-        profile_edit_data = super().profile_edit_test_data
+        with check, allure.step("Clicking on the 'Update My Profile' button and verifying that "
+                                "the correct error message is displayed"):
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+            assert self.sumo_pages.edit_my_profile_page._get_username_error_message_text(
+            ) == EditMyProfilePageMessages.USERNAME_INPUT_ERROR_MESSAGE
 
-        new_username = profile_edit_data["invalid_username_with_symbols"][
-            "username_with_invalid_symbols"
-        ]
-
-        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
-
-        self.logger.info("Clicking on the 'Update My Profile' button")
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
-
-        self.logger.info("Verify that the error message is displayed")
-        check.equal(
-            self.sumo_pages.edit_my_profile_page._get_username_error_message_text(),
-            EditMyProfilePageMessages.USERNAME_INPUT_ERROR_MESSAGE,
-            f"Incorrect error message displayed. "
-            f"Expected: {EditMyProfilePageMessages.USERNAME_INPUT_ERROR_MESSAGE} "
-            f"but received: "
-            f"{self.sumo_pages.edit_my_profile_page._get_username_error_message_text()}",
-        )
-
-        self.logger.info(
-            "Accessing the Edit Profile page and verifying that the username was not changed"
-        )
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-
-        assert (
-            self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()
-            == original_username
-        ), (
-            f"The username should be: {original_username} "
-            f"but instead is: "
-            f"{self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text}"
-        )
+        with allure.step("Accessing the Edit Profile page and verifying that the username was "
+                         "not changed"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            assert (self.sumo_pages.my_profile_page
+                    ._get_my_profile_display_name_header_text() == original_username)
 
     #  C891530,  C2107866
     @pytest.mark.editUserProfileTests
     def test_cancel_profile_edit(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a normal user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Accessing the Edit My Profile page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the Edit My Profile page"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
 
-        self.logger.info("Extracting all the edit my profile fields values")
         original_values = self.sumo_pages.edit_my_profile_page._get_value_of_all_fields()
 
-        self.logger.info("Populating edit profile fields with data")
-        self.sumo_pages.edit_profile_flow.edit_profile_with_test_data()
+        with allure.step("Populating edit profile fields with data"):
+            self.sumo_pages.edit_profile_flow.edit_profile_with_test_data()
 
-        self.logger.info("Clicking on the 'Cancel' button")
-        self.sumo_pages.edit_my_profile_page._click_cancel_button()
-
-        self.logger.info(
-            "Verifying that we are on the same page "
-            "and all the input field values were reverted back to original"
-        )
-
-        assert (
-            self.sumo_pages.edit_my_profile_page._get_value_of_all_fields() == original_values), \
-            (
-            f"Fields values were not restored to original values. "
-            f"Original values: {original_values}, current field "
-            f"values: {self.sumo_pages.edit_my_profile_page._get_value_of_all_fields()}"
-        )
+        with allure.step("Clicking on the 'Cancel' button and verifying that we are on the same "
+                         "page and all input field values were reverted back to original"):
+            self.sumo_pages.edit_my_profile_page._click_cancel_button()
+            assert self.sumo_pages.edit_my_profile_page._get_value_of_all_fields(
+            ) == original_values
 
     #  C946232
     @pytest.mark.editUserProfileTests
     def test_manage_firefox_account_redirects_to_firefox_account_settings_page(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.logger.info("Accessing the 'Edit my profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the 'Edit my profile' page and clicking on the 'Manage "
+                         "account' button"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._click_manage_firefox_account_button()
 
-        self.logger.info("Click on the 'Manage account' button")
-        self.sumo_pages.edit_my_profile_page._click_manage_firefox_account_button()
-
-        self.logger.info(
-            "Verifying that the user was redirected to "
-            "the Mozilla account settings page in a new tab"
-        )
-
-        with self.page.context.expect_page() as tab:
-            fxa_page = tab.value
-            print("Tab open")
-
-        assert FxAPageMessages.ACCOUNT_SETTINGS_URL in fxa_page.url
+        with allure.step("Verifying that the user was redirected to the Mozilla account settings "
+                         "page in a new tab"):
+            with self.page.context.expect_page() as tab:
+                fxa_page = tab.value
+            assert FxAPageMessages.ACCOUNT_SETTINGS_URL in fxa_page.url
 
     #  C1491461
     @pytest.mark.editUserProfileTests
     def test_duplicate_usernames_are_not_allowed(self):
-        self.logger.info("Sign in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
         original_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
 
-        self.logger.info("Clearing the username input field and adding an existing username to it")
-        self.sumo_pages.edit_my_profile_page._clear_username_field()
+        with allure.step("Clicking on the 'edit profile' option"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
 
-        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(
-            super().username_extraction_from_email(
-                super().user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+        with allure.step("Clearing the username input field and adding an existing username "
+                         "to it"):
+            self.sumo_pages.edit_my_profile_page._clear_username_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_username_field(
+                super().username_extraction_from_email(
+                    super().user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
+                )
             )
-        )
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Verify that the error message is displayed under the username "
+                                "input field and is the correct one"):
+            assert self.sumo_pages.edit_my_profile_page._get_username_error_message_text(
+            ) == EditMyProfilePageMessages.DUPLICATE_USERNAME_ERROR_MESSAGE
 
-        self.logger.info(
-            "Verify that the error message is displayed "
-            "under the username input field and is the correct one"
-        )
+        with check, allure.step("Verifying that the username displayed inside the top navbar is "
+                                "the correct one"):
+            assert self.sumo_pages.top_navbar._get_text_of_logged_in_username(
+            ) == original_username
 
-        check.equal(
-            self.sumo_pages.edit_my_profile_page._get_username_error_message_text(),
-            EditMyProfilePageMessages.DUPLICATE_USERNAME_ERROR_MESSAGE,
-            f"Incorrect error message displayed! The expected error message is: "
-            f"{EditMyProfilePageMessages.DUPLICATE_USERNAME_ERROR_MESSAGE}"
-            f" The displayed error message is:"
-            f" {self.sumo_pages.edit_my_profile_page._get_username_error_message_text()}",
-        )
-
-        self.logger.info(
-            "Verifying that the username displayed inside the top navbar is the correct one"
-        )
-
-        check.equal(
-            self.sumo_pages.top_navbar._get_text_of_logged_in_username(),
-            original_username,
-            f"Incorrect username displayed inside the top-navbar. "
-            f"Expected to be: {original_username} "
-            f" but got: {self.sumo_pages.top_navbar._get_text_of_logged_in_username()}",
-        )
-
-        self.logger.info("Accessing the my profile page")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-
-        self.logger.info(
-            "Verifying that the username displayed inside the My Profile page is the correct one"
-        )
-
-        assert (
-            self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()
-            == original_username
-        ), (
-            f"Incorrect username displayed inside the My Profile page."
-            f" Expected to be: {original_username}"
-            f" but got: "
-            f"{self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()}"
-        )
+        with allure.step("Accessing the my profile page and verifying that the username "
+                         "displayed inside the page is the correct one"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            assert self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
+            ) == original_username
 
     #  C1491462
     @pytest.mark.editUserProfileTests
     def test_profile_username_field_cannot_be_left_empty(self):
-        self.logger.info("Signing in with a normal account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
         original_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the Edit My Profile page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the Edit My Profile page and clearing the username input "
+                         "field"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_username_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info(
-            "Clearing the username input field and clicking on the Update My Profile button"
-        )
+        with check, allure.step("Verifying that we are still on the edit profile page"):
+            assert self.get_page_url() == EditMyProfilePageMessages.STAGE_EDIT_MY_PROFILE_URL
 
-        self.sumo_pages.edit_my_profile_page._clear_username_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Verifying that the displayed username inside the top navbar is the "
+                         "original one"):
+            assert self.sumo_pages.top_navbar._get_text_of_logged_in_username(
+            ) == original_username
 
-        self.logger.info("Verifying that we are still on the edit profile page")
-
-        check.equal(
-            self.get_page_url(),
-            EditMyProfilePageMessages.STAGE_EDIT_MY_PROFILE_URL,
-            f"We are not on the expected page. Expected page to be:"
-            f" {EditMyProfilePageMessages.STAGE_EDIT_MY_PROFILE_URL}"
-            f" but we are on the {self.get_page_url()} page instead",
-        )
-
-        self.logger.info(
-            "Verifying that the displayed username inside the top navbar is the original one"
-        )
-
-        assert self.sumo_pages.top_navbar._get_text_of_logged_in_username() == original_username, (
-            f"Expected username to be: {original_username}. "
-            f"The displayed username is "
-            f"{self.sumo_pages.top_navbar._get_text_of_logged_in_username()}"
-        )
-
-        self.logger.info("Accessing the my profile page")
-        self.sumo_pages.user_navbar._click_on_my_profile_option()
-
-        self.logger.info(
-            "Verifying that the username displayed inside the my profile page is the original one"
-        )
-
-        assert (
-            self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()
-            == original_username
-        ), (
-            f"Expected username to be: {original_username}. "
-            f"The displayed username is "
-            f"{self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()}"
-        )
+        with allure.step("Accessing the my profile page and verifying that the username is the "
+                         "original one"):
+            self.sumo_pages.user_navbar._click_on_my_profile_option()
+            assert self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
+            ) == original_username
 
     # C1491018, C891531,C1491021
     @pytest.mark.editUserProfileTests
     def test_username_can_contain_uppercase_and_lowercase_letters(self):
-        self.logger.info("Signing in with a normal account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_MESSAGE_4']
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_MESSAGE_4']
+            ))
 
         original_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
         new_username = super().profile_edit_test_data["uppercase_lowercase_valid_username"][
             "uppercase_lowercase_username"
         ]
 
-        self.logger.info("Accessing the edit my profile page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the edit my profile page and updating the username field to "
+                         "contain uppercase and lowercase characters"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_username_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info(
-            "Updating the username field to contain uppercase and lowercase characters"
-        )
-        self.sumo_pages.edit_my_profile_page._clear_username_field()
-        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
+        with allure.step("Verifying that the username displayed inside the top-navbar updates "
+                         "successfully"):
+            assert self.sumo_pages.top_navbar._get_text_of_logged_in_username() == new_username
 
-        self.logger.info("Clicking on the 'Update my Profile button'")
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Verifying that the username displayed inside the my profile section is "
+                         "the correct one"):
+            assert self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
+            ) == new_username
 
-        self.logger.info(
-            "Verifying that the username displayed inside the top-navbar updates successfully"
-        )
-
-        assert self.sumo_pages.top_navbar._get_text_of_logged_in_username() == new_username, (
-            f"The displayed username is incorrect. Expected: {new_username} "
-            f"but "
-            f"{self.sumo_pages.top_navbar._get_text_of_logged_in_username()} is displayed instead"
-        )
-
-        self.logger.info(
-            "Verifying that the username displayed inside "
-            "the my profile section is the correct one"
-        )
-
-        assert (
-            self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()
-            == new_username
-        ), (
-            f"The displayed username is incorrect. Expected: {new_username}"
-            f"but {self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()} "
-            f"is displayed instead"
-        )
-
-        self.logger.info("Reverting the username back to the original one")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_username_field()
-        self.sumo_pages.edit_my_profile_page._send_text_to_username_field(original_username)
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Reverting the username back to the original one"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_username_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_username_field(original_username)
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     #  C1491463, C1491464
     @pytest.mark.editUserProfileTests
     def test_display_name_replaces_the_username_text(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_MESSAGE_1']
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_MESSAGE_1']
+            ))
 
         original_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
@@ -450,918 +300,592 @@ class TestEditMyProfile(TestUtilities):
                 "display_name_firefox"
             ]
 
-        self.logger.info("Accessing the edit profile page and adding a new display name")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_display_name_field()
-        self.sumo_pages.edit_my_profile_page._send_text_to_display_name_field(new_display_name)
+        with allure.step("Accessing the edit profile page and adding a new display name"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_display_name_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_display_name_field(new_display_name)
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Clicking on the 'Update My Profile' button")
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Verifying that the top navbar username updates with the display name"):
+            assert self.sumo_pages.top_navbar._get_text_of_logged_in_username() == new_display_name
 
-        self.logger.info("Verifying that the top navbar username updates with the display name")
+        with allure.step(f"Verifying that the 'My profile' display name contains "
+                         f"{new_display_name}"):
+            assert self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
+            ) == f"{new_display_name} ({original_username})"
 
-        assert self.sumo_pages.top_navbar._get_text_of_logged_in_username() == new_display_name, (
-            f"Incorrect displayed signed in username in top-navbar. "
-            f"Expected: {new_display_name} but "
-            f"{self.sumo_pages.top_navbar._get_text_of_logged_in_username()} is displayed instead"
-        )
+        with allure.step("Reverting back and deleting the display name"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_display_name_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info(
-            "Verifying that the 'My profile' display name contains display name (username)"
-        )
+        with allure.step(f"Verifying that the displayed name inside the top navbar is reverted "
+                         f"back to {original_username}"):
+            assert self.sumo_pages.top_navbar._get_text_of_logged_in_username(
+            ) == original_username
 
-        assert (
-            self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()
-            == f"{new_display_name} ({original_username})"
-        ), (
-            f"Incorrect displayed signed in username inside the my profile page. "
-            f"Expected: {new_display_name} ({original_username})"
-            f"but {self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()} "
-            f"is displayed instead"
-        )
-
-        self.logger.info("Reverting back and deleting the display name")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_display_name_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
-
-        self.logger.info(
-            "Verifying that the displayed name inside the top navbar is reverted back to username"
-        )
-
-        assert self.sumo_pages.top_navbar._get_text_of_logged_in_username() == original_username, (
-            f"Incorrect displayed signed in username after deleting the display name. "
-            f"Expected: {original_username}"
-            f" but received: {self.sumo_pages.top_navbar._get_text_of_logged_in_username()}"
-        )
-
-        self.logger.info(
-            "Verifying that the displayed name inside the main "
-            "profile page is reverted back to the username"
-        )
-
-        assert {
-            self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()
-            == original_username
-        }, (
-            f"Incorrect displayed name inside the profile page. Expected: {original_username} but"
-            f" received "
-            f"{self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()}"
-        )
+        with allure.step("Verifying that the displayed name inside the main profile page is "
+                         "reverted back to the username"):
+            assert self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
+            ) == original_username
 
     # This needs update. No longer fails due to:
     # https://github.com/mozilla/sumo/issues/1345
     @pytest.mark.skip
     def test_biography_field_accepts_html_tags(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Accessing the edit profile page via top-navbar")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-
-        self.logger.info("Clearing the biography field and inputting html data to it")
-        self.sumo_pages.edit_my_profile_page._clear_biography_textarea_field()
-        html_test_data = super().profile_edit_test_data
-        self.sumo_pages.edit_my_profile_page._send_text_to_biography_field(
-            html_test_data["biography_field_with_html_data"]["biography_html_data"]
-        )
-
-        self.logger.info("Clicking on the 'Update My Profile button'")
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Accessing the edit profile page via top-navbar and adding data inside "
+                         "the biography field"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_biography_textarea_field()
+            html_test_data = super().profile_edit_test_data
+            self.sumo_pages.edit_my_profile_page._send_text_to_biography_field(
+                html_test_data["biography_field_with_html_data"]["biography_html_data"]
+            )
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     #  C2107899, C2107899
     @pytest.mark.editUserProfileTests
     def test_make_my_email_address_visible_checkbox_checked(self):
         logged_in_email = super().user_secrets_accounts["TEST_ACCOUNT_12"]
 
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the 'Edit My Profile' page and checking the 'make email "
+                         "visible checkbox'"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            if not self.sumo_pages.edit_my_profile_page._is_make_email_visible_checkbox_selected():
+                self.sumo_pages.edit_my_profile_page._click_make_email_visible_checkbox()
+                self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        if not self.sumo_pages.edit_my_profile_page._is_make_email_visible_checkbox_selected():
-            self.sumo_pages.edit_my_profile_page._click_make_email_visible_checkbox()
-            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Returning to My Profile page and verifying that the email is "
+                                "displayed"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            assert self.sumo_pages.my_profile_page._get_text_of_publicly_displayed_username(
+            ) == logged_in_email
 
-        self.logger.info(
-            "Checkbox is checked, returning to My Profile page "
-            "and verifying that the email is displayed"
-        )
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with allure.step("Signing in with a different user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
 
-        check.equal(
-            self.sumo_pages.my_profile_page._get_text_of_publicly_displayed_username(),
-            logged_in_email,
-            f"Incorrect email is displayed inside the "
-            f"'My Profile' page. Expected: {logged_in_email} "
-            f"received "
-            f"{self.sumo_pages.my_profile_page._get_text_of_publicly_displayed_username()}",
-        )
+        with check, allure.step("Accessing the previous user profile and verifying that the email"
+                                " address is displayed"):
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert self.sumo_pages.my_profile_page._get_text_of_publicly_displayed_username(
+            ) == logged_in_email
 
-        self.logger.info("Signing in with a different user")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with allure.step("Signing out"):
+            self.delete_cookies()
 
-        self.logger.info(
-            "Accessing the previous user profile and verifying that the email address is displayed"
-        )
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.equal(
-            self.sumo_pages.my_profile_page._get_text_of_publicly_displayed_username(),
-            logged_in_email,
-            f"Incorrect email is displayed inside the 'My Profile' page. "
-            f"Expected: {logged_in_email} "
-            f"received "
-            f"{self.sumo_pages.my_profile_page._get_text_of_publicly_displayed_username()}",
-        )
-
-        self.logger.info("Signing out")
-        self.delete_cookies()
-
-        self.logger.info(
-            "Accessing the previous user profile and verifying that "
-            "the email address is not displayed to signed out users"
-        )
-
-        # This also needs an update
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        expect(
-            self.sumo_pages.my_profile_page._publicly_displayed_email_element()
-        ).to_be_hidden()
+        with allure.step("Accessing the previous user profile and verifying that the email "
+                         "address is not displayed to signed out users"):
+            # This also needs an update
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            expect(
+                self.sumo_pages.my_profile_page._publicly_displayed_email_element()
+            ).to_be_hidden()
 
     #  C2107899
     @pytest.mark.editUserProfileTests
     def test_make_my_email_address_visible_checkbox_unchecked(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the 'Edit My Profile' page and unchecking the make email "
+                         "visible checkbox"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            if self.sumo_pages.edit_my_profile_page._is_make_email_visible_checkbox_selected():
+                self.sumo_pages.edit_my_profile_page._click_make_email_visible_checkbox()
+                self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        if self.sumo_pages.edit_my_profile_page._is_make_email_visible_checkbox_selected():
-            self.sumo_pages.edit_my_profile_page._click_make_email_visible_checkbox()
-            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Returning to My Profile page and verifying that the email is not "
+                         "displayed"):
+            self.sumo_pages.user_navbar._click_on_my_profile_option()
+            expect(
+                self.sumo_pages.my_profile_page._publicly_displayed_email_element()
+            ).to_be_hidden()
 
-        self.logger.info(
-            "Checkbox is unchecked, returning to My Profile page "
-            "and verifying that the email is not displayed"
-        )
-        self.sumo_pages.user_navbar._click_on_my_profile_option()
+        with allure.step("Signing in with a different non-admin user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
 
-        expect(
-            self.sumo_pages.my_profile_page._publicly_displayed_email_element()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with a different user")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.logger.info(
-            "Accessing the previous user profile and verifying that "
-            "the email address is not displayed"
-        )
-
-        # This also needs an update
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        expect(
-            self.sumo_pages.my_profile_page._publicly_displayed_email_element()
-        ).to_be_hidden()
+        with allure.step("Accessing the previous user profile and verifying that the email "
+                         "address is not displayed"):
+            # This also needs an update
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            expect(
+                self.sumo_pages.my_profile_page._publicly_displayed_email_element()
+            ).to_be_hidden()
 
     # C2107900, C2107900
     @pytest.mark.editUserProfileTests
     def test_website_information_is_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        website_field_test_data = super().profile_edit_test_data["valid_user_edit"]["website"]
-        self.sumo_pages.edit_my_profile_page._clear_website_field()
-        self.sumo_pages.edit_my_profile_page._send_text_to_website_field(website_field_test_data)
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Accessing the 'Edit My Profile' page and updating the website field"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            website_field_test_data = super().profile_edit_test_data["valid_user_edit"]["website"]
+            self.sumo_pages.edit_my_profile_page._clear_website_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_website_field(
+                website_field_test_data)
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Verify that the correct website is displayed")
+        with check, allure.step("Verify that the correct website is displayed"):
+            assert self.sumo_pages.my_profile_page._get_my_profile_website_text(
+            ) == website_field_test_data
 
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_website_text(),
-            website_field_test_data,
-            f"Incorrect website displayed. Expected: {website_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_website_text()}",
-        )
+        with allure.step("Signing in with a different non-admin user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+        with check, allure.step("Verifying that the correct website information is displayed for "
+                                "the first user"):
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert self.sumo_pages.my_profile_page._get_my_profile_website_text(
+            ) == website_field_test_data
 
-        self.logger.info(
-            "Signing in with a different user and verifying that the correct website information "
-            "is displayed for the first user"
-        )
+        with check, allure.step("Clicking on the website and verifying that the user is "
+                                "redirected to the correct page"):
+            self.sumo_pages.my_profile_page._click_on_my_website_link()
+            assert website_field_test_data in self.get_page_url()
 
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with check, allure.step("Navigating back to the SUMO page, signing out and verifying "
+                                "that the correct website is displayed for the first user"):
+            self.navigate_back()
+            self.delete_cookies()
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert self.sumo_pages.my_profile_page._get_my_profile_website_text(
+            ) == website_field_test_data
 
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+        with check, allure.step("Clicking on the website and verifying that the user is "
+                                "redirected to the correct page"):
+            self.sumo_pages.my_profile_page._click_on_my_website_link()
+            assert website_field_test_data in self.get_page_url()
 
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_website_text(),
-            website_field_test_data,
-            f"Incorrect website displayed. Expected: {website_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_website_text()}",
-        )
-
-        self.logger.info(
-            "Clicking on the website and verifying that the user is redirected correctly"
-        )
-        self.sumo_pages.my_profile_page._click_on_my_website_link()
-
-        check.is_in(
-            website_field_test_data,
-            self.get_page_url(),
-            f"Incorrect user redirect. Expected: {website_field_test_data} "
-            f"received: {self.get_page_url()}",
-        )
-
-        self.logger.info("Navigating back to the SUMO page")
-        self.navigate_back()
-
-        self.logger.info("Signin out from SUMO")
-        self.delete_cookies()
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_website_text(),
-            website_field_test_data,
-            f"Incorrect website displayed. Expected: {website_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_website_text()}",
-        )
-
-        self.logger.info(
-            "Clicking on the website and verifying that the user is redirected correctly"
-        )
-        self.sumo_pages.my_profile_page._click_on_my_website_link()
-
-        check.is_in(
-            website_field_test_data,
-            self.get_page_url(),
-            f"Incorrect user redirect. Expected: {website_field_test_data} "
-            f"received: {self.get_page_url()}",
-        )
-
-        self.logger.info("Navigating back to the SUMO page")
-        self.navigate_back()
-
-        self.logger.info("Clearing the website field changes")
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_website_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Navigating back to the SUMO page and clearing the website field"):
+            self.navigate_back()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_website_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     # C2107901, C2107901
     @pytest.mark.editUserProfileTests
     def test_twitter_information_is_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the Edit My Profile' page, clearing and adding data inside "
+                         "the twitter input field"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            twitter_field_test_data = super().profile_edit_test_data["valid_user_edit"][
+                "twitter_username"
+            ]
+            self.sumo_pages.edit_my_profile_page._clear_twitter_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_twitter_username_field(
+                twitter_field_test_data
+            )
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Clearing and adding data inside the twitter input field")
-        twitter_field_test_data = super().profile_edit_test_data["valid_user_edit"][
-            "twitter_username"
-        ]
-        self.sumo_pages.edit_my_profile_page._clear_twitter_field()
-        self.sumo_pages.edit_my_profile_page._send_text_to_twitter_username_field(
-            twitter_field_test_data
-        )
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Navigating back to the My Profile page and verify that the "
+                                "correct twitter is displayed"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            assert self.sumo_pages.my_profile_page._get_my_profile_twitter_text(
+            ) == twitter_field_test_data
 
-        self.logger.info(
-            "Navigating back to the My Profile page and verify "
-            "that the correct twitter is displayed"
-        )
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with check, allure.step("Signing in with a different user and verifying that the correct "
+                                "website information is displayed for the first user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert self.sumo_pages.my_profile_page._get_my_profile_twitter_text(
+            ) == twitter_field_test_data
 
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_twitter_text(),
-            twitter_field_test_data,
-            f"Incorrect twitter displayed. Expected: {twitter_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_twitter_text()}",
-        )
+        with allure.step("Clicking on the twitter link and verifying that the user is redirected "
+                         "correctly"):
+            self.sumo_pages.my_profile_page._click_on_twitter_link()
+            assert (MyProfileMessages.TWITTER_REDIRECT_LINK + twitter_field_test_data in self.
+                    get_page_url())
 
-        self.logger.info(
-            "Signing in with a different user and verifying that the correct website information "
-            "is displayed for the first user"
-        )
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with check, allure.step("Navigating back to the SUMO page, signing out, accessing the "
+                                "profile and verifying that the twitter information is displayed"):
+            self.navigate_back()
+            self.delete_cookies()
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert self.sumo_pages.my_profile_page._get_my_profile_twitter_text(
+            ) == twitter_field_test_data
 
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+        with check, allure.step("Clicking on the twitter link and verifying that the user is "
+                                "redirected correctly"):
+            self.sumo_pages.my_profile_page._click_on_twitter_link()
+            assert (MyProfileMessages.TWITTER_REDIRECT_LINK + twitter_field_test_data in self.
+                    get_page_url())
 
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_twitter_text(),
-            twitter_field_test_data,
-            f"Incorrect twitter displayed. Expected: {twitter_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_twitter_text()}",
-        )
-
-        self.logger.info(
-            "Clicking on the twitter link and verifying that the user is redirected correctly"
-        )
-        self.sumo_pages.my_profile_page._click_on_twitter_link()
-
-        check.is_in(
-            MyProfileMessages.TWITTER_REDIRECT_LINK + twitter_field_test_data,
-            self.get_page_url(),
-            f"Incorrect user redirect. "
-            f"Expected: {MyProfileMessages.TWITTER_REDIRECT_LINK + twitter_field_test_data} "
-            f"received: {self.get_page_url()}",
-        )
-
-        self.logger.info("Navigating back to the SUMO page")
-        self.navigate_back()
-
-        self.logger.info(
-            "Signing out, accessing the profile and verifying that "
-            "the twitter information is displayed"
-        )
-        self.delete_cookies()
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_twitter_text(),
-            twitter_field_test_data,
-            f"Incorrect twitter displayed. Expected: {twitter_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_twitter_text()}",
-        )
-
-        self.logger.info(
-            "Clicking on the twitter link and verifying that the user is redirected correctly"
-        )
-        self.sumo_pages.my_profile_page._click_on_twitter_link()
-
-        check.is_in(
-            MyProfileMessages.TWITTER_REDIRECT_LINK + twitter_field_test_data,
-            self.get_page_url(),
-            f"Incorrect user redirect. "
-            f"Expected: {MyProfileMessages.TWITTER_REDIRECT_LINK + twitter_field_test_data} "
-            f"received: {self.get_page_url()}",
-        )
-
-        self.logger.info("Navigating back to the SUMO page")
-        self.navigate_back()
-
-        self.logger.info("Clearing the twitter field changes")
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_twitter_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Navigating back to the SUMO page and clearing the twitter input field "
+                         "changes"):
+            self.navigate_back()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_twitter_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     # C2107903, C2107903
     @pytest.mark.editUserProfileTests
     def test_community_portal_username_is_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside "
+                         "the 'Community Portal' input field"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            community_portal_field_test_data = super().profile_edit_test_data["valid_user_edit"][
+                "community_portal_username"
+            ]
+            self.sumo_pages.edit_my_profile_page._clear_community_portal_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_community_portal_field(
+                community_portal_field_test_data
+            )
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Clearing and adding data inside the Community Portal input field")
+        with check, allure.step("Navigating back to the My Profile page and verify that the "
+                                "correct Community portal information is displayed"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            assert self.sumo_pages.my_profile_page._get_my_profile_community_portal_text(
+            ) == community_portal_field_test_data
 
-        community_portal_field_test_data = super().profile_edit_test_data["valid_user_edit"][
-            "community_portal_username"
-        ]
-        self.sumo_pages.edit_my_profile_page._clear_community_portal_field()
-        self.sumo_pages.edit_my_profile_page._send_text_to_community_portal_field(
-            community_portal_field_test_data
-        )
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Signing in with a different user and verifying that the correct "
+                                "community portal information is displayed for the first user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert self.sumo_pages.my_profile_page._get_my_profile_community_portal_text(
+            ) == community_portal_field_test_data
 
-        self.logger.info(
-            "Navigating back to the My Profile page and verify that "
-            "the correct Community portal information is displayed"
-        )
+        with check, allure.step("Clicking on the community portal link and verifying that the "
+                                "user is redirected correctly"):
+            self.sumo_pages.my_profile_page._click_on_community_portal_link()
+            assert MyProfileMessages.COMMUNITY_PORTAL_LINK in self.get_page_url()
 
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with check, allure.step("Navigating back to the SUMO page, signing out, accessing the "
+                                "profile and verifying that the community portal information is "
+                                "displayed"):
+            self.navigate_back()
+            self.delete_cookies()
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert self.sumo_pages.my_profile_page._get_my_profile_community_portal_text(
+            ) == community_portal_field_test_data
 
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_community_portal_text(),
-            community_portal_field_test_data,
-            f"Incorrect community portal information is displayed. "
-            f"Expected: {community_portal_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_community_portal_text()}",
-        )
+        with check, allure.step("Clicking on the community portal link and verifying that the "
+                                "user is redirected correctly"):
+            self.sumo_pages.my_profile_page._click_on_community_portal_link()
+            assert MyProfileMessages.COMMUNITY_PORTAL_LINK in self.get_page_url()
 
-        self.logger.info(
-            "Signing in with a different user and verifying "
-            "that the correct community portal information is displayed for the first user"
-        )
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_community_portal_text(),
-            community_portal_field_test_data,
-            f"Incorrect website displayed. Expected: {community_portal_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_community_portal_text()}",
-        )
-
-        self.logger.info(
-            "Clicking on the community portal link and verifying "
-            "that the user is redirected correctly"
-        )
-
-        self.sumo_pages.my_profile_page._click_on_community_portal_link()
-
-        check.is_in(
-            MyProfileMessages.COMMUNITY_PORTAL_LINK,
-            self.get_page_url(),
-            f"Incorrect user redirect. Expected: {MyProfileMessages.TWITTER_REDIRECT_LINK} "
-            f"received: {self.get_page_url()}",
-        )
-
-        self.logger.info("Navigating back to the SUMO page")
-        self.navigate_back()
-
-        self.logger.info(
-            "Signing out, accessing the profile and verifying that "
-            "the community portal information is displayed"
-        )
-        self.delete_cookies()
-
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_community_portal_text(),
-            community_portal_field_test_data,
-            f"Incorrect community portal displayed. Expected: "
-            f"{community_portal_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_community_portal_text()}",
-        )
-
-        self.logger.info(
-            "Clicking on the community portal link and verifying that "
-            "the user is redirected correctly"
-        )
-
-        self.sumo_pages.my_profile_page._click_on_community_portal_link()
-
-        check.is_in(
-            MyProfileMessages.COMMUNITY_PORTAL_LINK,
-            self.get_page_url(),
-            f"Incorrect user redirect. Expected: {MyProfileMessages.COMMUNITY_PORTAL_LINK} "
-            f"received: {self.get_page_url()}",
-        )
-
-        self.logger.info("Navigating back to the SUMO page")
-        self.navigate_back()
-
-        self.logger.info("Clearing the community portal field changes")
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_community_portal_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Navigating back to the SUMO page, and clearing the community portal "
+                         "field changes"):
+            self.navigate_back()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_community_portal_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     # C2107902,C2107902
     @pytest.mark.editUserProfileTests
     def test_people_directory_information_is_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside "
+                         "the 'People Directory' input field"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            people_directory_field_test_data = super().profile_edit_test_data["valid_user_edit"][
+                "people_directory_username"
+            ]
+            self.sumo_pages.edit_my_profile_page._clear_people_directory_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_people_directory_username(
+                people_directory_field_test_data
+            )
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Clearing and adding data inside the People Directory input field")
-        people_directory_field_test_data = super().profile_edit_test_data["valid_user_edit"][
-            "people_directory_username"
-        ]
-        self.sumo_pages.edit_my_profile_page._clear_people_directory_field()
-        self.sumo_pages.edit_my_profile_page._send_text_to_people_directory_username(
-            people_directory_field_test_data
-        )
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Navigating back to the My Profile page and verify that the "
+                                "correct People Directory information is displayed"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            assert self.sumo_pages.my_profile_page._get_my_profile_people_directory_text(
+            ) == people_directory_field_test_data
 
-        self.logger.info(
-            "Navigating back to the My Profile page and verify that "
-            "the correct People Directory information is displayed"
-        )
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with check, allure.step("Signing in with a different user and verifying that the correct "
+                                "people directory information is displayed for the first user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert self.sumo_pages.my_profile_page._get_my_profile_people_directory_text(
+            ) == people_directory_field_test_data
 
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_people_directory_text(),
-            people_directory_field_test_data,
-            f"Incorrect people directory text displayed. "
-            f"Expected: {people_directory_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_people_directory_text()}",
-        )
+        with check, allure.step("Signing out, accessing the profile and verifying that the "
+                                "people directory information is displayed"):
+            self.delete_cookies()
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert self.sumo_pages.my_profile_page._get_my_profile_people_directory_text(
+            ) == people_directory_field_test_data
 
-        self.logger.info(
-            "Signing in with a different user and verifying that "
-            "the correct people directory information is displayed for the first user"
-        )
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_people_directory_text(),
-            people_directory_field_test_data,
-            f"Incorrect people directory information displayed. "
-            f"Expected: {people_directory_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_people_directory_text()}",
-        )
-
-        self.logger.info(
-            "Signing out, accessing the profile and verifying that "
-            "the people directory information is displayed"
-        )
-        self.delete_cookies()
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_people_directory_text(),
-            people_directory_field_test_data,
-            f"Incorrect people directory displayed. Expected: "
-            f"{people_directory_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_people_directory_text()}",
-        )
-
-        self.logger.info("Clearing the people directory field changes")
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_people_directory_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Clearing the people directory field changes"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_people_directory_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     # C2107933, C2107933
     @pytest.mark.editUserProfileTests
     def test_matrix_information_is_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside "
+                         "the Matrix input field"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            matrix_field_test_data = super().profile_edit_test_data["valid_user_edit"][
+                "matrix_nickname"
+            ]
+            self.sumo_pages.edit_my_profile_page._clear_matrix_field()
+            self.sumo_pages.edit_my_profile_page._send_text_to_matrix_nickname(
+                matrix_field_test_data)
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Clearing and adding data inside the Matrix input field")
-        matrix_field_test_data = super().profile_edit_test_data["valid_user_edit"][
-            "matrix_nickname"
-        ]
-        self.sumo_pages.edit_my_profile_page._clear_matrix_field()
-        self.sumo_pages.edit_my_profile_page._send_text_to_matrix_nickname(matrix_field_test_data)
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Navigating back to the My Profile page and verify that the "
+                                "correct Matrix information is displayed"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            assert (matrix_field_test_data in self.sumo_pages.
+                    my_profile_page._get_my_profile_matrix_text())
 
-        self.logger.info(
-            "Navigating back to the My Profile page and verify that the "
-            "correct Matrix information is displayed"
-        )
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with check, allure.step("Signing in with a different user and verifying that the correct "
+                                "Matrix information is displayed for the first user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert (matrix_field_test_data in self.sumo_pages.
+                    my_profile_page._get_my_profile_matrix_text())
 
-        check.is_in(
-            matrix_field_test_data,
-            self.sumo_pages.my_profile_page._get_my_profile_matrix_text(),
-            f"Incorrect Matrix text displayed. Expected: {matrix_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_matrix_text()}",
-        )
+        with check, allure.step("Signing out, accessing the profile and verifying that the "
+                                "Matrix information is displayed"):
+            self.delete_cookies()
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert (matrix_field_test_data in self.sumo_pages.
+                    my_profile_page._get_my_profile_matrix_text())
 
-        self.logger.info(
-            "Signing in with a different user and verifying that the correct Matrix information "
-            "is displayed for the first user"
-        )
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
+        with allure.step("Clearing the Matrix field changes"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.is_in(
-            matrix_field_test_data,
-            self.sumo_pages.my_profile_page._get_my_profile_matrix_text(),
-            f"Incorrect matrix information displayed. Expected: {matrix_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_matrix_text()}",
-        )
-
-        self.logger.info(
-            "Signing out, accessing the profile and verifying that the "
-            "Matrix information is displayed"
-        )
-        self.delete_cookies()
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.is_in(
-            matrix_field_test_data,
-            self.sumo_pages.my_profile_page._get_my_profile_matrix_text(),
-            f"Incorrect matrix displayed. Expected: {matrix_field_test_data}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_profile_matrix_text()}",
-        )
-
-        self.logger.info("Clearing the Matrix field changes")
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_matrix_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_matrix_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     # C2107934, C2107934
     @pytest.mark.editUserProfileTests
     def test_country_location_information_is_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside "
+                         "the country input field"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            country_field_test_data_code = super().profile_edit_test_data["valid_user_edit"][
+                "country_code"
+            ]
+            country_field_test_data_value = super().profile_edit_test_data["valid_user_edit"][
+                "country_value"
+            ]
+            self.sumo_pages.edit_my_profile_page._clear_country_dropdown_field()
+            self.sumo_pages.edit_my_profile_page._select_country_dropdown_option_by_value(
+                country_field_test_data_code
+            )
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Clearing and adding data inside the Country input field")
-        country_field_test_data_code = super().profile_edit_test_data["valid_user_edit"][
-            "country_code"
-        ]
-        country_field_test_data_value = super().profile_edit_test_data["valid_user_edit"][
-            "country_value"
-        ]
-        self.sumo_pages.edit_my_profile_page._clear_country_dropdown_field()
-        self.sumo_pages.edit_my_profile_page._select_country_dropdown_option_by_value(
-            country_field_test_data_code
-        )
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Verify that the correct Country information is displayed"):
+            assert (country_field_test_data_value in self.sumo_pages.
+                    my_profile_page._get_text_of_profile_subheading_location())
 
-        self.logger.info("Verify that the correct Country information is displayed")
+        with check, allure.step("Signing in with a different user and verifying that the correct "
+                                "Country information is displayed for the first user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert (country_field_test_data_value in self.sumo_pages.
+                    my_profile_page._get_text_of_profile_subheading_location())
 
-        check.is_in(
-            country_field_test_data_value,
-            self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location(),
-            f"Incorrect Country text displayed. Expected: {country_field_test_data_value}, "
-            f"received: "
-            f"{self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location()}",
-        )
+        with check, allure.step("Signing out, accessing the profile and verifying that the "
+                                "Country information is displayed"):
+            self.delete_cookies()
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert (country_field_test_data_value in self.sumo_pages.
+                    my_profile_page._get_text_of_profile_subheading_location())
 
-        self.logger.info(
-            "Signing in with a different user and verifying that the correct Country information "
-            "is displayed for the first user"
-        )
+        with allure.step("Clearing the Country field changes"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.is_in(
-            country_field_test_data_value,
-            self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location(),
-            f"Incorrect country information displayed. "
-            f"Expected: {country_field_test_data_value}, "
-            f"received: "
-            f"{self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location()}",
-        )
-
-        self.logger.info(
-            "Signing out, accessing the profile and verifying that the "
-            "Country information is displayed"
-        )
-        self.delete_cookies()
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.is_in(
-            country_field_test_data_value,
-            self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location(),
-            f"Incorrect country displayed. Expected: {country_field_test_data_value}, "
-            f"received: "
-            f"{self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location()}",
-        )
-
-        self.logger.info("Clearing the Country field changes")
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_country_dropdown_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_country_dropdown_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     # C2107935, C2107935
     @pytest.mark.editUserProfileTests
     def test_city_location_information_is_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the 'Edit' My profile page, clearing and adding data inside "
+                         "the City input field"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            city_field_test_data_value = super().profile_edit_test_data["valid_user_edit"]["city"]
+            self.sumo_pages.edit_my_profile_page._clear_city_field()
+            self.sumo_pages.edit_my_profile_page._sent_text_to_city_field(
+                city_field_test_data_value)
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Clearing and adding data inside the City input field")
+        with check, allure.step("Verify that the correct City information is displayed"):
+            assert (city_field_test_data_value in self.sumo_pages.
+                    my_profile_page._get_text_of_profile_subheading_location())
 
-        city_field_test_data_value = super().profile_edit_test_data["valid_user_edit"]["city"]
-        self.sumo_pages.edit_my_profile_page._clear_city_field()
-        self.sumo_pages.edit_my_profile_page._sent_text_to_city_field(city_field_test_data_value)
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Signing in with a different user and verifying that the correct "
+                                "City information is displayed for the first user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert (city_field_test_data_value in self.sumo_pages.
+                    my_profile_page._get_text_of_profile_subheading_location())
 
-        self.logger.info("Verify that the correct City information is displayed")
+        with check, allure.step("Signing out, accessing the profile and verifying that the City "
+                                "information is displayed"):
+            self.delete_cookies()
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert (city_field_test_data_value in self.sumo_pages.my_profile_page.
+                    _get_text_of_profile_subheading_location())
 
-        check.is_in(
-            city_field_test_data_value,
-            self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location(),
-            f"Incorrect City text displayed. Expected: {city_field_test_data_value}, "
-            f"received: "
-            f"{self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location()}",
-        )
-
-        self.logger.info(
-            "Signing in with a different user and verifying that the correct City information "
-            "is displayed for the first user"
-        )
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.is_in(
-            city_field_test_data_value,
-            self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location(),
-            f"Incorrect city information displayed. Expected: {city_field_test_data_value}, "
-            f"received: "
-            f"{self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location()}",
-        )
-
-        self.logger.info(
-            "Signing out, accessing the profile and verifying that the "
-            "City information is displayed"
-        )
-        self.delete_cookies()
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.is_in(
-            city_field_test_data_value,
-            self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location(),
-            f"Incorrect city displayed. Expected: {city_field_test_data_value}, "
-            f"received: "
-            f"{self.sumo_pages.my_profile_page._get_text_of_profile_subheading_location()}",
-        )
-
-        self.logger.info("Clearing the City field changes")
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_city_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Clearing the City field changes"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_city_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     # C2107938, C2107938
     @pytest.mark.editUserProfileTests
     def test_involved_since_information_is_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
         username_one = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'Edit My Profile' page")
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
+        with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside "
+                         "the involved since input fields"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            involved_since_month_number_test_data = (super(
+            ).profile_edit_test_data["valid_user_edit"]["involved_from_month_number"])
+            involved_since_month_test_data_value = (
+                super().profile_edit_test_data["valid_user_edit"]["involved_from_month_value"])
+            involved_since_year_test_data_value = (super(
+            ).profile_edit_test_data["valid_user_edit"]["involved_from_year"])
+            self.sumo_pages.edit_my_profile_page._clear_involved_from_month_select_field()
+            self.sumo_pages.edit_my_profile_page._clear_involved_from_year_select_field()
+            self.sumo_pages.edit_my_profile_page._select_involved_from_month_option_by_value(
+                involved_since_month_number_test_data
+            )
+            self.sumo_pages.edit_my_profile_page._select_involved_from_year_option_by_value(
+                involved_since_year_test_data_value
+            )
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
-        self.logger.info("Clearing and adding data inside the involved since input fields")
-        involved_since_month_number_test_data = super().profile_edit_test_data["valid_user_edit"][
-            "involved_from_month_number"
-        ]
-        involved_since_month_test_data_value = super().profile_edit_test_data["valid_user_edit"][
-            "involved_from_month_value"
-        ]
-        involved_since_year_test_data_value = super().profile_edit_test_data["valid_user_edit"][
-            "involved_from_year"
-        ]
-        self.sumo_pages.edit_my_profile_page._clear_involved_from_month_select_field()
-        self.sumo_pages.edit_my_profile_page._clear_involved_from_year_select_field()
-        self.sumo_pages.edit_my_profile_page._select_involved_from_month_option_by_value(
-            involved_since_month_number_test_data
-        )
-        self.sumo_pages.edit_my_profile_page._select_involved_from_year_option_by_value(
-            involved_since_year_test_data_value
-        )
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with check, allure.step("Verify that the correct involved from information is displayed"):
+            assert (involved_since_month_test_data_value and involved_since_year_test_data_value in
+                    self.sumo_pages.my_profile_page._get_my_contributed_from_text())
 
-        self.logger.info("Verify that the correct involved from information is displayed")
+        with check, allure.step("Signing in with a different user and verifying that the correct "
+                                "involved from information is displayed for the first user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_13"]
+            ))
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert (involved_since_month_test_data_value and involved_since_year_test_data_value in
+                    self.sumo_pages.my_profile_page._get_my_contributed_from_text())
 
-        check.is_in(
-            involved_since_month_test_data_value and involved_since_year_test_data_value,
-            self.sumo_pages.my_profile_page._get_my_contributed_from_text(),
-            f"Incorrect involved from text displayed. "
-            f"Expected to contain: {involved_since_month_test_data_value} "
-            f"and {involved_since_year_test_data_value}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_contributed_from_text()}",
-        )
+        with check, allure.step("Signing out, accessing the profile and verifying that the "
+                                "involved from information is displayed"):
+            self.delete_cookies()
+            self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
+            assert (involved_since_month_test_data_value and involved_since_year_test_data_value in
+                    self.sumo_pages.my_profile_page._get_my_contributed_from_text())
 
-        self.logger.info(
-            "Signing in with a different user and verifying that the "
-            "correct involved from information is displayed for the first user"
-        )
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_13"]
-        ))
-
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.is_in(
-            involved_since_month_test_data_value and involved_since_year_test_data_value,
-            self.sumo_pages.my_profile_page._get_my_contributed_from_text(),
-            f"Incorrect involved from information displayed. "
-            f"Expected to contain: {involved_since_month_test_data_value} and"
-            f" {involved_since_year_test_data_value}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_contributed_from_text()}",
-        )
-
-        self.logger.info(
-            "Signing out, accessing the profile and verifying that the "
-            "involved from information is displayed"
-        )
-        self.delete_cookies()
-        self.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username_one))
-
-        check.is_in(
-            involved_since_month_test_data_value and involved_since_year_test_data_value,
-            self.sumo_pages.my_profile_page._get_my_contributed_from_text(),
-            f"Incorrect involved from text displayed. "
-            f"Expected to contain: {involved_since_month_test_data_value} "
-            f"and {involved_since_year_test_data_value}, "
-            f"received: {self.sumo_pages.my_profile_page._get_my_contributed_from_text()}",
-        )
-
-        self.logger.info("Clearing the involved from field changes")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-        self.sumo_pages.edit_my_profile_page._clear_involved_from_month_select_field()
-        self.sumo_pages.edit_my_profile_page._clear_involved_from_year_select_field()
-        self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        with allure.step("Clearing the involved from field changes"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            self.sumo_pages.edit_my_profile_page._clear_involved_from_month_select_field()
+            self.sumo_pages.edit_my_profile_page._clear_involved_from_year_select_field()
+            self.sumo_pages.edit_my_profile_page._click_update_my_profile_button()
 
     # C2087552, C2108840
     @pytest.mark.editUserProfileTests
@@ -1373,145 +897,103 @@ class TestEditMyProfile(TestUtilities):
             "*",
         )
 
-        self.logger.info("Accessing a user profile while not being signed in to SUMO")
-        self.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(target_username)
-        )
+        with allure.step("Accessing a user profile while not being signed in to SUMO"):
+            self.navigate_to_link(
+                MyProfileMessages.get_my_profile_stage_url(target_username)
+            )
 
-        self.logger.info("Verifying that the 'Edit user profile' option is not displayed")
+        with allure.step("Verifying that the 'Edit user profile' option is not displayed"):
+            expect(
+                self.sumo_pages.my_profile_page._edit_user_profile_option_element()
+            ).to_be_hidden()
 
-        expect(
-            self.sumo_pages.my_profile_page._edit_user_profile_option_element()
-        ).to_be_hidden()
+        with allure.step("Navigating to the profile edit link directly and verifying that the "
+                         "user is redirected to the auth page"):
+            self.navigate_to_link(
+                EditMyProfilePageMessages.get_url_of_other_profile_edit_page(target_username)
+            )
+            assert (
+                self.sumo_pages.auth_page._is_continue_with_firefox_button_displayed()
+            ), "The auth page is not displayed! It should be!"
+            expect(
+                self.sumo_pages.edit_my_profile_page._is_my_profile_edit_form_displayed()
+            ).to_be_hidden()
 
-        self.logger.info(
-            "Navigating to the profile edit link directly and verifying that the "
-            "user is redirected to the auth page"
-        )
+        with allure.step("Signing in with another non-admin account and accessing another user "
+                         "account"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+            self.navigate_to_link(
+                MyProfileMessages.get_my_profile_stage_url(target_username)
+            )
 
-        self.navigate_to_link(
-            EditMyProfilePageMessages.get_url_of_other_profile_edit_page(target_username)
-        )
+        with allure.step("Verifying that the 'Edit user profile' option is not displayed"):
+            expect(
+                self.sumo_pages.my_profile_page._edit_user_profile_option_element()
+            ).to_be_hidden()
 
-        assert (
-            self.sumo_pages.auth_page._is_continue_with_firefox_button_displayed()
-        ), "The auth page is not displayed! It should be!"
-
-        expect(
-            self.sumo_pages.edit_my_profile_page._is_my_profile_edit_form_displayed()
-        ).to_be_hidden()
-
-        self.logger.info("Signin in with a simple user account")
-        self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.logger.info("Accessing another user's account")
-        self.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(target_username)
-        )
-
-        self.logger.info("Verifying that the 'Edit user profile' option is not displayed")
-
-        expect(
-            self.sumo_pages.my_profile_page._edit_user_profile_option_element()
-        ).to_be_hidden()
-
-        self.logger.info(
-            "Navigating to the profile edit link directly and verifying that the "
-            "correct message is displayed and the "
-            "edit form is not displayed"
-        )
-
-        self.navigate_to_link(
-            EditMyProfilePageMessages.get_url_of_other_profile_edit_page(target_username)
-        )
-
-        check.equal(
-            self.sumo_pages.edit_my_profile_page._get_access_denied_header_text(),
-            EditMyProfilePageMessages.PROFILE_ACCESS_DENIED_HEADING,
-            f"Incorrect access denied heading displayed. "
-            f"Expected: {EditMyProfilePageMessages.PROFILE_ACCESS_DENIED_HEADING} "
-            f"received: {self.sumo_pages.edit_my_profile_page._get_access_denied_header_text()}",
-        )
-
-        check.equal(
-            self.sumo_pages.edit_my_profile_page._get_access_denied_subheading_text(),
-            EditMyProfilePageMessages.PROFILE_ACCESS_DENIED_SUBHEADING,
-            f"Incorrect access denied subheading displayed. "
-            f"Expected: {EditMyProfilePageMessages.PROFILE_ACCESS_DENIED_SUBHEADING} "
-            f" received: "
-            f"{self.sumo_pages.edit_my_profile_page._get_access_denied_subheading_text()}",
-        )
-
-        expect(
-            self.sumo_pages.edit_my_profile_page._is_my_profile_edit_form_displayed()
-        ).to_be_hidden()
+        with check, allure.step("Navigating to the profile edit link directly, verifying that "
+                                "the correct message is displayed and that the edit form is not "
+                                "displayed"):
+            self.navigate_to_link(
+                EditMyProfilePageMessages.get_url_of_other_profile_edit_page(target_username)
+            )
+            assert self.sumo_pages.edit_my_profile_page._get_access_denied_header_text(
+            ) == EditMyProfilePageMessages.PROFILE_ACCESS_DENIED_HEADING
+            assert self.sumo_pages.edit_my_profile_page._get_access_denied_subheading_text(
+            ) == EditMyProfilePageMessages.PROFILE_ACCESS_DENIED_SUBHEADING
+            expect(
+                self.sumo_pages.edit_my_profile_page._is_my_profile_edit_form_displayed()
+            ).to_be_hidden()
 
     # C2108839
     @pytest.mark.editUserProfileTests
     def test_report_user_is_displayed_and_accessible_for_signed_in_users_only(self):
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
+
         target_username = self.remove_character_from_string(
             super().username_extraction_from_email(
                 super().user_special_chars
             ),
             "*",
         )
-        self.logger.info("Signing in with a normal user ")
+        with allure.step("Accessing another user profile and verifying that the 'Report Abuse' "
+                         "option is displayed"):
+            self.navigate_to_link(
+                MyProfileMessages.get_my_profile_stage_url(target_username)
+            )
+            expect(
+                self.sumo_pages.my_profile_page._is_report_user_option_displayed()
+            ).to_be_visible()
 
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Clicking on the 'Report Abuse' option and verifying that the report "
+                         "abuse panel is displayed"):
+            self.sumo_pages.my_profile_page._click_on_report_abuse_option()
+            expect(
+                self.sumo_pages.my_profile_page._is_report_abuse_panel_displayed()
+            ).to_be_visible()
 
-        self.logger.info(
-            "Accessing another user profile and verifying that the "
-            "'Report Abuse' option is displayed"
-        )
+        with allure.step("Closing the report abuse panel and verifying that the report user "
+                         "panel is no longer displayed"):
+            self.sumo_pages.my_profile_page._click_on_report_abuse_close_button()
+            expect(
+                self.sumo_pages.my_profile_page._is_report_abuse_panel_displayed()
+            ).to_be_hidden()
 
-        self.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(target_username)
-        )
-
-        expect(
-            self.sumo_pages.my_profile_page._is_report_user_option_displayed()
-        ).to_be_visible()
-
-        self.logger.info("Clicking on the 'Report Abuse' option")
-        self.sumo_pages.my_profile_page._click_on_report_abuse_option()
-
-        self.logger.info("Verifying that the report abuse panel is displayed")
-
-        expect(
-            self.sumo_pages.my_profile_page._is_report_abuse_panel_displayed()
-        ).to_be_visible()
-
-        self.logger.info("Closing the report abuse panel")
-        self.sumo_pages.my_profile_page._click_on_report_abuse_close_button()
-
-        self.logger.info("Verifying that the report user panel is no longer displayed")
-
-        expect(
-            self.sumo_pages.my_profile_page._is_report_abuse_panel_displayed()
-        ).to_be_hidden()
-
-        self.logger.info(
-            "Signing out and verifying that the 'Report Abuse' options is not displayed"
-        )
-        self.delete_cookies()
-
-        self.logger.info(
-            "Accessing another users profile and verifying that the "
-            "'report abuse' option is not displayed"
-        )
-        self.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(target_username)
-        )
-
-        expect(
-            self.sumo_pages.my_profile_page._is_report_user_option_displayed()
-        ).to_be_hidden()
+        with allure.step("Signing out and verifying that the 'Report Abuse' option is not "
+                         "displayed on user profiles"):
+            self.delete_cookies()
+            self.navigate_to_link(
+                MyProfileMessages.get_my_profile_stage_url(target_username)
+            )
+            expect(
+                self.sumo_pages.my_profile_page._is_report_user_option_displayed()
+            ).to_be_hidden()
 
     # C2108841
     @pytest.mark.editUserProfileTests
@@ -1522,19 +1004,18 @@ class TestEditMyProfile(TestUtilities):
             ),
             "*",
         )
-        self.logger.info("Accessing another users profile")
-        self.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(target_username)
-        )
 
-        self.logger.info("Clicking on the 'Private Message' button")
-        self.sumo_pages.my_profile_page._click_on_private_message_button()
+        with allure.step("Accessing a user profile"):
+            self.navigate_to_link(
+                MyProfileMessages.get_my_profile_stage_url(target_username)
+            )
 
-        self.logger.info("Verifying that the non-signed in user is redirected to the fxa page")
-
-        assert (
-            self.sumo_pages.auth_page._is_continue_with_firefox_button_displayed()
-        ), "The auth page is not displayed! It should be!"
+        with allure.step("Clicking on the 'Private Message' button and verifying that the "
+                         "non-signed in user is redirected to the fxa page"):
+            self.sumo_pages.my_profile_page._click_on_private_message_button()
+            assert (
+                self.sumo_pages.auth_page._is_continue_with_firefox_button_displayed()
+            ), "The auth page is not displayed! It should be!"
 
     # C916055, C916054
     @pytest.mark.editUserProfileTests
@@ -1545,64 +1026,53 @@ class TestEditMyProfile(TestUtilities):
             ),
             "*",
         )
-        self.logger.info("Navigating to a user profile while not signed in with a user")
+        with allure.step("Navigating ot a user profile while not signed in with a user"):
+            self.navigate_to_link(
+                MyProfileMessages.get_my_profile_stage_url(target_username)
+            )
 
-        self.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(target_username)
-        )
+        with allure.step("Verifying that the deactivate user buttons are not displayed"):
+            expect(
+                self.sumo_pages.my_profile_page._is_deactivate_this_user_button_displayed()
+            ).to_be_hidden()
 
-        self.logger.info("Verifying that the deactivate this user buttons are not displayed")
+            expect(
+                self.sumo_pages.my_profile_page._deactivate_user_and_mark_content_as_spam_button()
+            ).to_be_hidden()
 
-        expect(
-            self.sumo_pages.my_profile_page._is_deactivate_this_user_button_displayed()
-        ).to_be_hidden()
+        with allure.step("Signing in with a non-admin account"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        expect(
-            self.sumo_pages.my_profile_page._deactivate_this_user_and_mark_content_as_spam_elem()
-        ).to_be_hidden()
+        with allure.step("Accessing another user profile and verifying that the deactivate "
+                         "buttons are not displayed"):
+            self.navigate_to_link(
+                MyProfileMessages.get_my_profile_stage_url(target_username)
+            )
+            expect(
+                self.sumo_pages.my_profile_page._is_deactivate_this_user_button_displayed()
+            ).to_be_hidden()
+            expect(
+                self.sumo_pages.my_profile_page._deactivate_user_and_mark_content_as_spam_button()
+            ).to_be_hidden()
 
-        self.logger.info("Sign in with a normal user account")
-        self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        with allure.step("Signing in with an admin account"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.delete_cookies()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
-
-        self.logger.info(
-            "Accessing another user profile and verify that the "
-            "deactivate this user buttons are not displayed"
-        )
-        self.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(target_username)
-        )
-
-        expect(
-            self.sumo_pages.my_profile_page._is_deactivate_this_user_button_displayed()
-        ).to_be_hidden()
-
-        expect(
-            self.sumo_pages.my_profile_page._deactivate_this_user_and_mark_content_as_spam_elem()
-        ).to_be_hidden()
-
-        self.logger.info("Signing in with a moderator account")
-        self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
-
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
-
-        self.logger.info(
-            "Accessing another user profile and verifying that "
-            "the deactivate user buttons are displayed"
-        )
-        self.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(target_username)
-        )
-
-        expect(
-            self.sumo_pages.my_profile_page._is_deactivate_this_user_button_displayed()
-        ).to_be_visible()
-
-        expect(
-            self.sumo_pages.my_profile_page._deactivate_this_user_and_mark_content_as_spam_elem()
-        ).to_be_visible()
+        with allure.step("Accessing another user profile and verifying that the deactivate user "
+                         "buttons are displayed"):
+            self.navigate_to_link(
+                MyProfileMessages.get_my_profile_stage_url(target_username)
+            )
+            expect(
+                self.sumo_pages.my_profile_page._is_deactivate_this_user_button_displayed()
+            ).to_be_visible()
+            expect(
+                self.sumo_pages.my_profile_page._deactivate_user_and_mark_content_as_spam_button()
+            ).to_be_visible()

--- a/playwright_tests/tests/user_page_tests/test_edit_my_settings.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_settings.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 
 from playwright_tests.core.testutilities import TestUtilities
 from playwright_tests.messages.my_profile_pages_messages.edit_settings_page_messages import (
@@ -10,49 +11,26 @@ class TestEditMySettings(TestUtilities):
     # C891396,  C2108836
     @pytest.mark.userSettings
     def test_all_checkboxes_can_be_selected_and_saved(self):
-        self.logger.info(
-            "Signing in to a normal user account "
-        )
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
-        self.sumo_pages.edit_profile_flow.check_all_user_settings()
+        with check, allure.step("Checking all user settings and verifying that the correct "
+                                "notification banner is displayed and all checkboxes are checked"):
+            self.sumo_pages.edit_profile_flow.check_all_user_settings()
+            assert self.sumo_pages.edit_my_profile_settings_page._settings_saved_notif_banner_txt(
+            ) == EditSettingsPageMessages.MODIFIED_SETTINGS_NOTIFICATION_BANNER_MESSAGE
+            assert (
+                self.sumo_pages.edit_my_profile_settings_page._are_all_checkbox_checked()
+            ), "Not all checkboxes are checked!"
 
-        self.logger.info("Verifying that the correct notification banner is displayed")
-        check.equal(
-            self.sumo_pages.edit_my_profile_settings_page._settings_saved_notif_banner_txt(),
-            EditSettingsPageMessages.MODIFIED_SETTINGS_NOTIFICATION_BANNER_MESSAGE,
-            f"Incorrect message displayed inside the notification banner. Expected:"
-            f" {EditSettingsPageMessages.MODIFIED_SETTINGS_NOTIFICATION_BANNER_MESSAGE} "
-            f"but received: "
-            f"{self.sumo_pages.edit_my_profile_settings_page._settings_saved_notif_banner_txt()}",
-        )
-
-        self.logger.info("Verifying that all the checkboxes are checked")
-
-        assert (
-            self.sumo_pages.edit_my_profile_settings_page._are_all_checkbox_checked()
-        ), "Not all checkboxes are checked!"
-
-        self.logger.info(
-            "Unchecking all the available checkboxes and clicking on the 'Update' button"
-        )
-
-        self.sumo_pages.edit_profile_flow.check_all_user_settings()
-
-        self.logger.info("Verifying that the correct notification banner is displayed")
-
-        check.equal(
-            self.sumo_pages.edit_my_profile_settings_page._settings_saved_notif_banner_txt(),
-            EditSettingsPageMessages.MODIFIED_SETTINGS_NOTIFICATION_BANNER_MESSAGE,
-            f"Incorrect message displayed inside the notification banner. Expected:"
-            f" {EditSettingsPageMessages.MODIFIED_SETTINGS_NOTIFICATION_BANNER_MESSAGE} "
-            f"but received: "
-            f"{self.sumo_pages.edit_my_profile_settings_page._settings_saved_notif_banner_txt()}",
-        )
-
-        self.logger.info("Verifying that all the checkboxes are unchecked")
-        assert not (
-            self.sumo_pages.edit_my_profile_settings_page._are_all_checkbox_checked()
-        ), "Not all checkboxes are unchecked!"
+        with check, allure.step("Unchecking all the checkboxes and verifying that the correct "
+                                "notification banner is displayed and all checkboxes are "
+                                "unchecked"):
+            self.sumo_pages.edit_profile_flow.check_all_user_settings()
+            assert self.sumo_pages.edit_my_profile_settings_page._settings_saved_notif_banner_txt(
+            ) == EditSettingsPageMessages.MODIFIED_SETTINGS_NOTIFICATION_BANNER_MESSAGE
+            assert not (
+                self.sumo_pages.edit_my_profile_settings_page._are_all_checkbox_checked()
+            ), "Not all checkboxes are unchecked!"

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -1,5 +1,6 @@
+import allure
 import pytest
-import pytest_check as check
+from pytest_check import check
 from playwright.sync_api import expect
 
 from playwright_tests.core.testutilities import TestUtilities
@@ -14,359 +15,252 @@ class TestMyProfilePage(TestUtilities):
     # C891409
     @pytest.mark.userProfile
     def test_my_profile_page_can_be_accessed_via_top_navbar(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts['TEST_ACCOUNT_12']
-        ))
+        with allure.step("Signing in with a non-admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts['TEST_ACCOUNT_12']
+            ))
 
         original_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'My profile' page via the top-navbar menu")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with allure.step("Accessing the 'My profile' page and verifying that we are redirected "
+                         "to the correct profile"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            expect(
+                self.page
+            ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username=original_username))
 
-        self.logger.info(
-            "Verifying that we are on the correct URL and viewing the correct profile"
-        )
-        expect(
-            self.page
-        ).to_have_url(MyProfileMessages.get_my_profile_stage_url(username=original_username))
+        with check, allure.step("Verifying that the page header is the expected one"):
+            assert self.sumo_pages.my_profile_page._get_my_profile_page_header(
+            ) == MyProfileMessages.STAGE_MY_PROFILE_PAGE_HEADER
 
-        self.logger.info("Verifying that the page header is the expected one")
-        check.equal(
-            self.sumo_pages.my_profile_page._get_my_profile_page_header(),
-            MyProfileMessages.STAGE_MY_PROFILE_PAGE_HEADER,
-            f"Page header is {self.sumo_pages.my_profile_page._get_my_profile_page_header()}"
-            f"Expected to be {MyProfileMessages.STAGE_MY_PROFILE_PAGE_HEADER}",
-        )
-
-        self.logger.info("Verifying that the 'My profile' navbar option is selected")
-        check.equal(
-            self.sumo_pages.my_profile_page._get_text_of_selected_navbar_option(),
-            UserProfileNavbarMessages.NAVBAR_OPTIONS[0],
-            f"Selected navbar option is: "
-            f"{self.sumo_pages.my_profile_page._get_text_of_selected_navbar_option}"
-            f"Expected to be: {UserProfileNavbarMessages.NAVBAR_OPTIONS[0]}",
-        )
+        with check, allure.step("Verifying that the 'My profile' navbar option is selected"):
+            assert self.sumo_pages.my_profile_page._get_text_of_selected_navbar_option(
+            ) == UserProfileNavbarMessages.NAVBAR_OPTIONS[0]
 
     #  C891411
     @pytest.mark.userProfile
     def test_my_profile_sign_out_button_functionality(self):
-        self.logger.info("Signing in with a normal user account")
-        self.sumo_pages.top_navbar._click_on_signin_signup_button()
+        with allure.step("Signing in with a non-admin account"):
+            self.sumo_pages.top_navbar._click_on_signin_signup_button()
 
-        self.sumo_pages.auth_flow_page.sign_in_flow(
-            username=super().user_special_chars,
-            account_password=super().user_secrets_pass
-        )
+            self.sumo_pages.auth_flow_page.sign_in_flow(
+                username=super().user_special_chars,
+                account_password=super().user_secrets_pass
+            )
 
-        self.logger.info("Accessing the 'My profile' page via the top-navbar menu")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with allure.step("Accessing the my profile page, clicking on the sign out button and "
+                         "verifying that the user is redirected to the homepage"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            self.sumo_pages.my_profile_page._click_my_profile_page_sign_out_button()
+            expect(
+                self.page
+            ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
 
-        self.logger.info("Clicking on the 'Sign Out' button from the 'My Profile' page")
-        self.sumo_pages.my_profile_page._click_my_profile_page_sign_out_button()
-
-        self.logger.info("Verifying that the user is redirected to the homepage")
-
-        expect(
-            self.page
-        ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
-
-        self.logger.info("Verify that the 'Sign in/Up' button from the page header is displayed")
-
-        expect(
-            self.sumo_pages.top_navbar._sign_in_up_button_displayed_element()
-        ).to_be_visible()
+        with allure.step("Verify that the 'Sign in/Up' button from the page header is displayed"):
+            expect(
+                self.sumo_pages.top_navbar._sign_in_up_button_displayed_element()
+            ).to_be_visible()
 
     # C2108828
     @pytest.mark.userProfile
     def test_provided_solutions_number_is_successfully_displayed(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin user account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
         repliant_username = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Navigating to the Firefox AAQ form")
-        self.navigate_to_link(
-            super().aaq_question_test_data["products_aaq_url"]["Firefox"]
-        )
-
-        self.logger.info("Posting a new AAQ question for Firefox product")
-        question_info = (
-            self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=super().aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+        with allure.step("Navigating to the Firefox AAQ form and posting a new AAQ question for "
+                         "the Firefox product"):
+            self.navigate_to_link(
+                super().aaq_question_test_data["products_aaq_url"]["Firefox"]
             )
-        )
+            question_info = (
+                self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                    subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
+                    topic_name=super(
+                    ).aaq_question_test_data["valid_firefox_question"]["topic_value"],
+                    body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+                )
+            )
 
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with allure.step("Navigating to the user profile page and extracting the original number "
+                         "of posted question solutions"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            original_number_of_solutions = self.number_extraction_from_string(
+                self.sumo_pages.my_profile_page._get_my_profile_solutions_text()
+            )
 
-        self.logger.info("Extracting original number of posted solutions")
-        original_number_of_solutions = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_solutions_text()
-        )
+        with allure.step("Navigating to the previously posted question and posting a reply to it"):
+            self.navigate_to_link(question_info["question_page_url"])
+            question_test_data = super().question_test_data
+            self.sumo_pages.question_page._add_text_to_post_a_reply_textarea(
+                question_test_data["question_reply_solution"]
+            )
+            answer_id = self.sumo_pages.question_page._click_on_post_reply_button(
+                repliant_username=repliant_username
+            )
 
-        self.logger.info("Navigating to the previously posted question")
-        self.navigate_to_link(question_info["question_page_url"])
+        with allure.step("Marking the reply as the question solution"):
+            self.sumo_pages.question_page._click_on_solves_the_problem_button(
+                target_reply_id=answer_id)
 
-        self.logger.info("Posting a reply for the question")
-        question_test_data = super().question_test_data
-
-        self.sumo_pages.question_page._add_text_to_post_a_reply_textarea(
-            question_test_data["question_reply_solution"]
-        )
-
-        self.logger.info("Clicking on the 'Post Reply' button and extracting answer id from url")
-        answer_id = self.sumo_pages.question_page._click_on_post_reply_button(
-            repliant_username=repliant_username
-        )
-
-        self.logger.info("Marking the reply as the solution")
-        self.sumo_pages.question_page._click_on_solves_the_problem_button(
-            target_reply_id=answer_id)
-
-        self.logger.info(
-            "Accessing the 'My profile' page of the account which provided a solution"
-        )
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-
-        new_number = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_solutions_text()
-        )
-
-        assert (
+        with allure.step("Accessing the 'My profile' page of the account which provided the "
+                         "solution and verifying that the original number of solutions has "
+                         "incremented"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
             self.number_extraction_from_string(
                 self.sumo_pages.my_profile_page._get_my_profile_solutions_text()
             )
-            == original_number_of_solutions + 1
-        ), (
-            f"The number of questions should have incremented! "
-            f"The original number of question was: {original_number_of_solutions}"
-            f" The new number of questions is: "
-            f"{new_number}"
-        )
+            assert (self.number_extraction_from_string(
+                self.sumo_pages.my_profile_page._get_my_profile_solutions_text(
+                )) == original_number_of_solutions + 1
+            )
 
-        self.logger.info("Deleting the my posted question")
-        self.navigate_to_link(question_info["question_page_url"])
-
-        self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
-
-        self.sumo_pages.question_page._click_delete_this_question_button()
-
-        self.logger.info("Verifying that we are on the product support forum page after deletion")
-
-        expect(
-            self.sumo_pages.product_support_page._product_product_title_element()
-        ).to_be_visible()
+        with allure.step("Deleting the posted question and verifying that we are redirected to "
+                         "the product support forum page after deletion"):
+            self.navigate_to_link(question_info["question_page_url"])
+            self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
+            self.sumo_pages.question_page._click_delete_this_question_button()
+            expect(
+                self.sumo_pages.product_support_page._product_product_title_element()
+            ).to_be_visible()
 
     # C890832,  C2094281
     @pytest.mark.userProfile
     def test_number_of_my_profile_answers_is_successfully_displayed(self):
-        reply_text = None
-
-        self.logger.info("Signing in with a user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
         repliant_user = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'My profile' page via the top-navbar menu")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-
-        self.logger.info("Extracting original number of posted answers")
-        original_number_of_answers = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_answers_text()
-        )
-
-        self.logger.info("Navigating to the Firefox AAQ form")
-        self.navigate_to_link(
-            super().aaq_question_test_data["products_aaq_url"]["Firefox"]
-        )
-
-        self.logger.info("Posting a new AAQ question")
-        question_info = (
-            self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=super().aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+        with allure.step("Accessing the 'My profile' page and extracting the number of posted "
+                         "answers"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            original_number_of_answers = self.number_extraction_from_string(
+                self.sumo_pages.my_profile_page._get_my_profile_answers_text()
             )
-        )
 
-        self.logger.info("Posting a reply for the question")
-        question_test_data = super().question_test_data
+        with allure.step("Navigating to the Firefox AAQ form and posting a new AAQ question"):
+            self.navigate_to_link(
+                super().aaq_question_test_data["products_aaq_url"]["Firefox"]
+            )
+            question_info = (
+                self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                    subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
+                    topic_name=super(
+                    ).aaq_question_test_data["valid_firefox_question"]["topic_value"],
+                    body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+                )
+            )
 
-        reply_text = question_test_data["non_solution_reply"]
+        with allure.step("Posting a reply for the question"):
+            question_test_data = super().question_test_data
+            reply_text = question_test_data["non_solution_reply"]
+            self.sumo_pages.question_page._add_text_to_post_a_reply_textarea(reply_text)
+            answer_id = self.sumo_pages.question_page._click_on_post_reply_button(
+                repliant_username=repliant_user
+            )
 
-        self.sumo_pages.question_page._add_text_to_post_a_reply_textarea(reply_text)
-
-        self.logger.info("Clicking on the 'Post Reply' button and extracting answer id from url")
-        answer_id = self.sumo_pages.question_page._click_on_post_reply_button(
-            repliant_username=repliant_user
-        )
-
-        self.logger.info("Accessing the 'My profile' page by clicking on the replient username")
-        self.sumo_pages.question_page._click_on_the_reply_author(answer_id)
-
-        self.logger.info("Verify that my number of profile answers has incremented successfully")
-        new_number = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_answers_text()
-        )
-
-        assert (
+        with allure.step("Accessing the 'My profile' page and verifying that the number of "
+                         "answers has incremented successfully"):
+            self.sumo_pages.question_page._click_on_the_reply_author(answer_id)
             self.number_extraction_from_string(
                 self.sumo_pages.my_profile_page._get_my_profile_answers_text()
             )
-            == original_number_of_answers + 1
-        ), (
-            f"The number of questions should have incremented! "
-            f"The original number of question was: {original_number_of_answers}"
-            f" The new number of questions is: "
-            f"{new_number}"
-        )
+            assert (
+                self.number_extraction_from_string(
+                    self.sumo_pages.my_profile_page._get_my_profile_answers_text()
+                ) == original_number_of_answers + 1
+            )
 
-        self.sumo_pages.my_profile_page._click_my_profile_answers_link()
-        self.logger.info(
-            "Verify that my answer is successfully displayed inside the profile answers list"
-        )
+        with allure.step("Clicking on the my profile answers and verifying that the posted "
+                         "answer is successfully displayed inside the list"):
+            self.sumo_pages.my_profile_page._click_my_profile_answers_link()
+            assert reply_text == self.sumo_pages.my_answers_page._get_my_answer_text(
+                answer_id=answer_id
+            ), "My question reply is not displayed inside the my profile answers list"
 
-        assert reply_text == self.sumo_pages.my_answers_page._get_my_answer_text(
-            answer_id=answer_id
-        ), "My question reply is not displayed inside the my profile answers list"
-
-        self.logger.info("Deleting the my posted question")
-        self.navigate_to_link(question_info["question_page_url"])
-
-        self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
-
-        self.sumo_pages.question_page._click_delete_this_question_button()
-
-        self.logger.info("Verifying that we are on the product support forum page after deletion")
-        expect(
-            self.sumo_pages.product_support_page._product_product_title_element()
-        ).to_be_visible()
+        with allure.step("Deleting the posted question and verifying that the user is redirected "
+                         "to the product support forum page"):
+            self.navigate_to_link(question_info["question_page_url"])
+            self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
+            self.sumo_pages.question_page._click_delete_this_question_button()
+            expect(
+                self.sumo_pages.product_support_page._product_product_title_element()
+            ).to_be_visible()
 
     #  C2094285, C2094284, C891309
     @pytest.mark.userProfile
     def test_number_of_posted_articles_is_successfully_displayed(self):
-        self.logger.info("Logging in with an moderator account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Accessing the View Profile page")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-
-        self.logger.info("Extracting the number of posted documents")
-        original_number_of_documents = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_documents_text()
-        )
-
-        self.logger.info("Create a new simple article")
-        article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
-
-        self.logger.info("Accessing the View Profile page")
-
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-
-        self.logger.info("Verifying that the number of posted documents has incremented")
-        new_number = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_documents_text()
-        )
-
-        assert (
-            self.number_extraction_from_string(
+        with allure.step("Accessing the profile page and extracting the number of documents"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            original_number_of_documents = self.number_extraction_from_string(
                 self.sumo_pages.my_profile_page._get_my_profile_documents_text()
             )
-            == original_number_of_documents + 1
-        ), (
-            f"The number of documents should have incremented! "
-            f"The original number of documents was: {original_number_of_documents}"
-            f" The new number of documents is: "
-            f"{new_number}"
-        )
 
-        self.logger.info("Click on the my posted documents link")
-        self.sumo_pages.my_profile_page._click_on_my_profile_document_link()
+        with allure.step("Creating a kb article"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
-        self.logger.info(
-            "Verifying that the posted document is listed inside the my profile documents list"
-        )
-        assert (
-            article_details['article_title'] in self.sumo_pages.my_documents_page.
-            _get_text_of_document_links()
-        ), (f"The {article_details['article_title']} is not listed inside the my posted documents "
-            f"list")
+        with allure.step("Accessing the profile page and verifying that the number of posted "
+                         "documents has incremented"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            assert (
+                self.number_extraction_from_string(
+                    self.sumo_pages.my_profile_page._get_my_profile_documents_text()
+                ) == original_number_of_documents + 1
+            )
 
-        self.logger.info(
-            "Verifying that clicking on the posted article title redirects the "
-            "user to that article"
-        )
-        self.sumo_pages.my_documents_page._click_on_a_particular_document(
-            article_details['article_title']
-        )
+        with allure.step("Clicking on my posted documents link and verifying that the posted "
+                         "document is listed"):
+            self.sumo_pages.my_profile_page._click_on_my_profile_document_link()
+            assert (
+                article_details['article_title'] in self.sumo_pages.my_documents_page.
+                _get_text_of_document_links()
+            )
 
-        self.logger.info("Deleting the created article")
-        self.sumo_pages.kb_article_page._click_on_show_history_option()
-
-        self.sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-
-        self.sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+        with allure.step("Deleting the article"):
+            self.sumo_pages.my_documents_page._click_on_a_particular_document(
+                article_details['article_title']
+            )
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     # C1491023
     @pytest.mark.userProfile
     def test_accounts_with_symbols_are_getting_a_corresponding_valid_username(self):
-        self.logger.info(
-            "Signing in with an account that contains SUMO-supported and unsupported characters"
-        )
+        with allure.step("Signing in with an account that contains SUMO-supported and "
+                         "unsupported characters"):
+            self.sumo_pages.top_navbar._click_on_signin_signup_button()
 
-        self.sumo_pages.top_navbar._click_on_signin_signup_button()
+            username = self.username_extraction_from_email(
+                self.remove_character_from_string(
+                    self.sumo_pages.auth_flow_page.sign_in_flow(
+                        username=super().user_special_chars,
+                        account_password=super().user_secrets_pass
+                    ),
+                    "*",
+                ))
 
-        username = self.username_extraction_from_email(
-            self.remove_character_from_string(
-                self.sumo_pages.auth_flow_page.sign_in_flow(
-                    username=super().user_special_chars,
-                    account_password=super().user_secrets_pass
-                ),
-                "*",
-            ))
+        with allure.step("Verifying that the username contains the supported characters and "
+                         "doesn't contain the unsupported ones in top navbar"):
+            assert self.sumo_pages.top_navbar._get_text_of_logged_in_username() == username
 
-        self.logger.info(
-            "Verifying that the username contains the supported characters "
-            "and doesn't contain the unsupported ones in top navbar"
-        )
-        assert self.sumo_pages.top_navbar._get_text_of_logged_in_username() == username, (
-            f" The displayed username inside the top-navbar is incorrect. "
-            f"The displayed username should be: {username} "
-            f"but instead is : {self.sumo_pages.top_navbar._get_text_of_logged_in_username()}"
-        )
+        with allure.step("Verifying that the username contains the supported characters and "
+                         "doesn't contain the unsupported ones in My Profile page"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            assert (self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()
+                    == username)
 
-        self.logger.info(
-            "Verifying that the username contains the supported characters "
-            "and doesn't contain the unsupported ones in My Profile page"
-        )
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-
-        assert (self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()
-                == username), (
-            f"The displayed username inside the my profile page is incorrect. "
-            f"The displayed username should be: {username}"
-            f"but instead is: "
-            f"{self.sumo_pages.my_profile_page._get_my_profile_display_name_header_text()}"
-        )
-
-        self.logger.info(
-            "Verifying that the username contains the supported characters and "
-            "doesn't contain the unsupported ones in Edit my Profile page"
-        )
-        self.sumo_pages.top_navbar._click_on_edit_profile_option()
-
-        assert (
-            self.sumo_pages.edit_my_profile_page._get_username_input_field_value() == username), (
-            f"The displayed username inside the Edit my Profile page is incorrect. "
-            f"The displayed field value should be: {username}"
-            f"but instead is: "
-            f"{self.sumo_pages.edit_my_profile_page._get_username_input_field_value()}"
-        )
+        with allure.step("Verifying that the username contains the supported characters and "
+                         "doesn't contain the unsupported ones in Edit my Profile page"):
+            self.sumo_pages.top_navbar._click_on_edit_profile_option()
+            assert (self.sumo_pages.edit_my_profile_page._get_username_input_field_value(
+            ) == username)

--- a/playwright_tests/tests/user_page_tests/test_my_questions.py
+++ b/playwright_tests/tests/user_page_tests/test_my_questions.py
@@ -1,3 +1,4 @@
+import allure
 import pytest
 
 from playwright.sync_api import expect
@@ -10,262 +11,196 @@ class TestMyQuestions(TestUtilities):
     #  C2094280,  C890790
     @pytest.mark.userQuestions
     def test_number_of_questions_is_incremented_when_posting_a_question(self):
-        self.logger.info("Signing in wit a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Accessing the 'My profile' page via the top-navbar menu")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-
-        self.logger.info("Extracting original number of posted questions")
-        original_number_of_questions = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_questions_text()
-        )
-
-        self.logger.info("Navigating to the Firefox AAQ form")
-        self.navigate_to_link(
-            super().aaq_question_test_data["products_aaq_url"]["Firefox"]
-        )
-
-        self.logger.info("Posting a new AAQ question for Firefox product")
-        question_info = (
-            self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=super().aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+        with allure.step("Accessing the 'My profile' page and extracting the original number of "
+                         "posted questions"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            original_number_of_questions = self.number_extraction_from_string(
+                self.sumo_pages.my_profile_page._get_my_profile_questions_text()
             )
-        )
 
-        self.logger.info("Navigating back to the My Profile page")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-        new_number = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_questions_text()
-        )
+        with allure.step("Navigating to the AAQ form and posting a new AAQ question"):
+            self.navigate_to_link(
+                super().aaq_question_test_data["products_aaq_url"]["Firefox"]
+            )
+            question_info = (
+                self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                    subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
+                    topic_name=super(
+                    ).aaq_question_test_data["valid_firefox_question"]["topic_value"],
+                    body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+                )
+            )
 
-        assert (
-            new_number
-            == original_number_of_questions + 1
-        ), (
-            f"The number of questions should have incremented! "
-            f"The original number of question was: "
-            f"{original_number_of_questions}"
-            f" The new number of questions is: "
-            f"{new_number}"
-        )
+        with allure.step("Navigating back to the profile page and verifying that the number of "
+                         "questions has incremented"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            new_number = self.number_extraction_from_string(
+                self.sumo_pages.my_profile_page._get_my_profile_questions_text()
+            )
+            assert new_number == original_number_of_questions + 1
 
-        self.logger.info("Deleting the my posted question")
-        self.navigate_to_link(question_info["question_page_url"])
-        self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
-        self.sumo_pages.question_page._click_delete_this_question_button()
+        with allure.step("Deleting the posted question"):
+            self.navigate_to_link(question_info["question_page_url"])
+            self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
+            self.sumo_pages.question_page._click_delete_this_question_button()
 
-        self.logger.info("Verifying that we are on the product support forum page after deletion")
-
-        expect(
-            self.sumo_pages.product_support_page._product_product_title_element()
-        ).to_be_visible()
+        with allure.step("Verifying that we are on the product support forum page after deletion"):
+            expect(
+                self.sumo_pages.product_support_page._product_product_title_element()
+            ).to_be_visible()
 
         # write tests to check my questions section as well
 
     # C1296000, #  C890790
     @pytest.mark.userQuestions
     def test_my_contributions_questions_reflects_my_questions_page_numbers(self):
-        self.logger.info("Signing in with a normal user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_12"]
-        ))
+        with allure.step("Signing in with a non-admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_12"]
+            ))
 
-        self.logger.info("Accessing the 'My profile' page via the top-navbar menu")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
+        with allure.step("Accessing the 'My profile' and extracting the number of questions "
+                         "listed inside the my profile page"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            number_of_questions = self.number_extraction_from_string(
+                self.sumo_pages.my_profile_page._get_my_profile_questions_text()
+            )
 
-        self.logger.info("Extracting the number of questions listed inside the my profile page")
-
-        number_of_questions = self.number_extraction_from_string(
-            self.sumo_pages.my_profile_page._get_my_profile_questions_text()
-        )
-
-        self.logger.info("Clicking on the my profile questions link")
-        self.sumo_pages.my_profile_page._click_on_my_profile_questions_link()
-
-        self.logger.info(
-            "Verifying that the number of questions from the"
-            " my profile pages matches the ones from my questions "
-            "page"
-        )
-
-        assert (number_of_questions
-                == self.sumo_pages.my_questions_page._get_number_of_questions()), (
-            f"The number of questions listed inside the my profile page is:"
-            f" {number_of_questions} "
-            f"The number of questions listed inside the my questions page is:"
-            f" {self.sumo_pages.my_questions_page._get_number_of_questions()}"
-        )
+        with allure.step("Clicking on the my profile questions link and verifying that the "
+                         "number of questions from the my profile page matches the one from the "
+                         "ones from my questions page"):
+            self.sumo_pages.my_profile_page._click_on_my_profile_questions_link()
+            assert (number_of_questions
+                    == self.sumo_pages.my_questions_page._get_number_of_questions())
 
     # C890821
     @pytest.mark.userQuestions
     def test_correct_messages_is_displayed_if_user_has_no_posted_questions(self):
-        self.logger.info("Signing in with a user which has no posted questions")
-        self.sumo_pages.top_navbar._click_on_signin_signup_button()
-
-        self.sumo_pages.auth_flow_page.sign_in_flow(
-            username=super().user_special_chars,
-            account_password=super().user_secrets_pass
-        )
+        with allure.step("Signing in with a user which has no posted questions"):
+            self.sumo_pages.top_navbar._click_on_signin_signup_button()
+            self.sumo_pages.auth_flow_page.sign_in_flow(
+                username=super().user_special_chars,
+                account_password=super().user_secrets_pass
+            )
 
         original_user = self.sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-        self.logger.info("Accessing the 'My questions' page")
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-        self.sumo_pages.user_navbar._click_on_my_questions_option()
-
-        self.logger.info("Verifying that the correct message is displayed")
-
-        assert (
-            self.sumo_pages.my_questions_page._get_text_of_no_question_message()
-            == MyQuestionsPageMessages.NO_POSTED_QUESTIONS_MESSAGE
-        ), (
-            f"Incorrect message is displayed!. "
-            f"Expected: {MyQuestionsPageMessages.NO_POSTED_QUESTIONS_MESSAGE} "
-            f"received: {self.sumo_pages.my_questions_page._get_text_of_no_question_message()}"
-        )
-
-        self.logger.info("Verifying that a question list is not displayed")
-
-        expect(
-            self.sumo_pages.my_questions_page._is_question_list_displayed()
-        ).to_be_hidden()
-
-        self.logger.info("Navigating to the Firefox AAQ form")
-        self.navigate_to_link(
-            super().aaq_question_test_data["products_aaq_url"]["Firefox"]
-        )
-
-        self.logger.info("Posting a new AAQ question for Firefox product")
-        question_info = (
-            self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=super().aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+        with allure.step("Accessing the 'My questions' page and verifying that the correct "
+                         "message is displayed"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            self.sumo_pages.user_navbar._click_on_my_questions_option()
+            assert (
+                self.sumo_pages.my_questions_page._get_text_of_no_question_message()
+                == MyQuestionsPageMessages.NO_POSTED_QUESTIONS_MESSAGE
             )
-        )
 
-        self.logger.info(
-            "Accessing the my questions page and verifying that the "
-            "no questions message is no longer displayed"
-        )
+        with allure.step("Verifying that the question list is not displayed"):
+            expect(
+                self.sumo_pages.my_questions_page._is_question_list_displayed()
+            ).to_be_hidden()
 
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-        self.sumo_pages.user_navbar._click_on_my_questions_option()
+        with allure.step("Navigating to the Firefox AAQ form and posting a new AAQ question for "
+                         "the Firefox product"):
+            self.navigate_to_link(
+                super().aaq_question_test_data["products_aaq_url"]["Firefox"]
+            )
+            question_info = (
+                self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                    subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
+                    topic_name=super(
+                    ).aaq_question_test_data["valid_firefox_question"]["topic_value"],
+                    body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+                )
+            )
 
-        expect(
-            self.sumo_pages.my_questions_page._is_no_question_message_displayed()
-        ).to_be_hidden()
+        with allure.step("Accessing the my questions page and verifying that the no question "
+                         "message is no longer displayed"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            self.sumo_pages.user_navbar._click_on_my_questions_option()
+            expect(
+                self.sumo_pages.my_questions_page._is_no_question_message_displayed()
+            ).to_be_hidden()
 
-        self.logger.info("Signing in with a moderator account")
-        self.sumo_pages.top_navbar._click_on_sign_out_button()
+        with allure.step("Signing in with an admin account and deleting the posted question"):
+            self.sumo_pages.top_navbar._click_on_sign_out_button()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.navigate_to_link(question_info["question_page_url"])
+            self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
+            self.sumo_pages.question_page._click_delete_this_question_button()
 
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Accessing the original user and verifying that the correct message is "
+                         "displayed"):
+            self.navigate_to_link(
+                MyQuestionsPageMessages.get_stage_my_questions_url(original_user)
+            )
+            assert (
+                self.sumo_pages.my_questions_page._get_text_of_no_question_message()
+                == MyQuestionsPageMessages.get_no_posted_questions_other_user_message(
+                    original_user)
+            )
 
-        self.logger.info("Deleting the my posted question")
-        self.navigate_to_link(question_info["question_page_url"])
-        self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
-        self.sumo_pages.question_page._click_delete_this_question_button()
-
-        self.logger.info(
-            "Accessing the original user and verifying that the correct message is displayed"
-        )
-        self.navigate_to_link(
-            MyQuestionsPageMessages.get_stage_my_questions_url(original_user)
-        )
-
-        assert (
-            self.sumo_pages.my_questions_page._get_text_of_no_question_message()
-            == MyQuestionsPageMessages.get_no_posted_questions_other_user_message(original_user)
-        ), (
-            f"Incorrect message displayed! "
-            f"Expected: "
-            f"{MyQuestionsPageMessages.get_no_posted_questions_other_user_message(original_user)} "
-            f"received: "
-            f"{self.sumo_pages.my_questions_page._get_text_of_no_question_message()}"
-        )
-
-        self.logger.info(
-            "Sign in with the original user an verify that the "
-            "correct message and the question list is no longer displayed"
-        )
-        self.delete_cookies()
-        self.sumo_pages.top_navbar._click_on_signin_signup_button()
-        self.sumo_pages.auth_flow_page.sign_in_flow(
-            username=super().user_special_chars,
-            account_password=super().user_secrets_pass
-        )
-
-        self.sumo_pages.top_navbar._click_on_view_profile_option()
-        self.sumo_pages.user_navbar._click_on_my_questions_option()
-
-        assert (
-            self.sumo_pages.my_questions_page._get_text_of_no_question_message()
-            == MyQuestionsPageMessages.NO_POSTED_QUESTIONS_MESSAGE
-        ), (
-            f"Incorrect message displayed! "
-            f"Expected: {MyQuestionsPageMessages.NO_POSTED_QUESTIONS_MESSAGE} "
-            f"received: {self.sumo_pages.my_questions_page._get_text_of_no_question_message()}"
-        )
+        with allure.step("Signing in with the original user and verifying that the correct "
+                         "message and the question list is no longer displayed"):
+            self.delete_cookies()
+            self.sumo_pages.top_navbar._click_on_signin_signup_button()
+            self.sumo_pages.auth_flow_page.sign_in_flow(
+                username=super().user_special_chars,
+                account_password=super().user_secrets_pass
+            )
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+            self.sumo_pages.user_navbar._click_on_my_questions_option()
+            assert (
+                self.sumo_pages.my_questions_page._get_text_of_no_question_message()
+                == MyQuestionsPageMessages.NO_POSTED_QUESTIONS_MESSAGE
+            )
 
     #  C890823, C890831
     @pytest.mark.userQuestions
     def test_my_question_page_reflects_posted_questions_and_redirects_to_the_correct_question(
             self,
     ):
-        self.logger.info("Signing in with a moderator user account")
-        self.start_existing_session(super().username_extraction_from_email(
-            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
-        ))
+        with allure.step("Signing in with an admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
 
-        self.logger.info("Navigating to the Firefox AAQ form")
-        self.navigate_to_link(
-            super().aaq_question_test_data["products_aaq_url"]["Firefox"]
-        )
-
-        self.logger.info("Posting a new AAQ question for Firefox product")
-        question_info = (
-            self.sumo_pages.aaq_flow.submit_an_aaq_question_for_a_product(
-                subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=super().aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+        with allure.step("Navigating to the Firefox AAQ form and posting a new AAQ question"):
+            self.navigate_to_link(
+                super().aaq_question_test_data["products_aaq_url"]["Firefox"]
             )
-        )
+            question_info = (
+                self.sumo_pages.aaq_flow.submit_an_aaq_question(
+                    subject=super().aaq_question_test_data["valid_firefox_question"]["subject"],
+                    topic_name=super(
+                    ).aaq_question_test_data["valid_firefox_question"]["topic_value"],
+                    body=super().aaq_question_test_data["valid_firefox_question"]["question_body"]
+                )
+            )
 
-        self.logger.info(
-            "Verifying that the first element from the "
-            "My Questions page is the recently posted question"
-        )
-        self.sumo_pages.top_navbar._click_on_my_questions_profile_option()
+        with allure.step("Navigating to my questions profile page and verifying that the first "
+                         "element from the My Questions page is the recently posted question"):
+            self.sumo_pages.top_navbar._click_on_my_questions_profile_option()
+            assert self.sumo_pages.my_questions_page._get_text_of_first_listed_question().replace(
+                " ", ""
+            ) == question_info["aaq_subject"].replace(" ", "")
 
-        assert self.sumo_pages.my_questions_page._get_text_of_first_listed_question().replace(
-            " ", ""
-        ) == question_info["aaq_subject"].replace(" ", ""), (
-            f" Expected: {question_info['aaq_subject']} "
-            f"Received: {self.sumo_pages.my_questions_page._get_text_of_first_listed_question()}"
-        )
-
-        self.logger.info(
-            "Clicking on the first listed item and verifying that "
-            "the user is redirected to the correct question"
-        )
-
-        self.sumo_pages.my_questions_page._click_on_a_question_by_index(1)
-
-        expect(
-            self.page
-        ).to_have_url(question_info["question_page_url"])
+        with allure.step("Clicking on the first list item and verifying that the user is "
+                         "redirected to the correct question"):
+            self.sumo_pages.my_questions_page._click_on_a_question_by_index(1)
+            expect(
+                self.page
+            ).to_have_url(question_info["question_page_url"])
 
         # assert self.sumo_pages.question_page.current_url() == question_info[
         # "question_page_url"], ( f"We are on the wrong page. Expected: {question_info} "
         # f"received: {self.sumo_pages.question_page.current_url()}" )
 
-        self.logger.info("Deleting the posted question")
-        self.sumo_pages.question_page._click_delete_this_question_question_tools_option()
-        self.sumo_pages.question_page._click_delete_this_question_button()
+        with allure.step("Deleting the posted question"):
+            self.sumo_pages.aaq_flow.deleting_question_flow()

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,36 @@ files = [
 ]
 
 [[package]]
+name = "allure-pytest"
+version = "2.13.2"
+description = "Allure pytest integration"
+optional = false
+python-versions = "*"
+files = [
+    {file = "allure-pytest-2.13.2.tar.gz", hash = "sha256:22243159e8ec81ce2b5254b4013802198821b1b42f118f69d4a289396607c7b3"},
+    {file = "allure_pytest-2.13.2-py3-none-any.whl", hash = "sha256:17de9dbee7f61c8e66a5b5e818b00e419dbcea44cb55c24319401ba813220690"},
+]
+
+[package.dependencies]
+allure-python-commons = "2.13.2"
+pytest = ">=4.5.0"
+
+[[package]]
+name = "allure-python-commons"
+version = "2.13.2"
+description = "Common module for integrate allure with python-based frameworks"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "allure-python-commons-2.13.2.tar.gz", hash = "sha256:8a03681330231b1deadd86b97ff68841c6591320114ae638570f1ed60d7a2033"},
+    {file = "allure_python_commons-2.13.2-py3-none-any.whl", hash = "sha256:2bb3646ec3fbf5b36d178a5e735002bc130ae9f9ba80f080af97d368ba375051"},
+]
+
+[package.dependencies]
+attrs = ">=16.0.0"
+pluggy = ">=0.4.0"
+
+[[package]]
 name = "amqp"
 version = "5.2.0"
 description = "Low-level AMQP client for Python (fork of amqplib)."
@@ -4794,4 +4824,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "33119e30eb969203679def29e16bb783f79ab7ea23879a6ddfdab8099214a880"
+content-hash = "345af3f80110ff3963071c53929d503114ffc87436c505a4ba5e5f671d854a5a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ pytest-rerunfailures = "^12.0"
 flake8 = "^7.0.0"
 pytest-check = "^2.3.1"
 playwright = "^1.42.0"
+allure-pytest = "^2.13.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
- Using allure.step() to define steps in allure report.
- Modifying the soft assertions to play nicely with allure reporting by interleaving check and step.
- Adding allure to poetry.
- Modifying the playwright.yml to exclude the HTML reporter & use Allure reporting instead.
- Building up the logic of attaching screencasts to Allure report on test failure.