### PR TITLE
Add synonyms to ES for bookmarks toolbar

### DIFF
--- a/kitsune/search/dictionaries/synonyms/en-US.txt
+++ b/kitsune/search/dictionaries/synonyms/en-US.txt
@@ -38,6 +38,7 @@ social, instagram
 # product features
 addon, extension, theme
 awesome bar, address bar, url bar, location bar, location field, url field
+bookmarks bar, bookmark bar, bookmarks toolbar, bookmark toolbar
 home page, homepage, home screen, homescreen, awesome screen, firefox hub, start screen
 search bar, search field, search strip, search box
 search engine, search provider


### PR DESCRIPTION
Added:

`bookmarks bar, bookmark bar, bookmarks toolbar, bookmark toolbar`

to product features in  `en-US.txt` synonyms file for ES.

https://github.com/mozilla/sumo/issues/1747