### PR TITLE
Add hubs announcment

### DIFF
--- a/kitsune/products/jinja2/products/documents.html
+++ b/kitsune/products/jinja2/products/documents.html
@@ -29,6 +29,14 @@
 
 {% endblock %}
 
+{% block product_announcement %}
+  {% if product.slug == 'hubs' %}
+  <div id="hubs-banner" class="mzp-c-notification-bar mzp-t-warning">
+    <button class="mzp-c-notification-bar-button close-button" type="button"></button>
+    <p>{{ _('Mozilla Hubs will shut down on May 31, 2024. For more information about the shutdown and how you can support Hubs\' life beyond Mozilla, please read <a href="https://hubs.mozilla.com/labs/sunset/">this article</a>.') }}</p>
+  </div>
+  {% endif %}
+{% endblock %}
 
 {% block content %}
     <article id="document-list">
@@ -87,8 +95,6 @@
       {% endif %}
 
       {{ topic_tabs(topics[:10], subtopics, product, topic, subtopic) }}
-
-
 
       <section class="topic-list">
         {% for document in documents %}

--- a/kitsune/products/jinja2/products/product.html
+++ b/kitsune/products/jinja2/products/product.html
@@ -12,13 +12,24 @@
 
 {% block title %}{{ _('{product} Help')|f(product=pgettext('DB: products.Product.title', product.title)) }}{% endblock %}
 
+{% block product_announcement %}
+  {% if product.slug == 'hubs' %}
+  <div id="hubs-banner" class="mzp-c-notification-bar mzp-t-warning">
+    <button class="mzp-c-notification-bar-button close-button" type="button"></button>
+    <p>{{ _('Mozilla Hubs will shut down on May 31, 2024. For more information about the shutdown and how you can support Hubs\' life beyond Mozilla, please read <a href="https://hubs.mozilla.com/labs/sunset/">this article</a>.') }}</p>
+  </div>
+  {% endif %}
+{% endblock %}
+
 {% block base_container_classes %}container_wide{% endblock %}
 
 {% block hidden_search_masthead %}{% endblock %}
 
 {% block masthead %}
 <section class="home-search-section sumo-page-section extra-pad-bottom shade-bg">
+
   <div class="mzp-l-content">
+
     {% block breadcrumbs %}
       {{ breadcrumbs(crumbs, id='main-breadcrumbs') }}
     {% endblock %}

--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -105,6 +105,9 @@
   {% endif %}
 </div>
 
+{% block product_announcement %}
+{% endblock %}
+
 <header class="mzp-c-navigation sumo-nav">
   <div class="mzp-c-navigation-l-content">
     <div class="sumo-nav--container">

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -13,6 +13,15 @@
 {% endif %}
 {% set extra_body_attrs = {'data-document-id': document.id, 'data-default-slug': document.parent.slug if document.parent else document.slug} %}
 
+{% block product_announcement %}
+  {% if product.slug == 'hubs' %}
+  <div id="hubs-banner" class="mzp-c-notification-bar mzp-t-warning">
+    <button class="mzp-c-notification-bar-button close-button" type="button"></button>
+    <p>{{ _('Mozilla Hubs will shut down on May 31, 2024. For more information about the shutdown and how you can support Hubs\' life beyond Mozilla, please read <a href="https://hubs.mozilla.com/labs/sunset/">this article</a>.') }}</p>
+  </div>
+  {% endif %}
+{% endblock %}
+
 {% block title %}
   {{ document.title }} | {% if not products or products|count > 1 %}{{ pgettext('site_title', 'Mozilla Support') }}{% else %}{{ _('{product} Help')|f(product=pgettext('DB: products.Product.title', product.title)) }}{% endif %}
 {% endblock %}


### PR DESCRIPTION
This adds an announcement about Hubs sunset to the product pages and wiki pages related to Hubs.

This is a temporary solution until we add Product based announcements to the admin.

