### PR TITLE
Expanding playwright coverage over premium products ticket submission

### DIFF
--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -1,3 +1,4 @@
+import random
 from playwright.sync_api import Page, ElementHandle, Locator, TimeoutError
 
 
@@ -121,6 +122,17 @@ class BasePage:
     # Choosing an option by value from a select element.
     def _select_option_by_value(self, xpath: str, value: str):
         self._get_element_locator(xpath).select_option(value=value)
+
+    # Selecting a random dropdown menu option by 'value'.
+    def _select_random_option_by_value(self, dropdown_locator: str, xpath_options: str):
+        elements = []
+        for element in self._get_elements_locators(xpath_options):
+            locator_value = self._get_element_locator_attribute_value(element, 'value')
+            if locator_value == '':
+                continue
+            else:
+                elements.append(locator_value)
+        self._select_option_by_value(dropdown_locator, random.choice(elements))
 
     # Accept a dialog.
     def _accept_dialog(self):

--- a/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
+++ b/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
@@ -15,34 +15,42 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, TestUtilities, Quest
     # Mozilla VPN has an extra optional dropdown menu for choosing an operating system.
     def submit_an_aaq_question(self,
                                subject: str,
-                               topic_name: str,
                                body: str,
-                               os="",
-                               attach_image=False):
-        question_subject = self.add__valid_data_to_all_aaq_fields_without_submitting(
-            subject,
-            topic_name,
-            body,
-            os,
-            attach_image
-        )
+                               topic_name='',
+                               attach_image=False,
+                               is_premium=False,
+                               email="",
+                               is_loginless=False
+                               ):
+        question_subject = ''
+        if is_premium:
+            self.add_valid_data_to_all_premium_products_aaq_fields(subject, body, is_loginless,
+                                                                   email)
+        else:
+            question_subject = self.add__valid_data_to_all_aaq_fields_without_submitting(
+                subject,
+                topic_name,
+                body,
+                attach_image
+            )
         # Submitting the question.
         super()._click_aaq_form_submit_button()
-        # Waiting for submitted question reply button visibility.
-        super()._is_post_reply_button_visible()
-        current_page_url = self._page.url
 
-        # Returning the posted question subject and url for further usage.
-        return {"aaq_subject": question_subject, "question_page_url": current_page_url,
-                "question_body": body}
+        # If the submission was done for freemium products we are retrieving the Question Subject,
+        # Question url & Question Body for further test usage.
+        if not is_premium:
+            # Waiting for submitted question reply button visibility.
+            super()._is_post_reply_button_visible()
+            current_page_url = self._page.url
+            return {"aaq_subject": question_subject, "question_page_url": current_page_url,
+                    "question_body": body}
 
-    # Populating the aaq form fields with given values without submitting the form.
-    # Mozilla VPN has an extra optional dropdown menu for choosing an operating system.
+    # Populating the aaq form fields for freemium products with given values without submitting the
+    # form.
     def add__valid_data_to_all_aaq_fields_without_submitting(self,
                                                              subject: str,
                                                              topic_value: str,
                                                              body_text: str,
-                                                             os='',
                                                              attach_image=False):
         aaq_subject = subject + super().generate_random_number(min_value=0, max_value=5000)
         # Adding text to subject field.
@@ -55,9 +63,6 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, TestUtilities, Quest
         super()._add_text_to_aaq_textarea_field(
             body_text
         )
-        # Some products contain another OS dropdown menu. We are selecting an option for those.
-        if os != "":
-            super()._select_aaq_form_os_value(os)
 
         if attach_image:
             # Uploading an image to the aaq question form.
@@ -70,6 +75,19 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, TestUtilities, Quest
 
         # Returning the entered question subject for further usage.
         return aaq_subject
