### PR TITLE
docs: Update conventions linting anchor

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -11,7 +11,7 @@ We follow most of the practices as detailed in the [Mozilla webdev
 bootcamp
 guide](https://mozweb.readthedocs.io/en/latest/guide/development_process.html).
 
-It is recommended that you [install pre-commit](hacking_howto.md/#install-lintingtools)
+It is recommended that you [install pre-commit](hacking_howto.md/#install-linting-tools)
 
 ## Type hints
 


### PR DESCRIPTION
Fixes a broken link reported by mkdocs warning in logs.

_(This is also to verify the new docs publishing workflow.)_