### PR TITLE
explicitly set the profile name to avoid random test errors

### DIFF
--- a/kitsune/users/tests/test_api.py
+++ b/kitsune/users/tests/test_api.py
@@ -23,7 +23,7 @@ class UsernamesTests(TestCase):
     url = reverse("users.api.usernames", locale="en-US")
 
     def setUp(self):
-        self.u = UserFactory(username="testUser")
+        self.u = UserFactory(username="testUser", profile__name="Ringo")
         self.client.login(username=self.u.username, password="testpass")
 
     def tearDown(self):
@@ -41,7 +41,13 @@ class UsernamesTests(TestCase):
         self.assertEqual(0, len(data))
 
     def test_query_current(self):
-        res = self.client.get(urlparams(self.url, term=self.u.username[0]))
+        # Test that we case-insensitively search the user's username.
+        res = self.client.get(urlparams(self.url, term=self.u.username[0].upper()))
+        self.assertEqual(200, res.status_code)
+        data = json.loads(res.content)
+        self.assertEqual(1, len(data))
+        # Test that we also case-insensitively search the name of the user's profile.
+        res = self.client.get(urlparams(self.url, term=self.u.profile.name.lower()))
         self.assertEqual(200, res.status_code)
         data = json.loads(res.content)
         self.assertEqual(1, len(data))


### PR DESCRIPTION
mozilla/sumo#1479

This PR fixes another random test-case failure. The `UsernamesTests.test_query_old` test case initiates a case-insensitive search for users whose `username` or `profile.name` starts with the letter `a`. In the setup for the test, a single user is created with an explicitly given `username` but a randomly generated `profile.name`. The test expects no users to be found, but since the `profile.name` is randomly generated, sometimes it's given a name that starts with the letter `a`, and the test fails. So the fix is simply to explicitly set the `profile.name` in the test setup.

I also took the opportunity to improve the quality of the `UsernamesTests.test_query_current` test case.