### PR TITLE
fix access to admin links

### DIFF
--- a/kitsune/dashboards/jinja2/dashboards/includes/announcement_list.html
+++ b/kitsune/dashboards/jinja2/dashboards/includes/announcement_list.html
@@ -1,11 +1,11 @@
-{% if in_staff_group(user) and user.has_perm('announcements.add_announcement') %}
+{% if user.is_staff and user.has_perm('announcements.add_announcement') %}
   <a class="add" href="{{ url('admin:announcements_announcement_add') }}">{{ _('Add announcement') }}</a>
 {% endif %}
 {% if announcements %}
   <ul id="doc-content" class="announcements">
     {% for a in announcements %}
       <li>
-        {% if in_staff_group(user) and user.has_perm('announcements.change_announcement') %}
+        {% if user.is_staff and user.has_perm('announcements.change_announcement') %}
           <a class="edit" href="{{ url('admin:announcements_announcement_change', a.id) }}">{{ _('Edit') }}</a>
         {% endif %}
         {{ a.content|wiki_to_html }}

--- a/kitsune/flagit/jinja2/flagit/includes/flagged_profile.html
+++ b/kitsune/flagit/jinja2/flagit/includes/flagged_profile.html
@@ -11,7 +11,7 @@
 <h3 class="sumo-page-intro">{{ _('Take Action:') }}</h3>
 <div class="actions sumo-button-wrap">
   <a class="sumo-button button-sm" href="{{ object.content_object.get_absolute_url() }}">View</a>
-  {% if user.has_perm('profile.change_profile') %}
+  {% if user.is_staff and user.has_perm('profile.change_profile') %}
     <a class="sumo-button button-sm edit" href="{{ url('admin:users_profile_change', object.object_id) }}">{{ _('Edit') }}</a>
   {% endif %}
 </div>

--- a/kitsune/groups/jinja2/groups/list.html
+++ b/kitsune/groups/jinja2/groups/list.html
@@ -3,7 +3,7 @@
 
 {% block content %}
   <article id="group-list" class="main sumo-page-section">
-    {% if in_staff_group(user) and user.has_perm('groups.add_groupprofile') %}
+    {% if user.is_staff and user.has_perm('groups.add_groupprofile') %}
     <div class="sumo-button-wrap">
       <a class="sumo-button primary-button add" href="{{ url('admin:groups_groupprofile_add') }}">{{ _('Add group profile') }}</a>
     </div>

--- a/kitsune/groups/jinja2/groups/profile.html
+++ b/kitsune/groups/jinja2/groups/profile.html
@@ -14,7 +14,7 @@
       {% endif %}
     </section>
     <section id="main-area">
-      {% if in_staff_group(user) and user.has_perm('groups.change_groupprofile') %}
+      {% if user.is_staff and user.has_perm('groups.change_groupprofile') %}
         <a class="edit" href="{{ url('admin:groups_groupprofile_change', profile.id) }}">{{ _('Edit in admin') }}</a>
       {% endif %}
       <h1>{{ profile.group.name }}</h1>


### PR DESCRIPTION
mozilla/sumo#1738

This PR makes some adjustments to the work in #5947. It resolves the issue above, as well as a few others where links to the admin are shown to users who may not have been `is_staff`. It looks like the `announcement_list.html` and `flagged_profile.html` files aren't used anywhere, but I'm still changing them just in case they're brought back in the future.