### PR TITLE
Expanding playwright coverage over the restricted visibility kb articles functionality

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -70,11 +70,10 @@ jobs:
         working-directory: playwright_tests
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
-            declare -a tests=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard")
-            any_failures=false
+            declare -a tests=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "restrictedArticleCreation" "kbRestrictedVisibilitySingleGroup" "whitelistingDifferentGroup" "kbRestrictedVisibilityMultipleGroups" "removingAllArticleRestrictions" "kbRemovedRestrictions" "deleteAllRestrictedTestArticles")
             for test in "${tests[@]}"; do
                 num_processes=2
-                if [[ "$test" =~ ^(beforeThreadTests|afterThreadTests)$ ]]; then
+                if [[ "$test" =~ ^(beforeThreadTests|afterThreadTests|restrictedArticleCreation|whitelistingDifferentGroup|removingAllArticleRestrictions|deleteAllRestrictedTestArticles)$ ]]; then
                   num_processes=1
                 fi
                 if ! poetry run pytest -m $test --numprocesses $num_processes --browser ${{ env.BROWSER }} --reruns 1; then

--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -18,6 +18,9 @@ class BasePage:
         self.__wait_for_dom_load_to_finnish()
         return self._page.locator(xpath).all()
 
+    def _get_current_page_url(self) -> str:
+        return self._page.url
+
     # Single locator retrieval without wait.
     def _get_element_locator_no_wait(self, xpath: str) -> Locator:
         return self._page.locator(xpath)
@@ -54,6 +57,9 @@ class BasePage:
     def _get_element_locator_attribute_value(self, locator: Locator, attribute: str) -> str:
         self.__wait_for_dom_load_to_finnish()
         return locator.get_attribute(attribute)
+
+    def _wait_for_given_timeout(self, timeout: float):
+        self._page.wait_for_timeout(timeout)
 
     # Fetching a particular element input value.
     def _get_element_input_value(self, xpath: str) -> str:

--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_media_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_media_flow.py
@@ -1,0 +1,17 @@
+from playwright.sync_api import Page
+
+from playwright_tests.pages.contribute.contributor_tools_pages.media_gallery import MediaGallery
+
+
+class AddKbMediaFlow(MediaGallery):
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def add_media_to_kb_article(self, file_type, file_name):
+        if file_type == 'Videos':
+            super()._click_on_videos_filter()
+
+        super()._fill_search_modal_gallery_searchbox_input_field(file_name)
+        super()._click_on_search_modal_gallery_search_button()
+        super()._select_media_file_from_list(file_name)
+        super()._click_on_insert_media_button()

--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_revision_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_revision_flow.py
@@ -2,6 +2,9 @@ from typing import Any
 
 from playwright_tests.core.testutilities import TestUtilities
 from playwright.sync_api import Page
+
+from playwright_tests.flows.explore_articles_flows.article_flows.add_kb_media_flow import \
+    AddKbMediaFlow
 from playwright_tests.pages.explore_help_articles.articles.kb_article_page import KBArticlePage
 from playwright_tests.pages.explore_help_articles.articles.kb_article_review_revision_page import \
     KBArticleReviewRevisionPage
@@ -9,13 +12,17 @@ from playwright_tests.pages.explore_help_articles.articles.kb_article_show_histo
     KBArticleShowHistoryPage
 from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_page import (
     EditKBArticlePage)
+from playwright_tests.pages.explore_help_articles.articles.submit_kb_article_page import \
+    SubmitKBArticlePage
 
 
 class AddKBArticleRevision(TestUtilities,
                            KBArticlePage,
                            EditKBArticlePage,
                            KBArticleShowHistoryPage,
-                           KBArticleReviewRevisionPage):
+                           KBArticleReviewRevisionPage,
+                           SubmitKBArticlePage,
+                           AddKbMediaFlow):
     def __init__(self, page: Page):
         super().__init__(page)
 

--- a/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
@@ -10,7 +10,18 @@ class EditArticleMetaFlow(TestUtilities, KBArticleEditMetadata):
     def __init__(self, page: Page):
         super().__init__(page)
 
-    def edit_article_metadata(self, title=None, needs_change=False, needs_change_comment=False):
+    def edit_article_metadata(self, title=None,
+                              needs_change=False,
+                              needs_change_comment=False,
+                              restricted_to_groups: list[str] = None,
+                              single_group=""):
+
+        if restricted_to_groups is not None:
+            for group in restricted_to_groups:
+                super()._add_and_select_restrict_visibility_group_metadata(group)
+        if single_group != "":
+            super()._add_and_select_restrict_visibility_group_metadata(single_group)
+
         if title is not None:
             super()._add_text_to_title_field(title)
 

--- a/playwright_tests/messages/explore_help_articles/kb_article_page_messages.py
+++ b/playwright_tests/messages/explore_help_articles/kb_article_page_messages.py
@@ -20,3 +20,4 @@ class KBArticlePageMessages:
                                           "Document with this Slug and Locale already exists."]
     KB_ARTICLE_RELEVANCY_ERROR = "Please select at least one product."
     KB_ARTICLE_TOPIC_ERROR = "Please select at least one topic."
+    KB_ARTICLE_RESTRICTED_BANNER = "This document is restricted."

--- a/playwright_tests/pages/ask_a_question/product_topics_pages/product_topics_page.py
+++ b/playwright_tests/pages/ask_a_question/product_topics_pages/product_topics_page.py
@@ -25,6 +25,10 @@ class ProductTopicPage(BasePage):
     def _get_page_title(self) -> str:
         return super()._get_text_of_element(self.__page_title)
 
+    def _get_a_particular_article_locator(self, article_title: str):
+        xpath = f"//h2[@class='sumo-card-heading']/a[normalize-space(text())='{article_title}']"
+        return super()._get_element_locator(xpath)
+
     # Navbar actions.
     def _get_selected_navbar_option(self) -> str:
         return super()._get_text_of_element(self.__selected_nav_link)

--- a/playwright_tests/pages/contribute/contributor_tools_pages/article_discussions_page.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/article_discussions_page.py
@@ -1,0 +1,12 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page, Locator
+
+
+class ArticleDiscussionsPage(BasePage):
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def _is_title_for_article_discussion_displayed(self, article_title: str) -> Locator:
+        xpath = f"//td[@class='title']/a[text()='{article_title}']"
+        return super()._get_element_locator(xpath)

