### PR TITLE
increase debounce threshold for instant searches

### DIFF
--- a/kitsune/sumo/static/sumo/js/instant_search.js
+++ b/kitsune/sumo/static/sumo/js/instant_search.js
@@ -200,7 +200,7 @@ import nunjucksEnv from "sumo/js/nunjucks"; // has to be loaded after templates
           "search_product_filter": getSearchProductFilter(),
           "search_content_filter": getSearchContentFilter()
         });
-      }, 200);
+      }, 600);
     }
 
     if (formId === "support-search" || formId === "mobile-search-results") {

--- a/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
@@ -52,7 +52,7 @@ describe('instant search', () => {
       $searchInput.val(query);
       $searchInput.trigger('input');
 
-      clock.tick(200);
+      clock.tick(600);
       // call the callback to actually render things
       cxhrMock.firstCall.args[1].success({
         num_results: 0,
@@ -70,7 +70,7 @@ describe('instant search', () => {
       $searchInput.val(query);
       $searchInput.trigger('input');
 
-      clock.tick(200);
+      clock.tick(600);
       // call the callback to actually render things
       cxhrMock.firstCall.args[1].success({
         num_results: 0,


### PR DESCRIPTION
mozilla/sumo#1717

I discovered that we're already "debouncing" changes to the instant search input box, but the pause threshold is far too low, so we're seeing too many fractured search terms in GA4. This PR increases the pause threshold from 200ms to 600ms, which should remove a lot of search-term fracturing.

### Alternative
Another option would be to make our "instant" searches behave like our searches made on the [search page](https://support.mozilla.org/en-US/search/). Those searches are only triggered once the user submits the search term via the "enter" key, so we're capturing the user's intention rather than all of the intermediate steps.