+
+    # Flow for adding valid data to premium products forms without submitting the ticket.
+    # We are currently choosing one random topic & os for each product ticket submission.
+    # Note: Some premium products forms (example: Mozilla VPN) has an extra "os" dropdown.
+    def add_valid_data_to_all_premium_products_aaq_fields(self, subject: str, body: str,
+                                                          is_loginless: bool, email: str):
+        if is_loginless:
+            super()._fill_contact_email_field(email)
+        super()._select_random_topic_by_value()
+        if super()._is_os_dropdown_menu_visible():
+            super()._select_random_os_by_value()
+        super()._add_text_to_premium_aaq_form_subject_field(subject)
+        super()._add_text_to_premium_aaq_textarea_body_field(body)
 
     # Adding an image to the aaq form.
     def adding_an_image_to_aaq_form(self):
@@ -105,7 +123,7 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, TestUtilities, Quest
         else:
             super()._click_aaq_form_cancel_button()
 
-    def delete_question_reply(self, answer_id: str, delete_reply:bool):
+    def delete_question_reply(self, answer_id: str, delete_reply: bool):
         super()._click_on_reply_more_options_button(answer_id)
         super()._click_on_delete_this_post_for_a_certain_reply(answer_id)
 

--- a/playwright_tests/messages/ask_a_question_messages/AAQ_messages/aaq_form_page_messages.py
+++ b/playwright_tests/messages/ask_a_question_messages/AAQ_messages/aaq_form_page_messages.py
@@ -8,3 +8,8 @@ class AAQFormMessages:
                  "understand the issue better than saying “something is wrong” or “the app is "
                  "broken”.")
     ERROR_MESSAGE = "This field is required."
+    LOGINLESS_RATELIMIT_REACHED_MESSAGE = "You've exceeded the number of submissions for today."
+
+    def get_premium_ticket_submission_success_message(self, user_email: str) -> str:
+        return (f"Done! Thank you for reaching out Mozilla Support. We've sent a confirmation "
+                f"email to {user_email}")

--- a/playwright_tests/pages/ask_a_question/aaq_pages/aaq_form_page.py
+++ b/playwright_tests/pages/ask_a_question/aaq_pages/aaq_form_page.py
@@ -4,6 +4,7 @@ from playwright_tests.core.basepage import BasePage
 
 class AAQFormPage(BasePage):
     __uploaded_image_title = ""
+    __premium_ticket_message = "//ul[@class='user-messages']//p"
 
     # Breadcrumb locators.
     __in_progress_item_label = ("//li[@class='progress--item is-current']//span["
@@ -16,7 +17,11 @@ class AAQFormPage(BasePage):
 
     # AAQ Subject locators.
     __aaq_subject_input_field = "//input[@id='id_title']"
+    __premium_aaq_subject_input_field = "//input[@id='id_subject']"
     __aaq_subject_input_field_error_message = "//input[@id='id_title']/following-sibling::ul/li"
+
+    # Loginless form locators.
+    __loginless_contact_email_input_field = "//input[@id='id_email']"
 
     # Product topic dropdown locators.
     __product_topic_options = "//select[@id='id_category']/option"
@@ -27,10 +32,12 @@ class AAQFormPage(BasePage):
                                                      "@class='errorlist']/li")
 
     # Product os dropdown locators (Available for Mozilla VPN product only).
+    __product_os_select_dropdown_options = "//select[@id='id_os']/option"
     __product_os_select_dropdown = "//select[@id='id_os']"
 
     # How can we help textarea field locators.
     __how_can_we_help_textarea = "//textarea[@id='id_content']"
+    __tell_us_more_premium_product_textarea = "//textarea[@id='id_description']"
     __how_can_we_help_textarea_error_field = ("//textarea[@id='id_content']/../following-sibling"
                                               "::ul/li")
 
@@ -66,6 +73,12 @@ class AAQFormPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
+    def _fill_contact_email_field(self, text: str):
+        super()._fill(self.__loginless_contact_email_input_field, text)
+
+    def _get_premium_card_submission_message(self) -> str:
+        return super()._get_text_of_element(self.__premium_ticket_message)
+
     # Breadcrumb actions.
     def _get_in_progress_item_label(self) -> str:
         return super()._get_text_of_element(self.__in_progress_item_label)
@@ -85,6 +98,12 @@ class AAQFormPage(BasePage):
 
     def _add_text_to_aaq_form_subject_field(self, text: str):
         super()._fill(self.__aaq_subject_input_field, text)