--- a/playwright_tests/pages/contribute/contributor_tools_pages/media_gallery.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/media_gallery.py
@@ -1,0 +1,98 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page
+
+
+class MediaGallery(BasePage):
+    # Media Gallery page locators.
+    __upload_a_new_media_file_button = "//a[@id='btn-upload']"
+    __search_gallery_searchbox = "//form[@id='gallery-search']/input"
+    __search_gallery_search_button = "//form[@id='gallery-search']/button"
+    # Media preview locators.
+    __image_heading = "//h1[@class='sumo-page-heading']"
+    __image_creator = "//ul[@id='media-meta']/li[@class='creator']/a"
+    __image_description = "//div[@class='description']/p"
+    __image_in_documents_text = "//div[@class='documents']/p"
+    __image_in_documents_list = "//div[@class='documents']//li/a"
+    __delete_this_image_button = "//form[@id='media-actions']//button"
+    __edit_this_image_button = "//form[@id='media-actions']//a"
+    # Insert media... modal locators.
+    __insert_media_panel = "//div[@id='media-modal']"
+    __search_gallery_searchbox_modal = "//form[@id='gallery-modal-search']/input"
+    __search_gallery_search_button_modal = "//form[@id='gallery-modal-search']/button"
+    __show_images_filter = "//div[@class='type']/ol/li[text()='Images']"
+    __show_videos_filter = "//div[@class='type']/ol/li[text()='Videos']"
+    __cancel_media_insert_button = "//a[@href='#cancel']"
+    __upload_media_button = "//a[text()='Upload Media']"
+    __insert_media_button = "//button[text()='Insert Media']"
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    # Media Gallery page actions.
+    def _click_on_upload_a_new_media_file_button(self):
+        super()._click(self.__upload_a_new_media_file_button)
+
+    # Media Gallery image preview actions.
+    def _get_image_heading(self) -> str:
+        return super()._get_text_of_element(self.__image_heading)
+
+    def _get_image_creator_text(self) -> str:
+        return super()._get_text_of_element(self.__image_creator)
+
+    def _click_on_image_creator_link(self):
+        super()._click(self.__image_creator)
+
+    def _get_image_description(self) -> str:
+        return super()._get_text_of_element(self.__image_description)
+
+    def _get_image_in_documents_text(self) -> str:
+        return super()._get_text_of_element(self.__image_in_documents_text)
+
+    def _get_image_in_documents_list_items_text(self) -> list[str]:
+        return super()._get_text_of_elements(self.__image_in_documents_list)
+
+    def _click_on_a_linked_in_document(self, document_name: str):
+        xpath = f"//div[@class='documents']//li/a[text()='{document_name}']"
+        super()._click(xpath)
+
+    def _click_on_delete_this_image_button(self):
+        super()._click(self.__delete_this_image_button)
+
+    def _click_on_edit_this_image_button(self):
+        super()._click(self.__edit_this_image_button)
+
+    # Media Gallery search
+    def _fill_search_media_gallery_searchbox_input_field(self, text: str):
+        super()._fill(self.__search_gallery_searchbox, text)
+
+    def _click_on_media_gallery_searchbox_search_button(self):
+        super()._click(self.__search_gallery_search_button)
+
+    # Modal search.
+    def _fill_search_modal_gallery_searchbox_input_field(self, text: str):
+        super()._fill(self.__search_gallery_searchbox_modal, text)
+
+    def _click_on_search_modal_gallery_search_button(self):
+        super()._click(self.__search_gallery_search_button_modal)
+
+    # Insert Media... kb panel actions.
+    def _click_on_images_filter(self):
+        super()._click(self.__show_images_filter)
+
+    def _click_on_videos_filter(self):
+        super()._click(self.__show_videos_filter)
+
+    def _click_on_cancel_media_insert(self):
+        super()._click(self.__insert_media_button)
+
+    def _click_on_upload_media_button(self):
+        super()._click(self.__upload_media_button)
+
+    def _select_media_file_from_list(self, media_file_name: str):
+        xpath = f"//ol[@id='media-list']/li/a[@title='{media_file_name}']"
+        # We need to wait a bit so that the list finishes to update in case of search.
+        super()._wait_for_given_timeout(1000)
+        super()._click(xpath)
+
+    def _click_on_insert_media_button(self):
+        super()._click(self.__insert_media_button)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
@@ -4,6 +4,7 @@ from playwright_tests.core.basepage import BasePage
 
 class KBArticlePage(BasePage):
     __kb_article_heading = "//h1[@class='sumo-page-heading']"
+    __kb_article_restricted_banner = "//div[contains(@class,'warning-box')]"
     __kb_article_content = "//section[@id='doc-content']"
     __kb_article_content_approved_content = "//section[@id='doc-content']/p"
     __kb_article_contributors = "//div[@class='document--contributors-list text-body-xs']/a"
@@ -14,14 +15,25 @@ class KBArticlePage(BasePage):
     __editing_tools_edit_article_option = "//li/a[text()='Edit Article']"
     __editing_tools_edit_article_metadata_option = "//a[text()='Edit Article Metadata']"
     __editing_tools_discussion_option = "//ul[@class='sidebar-nav--list']//a[text()='Discussion']"
+    __editing_tools_what_links_here = "//a[text()='What Links Here']"
     __editing_tools_show_history_option = "//a[contains(text(), 'Show History')]"
 
     def __init__(self, page: Page):
         super().__init__(page)
 
     # KB Article page content actions.
+    def _click_on_a_particular_breadcrumb(self, breadcrumb_name: str):
+        xpath = f"//ol[@id='breadcrumbs']//a[text()='{breadcrumb_name}']"
+        super()._click(xpath)
+
     def _get_text_of_article_title(self) -> str:
         return super()._get_text_of_element(self.__kb_article_heading)
+
+    def _get_restricted_visibility_banner_text(self) -> str:
+        return super()._get_text_of_element(self.__kb_article_restricted_banner)
+
+    def _is_restricted_visibility_banner_text_displayed(self) -> bool:
+        return super()._is_element_visible(self.__kb_article_restricted_banner)
 
     def _get_list_of_kb_article_contributors(self) -> list[str]:
         return super()._get_text_of_elements(self.__kb_article_contributors)
@@ -35,6 +47,9 @@ class KBArticlePage(BasePage):
 
     def _get_text_of_kb_article_content(self) -> str:
         return super()._get_text_of_element(self.__kb_article_content)
+
+    def _click_on_what_links_here_option(self):
+        super()._click(self.__editing_tools_what_links_here)
 
     # KB Article editing tools section actions.
     def _click_on_show_history_option(self):

--- a/playwright_tests/pages/explore_help_articles/articles/kb_category_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_category_page.py
@@ -1,0 +1,10 @@
+from playwright.sync_api import Locator
+
+from playwright_tests.core.basepage import BasePage
+
+
+class KBCategoryPage(BasePage):
+
+    def _get_a_particular_article_locator_from_list(self, article_name: str) -> Locator:
+        xpath = f"//ul[@class='documents']/li/a[text()='{article_name}']"
+        return super()._get_element_locator(xpath)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
@@ -9,6 +9,8 @@ class KBArticleEditMetadata(BasePage):
     __restricted_visibility_chosen_groups = ("//input[@id='id_restrict_to_groups-selectized"
                                              "']/../div[@class='item']")
     __clear_all_selected_groups_button = "//a[@class='clear']"
+    __kb_article_restrict_visibility_field = "//input[@id='id_restrict_to_groups-selectized']"
+    __kb_article_restrict_visibility_delete_all_groups = "//a[@title='Clear']"
     __title_input_field = "//input[@id='id_title']"
     __slug_input_field = "//input[@id='id_slug']"
     __category_select_field = "//select[@id='id_category']"
@@ -32,6 +34,18 @@ class KBArticleEditMetadata(BasePage):
 
     def _clear_all_restricted_visibility_group_selections(self):
         super()._click(self.__clear_all_selected_groups_button)
+
+    def _add_and_select_restrict_visibility_group_metadata(self, group_name: str):
+        option_xpath = f"//div[@class='option active']/span[text()='{group_name}']"
+        super()._fill(self.__kb_article_restrict_visibility_field, group_name)
+        super()._click(option_xpath)
+
+    def _delete_a_restricted_visibility_group_metadata(self, group_name: str):
+        xpath = f"//div[@class='item' and text()='{group_name}']/a"
+        super()._click(xpath)
+
+    def _delete_all_restricted_visibility_groups_metadata(self):
+        super()._click(self.__kb_article_restrict_visibility_delete_all_groups)
 
     def _get_text_of_title_input_field(self):
         return super()._get_text_of_element(self.__title_input_field)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_what_links_here_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_what_links_here_page.py
@@ -1,0 +1,13 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page, Locator
+
+
+class WhatLinksHerePage(BasePage):
+    __what_links_here_list = "//article[@id]//li/a"
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def _get_a_particular_what_links_here_article_locator(self, article_name: str) -> Locator:
+        xpath = f"//article[@id]//li/a[contains(text(), '{article_name}')]"
+        return super()._get_element_locator(xpath)

--- a/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
@@ -5,6 +5,8 @@ from playwright_tests.core.basepage import BasePage
 class SubmitKBArticlePage(BasePage):
     __kb_article_for_contributors_sidebar = "//nav[@id='for-contributors-sidebar']"
     # New KB article form locators.
+    __kb_article_restrict_visibility_field = "//input[@id='id_restrict_to_groups-selectized']"
+    __kb_article_restrict_visibility_delete_all_groups = "//a[@title='Clear']"
     __kb_article_form_title = "//input[@id='id_title']"
     __kb_article_form_slug = "//input[@id='id_slug']"
     __kb_article_category_select = "//select[@id='id_category']"
@@ -58,6 +60,18 @@ class SubmitKBArticlePage(BasePage):
         return super()._get_element_locator(self.__kb_article_for_contributors_sidebar)
 
     # New KB form actions.
