### PR TITLE
Expanding playwright coverage over kb article translations

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,6 +32,7 @@ on:
                     - AAQ
                     - KB Articles
                     - KB Restricted Visibility
+                    - KB Article Translation
                     - recentRevisionsDashboard
                     - kbDashboard
 
@@ -92,7 +93,7 @@ jobs:
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
             declare dispatch_test_suite="${{inputs.TestSuite}}"
-            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "messagingSystemCleanup" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "restrictedArticleCreation" "kbRestrictedVisibilitySingleGroup" "whitelistingDifferentGroup" "kbRestrictedVisibilityMultipleGroups" "removingAllArticleRestrictions" "kbRemovedRestrictions" "deleteAllRestrictedTestArticles")
+            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "messagingSystemCleanup" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "restrictedArticleCreation" "kbRestrictedVisibilitySingleGroup" "whitelistingDifferentGroup" "kbRestrictedVisibilityMultipleGroups" "removingAllArticleRestrictions" "kbRemovedRestrictions" "deleteAllRestrictedTestArticles" "kbArticleTranslation")
             if [ "$dispatch_test_suite" == "All" ] || [ "${{ github.event_name}}" == "schedule" ] ; then
                 for test in "${all_test_suites[@]}"; do
                     if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
@@ -123,6 +124,10 @@ jobs:
                         any_failures=true
                     fi
                 done
+            elif [ "$dispatch_test_suite" == "KB Article Translation" ]; then
+                if ! poetry run pytest -m kbArticleTranslation --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
+                    any_failures=true
+                fi
             else
                 if ! poetry run pytest -m $dispatch_test_suite --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
                         any_failures=true

--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -140,8 +140,3 @@ class BasePage:
             self._page.wait_for_selector(xpath, timeout=3500)
         except TimeoutError:
             print(f"{xpath} is not displayed")
-
-    # Clears the browser session storage and reloads the page after.
-    def clear_session_storage(self):
-        self._page.evaluate('window.localStorage.clear()')
-        self._page.reload()

--- a/playwright_tests/flows/auth_flows/auth_flow.py
+++ b/playwright_tests/flows/auth_flows/auth_flow.py
@@ -20,6 +20,11 @@ class AuthFlowPage(TestUtilities, AuthPage, Homepage):
             super()._add_data_to_password_input_field(password)
             super()._click_on_enter_your_password_submit_button()
 
