### PR TITLE
explicitly order results in get_helpful_votes_async

### DIFF
--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -1310,6 +1310,7 @@ def get_helpful_votes_async(request, document_slug):
             count_helpful=Count("helpful", filter=Q(helpful=True)),
             count_unhelpful=Count("helpful", filter=Q(helpful=False)),
         )
+        .order_by("date_created")
     )
 
     for res in results:


### PR DESCRIPTION
mozilla/sumo#1479

This PR fixes one of the primary causes of our flaky unit test runs. It turns out the root cause of the flakiness was because the `HelpfulVote` query in the `get_helpful_votes_async` view was not ordering the results, so it was left to the whims of Postgres to choose an ordering.  So in the end, this turned out to be a MySQL vs. Postgres "gotcha". In MySQL prior to version 8, when using a `GROUP BY` clause without an explicit `ORDER BY` clause, an implicit ascending order is always used, which does not obey the SQL standard (i.e., no ordering should be applied). When I converted the query to Postgres a number of months ago, the results were no longer reliably ordered because Postgres does obey the standard, and so doesn't order the results. The solution is to add `.order_by("date_created")` to the `HelpfulVote` query.