+    def _add_and_select_restrict_visibility_group(self, group_name: str):
+        option_xpath = f"//div[@class='option active']/span[text()='{group_name}']"
+        super()._fill(self.__kb_article_restrict_visibility_field, group_name)
+        super()._click(option_xpath)
+
+    def _delete_a_restricted_visibility_group(self, group_name: str):
+        xpath = f"//div[@class='item' and text()='{group_name}']/a"
+        super()._click(xpath)
+
+    def _delete_all_restricted_visibility_groups(self):
+        super()._click(self.__kb_article_restrict_visibility_delete_all_groups)
+
     def _add_text_to_article_form_title_field(self, text: str):
         # Clearing the field first from auto-population
         super()._clear_field(self.__kb_article_form_title)
@@ -112,7 +126,7 @@ class SubmitKBArticlePage(BasePage):
         return super()._get_element_locator(self.__kb_article_preview_content)
 
     def _click_on_a_relevant_to_option_checkbox(self, option_to_click: str):
-        xpath = f"//div[@id='id_products']//label[contains(text(), '{option_to_click}')]/input"
+        xpath = f"//input[@id='{option_to_click}']"
         super()._click(xpath)
 
     def _get_text_of_label_for_relevant_to_checkbox(self, option_to_click) -> str:
@@ -151,3 +165,6 @@ class SubmitKBArticlePage(BasePage):
 
     def _check_allow_translations_checkbox(self):
         super()._click(self.__kb_article_allow_translations)
+
+    def _get_article_page_url(self) -> str:
+        return super()._get_current_page_url()

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -4,6 +4,8 @@ from playwright_tests.flows.ask_a_question_flows.aaq_flows.aaq_flow import AAQFl
 from playwright_tests.flows.explore_articles_flows.article_flows.add_kb_article_flow import (
     AddKbArticleFlow)
 from playwright_tests.flows.auth_flows.auth_flow import AuthFlowPage
+from playwright_tests.flows.explore_articles_flows.article_flows.add_kb_media_flow import \
+    AddKbMediaFlow
 from playwright_tests.flows.explore_articles_flows.article_flows.add_kb_revision_flow import \
     AddKBArticleRevision
 from playwright_tests.flows.explore_articles_flows.article_flows.delete_kb_article_flow import \
@@ -16,7 +18,10 @@ from playwright_tests.flows.messaging_system_flows.messaging_system_flow import 
     MessagingSystemFlows)
 from playwright_tests.flows.user_profile_flows.edit_profile_data_flow import EditProfileDataFlow
 from playwright_tests.pages.ask_a_question.aaq_pages.aaq_form_page import AAQFormPage
+from playwright_tests.pages.contribute.contributor_tools_pages.article_discussions_page import \
+    ArticleDiscussionsPage
 from playwright_tests.pages.contribute.contributor_tools_pages.kb_dashboard_page import KBDashboard
+from playwright_tests.pages.contribute.contributor_tools_pages.media_gallery import MediaGallery
 from playwright_tests.pages.contribute.contributor_tools_pages.moderate_forum_content import \
     ModerateForumContent
 from playwright_tests.pages.contribute.contributor_tools_pages.recent_revisions_page import \
@@ -26,6 +31,7 @@ from playwright_tests.pages.explore_help_articles.articles.kb_article_discussion
 from playwright_tests.pages.explore_help_articles.articles.kb_article_page import KBArticlePage
 from playwright_tests.pages.explore_help_articles.articles.kb_article_review_revision_page import \
     KBArticleReviewRevisionPage