+    def login_with_existing_session(self):
+        if super()._is_continue_with_firefox_button_displayed():
+            super()._click_on_continue_with_firefox_accounts_button()
+        super()._click_on_user_logged_in_sign_in_button()
+
     # Sign in flow.
     def sign_in_flow(
         self, username: str, account_password: str
@@ -31,7 +36,9 @@ class AuthFlowPage(TestUtilities, AuthPage, Homepage):
         if super()._is_continue_with_firefox_button_displayed():
             super()._click_on_continue_with_firefox_accounts_button()
 
-        super().clear_session_storage()
+        if super()._is_use_a_different_account_button_displayed():
+            super()._click_on_use_a_different_account_button()
+
         self.__provide_login_credentials_and_submit(username, account_password)
 
         if super()._is_enter_otp_code_input_field_displayed():

--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
@@ -39,7 +39,8 @@ class AddKbArticleFlow(TestUtilities, SubmitKBArticlePage, AddKbMediaFlow, KBArt
                                  expiry_date=None,
                                  restricted_to_groups: list[str] = None,
                                  single_group="",
-                                 approve_first_revision=False
+                                 approve_first_revision=False,
+                                 ready_for_localization=False
                                  ) -> dict[str, Any]:
         self._page.goto(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
@@ -108,11 +109,9 @@ class AddKbArticleFlow(TestUtilities, SubmitKBArticlePage, AddKbMediaFlow, KBArt
 
         # Interacting with Allow Discussion checkbox
         if (allow_discussion is True) and (super(
-
         )._is_allow_discussion_on_article_checkbox_checked() is False):
             super()._check_allow_discussion_on_article_checkbox()
         elif (allow_discussion is False) and (super(
-
         )._is_allow_discussion_on_article_checkbox_checked() is True):
             super()._check_allow_discussion_on_article_checkbox()
 
@@ -180,7 +179,10 @@ class AddKbArticleFlow(TestUtilities, SubmitKBArticlePage, AddKbMediaFlow, KBArt
 
         if approve_first_revision:
             super()._click_on_show_history_option()
-            self.approve_kb_revision(first_revision_id)
+            if ready_for_localization:
+                self.approve_kb_revision(first_revision_id, ready_for_l10n=True)
+            else:
+                self.approve_kb_revision(first_revision_id)
 
         return {"article_title": kb_article_title,
                 "article_content": kb_article_test_data["article_content"],
@@ -200,7 +202,8 @@ class AddKbArticleFlow(TestUtilities, SubmitKBArticlePage, AddKbMediaFlow, KBArt
 
     def approve_kb_revision(self, revision_id: str,
                             revision_needs_change=False,
-                            ready_for_l10n=False):
+                            ready_for_l10n=False,
+                            significance_type=''):
         if (KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT not in
                 super()._get_current_page_url()):
             super()._click_on_show_history_option()
@@ -219,6 +222,14 @@ class AddKbArticleFlow(TestUtilities, SubmitKBArticlePage, AddKbMediaFlow, KBArt
 
         if ready_for_l10n:
             super()._check_ready_for_localization_checkbox()
+
+        if significance_type != '':
+            if significance_type == 'minor':
+                super()._click_on_minor_significance_option()
+            if significance_type == 'normal':
+                super()._click_on_normal_significance_option()
+            if significance_type == 'major':
+                super()._click_on_major_significance_option()
 
         super()._click_accept_revision_accept_button()
 
@@ -285,6 +296,9 @@ class AddKbArticleFlow(TestUtilities, SubmitKBArticlePage, AddKbMediaFlow, KBArt
         if approve_revision:
             self.approve_kb_revision(revision_id)
 
+        revision_time = super()._get_revision_time(revision_id)
+
         return {"revision_id": revision_id,
+                "revision_time": revision_time,
                 "changes_description": self.kb_article_test_data['changes_description']
                 }

--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_media_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_media_flow.py
@@ -12,6 +12,5 @@ class AddKbMediaFlow(MediaGallery):
             super()._click_on_videos_filter()
 
         super()._fill_search_modal_gallery_searchbox_input_field(file_name)
-        super()._click_on_search_modal_gallery_search_button()
-        super()._select_media_file_from_list(file_name)
+        super()._select_media_file_from_list(file_name, is_modal=True)
         super()._click_on_insert_media_button()

--- a/playwright_tests/flows/explore_articles_flows/article_flows/kb_localization_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/kb_localization_flow.py
@@ -1,0 +1,94 @@
+from typing import Any
+
+from playwright.sync_api import Page
+
+from playwright_tests.core.testutilities import TestUtilities
+from playwright_tests.pages.explore_help_articles.articles.kb_article_review_revision_page import \
+    KBArticleReviewRevisionPage
+from playwright_tests.pages.explore_help_articles.articles.kb_article_show_history_page import \
+    KBArticleShowHistoryPage
+from playwright_tests.pages.explore_help_articles.articles.kb_translate_article_page import \
+    TranslateArticlePage
+from playwright_tests.pages.explore_help_articles.articles.submit_kb_article_page import \
+    SubmitKBArticlePage
+
+
+class KbArticleTranslationFlow(TranslateArticlePage, TestUtilities, SubmitKBArticlePage,
+                               KBArticleShowHistoryPage, KBArticleReviewRevisionPage):
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def _add_article_translation(self, approve_translation_revision: bool, title='', slug='',
+                                 allow_discussions=True, keyword='', summary='', body='',
+                                 save_as_draft=False, submit=True) -> dict[str, Any]:
+
+        if title != '':
+            translation_title = title
+            super()._fill_translation_title_field(translation_title)
+
+        else:
+            translation_title = super().kb_article_test_data['translated_title'] + super(
+            ).generate_random_number(1, 1000)
+            super()._fill_translation_title_field(translation_title)
+
+        if slug != '':
+            translation_slug = slug
+            super()._fill_translation_slug_field(translation_slug)
+        else:
+            translation_slug = super().kb_article_test_data['translated_slug'] + super(
+            ).generate_random_number(1, 1000)
+            super()._fill_translation_slug_field(translation_slug)
+
+        if not allow_discussions:
+            super()._click_on_allow_translated_article_comments_checkbox()
+
+        if keyword != '':
+            translation_keyword = keyword
+            super()._fill_translated_article_keyword(translation_keyword)
+        else:
+            translation_keyword = super().kb_article_test_data['translated_keyword']
+            super()._fill_translated_article_keyword(translation_keyword)
+
+        if summary != '':
+            translation_summary = summary
+            super()._fill_translated_article_summary(translation_summary)
+        else:
+            translation_summary = super().kb_article_test_data['translated_search_summary']
+            super()._fill_translated_article_summary(translation_summary)
+
+        if body != '':
+            translation_body = body
+            super()._fill_body_translation_field(translation_body)
+        else:
+            translation_body = super().kb_article_test_data['translated_body']
+            super()._fill_body_translation_field(translation_body)
+
+        if save_as_draft:
+            super()._click_on_save_translation_as_draft_button()
+
+        if submit:
+            super()._click_on_submit_translation_for_approval_button()
+            super()._fill_translation_changes_description_field(
+                super().kb_article_test_data['translated_review_description']
+            )
+            super()._click_on_description_submit_button()
+
+        first_revision_id = super()._get_last_revision_id()
+        if approve_translation_revision:
+            self.approve_kb_translation(first_revision_id)
+
+        return {
+            "translation_title": translation_title,
+            "translation_slug": translation_slug,
+            "translation_keyword": translation_keyword,
+            "translation_summary": translation_summary,
+            "translation_body": translation_body,
+            "revision_id": first_revision_id
+        }
+
+    def approve_kb_translation(self, revision_id: str):
+        super()._click_on_review_revision(
+            revision_id
+        )
+        super()._click_on_approve_revision_button()
+        super()._click_accept_revision_accept_button()

--- a/playwright_tests/messages/explore_help_articles/kb_article_page_messages.py
+++ b/playwright_tests/messages/explore_help_articles/kb_article_page_messages.py
@@ -15,12 +15,18 @@ class KBArticlePageMessages:
     UNREVIEWED_REVISION_STATUS = "Unreviewed"
     REVIEW_REVISION_STATUS = "Review"
     CURRENT_REVISION_STATUS = "Current"
+    PREVIOUS_APPROVED_REVISION_STATUS = "Approved"
+    MINOR_SIGNIFICANCE = ''
+    NORMAL_SIGNIFICANCE = 'M'
+    MAJOR_SIGNIFICANCE = 'MT'
     KB_ARTICLE_NOT_APPROVED_CONTENT = "This article doesn't have approved content yet."
     KB_ARTICLE_SUBMISSION_TITLE_ERRORS = ["Document with this Title and Locale already exists.",
                                           "Document with this Slug and Locale already exists."]
     KB_ARTICLE_RELEVANCY_ERROR = "Please select at least one product."
     KB_ARTICLE_TOPIC_ERROR = "Please select at least one topic."
     KB_ARTICLE_RESTRICTED_BANNER = "This document is restricted."
+    KB_ARTICLE_NOT_READY_FOR_TRANSLATION_BANNER = ("Traduci un document în engleză care nu este "
+                                                   "încă gata de localizare.")
 
     def get_template_error(self, article_title) -> str:
         return (f'Documents in the Template category must have titles that start with '

--- a/playwright_tests/messages/explore_help_articles/kb_translation_messages.py
+++ b/playwright_tests/messages/explore_help_articles/kb_translation_messages.py
@@ -1,0 +1,11 @@
+class KbTranslationMessages:
+    LOCALIZATION_DASHBOARD_NEEDS_REVIEW_STATUS = "Necesită revizuire"
+    LOCALIZATION_DASHBOARD_NEEDS_TRANSLATION_STATUS = "Necesită traducere"
+    LOCALIZATION_DASHBOARD_NEEDS_ACTUALIZATION_STATUS = "Necesită actualizare"
+    LOCALIZATION_DASHBOARD_TRANSLATED_STATUS = "Updated"
+
+    def _get_kb_article_translation_ro_page(self, article_slug: str) -> str:
+        return f"https://support.allizom.org/ro/kb/{article_slug}/translate"
+
+    def get_unreviewed_localization_modified_by_text(self, username: str) -> str:
+        return f"modificat de {username}"

--- a/playwright_tests/pages/contribute/contributor_tools_pages/l10n_most_visited_translations.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/l10n_most_visited_translations.py
@@ -1,0 +1,24 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page, Locator
+
+
+class MostVisitedTranslations(BasePage):
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def _get_a_particular_article_title_locator(self, article_name: str) -> Locator:
+        xpath = f"//td/a[text()='{article_name}']"
+        return super()._get_element_locator(xpath)
+
+    def _get_updated_localization_status(self, article_name: str) -> str:
+        return super()._get_text_of_element(f"//td/a[text()='{article_name}']/../"
+                                            f"following-sibling::td[@class='status']/span")
+
+    def _click_on_a_particular_article_status(self, article_name: str):
+        super()._click(f"//td/a[text()='{article_name}']/../following-sibling::td[@class='status']"
+                       f"/a")
+
+    def _get_a_particular_translation_status(self, article_name: str) -> str:
+        return super()._get_text_of_element(f"//td/a[text()='{article_name}']/../"
+                                            f"following-sibling::td[@class='status']/a").strip()

--- a/playwright_tests/pages/contribute/contributor_tools_pages/l10n_unreviewed.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/l10n_unreviewed.py
@@ -1,0 +1,18 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page, Locator
+
+
+class UnreviewedLocalizationPage(BasePage):
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def _get_listed_article(self, title: str) -> Locator:
+        return super()._get_element_locator(f"//td[@class='doc-title']/a[text()='{title}']")
+
+    def _click_on_a_listed_article(self, title: str):
+        super()._click(f"//td[@class='doc-title']/a[text()='{title}']")
+
+    def _get_modified_by_text(self, title: str) -> str:
+        return super()._get_text_of_element(f"//td[@class='doc-title']/a[text()='{title}']/"
+                                            f"following-sibling::div[@class='users']")

--- a/playwright_tests/pages/contribute/contributor_tools_pages/media_gallery.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/media_gallery.py
@@ -87,10 +87,15 @@ class MediaGallery(BasePage):
     def _click_on_upload_media_button(self):
         super()._click(self.__upload_media_button)
 
-    def _select_media_file_from_list(self, media_file_name: str):
+    def _select_media_file_from_list(self, media_file_name: str, is_modal=False):
+        if is_modal:
+            self._click_on_search_modal_gallery_search_button()
+        else:
+            self._click_on_media_gallery_searchbox_search_button()
+        xpath = f"//ol[@id='media-list']/li/a[@title='{media_file_name}']"
         # We need to wait a bit so that the list finishes to update in case of search.
         super()._wait_for_given_timeout(1000)
-        super()._click(f"//ol[@id='media-list']/li/a[@title='{media_file_name}']")
+        super()._click(xpath)
 
     def _click_on_insert_media_button(self):
         super()._click(self.__insert_media_button)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
@@ -78,6 +78,9 @@ class KBArticlePage(BasePage):
     def _get_edit_article_metadata_locator(self):
         return super()._get_element_locator(self.__editing_tools_edit_article_metadata_option)
 
+    def _click_on_translate_article_option(self):
+        super()._click(self.__editing_tools_translate_article)
+
     def _get_translate_article_option_locator(self):
         return super()._get_element_locator(self.__editing_tools_translate_article)
 

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_review_revision_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_review_revision_page.py
@@ -40,8 +40,13 @@ class KBArticleReviewRevisionPage(BasePage):
     __ready_for_localization_modal_checkbox = "//input[@id='id_is_ready_for_localization']"
     __needs_change_modal_checkbox = "//input[@id='id_needs_change']"
     __needs_change_comment_textarea = "//textarea[@id='id_needs_change_comment']"
-    __modal_accept_button = "//button[text()='Accept']"
-    __modal_cancel_button = "//form[@id='approve-modal']//a[text()='Cancel']"
+    __modal_accept_button = "//form[@id='approve-modal']/div/button"
+    __modal_cancel_button = "//form[@id='approve-modal']/div/a"
+
+    # Revision significance
+    __minor_significance = "//input[@id='id_significance_0']"
+    __normal_significance = "//input[@id='id_significance_1']"
+    __major_significance = "//input[@id='id_significance_2']"
 
     def __init__(self, page: Page):
         super().__init__(page)
@@ -123,3 +128,12 @@ class KBArticleReviewRevisionPage(BasePage):
 
     def _add_text_to_needs_change_comment(self, text: str):
         super()._fill(self.__needs_change_comment_textarea, text)
+
+    def _click_on_minor_significance_option(self):
+        super()._click(self.__minor_significance)
+
+    def _click_on_normal_significance_option(self):
+        super()._click(self.__normal_significance)
+
+    def _click_on_major_significance_option(self):
+        super()._click(self.__major_significance)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
@@ -9,6 +9,7 @@ class KBArticleShowHistoryPage(BasePage):
     __show_history_revision_history_for = ("//dt[text()='Revision history "
                                            "for:']/following-sibling::dd[1]")
     __ready_for_l10_modal_submit_button = "//button[@id='submit-l10n']"
+    __l10n_modal = "//div[@class='mzp-c-modal-window']"
 
     # Document contributors locators
     __show_history_page_banner = "//li[@class='mzp-c-notification-bar mzp-t-success']/p"
@@ -36,6 +37,9 @@ class KBArticleShowHistoryPage(BasePage):
         super().__init__(page)
 
     # Page actions.
+    def _get_l10n_modal_locator(self) -> Locator:
+        return super()._get_element_locator(self.__l10n_modal)
+
     def _get_show_history_page_banner(self) -> str:
         return super()._get_text_of_element(self.__show_history_page_banner)
 
@@ -56,6 +60,10 @@ class KBArticleShowHistoryPage(BasePage):
 
     def _click_on_ready_for_l10n_option(self, revision_id: str):
         super()._click(f"//tr[@id='{revision_id}']/td[@class='l10n']/a")
+
+    def _get_ready_for_localization_status(self, revision_id: str) -> Locator:
+        return super()._get_element_locator(f"//tr[@id='{revision_id}']/td[@class='l10n']/"
+                                            f"a[@class='yes']")
 
     def _click_on_submit_l10n_readiness_button(self):
         super()._click(self.__ready_for_l10_modal_submit_button)
@@ -158,3 +166,7 @@ class KBArticleShowHistoryPage(BasePage):
 
     def _get_all_contributors_locator(self) -> Locator:
         return super()._get_element_locator(self.__all_contributors_list_items)
+
+    def _get_revision_significance(self, revision_id: str) -> str:
+        return super()._get_text_of_element(f"//tr[@id='{revision_id}']"
+                                            f"/td[@class='significance']").strip()

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
@@ -38,6 +38,9 @@ class KBArticleEditMetadata(BasePage):
     def _clear_all_restricted_visibility_group_selections(self):
         super()._click(self.__clear_all_selected_groups_button)
 
+    def _is_clear_all_restricted_visibility_group_selection_visible(self) -> bool:
+        return super()._is_element_visible(self.__clear_all_selected_groups_button)
+
     def _add_and_select_restrict_visibility_group_metadata(self, group_name: str):
         super()._fill(self.__kb_article_restrict_visibility_field, group_name)
         super()._click(f"//div[@class='option active']/span[text()='{group_name}']")

--- a/playwright_tests/pages/explore_help_articles/articles/kb_translate_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_translate_article_page.py
@@ -1,0 +1,74 @@
+from playwright_tests.core.basepage import BasePage
+from playwright.sync_api import Page, Locator
+
+
+class TranslateArticlePage(BasePage):
+    __translating_an_unready_article_banner = "//ul[@class='user-messages']/li"
+    __list_romanian_locale = "//li/a[normalize-space(text())='română (ro)']"
+    __article_translation_page_title = "//h1[@class='sumo-page-heading']"
+    __translation_title_field = "//input[@id='id_title']"
+    __translation_slug_field = "//input[@id='id_slug']"
+    __allow_article_comments_label = "//label[@for='id_allow_discussion']"
+    __translation_keyword_field = "//input[@id='id_keywords']"
+    __translation_summary_field = "//textarea[@id='id_summary']"
+    __translation_english_readonly_field = "//div[@id='content-or-diff']/textarea"
+    __translation_ro_text = "//textarea[@id='id_content']"
+    __change_body_view = "//a[text()='Comută evidențierea sintaxei']"
+    __send_translation_for_approval_button = "//button[text()='Trimite pentru aprobare']"
+    __save_translation_as_draft_button = "//button[text()='Salvează ca ciornă']"
+    __draft_saved_successfully_message = "//div[@id='draft-message']"
+    __translation_changes_description_input_field = "//input[@id='id_comment']"
+    __translation_changes_description_submit_button = "//button[@id='submit-document-form']"
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def _click_on_romanian_locale_from_list(self):
+        super()._click(self.__list_romanian_locale)
+
+    def _get_text_of_article_unready_for_translation_banner(self) -> str:
+        return super()._get_text_of_element(self.__translating_an_unready_article_banner)
+
+    def _get_unready_for_translation_banner(self) -> Locator:
+        return super()._get_element_locator(self.__translating_an_unready_article_banner)
+
+    def _get_translate_page_title(self) -> str:
+        return super()._get_text_of_element(self.__article_translation_page_title)
+
+    def _fill_translation_title_field(self, text: str):
+        super()._fill(self.__translation_title_field, text)
+
+    def _fill_translation_slug_field(self, text: str):
+        super()._fill(self.__translation_slug_field, text)
+
+    def _click_on_allow_translated_article_comments_checkbox(self):
+        super()._click(self.__allow_article_comments_label)
+
+    def _fill_translated_article_keyword(self, text: str):
+        super()._fill(self.__translation_keyword_field, text)
+
+    def _fill_translated_article_summary(self, text: str):
+        super()._fill(self.__translation_summary_field, text)
+
+    def _get_text_of_english_version(self) -> str:
+        return super()._get_text_of_element(self.__translation_english_readonly_field)
+
+    def _fill_body_translation_field(self, text: str):
+        super()._click(self.__change_body_view)
+        super()._clear_field(self.__translation_ro_text)
+        super()._fill(self.__translation_ro_text, text)
+
+    def _click_on_submit_translation_for_approval_button(self):
+        super()._get_element_locator(self.__send_translation_for_approval_button).first.click()
+
+    def _fill_translation_changes_description_field(self, text: str):
+        super()._fill(self.__translation_changes_description_input_field, text)
+
+    def _click_on_description_submit_button(self):
+        super()._click(self.__translation_changes_description_submit_button)
+
+    def _click_on_save_translation_as_draft_button(self):
+        super()._get_element_locator(self.__save_translation_as_draft_button).first.click()
+
+    def _get_draft_success_message_locator(self) -> Locator:
+        return super()._get_element_locator(self.__draft_saved_successfully_message)

--- a/playwright_tests/pages/footer.py
+++ b/playwright_tests/pages/footer.py
@@ -14,3 +14,6 @@ class FooterSection(BasePage):
     # Footer section actions.
     def _get_all_footer_links(self) -> list[ElementHandle]:
         return super()._get_element_handles(self.__all_footer_links)
+
+    def _switch_to_ro_locale(self):
+        super()._select_option_by_value(self.__language_selector, 'ro')

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -4,6 +4,8 @@ from playwright_tests.flows.ask_a_question_flows.aaq_flows.aaq_flow import AAQFl
 from playwright_tests.flows.explore_articles_flows.article_flows.add_kb_article_flow import (
     AddKbArticleFlow)
 from playwright_tests.flows.auth_flows.auth_flow import AuthFlowPage
+from playwright_tests.flows.explore_articles_flows.article_flows.kb_localization_flow import \
+    KbArticleTranslationFlow
 from playwright_tests.flows.explore_articles_flows.article_flows.add_kb_media_flow import \
     AddKbMediaFlow
 from playwright_tests.flows.explore_articles_flows.article_flows.delete_kb_article_flow import \
@@ -20,6 +22,10 @@ from playwright_tests.pages.ask_a_question.aaq_pages.aaq_form_page import AAQFor
 from playwright_tests.pages.contribute.contributor_tools_pages.article_discussions_page import \
     ArticleDiscussionsPage
 from playwright_tests.pages.contribute.contributor_tools_pages.kb_dashboard_page import KBDashboard
+from playwright_tests.pages.contribute.contributor_tools_pages.l10n_most_visited_translations \
+    import MostVisitedTranslations
+from playwright_tests.pages.contribute.contributor_tools_pages.l10n_unreviewed import \
+    UnreviewedLocalizationPage
 from playwright_tests.pages.contribute.contributor_tools_pages.media_gallery import MediaGallery
 from playwright_tests.pages.contribute.contributor_tools_pages.moderate_forum_content import \
     ModerateForumContent
@@ -41,6 +47,8 @@ from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_meta 
     KBArticleEditMetadata
 from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_page import \
     EditKBArticlePage
+from playwright_tests.pages.explore_help_articles.articles.kb_translate_article_page import \
+    TranslateArticlePage
 from playwright_tests.pages.explore_help_articles.articles.kb_what_links_here_page import \
     WhatLinksHerePage
 from playwright_tests.pages.explore_help_articles.articles.products_page import ProductsPage
@@ -139,6 +147,7 @@ class SumoPages:
         self.kb_article_edit_article_metadata_page = KBArticleEditMetadata(page)
         self.kb_what_links_here_page = WhatLinksHerePage(page)
         self.kb_category_page = KBCategoryPage(page)
+        self.translate_article_page = TranslateArticlePage(page)
 
         # Product Topics page
         self.product_topics_page = ProductTopicPage(page)
@@ -165,6 +174,8 @@ class SumoPages:
         # Dashboard pages.
         self.kb_dashboard_page = KBDashboard(page)
         self.recent_revisions_page = RecentRevisions(page)
+        self.localization_unreviewed_page = UnreviewedLocalizationPage(page)
+        self.most_visited_translations_page = MostVisitedTranslations(page)
 
         # Media Gallery page.
         self.media_gallery = MediaGallery(page)
@@ -186,6 +197,9 @@ class SumoPages:
 
         # KB article Flow
         self.submit_kb_article_flow = AddKbArticleFlow(page)
+
+        # KB article translation Flow
+        self.submit_kb_translation_flow = KbArticleTranslationFlow(page)
 
         # KB article deletion Flow
         self.kb_article_deletion_flow = DeleteKbArticleFlow(page)

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -32,5 +32,6 @@ markers =
     kbRestrictedVisibilityMultipleGroups: Tests belonging to the kb article restriction with multiple restricted groups.
     removingAllArticleRestrictions: Removing all restrictions action.
     kbRemovedRestrictions: Tests belonging to the kb article restriction with all restrictions removed.
+    kbArticleTranslation: Tests belonging to kb article translation.
     deleteAllRestrictedTestArticles: Deleting all restricted test articles.
 addopts = --alluredir=./reports/allure_reports --tb=no

--- a/playwright_tests/test_data/add_kb_article.json
+++ b/playwright_tests/test_data/add_kb_article.json
@@ -28,5 +28,11 @@
   "restricted_visibility_groups": [
     "Accessibility",
     "Contributors"
-  ]
+  ],
+  "translated_title": "Articol Tradus",
+  "translated_slug": "articol-tradus-",
+  "translated_keyword": "Articol Automat Tradus",
+  "translated_search_summary": "Articol Automat Tradus sumar cautare",
+  "translated_body": "Body-ul articolului tradus",
+  "translated_review_description": "Descriere Traducere"
 }

--- a/playwright_tests/test_data/general_data.json
+++ b/playwright_tests/test_data/general_data.json
@@ -75,7 +75,8 @@
   "dashboard_links": {
     "recent_revisions": "https://support.allizom.org/en-US/kb/revisions",
     "kb_overview": "https://support.allizom.org/en-US/contributors/kb-overview",
-    "l10n_most_visited_translations": "https://support.allizom.org/ro/localization/most-visited-translations"
+    "l10n_most_visited_translations": "https://support.allizom.org/ro/localization/most-visited-translations",
+    "localization_unreviewed": "https://support.allizom.org/ro/localization/unreviewed"
   },
   "discussions_links": {
     "article_discussions": "https://support.allizom.org/en-US/kb/all/discussions"

--- a/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
@@ -66,6 +66,7 @@ class TestPopularTopicsPage(TestUtilities):
     @pytest.mark.productTopicsPage
     def test_aaq_redirect(self):
         with allure.step("Navigating to product topics pages"):
+            count = 0
             for product_topic in super().general_test_data["product_topics"]:
                 topic_url = super().general_test_data["product_topics"][product_topic]
                 self.navigate_to_link(topic_url)
@@ -83,10 +84,14 @@ class TestPopularTopicsPage(TestUtilities):
 
                     with allure.step("Signing in to SUMO and verifying that we are on the "
                                      "correct AAQ form page"):
-                        self.sumo_pages.auth_flow_page.sign_in_flow(
-                            username=super().user_special_chars,
-                            account_password=super().user_secrets_pass
-                        )
+                        if count == 0:
+                            self.sumo_pages.auth_flow_page.sign_in_flow(
+                                username=super().user_special_chars,
+                                account_password=super().user_secrets_pass
+                            )
+                            count += 1
+                        else:
+                            self.sumo_pages.auth_flow_page.login_with_existing_session()
                         expect(
                             self.page
                         ).to_have_url(super(

--- a/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
@@ -94,7 +94,7 @@ class TestProductSolutionsPage(TestUtilities):
         with allure.step("Accessing the contact support page via the top navbar Get Help > "
                          "Browse All products"):
             self.sumo_pages.top_navbar._click_on_browse_all_products_option()
-
+        count = 0
         for freemium_product in super().general_test_data["freemium_products"]:
             with allure.step(f"Clicking on the {freemium_product} card "):
                 self.sumo_pages.contact_support_page._click_on_a_particular_card(freemium_product)
@@ -111,10 +111,14 @@ class TestProductSolutionsPage(TestUtilities):
                              "displayed"):
                 self.sumo_pages.product_solutions_page._click_ask_now_button()
                 self.logger.info("Signing in to SUMO")
-                self.sumo_pages.auth_flow_page.sign_in_flow(
-                    username=super().user_special_chars,
-                    account_password=super().user_secrets_pass,
-                )
+                if count == 0:
+                    self.sumo_pages.auth_flow_page.sign_in_flow(
+                        username=super().user_special_chars,
+                        account_password=super().user_secrets_pass,
+                    )
+                    count += 1
+                else:
+                    self.sumo_pages.auth_flow_page.login_with_existing_session()
 
             with allure.step("Verifying that we are on the correct AAQ form page"):
                 expect(
@@ -133,7 +137,7 @@ class TestProductSolutionsPage(TestUtilities):
         with allure.step("Accessing the contact support page via the top navbar Get Help > "
                          "Browse All products"):
             self.sumo_pages.top_navbar._click_on_browse_all_products_option()
-
+        count = 0
         for premium_product in super().general_test_data["premium_products"]:
             with allure.step(f"Clicking on the {premium_product} card"):
                 self.sumo_pages.contact_support_page._click_on_a_particular_card(premium_product)
@@ -152,10 +156,14 @@ class TestProductSolutionsPage(TestUtilities):
                 self.sumo_pages.product_solutions_page._click_contact_support_button()
 
                 self.logger.info("Signing in to SUMO")
-                self.sumo_pages.auth_flow_page.sign_in_flow(
-                    username=super().user_special_chars,
-                    account_password=super().user_secrets_pass,
-                )
+                if count == 0:
+                    self.sumo_pages.auth_flow_page.sign_in_flow(
+                        username=super().user_special_chars,
+                        account_password=super().user_secrets_pass,
+                    )
+                    count += 1
+                else:
+                    self.sumo_pages.auth_flow_page.login_with_existing_session()
 
             with allure.step("Verifying that we are on the correct AAQ form page"):
                 expect(

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
@@ -174,6 +174,7 @@ class TestKBDashboard(TestUtilities, KBDashboardPageMessages):
             )
             self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
+    # C2496647
     @pytest.mark.kbDashboard
     def test_kb_dashboard_revision_deferred_status(self):
         with allure.step("Signing in with an admin account"):
@@ -217,6 +218,7 @@ class TestKBDashboard(TestUtilities, KBDashboardPageMessages):
             self.navigate_to_link(article_url)
             self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
+    # C2496646
     @pytest.mark.kbDashboard
     def test_kb_dashboard_needs_update_when_reviewing_a_revision(self):
         with allure.step("Signing in with an admin account"):
@@ -248,7 +250,7 @@ class TestKBDashboard(TestUtilities, KBDashboardPageMessages):
             self.navigate_to_link(article_url)
             self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
-    # C2266377, C2243456
+    # C2266377, C2243456, C2496646
     @pytest.mark.kbDashboard
     def test_kb_dashboard_needs_update_edit_metadata(self):
         with allure.step("Signing in with the admin account"):
@@ -304,7 +306,7 @@ class TestKBDashboard(TestUtilities, KBDashboardPageMessages):
             self.navigate_to_link(article_url)
             self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
-    # C2266378
+    # C2266378, C2489548
     @pytest.mark.kbDashboard
     def test_ready_for_l10n_kb_dashboard_revision_approval(self):
         with allure.step("Signing in with the admin account"):

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
@@ -1,0 +1,312 @@
+from playwright_tests.core.testutilities import TestUtilities
+import pytest
+import allure
+from pytest_check import check
+from playwright.sync_api import expect
+
+from playwright_tests.messages.explore_help_articles.kb_article_page_messages import (
+    KBArticlePageMessages)
+from playwright_tests.messages.explore_help_articles.kb_translation_messages import (
+    KbTranslationMessages)
+
+
+class TestArticleTranslation(TestUtilities, KbTranslationMessages):
+
+    # C2489548, C2490043
+    @pytest.mark.kbArticleTranslation
+    def test_not_ready_for_localization_articles_dashboard_status(self):
+        with allure.step("Signing in with an Admin account"):
+            username = self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        with allure.step("Create a new simple article and approving it without marking it as "
+                         "ready for localization"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                approve_first_revision=True
+            )
+            parent_article_url = self.get_page_url()
+
+        with allure.step("Clicking on the Translate Article Editing Tools option and selecting "
+                         "the ro locale"):
+            self.sumo_pages.kb_article_page._click_on_translate_article_option()
+            self.sumo_pages.translate_article_page._click_on_romanian_locale_from_list()
+            translation_url = self.get_page_url()
+
+        with check, allure.step("Verifying that the correct banner is displayed"):
+            check.equal(
+                (self.sumo_pages.translate_article_page
+                 ._get_text_of_article_unready_for_translation_banner()),
+                KBArticlePageMessages.KB_ARTICLE_NOT_READY_FOR_TRANSLATION_BANNER
+            )
+
+        with allure.step("Navigating to the localization dashboard and verifying that the "
+                         "article is not listed"):
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['l10n_most_visited_translations']
+            )
+            expect(
+                (self.sumo_pages.most_visited_translations_page
+                 ._get_a_particular_article_title_locator(article_details['article_title']))
+            ).to_be_hidden()
+
+        with allure.step("Navigating to the localization unreviewed page and verifying that the "
+                         "article is not listed"):
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['localization_unreviewed']
+            )
+            expect(
+                self.sumo_pages.localization_unreviewed_page._get_listed_article(
+                    article_details['article_title']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Navigating back to the translation page and performing a translation"):
+            self.navigate_to_link(translation_url)
+            translation = self.sumo_pages.submit_kb_translation_flow._add_article_translation(
+                approve_translation_revision=False
+            )
+
+        with allure.step("Navigating to the localization dashboard and verifying that the "
+                         "article is not listed"):
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['l10n_most_visited_translations']
+            )
+            expect(
+                (self.sumo_pages.most_visited_translations_page
+                 ._get_a_particular_article_title_locator(translation['translation_title']))
+            ).to_be_hidden()
+
+        with allure.step("Navigating to the localization unreviewed page and verifying that the "
+                         "article is displayed"):
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['localization_unreviewed']
+            )
+            expect(
+                self.sumo_pages.localization_unreviewed_page._get_listed_article(
+                    translation['translation_title']
+                )
+            ).to_be_visible()
+
+        with check, allure.step("Verifying that the correct modified by text is displayed"):
+            check.equal(
+                self.sumo_pages.localization_unreviewed_page._get_modified_by_text(
+                    translation['translation_title']
+                ),
+                super().get_unreviewed_localization_modified_by_text(username)
+            )
+        with allure.step("Clicking on the article approving the revision"):
+            self.sumo_pages.localization_unreviewed_page._click_on_a_listed_article(
+                translation['translation_title']
+            )
+            self.sumo_pages.submit_kb_translation_flow.approve_kb_translation(
+                translation['revision_id']
+            )
+
+        with allure.step("Navigating to the localization unreviewed page and verifying that the "
+                         "article is not displayed"):
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['l10n_most_visited_translations']
+            )
+            expect(
+                self.sumo_pages.localization_unreviewed_page._get_listed_article(
+                    translation['translation_title']
+                )
+            ).to_be_hidden()
+
+        with check, allure.step("Navigating to the localization dashboard and verifying that the "
+                                "article is not displayed"):
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['l10n_most_visited_translations']
+            )
+            expect(
+                self.sumo_pages.localization_unreviewed_page._get_listed_article(
+                    translation['translation_title']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Navigating to the parent article and marking it as ready for l10n"):
+            self.navigate_to_link(parent_article_url)
+            self.sumo_pages.kb_article_show_history_page._click_on_ready_for_l10n_option(
+                article_details['first_revision_id']
+            )
+            self.sumo_pages.kb_article_show_history_page._click_on_submit_l10n_readiness_button()
+
+        with check, allure.step("Navigating to the localization dashboard and verifying that the "
+                                "article is displayed with the correct status"):
+            self.wait_for_given_timeout(2000)
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['l10n_most_visited_translations']
+            )
+            check.equal(
+                self.sumo_pages.most_visited_translations_page._get_updated_localization_status(
+                    translation['translation_title']
+                ),
+                super().LOCALIZATION_DASHBOARD_TRANSLATED_STATUS
+            )
+
+        with allure.step("Deleting the parent article"):
+            self.navigate_to_link(parent_article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+
+        with check, allure.step("Manually navigating to the 'Discuss' endpoint and verifying "
+                                "that the 404 page is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    translation_url
+                )
+            response = navigation_info.value
+            assert response.status == 404
+
+    # C2489548
+    @pytest.mark.kbArticleTranslation
+    def test_ready_for_localization_articles_dashboard_status(self):
+        with allure.step("Signing in with an Admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        with allure.step("Create a new simple article and marking it as ready for localization"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                approve_first_revision=True, ready_for_localization=True
+            )
+            parent_article_url = self.get_page_url()
+
+        with check, allure.step("Navigating to the localization dashboard and verifying that the "
+                                "correct status is displayed"):
+            self.wait_for_given_timeout(2000)
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['l10n_most_visited_translations']
+            )
+            check.equal(
+                (self.sumo_pages.most_visited_translations_page
+                 ._get_a_particular_translation_status(article_details['article_title'])),
+                super().LOCALIZATION_DASHBOARD_NEEDS_TRANSLATION_STATUS
+            )
+
+        with allure.step("Navigating to the article translation page and verifying that no "
+                         "banner is displayed"):
+            self.sumo_pages.most_visited_translations_page._click_on_a_particular_article_status(
+                article_details['article_title']
+            )
+            translation_url = self.get_page_url()
+            expect(
+                self.sumo_pages.translate_article_page._get_unready_for_translation_banner()
+            ).to_be_hidden()
+
+        with allure.step("Performing an article translation"):
+            translation = self.sumo_pages.submit_kb_translation_flow._add_article_translation(
+                approve_translation_revision=False
+            )
+
+        with check, allure.step("Navigating to the localization dashboard and verifying that the "
+                                "correct status is displayed"):
+            self.wait_for_given_timeout(2000)
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['l10n_most_visited_translations']
+            )
+            check.equal(
+                (self.sumo_pages.most_visited_translations_page
+                 ._get_a_particular_translation_status(translation['translation_title'])),
+                super().LOCALIZATION_DASHBOARD_NEEDS_REVIEW_STATUS
+            )
+
+        with check, allure.step("Navigating to the article translation and approving the "
+                                "translation revision"):
+            self.sumo_pages.most_visited_translations_page._click_on_a_particular_article_status(
+                translation['translation_title']
+            )
+            self.sumo_pages.submit_kb_translation_flow.approve_kb_translation(
+                translation['revision_id']
+            )
+
+        with check, allure.step("Navigating to the localization dashboard an verifying that the "
+                                "correct status is displayed"):
+            self.wait_for_given_timeout(2000)
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['l10n_most_visited_translations']
+            )
+            check.equal(
+                self.sumo_pages.most_visited_translations_page._get_updated_localization_status(
+                    translation['translation_title']
+                ),
+                super().LOCALIZATION_DASHBOARD_TRANSLATED_STATUS
+            )
+
+        with allure.step("Deleting the parent article"):
+            self.navigate_to_link(parent_article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()
+
+        with check, allure.step("Manually navigating to the 'Discuss' endpoint and verifying "
+                                "that the 404 page is returned"):
+            with self.page.expect_navigation() as navigation_info:
+                self.navigate_to_link(
+                    translation_url
+                )
+            response = navigation_info.value
+            assert response.status == 404
+
+    # C2490043
+    @pytest.mark.kbArticleTranslation
+    def test_revisions_cannot_be_marked_as_ready_for_l10n_if_lacking_permissions(self):
+        with allure.step("Signing in with an Admin account"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+        with allure.step("Create a new simple article and marking it as ready for localization"):
+            article_details = self.sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+                approve_first_revision=True
+            )
+        article_url = self.get_page_url()
+
+        with allure.step("Signing in with a different account that has no permissions to mark a "
+                         "revision as ready for l10n"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_2"]
+            ))
+
+        with allure.step("Clicking on the ready for l10n button and verifying that it has no "
+                         "effect"):
+            self.sumo_pages.kb_article_show_history_page._click_on_ready_for_l10n_option(
+                article_details['first_revision_id']
+            )
+            self.wait_for_given_timeout(2000)
+            expect(
+                self.sumo_pages.kb_article_show_history_page._get_l10n_modal_locator()
+            ).to_be_hidden()
+
+            expect(
+                self.sumo_pages.kb_article_show_history_page._get_ready_for_localization_status(
+                    article_details['first_revision_id']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Navigating to the localization dashboard and verifying that the "
+                         "article is not listed"):
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['l10n_most_visited_translations']
+            )
+            expect(
+                (self.sumo_pages.most_visited_translations_page
+                 ._get_a_particular_article_title_locator(article_details['article_title']))
+            ).to_be_hidden()
+
+        with allure.step("Navigating to the localization unreviewed page and verifying that the "
+                         "article is not listed"):
+            self.navigate_to_link(
+                super().general_test_data['dashboard_links']['localization_unreviewed']
+            )
+            expect(
+                self.sumo_pages.localization_unreviewed_page._get_listed_article(
+                    article_details['article_title']
+                )
+            ).to_be_hidden()
+
+        with allure.step("Navigating back to the article and deleting it"):
+            self.start_existing_session(super().username_extraction_from_email(
+                self.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
+            ))
+
+            self.navigate_to_link(article_url)
+            self.sumo_pages.kb_article_deletion_flow.delete_kb_article()

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
@@ -149,6 +149,10 @@ class TestKbArticleRestrictedVisibility(TestUtilities):
             ))
             self.navigate_to_link(article_url)
             self.sumo_pages.kb_article_page._click_on_edit_article_metadata()
+            if (self.sumo_pages.kb_article_edit_article_metadata_page
+                    ._is_clear_all_restricted_visibility_group_selection_visible()):
+                (self.sumo_pages.kb_article_edit_article_metadata_page
+                    ._clear_all_restricted_visibility_group_selections())
             self.sumo_pages.edit_article_metadata_flow.edit_article_metadata(
                 single_group=super(
                 ).kb_article_test_data['restricted_visibility_groups'][0]

--- a/playwright_tests/tests/user_page_tests/test_my_questions.py
+++ b/playwright_tests/tests/user_page_tests/test_my_questions.py
@@ -150,10 +150,7 @@ class TestMyQuestions(TestUtilities):
                          "message and the question list is no longer displayed"):
             self.delete_cookies()
             self.sumo_pages.top_navbar._click_on_signin_signup_button()
-            self.sumo_pages.auth_flow_page.sign_in_flow(
-                username=super().user_special_chars,
-                account_password=super().user_secrets_pass
-            )
+            self.sumo_pages.auth_flow_page.login_with_existing_session()
             self.sumo_pages.top_navbar._click_on_view_profile_option()
             self.sumo_pages.user_navbar._click_on_my_questions_option()
             assert (


### PR DESCRIPTION
- Adding playwright coverage for KB article translation.
- Adding the new kb article translation tests to pytest.ini and playwright.yml workflow file.
- Adding test data for KB article translation.
- Adding Page object & flows for kb article translation.
- Mapping some automated tests with existing TestRail manual tests.
- Expanding the coverage for some existing kb article tests.
- Trying to fix the random OIDC failure when creating the auth sessions.