### PR TITLE
Stop logging warnings about missing Locales

### DIFF
--- a/kitsune/wiki/permissions.py
+++ b/kitsune/wiki/permissions.py
@@ -109,7 +109,6 @@ def _is_leader(locale, user):
     try:
         locale_team = Locale.objects.get(locale=locale)
     except Locale.DoesNotExist:
-        log.warning("Locale not created for %s" % locale)
         return False
 
     return user in locale_team.leaders.all()
@@ -126,7 +125,6 @@ def _is_reviewer(locale, user):
     try:
         locale_team = Locale.objects.get(locale=locale)
     except Locale.DoesNotExist:
-        log.warning("Locale not created for %s" % locale)
         return False
 
     return user in locale_team.reviewers.all()


### PR DESCRIPTION
Logging a warning here doesn't seem to have any benefit at the moment and creates noise during testing.

I propose we remove the logging.

