### PR TITLE
Update docs workflow to build directly to deployment

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,28 +1,52 @@
 name: Publish Docs in GitHub Pages
+
 on:
+  workflow_dispatch: # allow manual runs
   push:
     branches:
       - main
+    paths: # avoid extra builds
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/publish-docs.yml
+
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false # skip any intermediate builds but let finish
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - id: pages
+        uses: actions/configure-pages@v4
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: |
             mkdocs-material-
       - run: pip install mkdocs-material 
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs build -d dist
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This moves the whole build and deploy into actions workflow, skipping committing to `gh-pages` branch (that could eventually be removed), and publishing straight to the deployment environment.

It also triggers only for `docs/**` and related changes, so saves unnecessary runs when there's nothing to publish.

_(Usually needs manual switch in repo Settings from branch deploy to action deploy to work, otherwise the env is protected from the classic runs…)_