+
+    def _add_text_to_premium_aaq_form_subject_field(self, text: str):
+        super()._fill(self.__premium_aaq_subject_input_field, text)
+
+    def _add_text_to_premium_aaq_textarea_body_field(self, text: str):
+        super()._fill(self.__tell_us_more_premium_product_textarea, text)
 
     # Question body actions.
     def _get_value_of_question_body_textarea_field(self) -> str:
@@ -153,7 +172,7 @@ class AAQFormPage(BasePage):
         super()._fill(self.__product_os, text)
 
     def _select_aaq_form_os_value(self, value: str):
-        super()._select_option_by_value(self.__product_os_select_dropdown, value)
+        super()._select_option_by_value(self.__product_os_select_dropdown_options, value)
 
     # Troubleshooting information actions.
     def _add_text_to_troubleshooting_information_textarea(self, text: str):
@@ -161,6 +180,17 @@ class AAQFormPage(BasePage):
 
     def _click_on_learn_more_button(self):
         super()._click(self.__learn_more_button)
+
+    def _is_os_dropdown_menu_visible(self) -> bool:
+        return super()._is_element_visible(self.__product_os_select_dropdown)
+
+    def _select_random_os_by_value(self):
+        super()._select_random_option_by_value(self.__product_os_select_dropdown,
+                                               self.__product_os_select_dropdown_options)
+
+    def _select_random_topic_by_value(self):
+        super()._select_random_option_by_value(self.__product_topic_select_dropdown,
+                                               self.__product_topic_options)
 
     def _click_on_share_data_button(self):
         super()._click(self.__share_data_button)

--- a/playwright_tests/pages/auth_page.py
+++ b/playwright_tests/pages/auth_page.py
@@ -9,6 +9,7 @@ class AuthPage(BasePage):
     __fxa_sign_in_page_header = "//h1[@id='fxa-signin-password-header']"
     __auth_page_main_header = "//h1[@class='sumo-page-heading']"
     __auth_page_subheading_text = "//div[@class='sumo-page-section']/p"
+    __cant_sign_in_to_my_Mozilla_account_link = "//div[@class='trouble-text']//a"
 
     # Continue with firefox accounts button
     __continue_with_firefox_accounts_button = "//p[@class='login-button-wrap']/a"
@@ -33,6 +34,9 @@ class AuthPage(BasePage):
 
     def __init__(self, page: Page):
         super().__init__(page)
+
+    def _click_on_cant_sign_in_to_my_mozilla_account_link(self):
+        super()._click(self.__cant_sign_in_to_my_Mozilla_account_link)
 
     def _click_on_continue_with_firefox_accounts_button(self):
         super()._click(self.__continue_with_firefox_accounts_button)

--- a/playwright_tests/test_data/aaq_question.json
+++ b/playwright_tests/test_data/aaq_question.json
@@ -15,6 +15,10 @@
     "common_responses_category": "General",
     "common_responses_response": "Zoom feature"
   },
+  "premium_aaq_question": {
+    "subject": "playwright test ticket",
+    "body": "playwright test ticket"
+  },
   "troubleshooting_information_kb_article_url": "https://support.mozilla.org/en-US/kb/use-troubleshooting-information-page-fix-firefox",
   "troubleshooting_information": "Test Troubleshooting data",
   "troubleshoot_product_and_os_versions": ["Test os", "Test product version"],


### PR DESCRIPTION
- Updating the aaq submission flow to work with premium and loginless forms.
- Adding new locators for the premium and loginless forms and helper functions.
- Expanding playwright coverage for the following cases:
1. Verifying that the premium tickets can be successfully submitted for all premium products. Currently, we are sending one ticket /each premium product and choosing a random topic & os from the dropdowns. We are also making use of the whitelisted subject & body keyword so that Zendesk automatically closes those tickets to avoid spam.
2. Verifying that 3 loginless tickets can be successfully submitted before hitting the ratelimit. (making use of the whitelisted subject & body keyword in order to avoid spamming Zendesk).