### PR TITLE
Make `products/` configurable and served in WT

### DIFF
--- a/kitsune/products/jinja2/products/blocks/product_snippet_block.html
+++ b/kitsune/products/jinja2/products/blocks/product_snippet_block.html
@@ -1,0 +1,17 @@
+<div class="card card--product zoom-on-hover"> 
+  {% set product = value.product %}
+  <img class="card--icon" src="{{ product.image_url }}" alt="{{ product.title }}" />
+  <div class="card--details">
+    <h3 class="card--title">
+      <a class="expand-this-link" href="{{ url('products.product', slug=product.slug) }}"
+          data-event-name="link_click"
+          data-event-parameters='{
+            "link_name": "product-home",
+            "link_detail": "{{ product.slug }}"
+          }'>
+        {{ product.title }}
+      </a>
+    </h3>
+    <p class="card--desc">{{ product.description }}</p>
+  </div>
+</div>

--- a/kitsune/products/jinja2/products/product_card_preview.html
+++ b/kitsune/products/jinja2/products/product_card_preview.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% set title = _('Products') %}
+{% block contentwrap %}
+  <section class="mzp-l-content sumo-page-section" id="main-content">
+    <div class="sumo-card-grid is-product-wrap">
+      <div class="scroll-wrap">
+        <div class="card card--product zoom-on-hover"> 
+          <img class="card--icon" src="{{ object.image_url }}" alt="{{ object.title }}" />
+          <div class="card--details">
+            <h3 class="card--title">
+              <a class="expand-this-link" href=""
+                 data-event-name="link_click"
+                 data-event-parameters='{
+                   "link_name": "product-home",
+                   "link_detail": "{{ object.slug }}"
+                 }'>
+                {{ object.title }}
+              </a>
+            </h3>
+            <p class="card--desc">{{ object.description }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/kitsune/products/jinja2/products/products.html
+++ b/kitsune/products/jinja2/products/products.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from 'products/includes/product_macros.html' import product_cards with context %}
-{% set title = _('Products') %}
+
 {% set crumbs = [(None, title)] %}
 {% set canonical_url = canonicalize(viewname='products') %}
 {% set ga_content_group = "list-products" %}
@@ -16,7 +16,7 @@
   </div>
   <div class="mzp-l-content narrow">
     <div class="home-search-section--content">
-      <h1 class="sumo-page-heading-xl">{{ title }}</h1>
+      <h1 class="sumo-page-heading-xl">{{ page.title }}</h1>
       {{ search_box(settings, id='support-search-masthead', params=search_params) }}
     </div>
   </div>
@@ -26,6 +26,12 @@
 
 {% block contentwrap %}
   <section class="mzp-l-content sumo-page-section" id="main-content">
-    {{ product_cards(products) }}
+    <div class="sumo-card-grid is-product-wrap">
+      <div class="scroll-wrap">
+        {% for block in page.body %}
+            {{ block.render() }}
+        {% endfor %}
+        <div class="sumo-card-grid is-product-wrap">
+    <div class="scroll-wrap">
   </section>
 {% endblock %}

--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -16,7 +16,7 @@ from kitsune.wiki.facets import documents_for, topics_for
 from kitsune.wiki.utils import get_featured_articles
 
 
-@check_simple_wiki_locale
+@check_simple_wiki_locale  # Is this important for Wagtail?
 def product_list(request):
     """The product picker page."""
     template = "products/products.html"

--- a/kitsune/urls.py
+++ b/kitsune/urls.py
@@ -9,6 +9,8 @@ from waffle.views import wafflejs
 from wagtail.urls import serve_pattern
 import wagtail.views
 
+from wagtail import urls as wagtail_urls
+
 from kitsune.dashboards.api import WikiMetricList
 from kitsune.sumo import views as sumo_views
 from kitsune.sumo.i18n import i18n_patterns
@@ -24,6 +26,7 @@ from django.contrib import admin  # noqa
 admin.autodiscover()
 
 urlpatterns = i18n_patterns(
+    path("products/", include(wagtail_urls)),
     path("kb", include("kitsune.wiki.urls")),
     path("search/", include("kitsune.search.urls")),
     path("forums/", include("kitsune.forums.urls")),


### PR DESCRIPTION
* Register Product model as Wagtail snippet
* Add panels and preview template for Products
* Add a custom `StructBlock` for Products that lets user choose products
* Add ability to preview block in `/cms/`
* Add a new page type "LandingPage" that user can add to site and configure
* Allow user to preview new page in `/cms/`

NOTE: To use this locally, you need to enable wagtail admin, and set up a Site in the admin that has a root at /products. This URL approach is one that works, but I'm looking at other options.