### PR TITLE
Address Wagtail CSP issues

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -459,7 +459,9 @@ TEMPLATES = [
     },
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [
+            path("dist"),
+        ],
         "APP_DIRS": True,
         "OPTIONS": {
             "debug": DEBUG,
@@ -1204,6 +1206,8 @@ CSP_IMG_SRC = (
     "https://*.google-analytics.com",
     "https://profile.accounts.firefox.com",
     "https://firefoxusercontent.com",
+    "http://www.gravatar.com",
+    "https://www.gravatar.com",
     "https://secure.gravatar.com",
     "https://i1.wp.com",
     "https://mozillausercontent.com",
@@ -1248,6 +1252,7 @@ CSP_CONNECT_SRC = (
     "https://accounts.firefox.com/metrics-flow",
     "https://accounts.stage.mozaws.net/metrics-flow",
     "https://basket.mozilla.org",
+    "https://releases.wagtail.org",
 )
 
 if DEBUG:

--- a/kitsune/sumo/static/sumo/scss/wagtail.scss
+++ b/kitsune/sumo/static/sumo/scss/wagtail.scss
@@ -1,0 +1,4 @@
+.sw-login-headline {
+    font-size: 1.5rem;
+    text-align: center;
+}

--- a/kitsune/sumo/templates/wagtailadmin/admin_base.html
+++ b/kitsune/sumo/templates/wagtailadmin/admin_base.html
@@ -1,4 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
+{% load i18n wagtailadmin_tags %}
 {% load sumo_tags %}
 
 {% block branding_favicon %}
@@ -6,3 +7,57 @@
 {% endblock %}
 
 {% block branding_title %}{{ _("Mozilla Support") }}{% endblock %}
+
+{% block extra_css %}
+  {% include "entrypoints/wagtail.html" %}
+{% endblock %}
+
+{% block js %}
+    <script nonce="{{ request.csp_nonce }}">
+        (function(document, window) {
+            window.wagtailConfig = window.wagtailConfig || {};
+            wagtailConfig.ADMIN_API = {
+                PAGES: '{% url "wagtailadmin_api:pages:listing" %}',
+                DOCUMENTS: '{% url "wagtailadmin_api:documents:listing" %}',
+                IMAGES: '{% url "wagtailadmin_api:images:listing" %}',
+                {# // Use this to add an extra query string on all API requests. #}
+                {# // Example value: '&order=-id' #}
+                EXTRA_CHILDREN_PARAMETERS: '',
+            };
+
+            {% i18n_enabled as i18n_enabled %}
+            {% locales as locales %}
+            wagtailConfig.I18N_ENABLED = {% if i18n_enabled %}true{% else %}false{% endif %};
+            wagtailConfig.LOCALES = {{ locales|safe }};
+
+            {% if locale %}
+                wagtailConfig.ACTIVE_CONTENT_LOCALE = '{{ locale.language_code }}'
+            {% endif %}
+
+            wagtailConfig.STRINGS = {% js_translation_strings %};
+
+            wagtailConfig.ADMIN_URLS = {
+                PAGES: '{% url "wagtailadmin_explore_root" %}'
+            };
+        })(document, window);
+    </script>
+    {% wagtail_config as config %}
+    {{ config|json_script:"wagtail-config" }}
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery-3.6.0.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery-ui-1.13.2.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.datetimepicker.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-transition.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-modal.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
+    <script src="{% url 'wagtailadmin_javascript_catalog' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/core.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/wagtailadmin.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/telepath/telepath.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/sidebar.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
+
+    {% hook_output 'insert_global_admin_js' %}
+
+    {% block extra_js %}{% endblock %}
+{% endblock %}

--- a/kitsune/sumo/templates/wagtailadmin/login.html
+++ b/kitsune/sumo/templates/wagtailadmin/login.html
@@ -24,9 +24,9 @@
 
         {% block above_login %}{% endblock %}
 
-        <p style="text-align:center; font-weight: bold; font-size: 150%">
+        <h2 class="sw-login-headline">
             <a href="{% url 'oidc_authentication_init' %}?next=/cms">{{ _("Sign in via SSO") }}</a>
-        </p>
+        </h2>
 
         {% block below_login %}{% endblock %}
 

--- a/kitsune/sumo/templates/wagtailadmin/shared/icons.html
+++ b/kitsune/sumo/templates/wagtailadmin/shared/icons.html
@@ -1,0 +1,9 @@
+{% spaceless %}
+    <div class="w-hidden">
+        <svg>
+            <defs>
+                {{ icons|safe }}
+            </defs>
+        </svg>
+    </div>
+{% endspaceless %}

--- a/webpack/entrypoints-html.js
+++ b/webpack/entrypoints-html.js
@@ -11,7 +11,7 @@ module.exports = Object.keys(entrypoints).map(entry =>
     inject: false,
     scriptLoading: "defer",
     templateContent: ({htmlWebpackPlugin}) => {
-      if (entry == "screen") {
+      if ((entry == "screen") || (entry == "wagtail")) {
         return `<link href="${htmlWebpackPlugin.files.css[0]}" rel="stylesheet" nonce="{{ request.csp_nonce }}">`;
       }
       // inject nonce in the script for django-csp to populate

--- a/webpack/entrypoints.js
+++ b/webpack/entrypoints.js
@@ -1,5 +1,6 @@
 const entrypoints = {
   screen: ["sumo/scss/screen.scss"],
+  wagtail: ["sumo/scss/wagtail.scss"],
   common: [
     "sumo/js/i18n.js",
     "sumo/js/kbox.js",


### PR DESCRIPTION
mozilla/sumo#1817

## Highlights
- This PR ensures a tight CSP policy for Wagtail CMS login page (`/cms/login/`), but loosens the policy with `unsafe-inline` for `script-src` and `style-src` for all of the other Wagtail CMS pages (`/cms/*`), which are currently restricted to Mozilla LDAP users.
- It looks possible to remove `unsafe-inline` for all of the non-login Wagtail CMS pages, but that'll require calculating some hashes for scripts that are constant, overriding about 17 other templates (by copying most of their code) and adding a `nonce` to all of their inline scripts, and that's only what I know so far. There may be more. All of that work is postponed until a later date. Hopefully, Wagtail will resolve more of their CSP issues before we need to tackle that, but I think we'll need to tackle that at the point when we're ready to open the Wagtail CMS to users outside of Mozilla.
- It adds a new `wagtail.scss` file that's built by our usual `webpack` flow and included in all of the Wagtail CMS pages, so we can add our own CSS as needed.
- It overrides `wagtail/admin/templates/wagtailadmin/admin_base.html` with `kitsune/sumo/templates/wagtailadmin/admin_base.html` to include a `nonce` to secure the inline script it contains. It's not clean in the sense that it copies code from Wagtail, but I couldn't see any other way forward.