+from playwright_tests.pages.explore_help_articles.articles.kb_category_page import KBCategoryPage
 from playwright_tests.pages.explore_help_articles.articles.kb_revision_preview_page import \
     KBArticleRevisionsPreviewPage
 from playwright_tests.pages.explore_help_articles.articles.kb_article_show_history_page import (
@@ -35,6 +41,8 @@ from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_meta 
     KBArticleEditMetadata
 from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_page import \
     EditKBArticlePage
+from playwright_tests.pages.explore_help_articles.articles.kb_what_links_here_page import \
+    WhatLinksHerePage
 from playwright_tests.pages.explore_help_articles.articles.products_page import ProductsPage
 from playwright_tests.pages.explore_help_articles.articles.submit_kb_article_page import \
     SubmitKBArticlePage
@@ -129,6 +137,8 @@ class SumoPages:
         self.kb_article_review_revision_page = KBArticleReviewRevisionPage(page)
         self.kb_article_preview_revision_page = KBArticleRevisionsPreviewPage(page)
         self.kb_article_edit_article_metadata_page = KBArticleEditMetadata(page)
+        self.kb_what_links_here_page = WhatLinksHerePage(page)
+        self.kb_category_page = KBCategoryPage(page)
 
         # Product Topics page
         self.product_topics_page = ProductTopicPage(page)
@@ -146,9 +156,15 @@ class SumoPages:
         self.support_forums_page = SupportForumsPage(page)
         self.product_support_forum = ProductSupportForum(page)
 
+        # Article Discussions page.
+        self.article_discussions_page = ArticleDiscussionsPage(page)
+
         # Dashboard pages.
         self.kb_dashboard_page = KBDashboard(page)
         self.recent_revisions_page = RecentRevisions(page)
+
+        # Media Gallery page.
+        self.media_gallery = MediaGallery(page)
 
         # Moderate Forum Page
         self.moderate_forum_content_page = ModerateForumContent(page)
@@ -179,3 +195,6 @@ class SumoPages:
 
         # KB article edit metadata Flow
         self.edit_article_metadata_flow = EditArticleMetaFlow(page)
+
+        # KB add article media Flow
+        self.add_kb_media_flow = AddKbMediaFlow(page)

--- a/playwright_tests/pages/top_navbar.py
+++ b/playwright_tests/pages/top_navbar.py
@@ -26,12 +26,16 @@ class TopNavbar(BasePage):
 
     # Contributor Tools
     __contributor_tools_option = "//a[contains(text(),'Contributor Tools')]"
+    __article_discussions_option = ("//div[@id='main-navigation']//a[normalize-space(text("
+                                    "))='Article Discussions']")
     __moderate_forum_content = ("//div[@id='main-navigation']//a[contains(text(), 'Moderate "
                                 "Forum Content')]")
     __recent_revisions_option = ("//ul[@class='mzp-c-menu-item-list sumo-nav--sublist']//a["
                                  "normalize-space(text())='Recent Revisions']")
     __dashboards_option = ("//ul[@class='mzp-c-menu-item-list sumo-nav--sublist']//a["
                            "normalize-space(text())='Dashboards']")
+    __media_gallery_option = ("//ul[@class='mzp-c-menu-item-list sumo-nav--sublist']//a["
+                              "normalize-space(text())='Media Gallery']")
 
     # Sign in button
     __signin_signup_button = "//div[@id='profile-navigation']//a[contains(text(), 'Sign In/Up')]"
@@ -63,6 +67,10 @@ class TopNavbar(BasePage):
     def _click_on_contribute_top_navbar_option(self):
         super()._click(self.__contribute_option)
 
+    def _click_on_article_discussions_option(self):
+        super()._hover_over_element(self.__contributor_tools_option)
+        super()._click(self.__article_discussions_option)
+
     # Contributor tools
     def _click_on_moderate_forum_content_option(self):
         super()._hover_over_element(self.__contributor_tools_option)
@@ -75,6 +83,10 @@ class TopNavbar(BasePage):
     def _click_on_dashboards_option(self):
         super()._hover_over_element(self.__contributor_tools_option)
         super()._click(self.__dashboards_option)
+
+    def _click_on_media_gallery_option(self):
+        super()._hover_over_element(self.__contributor_tools_option)
+        super()._click(self.__media_gallery_option)
 
     # Explore our Help Articles actions.
     def _click_on_explore_our_help_articles_option(self):

--- a/playwright_tests/pages/user_pages/my_profile_documents_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_documents_page.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page
+from playwright.sync_api import Page, Locator
 from playwright_tests.core.basepage import BasePage
 
 
@@ -16,3 +16,7 @@ class MyProfileDocumentsPage(BasePage):
 
     def _get_text_of_document_links(self) -> list[str]:
         return super()._get_text_of_elements(self.__documents_link_list)
+
+    def _get_a_particular_document_locator(self, document_name: str) -> Locator:
+        xpath = f"//main//a[contains(text(),'{document_name}')]"
+        return super()._get_element_locator(xpath)

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -25,4 +25,11 @@ markers =
     kbArticleShowHistory: Tests belonging to the kb article show history section.
     recentRevisionsDashboard: Tests belonging to the recent revisions dashboard.
     kbDashboard: Tests belonging to the KB dashboard.
+    restrictedArticleCreation: Prerequisite for restricted visibility kb tests.
+    kbRestrictedVisibilitySingleGroup: Tests belonging to the kb article restriction with one group.
+    whitelistingDifferentGroup: Whitelisting a different group action.
+    kbRestrictedVisibilityMultipleGroups: Tests belonging to the kb article restriction with multiple restricted groups.
+    removingAllArticleRestrictions: Removing all restrictions action.
+    kbRemovedRestrictions: Tests belonging to the kb article restriction with all restrictions removed.
+    deleteAllRestrictedTestArticles: Deleting all restricted test articles.
 addopts = --alluredir=./reports/allure_reports

--- a/playwright_tests/test_data/add_kb_article.json
+++ b/playwright_tests/test_data/add_kb_article.json
@@ -1,18 +1,20 @@
 {
   "kb_article_title": "Automation test article ",
   "kb_template_title": "Template: Automation test article",
+  "kb_template_category": "Templates",
   "updated_kb_article_title": "Updated test article",
   "different_slug": "different-slug-",
-  "category_options": "Navigation",
-  "relevant_to_option": "Hubs",
-  "selected_parent_topic": "Firefox for Android",
-  "selected_child_topic": "How to use Firefox for Android",
+  "category_options": "Troubleshooting",
+  "relevant_to_option": "id_products_0",
+  "selected_parent_topic": "Firefox",
+  "selected_child_topic": "Bookmarks and tabs",
   "related_documents": "Stage test owl",
   "keywords": "auto test keyword",
   "updated_keywords": "auto updated keyword",
   "search_result_summary": "This is a search result summary test",
   "updated_search_result_summary": "Updated This is a search result summary test",
-  "article_content": "'''Lorem ipsum''' dolor ''sit amet'', consectetur [https://www.mediafax.ro adipiscing] elit, [[Stage test owl|sed]] do eiusmod tempor incididunt # ut labore * et dolore magna aliqua. Tincidunt id aliquet risus feugiat in ante. Etiam non quam lacus suspendisse faucibus interdum posuere. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Velit egestas dui id ornare arcu odio ut sem nulla. Risus nec feugiat in fermentum posuere urna nec tincidunt. Sed egestas egestas fringilla phasellus faucibus. Amet consectetur adipiscing elit duis tristique. Lorem mollis aliquam ut porttitor. Purus sit amet volutpat consequat mauris. Lobortis mattis aliquam faucibus purus in. Enim praesent elementum facilisis leo vel. Volutpat lacus laoreet non curabitur gravida arcu. Tempus iaculis urna id volutpat.",
+  "article_content": "'''Lorem ipsum''' dolor ''sit amet'', consectetur [https://www.mediafax.ro adipiscing] elit, [[Stage test owl|sed]] do eiusmod [[DoNotDelete]] tempor incididunt # ut labore * et dolore magna aliqua. Tincidunt id aliquet risus feugiat in ante. Etiam non quam lacus suspendisse faucibus interdum posuere. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Velit egestas dui id ornare arcu odio ut sem nulla. Risus nec feugiat in fermentum posuere urna nec tincidunt. Sed egestas egestas fringilla phasellus faucibus. Amet consectetur adipiscing elit duis tristique. Lorem mollis aliquam ut porttitor. Purus sit amet volutpat consequat mauris. Lobortis mattis aliquam faucibus purus in. Enim praesent elementum facilisis leo vel. Volutpat lacus laoreet non curabitur gravida arcu. Tempus iaculis urna id volutpat.",
+  "article_image": "Automation test image",
   "updated_article_content": "Updated Content",
   "article_content_html_rendered": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod DoNotDelete tempor incididunt # ut labore * et dolore magna aliqua. Tincidunt id aliquet risus feugiat in ante. Etiam non quam lacus suspendisse faucibus interdum posuere. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Velit egestas dui id ornare arcu odio ut sem nulla. Risus nec feugiat in fermentum posuere urna nec tincidunt. Sed egestas egestas fringilla phasellus faucibus. Amet consectetur adipiscing elit duis tristique. Lorem mollis aliquam ut porttitor. Purus sit amet volutpat consequat mauris. Lobortis mattis aliquam faucibus purus in. Enim praesent elementum facilisis leo vel. Volutpat lacus laoreet non curabitur gravida arcu. Tempus iaculis urna id volutpat.",
   "updated_article_content_html_rendered": "Updated Content",
@@ -22,5 +24,9 @@
   "expiry_date": "05.02.2050",
   "old_expiry_date": "05.02.2002",
   "updated_expiry_date": "07.05.2051",
-  "changes_description": "Automation description test"
+  "changes_description": "Automation description test",
+  "restricted_visibility_groups": [
+    "Accessibility",
+    "Contributors"
+  ]
 }

--- a/playwright_tests/test_data/general_data.json
+++ b/playwright_tests/test_data/general_data.json
@@ -74,6 +74,11 @@
   },
   "dashboard_links": {
     "recent_revisions": "https://support.allizom.org/en-US/kb/revisions",
-    "kb_overview": "https://support.allizom.org/en-US/contributors/kb-overview"
-  }
+    "kb_overview": "https://support.allizom.org/en-US/contributors/kb-overview",
+    "l10n_most_visited_translations": "https://support.allizom.org/ro/localization/most-visited-translations"
+  },
+  "discussions_links": {
+    "article_discussions": "https://support.allizom.org/en-US/kb/all/discussions"
+  },
+  "test_article_link": "https://support.allizom.org/en-US/kb/donotdelete"
 }

