### PR TITLE
restore more natural width of product metadata tooltip

### DIFF
--- a/kitsune/sumo/static/sumo/scss/base/_utilities.scss
+++ b/kitsune/sumo/static/sumo/scss/base/_utilities.scss
@@ -131,6 +131,7 @@
     z-index: 1;
     visibility: hidden;
     overflow-wrap: break-word;
+    width: max-content;
 
     @media #{p.$mq-xs} {
       max-width: p.$content-xs;


### PR DESCRIPTION
The [original SCSS code for the product metadata tooltip](https://github.com/mozilla/kitsune/pull/6032) included a `width: max-content` that combined with the `max-width` settings for the various screen sizes to create a more natural width for that tooltip. That was lost when the [fix for the product metadata overlap](https://github.com/mozilla/kitsune/pull/6034) was merged. This PR restores it.

## Current
<img width="805" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/90447f1a-e036-45cb-83e0-40e2828916ec">

## After (various screen widths shown)
<img width="1059" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/3ebd071b-cb4c-4a30-aeda-65374b70ca2c">

<img width="745" alt="image" src="https://github.com/mozilla/kitsune/assets/3743693/278e6994-5d7c-4bac-822e-d7e9f73b4028">


