### PR TITLE
This proposes a fix for 1774

### DIFF
--- a/kitsune/messages/api.py
+++ b/kitsune/messages/api.py
@@ -1,13 +1,8 @@
-from django.conf import settings
-
-from django.contrib.auth.models import Group, User
-from django.db.models import Q
 from django.views.decorators.http import require_GET
 
 from kitsune.access.decorators import login_required
+from kitsune.messages.utils import create_suggestion, find_users_and_groups_by_search
 from kitsune.sumo.decorators import json_view
-from kitsune.sumo.utils import webpack_static
-from kitsune.users.templatetags.jinja_helpers import profile_avatar
 
 
 @login_required
@@ -15,38 +10,11 @@ from kitsune.users.templatetags.jinja_helpers import profile_avatar
 @json_view
 def get_autocomplete_suggestions(request):
     """An API to provide auto-complete data for user names or groups."""
-    pre = request.GET.get("term", "") or request.GET.get("query", "") or request.GET.get("to", "")
+    pre = request.GET.get("term", "") or request.GET.get("query", "")
     if not pre or not request.user.is_authenticated:
         return []
-
-    def create_suggestion(item):
-        """Create a dictionary object for the autocomplete suggestion."""
-        is_user = isinstance(item, User)
-        return {
-            "type": "User" if is_user else "Group",
-            "type_icon": webpack_static(
-                settings.DEFAULT_USER_ICON if is_user else settings.DEFAULT_GROUP_ICON
-            ),
-            "name": item.username if is_user else item.name,
-            "type_and_name": f"User: {item.username}" if is_user else f"Group: {item.name}",
-            "display_name": item.profile.name if is_user else item.name,
-            "avatar": (
-                profile_avatar(item, 24) if is_user else webpack_static(settings.DEFAULT_AVATAR)
-            ),
-        }
-
-    suggestions = []
-    user_criteria = Q(username__istartswith=pre) | Q(profile__name__istartswith=pre)
-    users = User.objects.filter(
-        user_criteria, is_active=True, profile__is_fxa_migrated=True
-    ).select_related("profile")[:10]
-
-    for user in users:
-        suggestions.append(create_suggestion(user))
-
-    if request.user.profile.in_staff_group:
-        groups = Group.objects.filter(name__istartswith=pre, profile__isnull=False)[:10]
-        for group in groups:
-            suggestions.append(create_suggestion(group))
-
+    users_and_groups = find_users_and_groups_by_search(
+        pre, show_groups=request.user.profile.in_staff_group
+    )
+    suggestions = [create_suggestion(obj) for obj in users_and_groups]
     return suggestions

--- a/kitsune/messages/api.py
+++ b/kitsune/messages/api.py
@@ -15,7 +15,7 @@ from kitsune.users.templatetags.jinja_helpers import profile_avatar
 @json_view
 def get_autocomplete_suggestions(request):
     """An API to provide auto-complete data for user names or groups."""
-    pre = request.GET.get("term", "") or request.GET.get("query", "")
+    pre = request.GET.get("term", "") or request.GET.get("query", "") or request.GET.get("to", "")
     if not pre or not request.user.is_authenticated:
         return []
 


### PR DESCRIPTION
Uses the `get_autocomplete_suggestions` method from `api.py` when we receive a GET request that contains `to`

- This ensures that what is sent as 'to' is handled like entered text
- `api.py` returns confirmed User or Group in the right format 
- We populate the field with the returned items

Caveat : if a name is passed in 'to' that is both a User and a Group, both will be returned and populated (if the user has
 permissions). The end user can remove one if they'd like. This shouldn't be a problem as the bulk of this usage will be from people clicking "Private Message" on a profile page.