--- a/playwright_tests/test_data/restricted_visibility_articles.json
+++ b/playwright_tests/test_data/restricted_visibility_articles.json
@@ -1,0 +1,1 @@
+{"restricted_kb_article_title": "", "restricted_kb_article_url": "", "restricted_kb_article_thread": "", "restricted_kb_article_child_topic": "", "restricted_kb_template_title": "", "restricted_kb_template_url": "", "restricted_kb_template_thread": "", "simple_article_url": "", "simple_article_template_url": ""}

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
@@ -1,0 +1,1249 @@
+import json
+from typing import Any
+
+import allure
+from pytest_check import check
+import pytest
+from playwright.sync_api import expect
+from playwright_tests.core.testutilities import TestUtilities
+from playwright_tests.messages.explore_help_articles.kb_article_page_messages import (
+    KBArticlePageMessages)
+
+
+class TestKbArticleRestrictedVisibility(TestUtilities):
+    with open("test_data/restricted_visibility_articles.json", "r") as restricted_kb_articles_file:
+        restricted_kb_articles = json.load(restricted_kb_articles_file)
+    restricted_kb_articles_file.close()
+
+    # C2466509, C2483803
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_url", [
+        (restricted_kb_articles["restricted_kb_article_url"]),
+        (restricted_kb_articles["restricted_kb_template_url"]),])
+    def test_kb_restrict_visibility_to_a_single_group(self, article_url):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+        self.navigate_to_link(article_url)
+        self.sumo_pages.kb_article_page._click_on_article_option()
+        article_url = self.get_page_url()
+        with check, allure.step("Navigating to the article and verifying that 404 is not "
+                                "returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status != 404
+
+        with check, allure.step("Verifying that the correct restricted banner is displayed"):
+            assert (KBArticlePageMessages
+                    .KB_ARTICLE_RESTRICTED_BANNER in self.sumo_pages.kb_article_page
+                    ._get_restricted_visibility_banner_text())
+
+        with allure.step("Signing out from SUMO"):
+            self.delete_cookies()
+
+        with check, allure.step("Navigating to the article and verifying that 404 is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status == 404
+
+        with check, allure.step("Signing in with a user which is not part of the whitelisted "
+                                "group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+
+        with check, allure.step("Navigating to the article and verifying that 404 is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status == 404
+
+        with check, allure.step("Signing in with a user which is part of the whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+
+        with check, allure.step("Navigating to the article and verifying that 404 is not "
+                                "returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status != 404
+
+        with allure.step("Verifying that the correct restricted banner is displayed"):
+            assert (KBArticlePageMessages
+                    .KB_ARTICLE_RESTRICTED_BANNER in self.sumo_pages.kb_article_page
+                    ._get_restricted_visibility_banner_text())
+
+    #  C2466510
+    @pytest.mark.kbRestrictedVisibilityMultipleGroups
+    @pytest.mark.parametrize("article_url", [
+        (restricted_kb_articles["restricted_kb_article_url"]),
+        (restricted_kb_articles["restricted_kb_template_url"]),])
+    def test_kb_restrict_visibility_to_multiple_groups(self, article_url):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.navigate_to_link(article_url)
+        self.sumo_pages.kb_article_page._click_on_article_option()
+        article_url = self.get_page_url()
+        with allure.step("Signing in with a user which is part of the whitelisted groups"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+
+        with check, allure.step("Navigating to the article and verifying that 404 is not "
+                                "returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status != 404
+
+        with check, allure.step("Verifying that the correct restricted banner is displayed"):
+            assert (KBArticlePageMessages
+                    .KB_ARTICLE_RESTRICTED_BANNER in self.sumo_pages.kb_article_page
+                    ._get_restricted_visibility_banner_text())
+
+        with allure.step("Signing in with a user which is part of the whitelisted groups"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+
+        with check, allure.step("Navigating to the article and verifying that 404 is not "
+                                "returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status != 404
+
+        with check, allure.step("Verifying that the correct restricted banner is displayed"):
+            assert (KBArticlePageMessages
+                    .KB_ARTICLE_RESTRICTED_BANNER in self.sumo_pages.kb_article_page
+                    ._get_restricted_visibility_banner_text())
+
+        with allure.step("Signing in with a user which is not part of the whitelisted groups"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_2"]
+            ))
+
+        with allure.step("Navigating to the article and verifying that 404 is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status == 404
+
+    # C2466511, C2466512
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_url", [
+        (restricted_kb_articles['simple_article_url']),
+        (restricted_kb_articles['simple_article_template_url'])
+    ])
+    def test_kb_restricted_visibility_metadata_edit(self, article_url):
+        with allure.step("Signing in with an admin account and editing the metadata by adding a "
+                         "group as whitelisted"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(
+                single_group=super(
+                ).kb_article_test_data['restricted_visibility_groups'][0]
+            )
+
+        with allure.step("Signing in with a user which is part of the second group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+
+        with check, allure.step("Navigating to the article and verifying that 404 is not "
+                                "returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status != 404
+
+        with allure.step("Signing in with an admin account and editing the metadata by adding a "
+                         "different group as whitelisted"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(
+                single_group=super().kb_article_test_data['restricted_visibility_groups'][1]
+            )
+
+        with allure.step("Signing in with a user which is part of the second group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+
+        with check, allure.step("Navigating to the article and verifying that 404 is not "
+                                "returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status != 404
+
+        with allure.step("Signing in with a user which is not part of the whitelisted groups"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_2"]
+            ))
+
+        with check, allure.step("Navigating to the article and verifying that 404 is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status == 404
+
+        with allure.step("Signing in with an admin account and removing the first group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            (self.sumo_pages.kb_article_edit_article_metadata_page
+                ._delete_a_restricted_visibility_group_metadata(
+                    super().kb_article_test_data['restricted_visibility_groups'][0]))
+            self.sumo_pages.kb_article_edit_article_metadata_page._click_on_save_changes_button()
+
+        with allure.step("Signing in with an account belonging to the removed group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+
+        with check, allure.step("Navigating to the article and verifying that the 404 is "
+                                "returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status == 404
+
+        with allure.step("Signing in with an account that is part of the whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+
+        with check, allure.step("Navigating to the article and verifying that 404 is not "
+                                "returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status != 404
+
+        with allure.step("Signing in with an admin account and removing all restricted groups"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+            self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            (self.sumo_pages.kb_article_edit_article_metadata_page
+             ._delete_all_restricted_visibility_groups_metadata())
+            (self.sumo_pages.kb_article_edit_article_metadata_page
+             ._click_on_save_changes_button())
+
+        with allure.step("Deleting user session"):
+            self.delete_cookies()
+
+        with check, allure.step("Navigating to the article and verifying that 404 is not "
+                                "returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(article_url)
+            response = navigation_info.value
+            assert response.status != 404
+
+        with allure.step("Verifying that the restricted banner is no longer displayed"):
+            assert not (self.sumo_pages.kb_article_page
+                        ._is_restricted_visibility_banner_text_displayed())
+
+    # C2466516
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title'])
+    ])
+    def test_restricted_visibility_in_search_results(self, article_title):
+        with allure.step("Wait for ~1 minute until the kb article is available in search"):
+            self.wait_for_given_timeout(60000)
+
+        with allure.step("Clicking on the top-navbar sumo logo"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+
+        with check, allure.step("Verifying that the article is not displayed inside the search "
+                                "results"):
+            self.sumo_pages.search_page._type_into_searchbar(
+                article_title
+            )
+            expect(
+                self.sumo_pages.search_page._get_locator_of_a_particular_article(
+                    article_title
+                )
+            ).to_be_hidden()
+
+        with allure.step("Signing in with an account that is part of that whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+
+        with check, allure.step("Verifying that the article is not inside the search "
+                                "results"):
+            self.sumo_pages.search_page._type_into_searchbar(
+                article_title
+            )
+            expect(
+                self.sumo_pages.search_page._get_locator_of_a_particular_article(
+                    article_title
+                )
+            ).to_be_hidden()
+
+        with allure.step("Signing in with an account that is not part of that whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+
+        with check, allure.step("Verifying that the article is not displayed inside the search "
+                                "results"):
+            self.sumo_pages.search_page._type_into_searchbar(
+                article_title
+            )
+            expect(
+                self.sumo_pages.search_page._get_locator_of_a_particular_article(
+                    article_title
+                )
+            ).to_be_hidden()
+
+        with allure.step("Deleting the user session"):
+            self.delete_cookies()
+
+        with allure.step("Verifying that the article is not displayed inside the search results"):
+            self.sumo_pages.search_page._type_into_searchbar(
+                article_title
+            )
+            expect(
+                self.sumo_pages.search_page._get_locator_of_a_particular_article(
+                    article_title
+                )
+            ).to_be_hidden()
+
+    # C2466518
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_restricted_visibility_in_recent_revisions_single_group(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with check, allure.step("Navigating to the recent revisions page and verifying that the "
+                                "article is displayed"):
+            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with allure.step("Signing in with an account belonging to group one"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+
+        with check, allure.step("Verifying that the article is displayed"):
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with allure.step("Signing in with a user belonging to a different user group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+
+        with allure.step("Verifying that the article is not displayed"):
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_title
+                )
+            ).to_be_hidden()
+
+    # C2466518
+    @pytest.mark.kbRestrictedVisibilityMultipleGroups
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_restricted_visibility_in_recent_revisions_multiple_groups(self, article_title):
+        with allure.step("Signing in with the user belonging to group 2 and verifying that the "
+                         "article is displayed inside the recent revisions page"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+
+        with allure.step("Verifying that the article is displayed"):
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_title
+                )
+            ).to_be_visible()
+
+    # C2466518
+    @pytest.mark.kbRemovedRestrictions
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_removed_restriction_in_recent_revisions(self, article_title):
+        with allure.step("Navigating to the recent revisions page, signing out and verifying "
+                         "that the article is displayed"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['recent_revisions'])
+            expect(
+                self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
+                    article_title
+                )
+            ).to_be_visible()
+
+    # C2466524
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_kb_restricted_visibility_media_gallery_single_group(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with allure.step("Navigating to the 'Media Gallery' page"):
+            self.sumo_pages.top_navbar._click_on_media_gallery_option()
+
+        with check, allure.step("Searching for the added image and verifying that the article is "
+                                "displayed for admin users inside the 'Articles' image list"):
+            self.sumo_pages.media_gallery._fill_search_media_gallery_searchbox_input_field(
+                super().kb_article_test_data['article_image']
+            )
+            self.sumo_pages.media_gallery._click_on_media_gallery_searchbox_search_button()
+            self.sumo_pages.media_gallery._select_media_file_from_list(
+                super().kb_article_test_data['article_image']
+            )
+            assert article_title in (self.sumo_pages.media_gallery
+                                     ._get_image_in_documents_list_items_text())
+
+        with allure.step("Signing out from SUMO"):
+            self.delete_cookies()
+
+        with check, allure.step("Verifying that the article is not displayed for signed out "
+                                "users inside the 'Articles image list'"):
+            assert article_title not in (self.sumo_pages.media_gallery
+                                         ._get_image_in_documents_list_items_text())
+
+        with allure.step("Signing in with an account that is not part of a whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+
+        with check, allure.step("Verifying that the article is not displayed for users belonging "
+                                "to a non-whitelisted group inside the 'Articles image list'"):
+            assert article_title not in (self.sumo_pages.media_gallery
+                                         ._get_image_in_documents_list_items_text())
+
+        with allure.step("Signing in with an account that is part of the whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+
+        with allure.step("Verifying that the article is displayed for users belonging to a "
+                         "whitelisted inside the 'Articles image list'"):
+            assert article_title in (self.sumo_pages.media_gallery
+                                     ._get_image_in_documents_list_items_text())
+
+    # C2466524
+    @pytest.mark.kbRestrictedVisibilityMultipleGroups
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title']),
+    ])
+    def test_kb_restricted_visibility_media_gallery_multiple_groups(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+        with allure.step("Navigating to the 'Media Gallery' page"):
+            self.sumo_pages.top_navbar._click_on_media_gallery_option()
+
+        with check, allure.step("Searching for the added image and verifying that the article is "
+                                "displayed for admin users inside the 'Articles' image list"):
+            self.sumo_pages.media_gallery._fill_search_media_gallery_searchbox_input_field(
+                super().kb_article_test_data['article_image']
+            )
+            self.sumo_pages.media_gallery._click_on_media_gallery_searchbox_search_button()
+            self.sumo_pages.media_gallery._select_media_file_from_list(
+                super().kb_article_test_data['article_image']
+            )
+
+        with allure.step("Verifying that the article is displayed for users belonging to the "
+                         "second whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            assert article_title in (self.sumo_pages.media_gallery
+                                     ._get_image_in_documents_list_items_text())
+
+    # C2466524
+    @pytest.mark.kbRemovedRestrictions
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title']),
+    ])
+    def test_removed_restriction_in_media_gallery(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with allure.step("Navigating to the media gallery image page and verifying that the "
+                         "article is displayed for signed out users"):
+            self.sumo_pages.top_navbar._click_on_media_gallery_option()
+            self.sumo_pages.media_gallery._fill_search_media_gallery_searchbox_input_field(
+                super().kb_article_test_data['article_image']
+            )
+            self.sumo_pages.media_gallery._click_on_media_gallery_searchbox_search_button()
+            self.sumo_pages.media_gallery._select_media_file_from_list(
+                super().kb_article_test_data['article_image']
+            )
+            self.delete_cookies()
+            assert article_title in (self.sumo_pages.media_gallery
+                                     ._get_image_in_documents_list_items_text())
+
+    # C2466531
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("thread_title", [
+        (restricted_kb_articles['restricted_kb_article_thread']),
+        (restricted_kb_articles['restricted_kb_template_thread'])
+    ])
+    def test_kb_restricted_visibility_discussion_single_group(self, thread_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with allure.step("Navigating to the Article Discussions page"):
+            self.sumo_pages.top_navbar._click_on_article_discussions_option()
+
+        with check, allure.step("Verifying that the the kb article is displayed for admin users"):
+            expect(
+                self.sumo_pages.article_discussions_page
+                ._is_title_for_article_discussion_displayed(thread_title)
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the kb article is displayed for whitelisted "
+                                "group users"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+            expect(
+                self.sumo_pages.article_discussions_page
+                ._is_title_for_article_discussion_displayed(thread_title)
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the kb article is not displayed for signed out "
+                                "users"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.article_discussions_page
+                ._is_title_for_article_discussion_displayed(thread_title)
+            ).to_be_hidden()
+
+        with allure.step("Verifying that the kb article is displayed for non-whitelisted group "
+                         "users"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            expect(
+                self.sumo_pages.article_discussions_page
+                ._is_title_for_article_discussion_displayed(thread_title)
+            ).to_be_hidden()
+
+    # C2466531
+    @pytest.mark.kbRestrictedVisibilityMultipleGroups
+    @pytest.mark.parametrize("thread_title", [
+        (restricted_kb_articles['restricted_kb_article_thread']),
+        (restricted_kb_articles['restricted_kb_template_thread'])
+    ])
+    def test_kb_restricted_visibility_discussion_multiple_groups(self, thread_title):
+        with allure.step("Navigating to the article discussion page and verifying that the "
+                         "article is displayed inside the article discussions list for the "
+                         "second whitelisted group user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            self.navigate_to_link(
+                super().general_test_data['discussions_links']['article_discussions']
+            )
+            expect(
+                self.sumo_pages.article_discussions_page
+                ._is_title_for_article_discussion_displayed(thread_title)
+            ).to_be_visible()
+
+    # C2466531
+    @pytest.mark.kbRemovedRestrictions
+    @pytest.mark.parametrize("thread_title", [
+        (restricted_kb_articles['restricted_kb_article_thread']),
+        (restricted_kb_articles['restricted_kb_template_thread'])
+    ])
+    def test_kb_restricted_visibility_discussion_removed_restriction(self, thread_title):
+        with allure.step("Navigating to the article discussion page and verifying that the "
+                         "article is displayed for signed out users"):
+            self.delete_cookies()
+            self.navigate_to_link(
+                super().general_test_data['discussions_links']['article_discussions']
+            )
+            expect(
+                self.sumo_pages.article_discussions_page
+                ._is_title_for_article_discussion_displayed(thread_title)
+            ).to_be_visible()
+
+    # C2466533
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_title, article_url", [
+        (restricted_kb_articles['restricted_kb_article_title'],
+         restricted_kb_articles["restricted_kb_article_url"])
+    ])
+    def test_kb_restricted_visibility_in_topics_page_single_group(self, article_title,
+                                                                  article_url):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.navigate_to_link(article_url)
+        self.sumo_pages.kb_article_page._click_on_article_option()
+        with allure.step("Clicking on the article child topic"):
+            self.sumo_pages.kb_article_page._click_on_a_particular_breadcrumb(
+                self.restricted_kb_articles['restricted_kb_article_child_topic']
+            )
+
+        with check, allure.step("Verifying that the article is listed inside the article topic "
+                                "page for admin users"):
+            expect(
+                self.sumo_pages.product_topics_page._get_a_particular_article_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the article is not listed for signed out users"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.product_topics_page._get_a_particular_article_locator(
+                    article_title
+                )
+            ).to_be_hidden()
+
+        with check, allure.step("Verifying that the article is listed for users belonging to a "
+                                "whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+            expect(
+                self.sumo_pages.product_topics_page._get_a_particular_article_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with allure.step("Verifying that the article is not listed for users belonging to a "
+                         "non-whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            expect(
+                self.sumo_pages.product_topics_page._get_a_particular_article_locator(
+                    article_title
+                )
+            ).to_be_hidden()
+
+    # C2466533
+    @pytest.mark.kbRestrictedVisibilityMultipleGroups
+    @pytest.mark.parametrize("article_title, article_url", [
+        (restricted_kb_articles['restricted_kb_article_title'],
+         restricted_kb_articles["restricted_kb_article_url"])
+    ])
+    def test_kb_restricted_visibility_in_topics_page_multiple_groups(self, article_title,
+                                                                     article_url):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        self.navigate_to_link(article_url)
+        self.sumo_pages.kb_article_page._click_on_article_option()
+        with allure.step("Clicking on the article child topic"):
+            self.sumo_pages.kb_article_page._click_on_a_particular_breadcrumb(
+                self.restricted_kb_articles['restricted_kb_article_child_topic']
+            )
+
+        with allure.step("Verifying that the article is displayed for the second whitelisted "
+                         "group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            expect(
+                self.sumo_pages.product_topics_page._get_a_particular_article_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+    #  C2539825
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_kb_restricted_visibility_profile_level_single_group(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with allure.step("Navigating to the user profile page"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+
+        with allure.step("Clicking on the documents link"):
+            self.sumo_pages.my_profile_page._click_on_my_profile_document_link()
+            op_document_contributions_link = self.get_page_url()
+
+        with check, allure.step("Verifying that the article is displayed inside the document "
+                                "contribution page for admin users"):
+            expect(
+                self.sumo_pages.my_documents_page._get_a_particular_document_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the article is displayed inside the op document "
+                                "contributions list for a whitelisted user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+            self.navigate_to_link(op_document_contributions_link)
+            expect(
+                self.sumo_pages.my_documents_page._get_a_particular_document_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with allure.step("Verifying that the article is not displayed inside the op document "
+                         "contributions list for a non whitelisted user"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            self.navigate_to_link(op_document_contributions_link)
+            expect(
+                self.sumo_pages.my_documents_page._get_a_particular_document_locator(
+                    article_title
+                )
+            ).to_be_hidden()
+
+    #  C2539825
+    @pytest.mark.kbRestrictedVisibilityMultipleGroups
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])])
+    def test_kb_restricted_visibility_profile_level_multiple_groups(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with allure.step("Navigating to the user profile page"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+
+        with allure.step("Clicking on the documents link"):
+            self.sumo_pages.my_profile_page._click_on_my_profile_document_link()
+
+        with allure.step("Verifying that the article is displayed inside the op document "
+                         "contributions list for the newly whitelisted users group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            expect(
+                self.sumo_pages.my_documents_page._get_a_particular_document_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+    #  C2539825
+    @pytest.mark.kbRemovedRestrictions
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title']),
+    ])
+    def test_kb_restricted_visibility_profile_level_restriction_removed(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with allure.step("Navigating to the user profile page"):
+            self.sumo_pages.top_navbar._click_on_view_profile_option()
+
+        with allure.step("Clicking on the documents link"):
+            self.sumo_pages.my_profile_page._click_on_my_profile_document_link()
+
+        with allure.step("Verifying that the article is displayed inside the op document list "
+                         "for signed out users"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.my_documents_page._get_a_particular_document_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+    # C2468303
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_kb_restricted_visibility_in_l10n_dashboards_single_restriction(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with check, allure.step("Verifying that the article is displayed for admin users inside "
+                                "the kb-overview dashboard"):
+            self.navigate_to_link(super(
+            ).general_test_data['dashboard_links']['l10n_most_visited_translations'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the article is displayed for users belonging to "
+                                "the whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+            self.navigate_to_link(super(
+            ).general_test_data['dashboard_links']['l10n_most_visited_translations'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with allure.step("Verifying that the article is not displayed for users belonging to "
+                         "non-whitelisted groups"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            self.navigate_to_link(super(
+            ).general_test_data['dashboard_links']['l10n_most_visited_translations'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_title
+                )
+            ).to_be_hidden()
+
+    # C2468303
+    @pytest.mark.kbRemovedRestrictions
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_kb_restricted_visibility_in_l10n_dashboards_removed_restriction(self, article_title):
+        with allure.step("Signing out and verifying that the article is displayed inside the "
+                         "kb-overview dashboard"):
+            self.delete_cookies()
+            self.navigate_to_link(super(
+            ).general_test_data['dashboard_links']['l10n_most_visited_translations'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+    # C2466519
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_article_title'])
+    ])
+    def test_kb_restricted_visibility_in_dashboards_single_group(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with check, allure.step("Verifying that the article is displayed for admin users inside "
+                                "the kb-overview dashboard"):
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the article is displayed for users belonging to "
+                                "the whitelisted group"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with allure.step("Verifying that the article is not displayed for users belonging to "
+                         "non-whitelisted groups"):
+            self.sumo_pages.top_navbar._click_on_sumo_nav_logo()
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_title
+                )
+            ).to_be_hidden()
+
+    # C2466519
+    @pytest.mark.kbRemovedRestrictions
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_article_title'])
+    ])
+    def test_kb_restricted_visibility_in_dashboards_removed_restriction(self, article_title):
+        with allure.step("Signing out and verifying that the article is displayed inside the "
+                         "kb-overview dashboard"):
+            self.delete_cookies()
+            self.navigate_to_link(super().general_test_data['dashboard_links']['kb_overview'])
+            expect(
+                self.sumo_pages.kb_dashboard_page._get_a_particular_article_title_locator(
+                    article_title
+                )
+            ).to_be_visible()
+
+    # C2539174
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_kb_restricted_visibility_what_links_here_page_single_group(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with allure.step("Navigating to the test article linked to the document"):
+            self.navigate_to_link(super().general_test_data['test_article_link'])
+
+        with check, allure.step("Navigating to the 'What Links Here' page and verifying that the "
+                                "restricted article is displayed for admin accounts"):
+            self.sumo_pages.kb_article_page._click_on_what_links_here_option()
+            expect(
+                self.sumo_pages.kb_what_links_here_page
+                ._get_a_particular_what_links_here_article_locator(article_title)
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the restricted article is displayed for users "
+                                "belonging to a whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+            expect(
+                self.sumo_pages.kb_what_links_here_page
+                ._get_a_particular_what_links_here_article_locator(article_title)
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the restricted article is not displayed for "
+                                "users belonging to a non-whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            expect(
+                self.sumo_pages.kb_what_links_here_page
+                ._get_a_particular_what_links_here_article_locator(article_title)
+            ).to_be_hidden()
+
+        with allure.step("Verifying that the article is not displayed for signed out users"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_what_links_here_page
+                ._get_a_particular_what_links_here_article_locator(article_title)
+            ).to_be_hidden()
+
+    # C2539174
+    @pytest.mark.kbRestrictedVisibilityMultipleGroups
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_kb_restricted_visibility_what_links_here_page_multiple_groups(self, article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+        ))
+        with allure.step("Navigating to the test article linked to the document"):
+            self.navigate_to_link(super().general_test_data['test_article_link'])
+
+        with allure.step("Navigating to the 'What Links Here' page and verifying that the linked "
+                         "article is displayed to the newly added group members"):
+            self.sumo_pages.kb_article_page._click_on_what_links_here_option()
+            expect(
+                self.sumo_pages.kb_what_links_here_page
+                ._get_a_particular_what_links_here_article_locator(article_title)
+            ).to_be_visible()
+
+    # C2539174
+    @pytest.mark.kbRemovedRestrictions
+    @pytest.mark.parametrize("article_title", [
+        (restricted_kb_articles['restricted_kb_article_title']),
+        (restricted_kb_articles['restricted_kb_template_title'])
+    ])
+    def test_kb_restricted_visibility_what_links_here_page_removed_restrictions(self,
+                                                                                article_title):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+        with allure.step("Navigating to the test article linked to the document"):
+            self.navigate_to_link(super().general_test_data['test_article_link'])
+
+        with allure.step("Navigating to the 'What Links Here' page and verifying that the "
+                         "article is displayed for signed out users"):
+            self.sumo_pages.kb_article_page._click_on_what_links_here_option()
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_what_links_here_page
+                ._get_a_particular_what_links_here_article_locator(article_title)
+            ).to_be_visible()
+
+    # C2539824
+    @pytest.mark.kbRestrictedVisibilitySingleGroup
+    @pytest.mark.parametrize("article_title, article_url", [
+        (restricted_kb_articles['restricted_kb_article_title'],
+         restricted_kb_articles['restricted_kb_article_url']),
+        (restricted_kb_articles['restricted_kb_template_title'],
+         restricted_kb_articles['restricted_kb_template_url'])
+    ])
+    def test_kb_restricted_visibility_category_page_single_group(self, article_title, article_url):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        with check, allure.step("Navigating to the article category field and verifying that the "
+                                "restricted kb article is displayed for admin accounts"):
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            self.sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+
+            expect(
+                self.sumo_pages.kb_category_page._get_a_particular_article_locator_from_list(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the restricted kb article is displayed for users "
+                                "belonging to a whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
+            ))
+            expect(
+                self.sumo_pages.kb_category_page._get_a_particular_article_locator_from_list(
+                    article_title
+                )
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the restricted kb article is displayed for users "
+                                "belonging to a non-whitelisted group"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            expect(
+                self.sumo_pages.kb_category_page._get_a_particular_article_locator_from_list(
+                    article_title
+                )
+            ).to_be_hidden()
+
+        with allure.step("Verifying that the restricted kb article is displayed for signed out "
+                         "users"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_category_page._get_a_particular_article_locator_from_list(
+                    article_title
+                )
+            ).to_be_hidden()
+
+    # C2539824
+    @pytest.mark.kbRestrictedVisibilityMultipleGroups
+    @pytest.mark.parametrize("article_title, article_url", [
+        (restricted_kb_articles['restricted_kb_article_title'],
+         restricted_kb_articles['restricted_kb_article_url']),
+        (restricted_kb_articles['restricted_kb_template_title'],
+         restricted_kb_articles['restricted_kb_template_url'])
+    ])
+    def test_kb_restricted_visibility_category_page_multiple_groups(self, article_title,
+                                                                    article_url):
+
+        with allure.step("Verifying that the restricted kb article is displayed for the second "
+                         "whitelisted group users"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
+            ))
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_page._click_on_show_history_option()
+            self.sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+            expect(
+                self.sumo_pages.kb_category_page._get_a_particular_article_locator_from_list(
+                    article_title
+                )
+            ).to_be_visible()
+
+    # C2539824
+    @pytest.mark.kbRemovedRestrictions
+    @pytest.mark.parametrize("article_title, article_url", [
+        (restricted_kb_articles['restricted_kb_article_title'],
+         restricted_kb_articles['restricted_kb_article_url']),
+        (restricted_kb_articles['restricted_kb_template_title'],
+         restricted_kb_articles['restricted_kb_template_url'])
+    ])
+    def test_kb_restricted_visibility_category_page_removed_restriction(self, article_title,
+                                                                        article_url):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+        self.navigate_to_link(article_url)
+        self.sumo_pages.kb_article_page._click_on_show_history_option()
+        self.sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+
+        with allure.step("Navigating to the article discussion page and verifying that the "
+                         "article is displayed for signed out users"):
+            self.delete_cookies()
+            expect(
+                self.sumo_pages.kb_category_page._get_a_particular_article_locator_from_list(
+                    article_title
+                )
+            ).to_be_visible()
+
+    @pytest.mark.whitelistingDifferentGroup
+    def test_whitelisting_a_different_group(self):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        for key, value in self.restricted_kb_articles.items():
+            if key.endswith("_url"):
+                self.navigate_to_link(value)
+                self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+                self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(
+                    single_group=super().kb_article_test_data['restricted_visibility_groups'][1]
+                )
+
+    @pytest.mark.removingAllArticleRestrictions
+    def test_removing_all_article_restrictions(self):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        for key, value in self.restricted_kb_articles.items():
+            if key.endswith("_url"):
+                self.navigate_to_link(value)
+                self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+                (self.sumo_pages.kb_article_edit_article_metadata_page
+                 ._delete_all_restricted_visibility_groups_metadata())
+                (self.sumo_pages.kb_article_edit_article_metadata_page
+                 ._click_on_save_changes_button())
+
+    @pytest.mark.restrictedArticleCreation
+    def test_create_articles_for_restriction_test(self):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        restricted_kb_article = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+            single_group=super(
+            ).kb_article_test_data['restricted_visibility_groups'][0],
+            article_content_image=super().kb_article_test_data['article_image']
+        )
+
+        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+            revision_id=self.sumo_pages.kb_article_show_history_page._get_last_revision_id(),
+            ready_for_l10n=True
+        )
+        restricted_kb_article_thread = self._create_discussion_thread()
+
+        restricted_kb_template = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+            is_template=True,
+            single_group=super(
+            ).kb_article_test_data['restricted_visibility_groups'][0],
+            article_content_image=super().kb_article_test_data['article_image']
+        )
+
+        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+            revision_id=self.sumo_pages.kb_article_show_history_page._get_last_revision_id(),
+            ready_for_l10n=True
+        )
+
+        restricted_kb_template_thread = self._create_discussion_thread()
+
+        simple_article = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+
+        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+            revision_id=self.sumo_pages.kb_article_show_history_page._get_last_revision_id(),
+            ready_for_l10n=True
+        )
+
+        simple_article_template = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+            is_template=True,
+        )
+
+        self.sumo_pages.kb_article_revision_flow.approve_kb_revision(
+            revision_id=self.sumo_pages.kb_article_show_history_page._get_last_revision_id(),
+            ready_for_l10n=True
+        )
+
+        # Dumping the necessary data into a JSON for further test usage
+        dictionary = {
+            "restricted_kb_article_title": restricted_kb_article['article_title'],
+            "restricted_kb_article_url": restricted_kb_article['article_url'],
+            "restricted_kb_article_thread": restricted_kb_article_thread['thread_title'],
+            "restricted_kb_article_child_topic": restricted_kb_article['article_child_topic'],
+            "restricted_kb_template_title": restricted_kb_template['article_title'],
+            "restricted_kb_template_url": restricted_kb_template['article_url'],
+            "restricted_kb_template_thread": restricted_kb_template_thread['thread_title'],
+            "simple_article_url": simple_article["article_url"],
+            "simple_article_template_url": simple_article_template["article_url"]
+        }
+
+        with open("test_data/restricted_visibility_articles.json", "w") as restricted_articles:
+            json.dump(dictionary, restricted_articles)
+
+    def _create_discussion_thread(self) -> dict[str, Any]:
+        with allure.step("Posting a new kb article discussion thread"):
+            self.sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+            self.sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
+            thread = self.sumo_pages.post_kb_discussion_thread_flow.add_new_kb_discussion_thread()
+
+        return thread
+
+    @pytest.mark.deleteAllRestrictedTestArticles
+    def test_delete_all_created_articles(self):
+        self.start_existing_session(super().username_extraction_from_email(
+            self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+        ))
+
+        for key, value in self.restricted_kb_articles.items():
+            if key.endswith("_url"):
+                self.navigate_to_link(value)
+                self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+
+        # Deleting all articles from the JSON file
+        with open("test_data/restricted_visibility_articles.json", "w") as restricted_kbs_file:
+            json.dump({
+                "restricted_kb_article_title": "",
+                "restricted_kb_article_url": "",
+                "restricted_kb_article_thread": "",
+                "restricted_kb_article_child_topic": "",
+                "restricted_kb_template_title": "",
+                "restricted_kb_template_url": "",
+                "restricted_kb_template_thread": "",
+                "simple_article_url": "",
+                "simple_article_template_url": ""
+            }, restricted_kbs_file)

--- a/playwright_tests/tests/homepage_tests/test_homepage.py
+++ b/playwright_tests/tests/homepage_tests/test_homepage.py
@@ -63,8 +63,8 @@ class TestHomepage(TestUtilities):
                 )
 
                 assert (
-                    self.sumo_pages.kb_article_page._get_text_of_article_title()
-                    == articles_names[counter]
+                    self.sumo_pages.kb_article_page._get_text_of_article_title().strip()
+                    == articles_names[counter].strip()
                 ), (f"Incorrect featured article displayed. Expected: {featured_article} "
                     f"Received: {self.sumo_pages.kb_article_page._get_text_of_article_title()}")
 


### PR DESCRIPTION
- Expanding playwright coverage over the restricted visibility kb articles functionality.

This coverage includes checks over the expected kb discoverability when using different accounts (non-whitelisted, whitelisted, signed out and admin). The checks are performed on the following SUMO areas: Search Results, Recent Revisions page, Localization Dashboards, KB Dashboards, Media Gallery, Article Discussions page, Frequent Topics page, What Links Here page, KB Category page & user document contributions page. The above checks are performed against both restricted kb articles & restricted kb templates.

This also includes coverage for the previous test failures:
https://github.com/mozilla/sumo/issues/1658
https://github.com/mozilla/sumo/issues/1660
https://github.com/mozilla/sumo/issues/1662
https://github.com/mozilla/sumo/issues/1663

- Updated & Created some additional pages, flows & test data needed for testing the restricted kb articles functionality & for further expanding the playwright coverage (in the near future).
- Updating the workflow file to contain the newly added tests.