### PR TITLE
Remove 'Last updated' meta from unapproved doc

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -19,9 +19,11 @@
       {{ product_titles | truncate(truncate_length) }}
       <span class="tooltip">{{ product_titles }}</span>
     </span>
+    {% if created_date %}
     <span class="last-updated">
       <img class="pencil" src="{{ webpack_static('sumo/img/pencil.svg') }}" /> <strong>{{ _("Last updated") }}:</strong> <span class="time">{{ created_date|naturaltime }}</span>
     </span>
+    {% endif %}
     {% if helpful_votes %}
     <span class="helpful-info">
       <img class="thumbsup" src="{{ webpack_static('sumo/img/thumbs-up.svg') }}"/>{{ _('<span class="{0}">{1}{2}</span> of users voted this helpful')|fe("helpful-count", helpful_votes, "%") }}


### PR DESCRIPTION
If there isn't a created date for the revision, we aren't going to display any date metadata.

This is usually only the case when a document is new and has no approved revisions. It doesn't seem relevant to display the unapproved revision created date as meta, especially since the review process lists the rev date out in the primary listing for approvers.