### PR TITLE
Expanding playwright localization coverage

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,6 +49,10 @@ env:
     TEST_ACCOUNTS_PS: ${{secrets.AUTOMATION_ACCOUNTS_PASSWORD}}
     TEST_ACCOUNT_MODERATOR: ${{secrets.AUTOMATION_MODERATOR_ACCOUNT}}
     BROWSER: ${{secrets.BROWSER}}
+    DATABASE_URL: postgres://kitsune:kitsune@postgres:5432/kitsune
+    SECRET_KEY: secret
+    REDIS_DEFAULT_URL=: edis://redis:6379/1
+    REDIS_HELPFULVOTES_URL: redis://redis:6379/2
 
 
 jobs:

--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -58,6 +58,14 @@ class BasePage:
         self.__wait_for_dom_load_to_finnish()
         return locator.get_attribute(attribute)
 
+    def _get_attribute_values_of_elements(self, locator: list[Locator],
+                                          attribute: str) -> list[str]:
+        self.__wait_for_dom_load_to_finnish()
+        values = []
+        for element in locator:
+            values.append(element.get_attribute(attribute))
+        return values
+
     def _wait_for_given_timeout(self, timeout: float):
         self._page.wait_for_timeout(timeout)
 

--- a/playwright_tests/core/testutilities.py
+++ b/playwright_tests/core/testutilities.py
@@ -154,6 +154,9 @@ class TestUtilities:
         if response.status >= 400:
             self.refresh_page()
 
+    def set_extra_http_headers(self, headers):
+        self.page.set_extra_http_headers(headers)
+
     # Wait for a given timeout
     def wait_for_given_timeout(self, milliseconds: int):
         self.page.wait_for_timeout(milliseconds)

--- a/playwright_tests/pages/footer.py
+++ b/playwright_tests/pages/footer.py
@@ -6,7 +6,8 @@ class FooterSection(BasePage):
 
     # Footer section locators.
     __all_footer_links = "//footer//a"
-    __language_selector = "mzp-c-language-switcher-select"
+    __language_selector = "//select[@id='mzp-c-language-switcher-select']"
+    __language_selector_options = "//select[@id='mzp-c-language-switcher-select']/option"
 
     def __init__(self, page: Page):
         super().__init__(page)
@@ -15,5 +16,9 @@ class FooterSection(BasePage):
     def _get_all_footer_links(self) -> list[ElementHandle]:
         return super()._get_element_handles(self.__all_footer_links)
 
-    def _switch_to_ro_locale(self):
-        super()._select_option_by_value(self.__language_selector, 'ro')
+    def _get_all_footer_locales(self) -> list[str]:
+        return super()._get_attribute_values_of_elements(super()._get_elements_locators(
+            self.__language_selector_options), "value")
+
+    def _switch_to_a_locale(self, locale: str):
+        super()._select_option_by_value(self.__language_selector, locale)

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
@@ -28,7 +28,9 @@ class TestRecentRevisionsDashboard(TestUtilities):
 
         with allure.step("Navigating to the recent revisions dashboard and verifying that the "
                          "posted article is displayed for admin accounts"):
-            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            self.navigate_to_link(
+                self.general_test_data['dashboard_links']['recent_revisions']
+            )
             expect(
                 self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
                     article_details['article_title']
@@ -92,7 +94,9 @@ class TestRecentRevisionsDashboard(TestUtilities):
 
         with allure.step("Navigating back to the recent revisions page and verifying that the "
                          "article is no longer displayed"):
-            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            self.navigate_to_link(
+                self.general_test_data['dashboard_links']['recent_revisions']
+            )
             expect(
                 self.sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
                     article_details['article_title']
@@ -127,7 +131,9 @@ class TestRecentRevisionsDashboard(TestUtilities):
 
         with allure.step("Navigating to the Recent Revisions dashboard and verifying that own "
                          "revision is visible"):
-            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            self.navigate_to_link(
+                self.general_test_data['dashboard_links']['recent_revisions']
+            )
             expect(
                 self.sumo_pages.recent_revisions_page.
                 _get_recent_revision_based_on_article_title_and_user(
@@ -210,7 +216,9 @@ class TestRecentRevisionsDashboard(TestUtilities):
         with allure.step("Navigating back to the recent revision dashboard, signing out and "
                          "verifying that the revision is no longer displayed for the deleted kb "
                          "article"):
-            self.sumo_pages.top_navbar._click_on_recent_revisions_option()
+            self.navigate_to_link(
+                self.general_test_data['dashboard_links']['recent_revisions']
+            )
             self.wait_for_given_timeout(1000)
             self.delete_cookies()
             expect(

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
@@ -920,7 +920,7 @@ class TestKbArticleRestrictedVisibility(TestUtilities):
                 )
             ).to_be_visible()
 
-    # C2539174
+    # C2539174 C2101640
     @pytest.mark.kbRestrictedVisibilitySingleGroup
     @pytest.mark.parametrize("article_title", [
         (restricted_kb_articles['restricted_kb_article_title']),

--- a/playwright_tests/tests/footer_tests/test_footer.py
+++ b/playwright_tests/tests/footer_tests/test_footer.py
@@ -1,8 +1,9 @@
+import re
 import allure
 import pytest
 import requests
 from pytest_check import check
-
+from playwright.sync_api import expect
 from playwright_tests.core.testutilities import TestUtilities
 from urllib.parse import urljoin
 
@@ -42,3 +43,14 @@ class TestFooter(TestUtilities):
             # We are currently treating them as pass cases.
             with check, allure.step(f"Verifying that {url} is not broken are not broken"):
                 assert response.status_code in set(range(400)) | {403, 429}
+
+    # C2316348
+    @pytest.mark.footerSectionTests
+    def test_locale_selector(self):
+        with allure.step("Verifying that all footer select options are redirecting the user to "
+                         "the correct page locale"):
+            for locale in self.sumo_pages.footer_section._get_all_footer_locales():
+                self.sumo_pages.footer_section._switch_to_a_locale(locale)
+                expect(
+                    self.page
+                ).to_have_url(re.compile(f".*{locale}"))


### PR DESCRIPTION
1. Verifying that SUMO redirects to a fallback locale when trying to access an unsupported one.
2. Verifying SUMO's fallback mechanism for the fy, zh-Hans and zh-Hant locales. (currently skipped due to a known failure).
3. Verifying that accessing all supported SUMO locales returns status code 200
4. Verifying SUMO locale priority:
- SUMO should redirect to the locale specified inside the user profile if no locale is specified in the URL.
- Verifying that SUMO should respect the ?lang query parameter and redirect to that particular locale regardless of the locale specified inside the user profile.
- Verifying that SUMO redirects to the locale specified inside the Accept-Language header if no preferred language is set at profile level.
- Verifying the fallback mechanism of the Accept-Language header if the first specified language is not supported or invalid.
- Verifying that selecting all the available options inside the "Language" dropdown menu displayed inside the footer section redirects the user to the chosen locale successfully.
5. Adding the required env variables for decouple in order to use the SUMO_LANGUAGES, FALLBACK_LANGUAGES, NON_SUPPORTED_LOCALES dictionaries in tests.
6. Fixing the Recent Revisions Dashboard test failures.
7. Adding playwright capability of setting/manipulating the http header.