### PR TITLE
Make products/ configurable and served in WT

### DIFF
--- a/kitsune/products/jinja2/products/blocks/product_snippet_block.html
+++ b/kitsune/products/jinja2/products/blocks/product_snippet_block.html
@@ -1,0 +1,17 @@
+<div class="card card--product zoom-on-hover"> 
+  {% set product = value.product %}
+  <img class="card--icon" src="{{ product.image_url }}" alt="{{ product.title }}" />
+  <div class="card--details">
+    <h3 class="card--title">
+      <a class="expand-this-link" href="{{ url('products.product', slug=product.slug) }}"
+          data-event-name="link_click"
+          data-event-parameters='{
+            "link_name": "product-home",
+            "link_detail": "{{ product.slug }}"
+          }'>
+        {{ product.title }}
+      </a>
+    </h3>
+    <p class="card--desc">{{ product.description }}</p>
+  </div>
+</div>

--- a/kitsune/products/jinja2/products/product_card_preview.html
+++ b/kitsune/products/jinja2/products/product_card_preview.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% set title = _('Products') %}
+{% block contentwrap %}
+  <section class="mzp-l-content sumo-page-section" id="main-content">
+    <div class="sumo-card-grid is-product-wrap">
+      <div class="scroll-wrap">
+        <div class="card card--product zoom-on-hover"> 
+          <img class="card--icon" src="{{ object.image_url }}" alt="{{ object.title }}" />
+          <div class="card--details">
+            <h3 class="card--title">
+              <a class="expand-this-link" href=""
+                 data-event-name="link_click"
+                 data-event-parameters='{
+                   "link_name": "product-home",
+                   "link_detail": "{{ object.slug }}"
+                 }'>
+                {{ object.title }}
+              </a>
+            </h3>
+            <p class="card--desc">{{ object.description }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/kitsune/products/jinja2/products/products_wagtail.html
+++ b/kitsune/products/jinja2/products/products_wagtail.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% from 'products/includes/product_macros.html' import product_cards with context %}
+
+{% set crumbs = [(None, title)] %}
+{% set canonical_url = canonicalize(viewname='products') %}
+{% set ga_content_group = "list-products" %}
+
+{% block hidden_search_masthead %}{% endblock %}
+
+{% block masthead %}
+<section class="home-search-section sumo-page-section shade-bg" id="products-and-services" >
+  <div class="mzp-l-content">
+    {% block breadcrumbs %}
+      {{ breadcrumbs(crumbs, id='main-breadcrumbs') }}
+    {% endblock %}
+  </div>
+  <div class="mzp-l-content narrow">
+    <div class="home-search-section--content">
+      <h1 class="sumo-page-heading-xl">{{ page.title }}</h1>
+      {{ search_box(settings, id='support-search-masthead', params=search_params) }}
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+
+{% block contentwrap %}
+  <section class="mzp-l-content sumo-page-section" id="main-content">
+    <div class="sumo-card-grid is-product-wrap">
+      <div class="scroll-wrap">
+        {% for block in page.body %}
+            {{ block.render() }}
+        {% endfor %}
+        <div class="sumo-card-grid is-product-wrap">
+    <div class="scroll-wrap">
+  </section>
+{% endblock %}

--- a/kitsune/products/models.py
+++ b/kitsune/products/models.py
@@ -7,6 +7,13 @@ from kitsune.sumo.models import ModelBase
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.sumo.utils import webpack_static
 
+from wagtail import blocks
+from wagtail.fields import StreamField
+from wagtail.admin.panels import FieldPanel
+from wagtail.models import Page, PreviewableMixin
+from wagtail.snippets.blocks import SnippetChooserBlock
+from wagtail.snippets.models import register_snippet
+
 HOT_TOPIC_SLUG = "hot"
 
 
@@ -15,7 +22,10 @@ class ProductQuerySet(models.QuerySet):
         return self.filter(questions_locales__locale=request.LANGUAGE_CODE).filter(codename="")
 
 
-class Product(ModelBase):
+# Wagtail: Registering our existing Product model as a Wagtail Snippet
+# And adding PreviewablerMixin to allow prevewing in the Wagtail Admin
+@register_snippet
+class Product(ModelBase, PreviewableMixin):
     title = models.CharField(max_length=255, db_index=True)
     codename = models.CharField(max_length=255, blank=True, default="")
     slug = models.SlugField()
@@ -79,6 +89,46 @@ class Product(ModelBase):
 
     def get_absolute_url(self):
         return reverse("products.product", kwargs={"slug": self.slug})
+
+    # Wagtail Product additions
+    panels = [
+        FieldPanel("title"),
+        FieldPanel("codename"),
+        FieldPanel("slug"),
+        FieldPanel("description"),
+        FieldPanel("image"),
+        FieldPanel("image_alternate"),
+        FieldPanel("display_order"),
+        FieldPanel("visible"),
+        FieldPanel("platforms"),
+    ]
+
+    def get_preview_template(self, request, mode_name):
+        return "products/product_card_preview.html"
+
+
+# Wagtail: This is a StructBlock that allows selection of a Product Snippet
+class ProductSnippetBlock(blocks.StructBlock):
+    product = SnippetChooserBlock(target_model="products.Product", required=True)
+
+    class Meta:
+        template = "products/blocks/product_snippet_block.html"
+        icon = "placehoder"
+        label = "Product Card"
+
+
+# Wagtail: This is the product index we want to serve
+class LandingPage(Page):
+    body = StreamField([("product_snippet", ProductSnippetBlock())])
+
+    content_panels = Page.content_panels + [FieldPanel("body")]
+
+    def get_template(self, request):
+        return "products/products_wagtail.html"
+
+    class Meta:
+        verbose_name = "Product Index"
+        verbose_name_plural = "Product Idexes"
 
 
 # Note: This is the "new" Topic class

--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -16,7 +16,7 @@ from kitsune.wiki.facets import documents_for, topics_for
 from kitsune.wiki.utils import get_featured_articles
 
 
-@check_simple_wiki_locale
+@check_simple_wiki_locale  # Is this important for Wagtail?
 def product_list(request):
     """The product picker page."""
     template = "products/products.html"

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -553,6 +553,7 @@ if READ_ONLY:
     OIDC_ENABLE = False
     ENABLE_ADMIN = False
     WAGTAIL_ENABLE_ADMIN = False
+    WAGTAIL_ENABLE = False
 else:
     OIDC_ENABLE = config("OIDC_ENABLE", default=True, cast=bool)
     ENABLE_ADMIN = config("ENABLE_ADMIN", default=OIDC_ENABLE, cast=bool)
@@ -1310,6 +1311,7 @@ MOZILLA_ACCOUNT_ARTICLES = [
 ]
 
 # Wagtail settings
+WAGTAIL_ENABLE = config("WAGTAIL_ENABLE", default=False, cast=bool)
 WAGTAIL_ENABLE_ADMIN = config("WAGTAIL_ENABLE_ADMIN", default=False, cast=bool)
 WAGTAIL_I18N_ENABLED = True
 WAGTAIL_CONTENT_LANGUAGES = LANGUAGES

--- a/kitsune/urls.py
+++ b/kitsune/urls.py
@@ -9,6 +9,8 @@ from waffle.views import wafflejs
 from wagtail.urls import serve_pattern
 import wagtail.views
 
+from wagtail import urls as wagtail_urls
+
 from kitsune.dashboards.api import WikiMetricList
 from kitsune.sumo import views as sumo_views
 from kitsune.sumo.i18n import i18n_patterns
@@ -23,7 +25,7 @@ from django.contrib import admin  # noqa
 
 admin.autodiscover()
 
-urlpatterns = i18n_patterns(
+urlpatterns = [
     path("kb", include("kitsune.wiki.urls")),
     path("search/", include("kitsune.search.urls")),
     path("forums/", include("kitsune.forums.urls")),
@@ -50,7 +52,13 @@ urlpatterns = i18n_patterns(
         waffle_flag("wagtail_experiments")(wagtail.views.serve),
         name="wagtail_serve",
     ),
-)
+]
+
+if settings.WAGTAIL_ENABLE:
+    newpath = path("products/", include(wagtail_urls))
+    urlpatterns.insert(0, newpath)
+
+urlpatterns = i18n_patterns(*urlpatterns)
 
 if settings.OIDC_ENABLE:
     urlpatterns.append(path("", include("kitsune.users.urls_oidc")))


### PR DESCRIPTION
* Register Product model as Wagtail snippet
* Add panels and preview template for Products
* Add a custom StructBlock for Products that lets user choose products
* Add ability to preview block in `/cms/`
* Add a new page type "LandingPage" that user can add to site and configure
* Allow user to preview new page in `/cms/`
* wagtail_urls conditionally added
* WAGTAIL_ENABLE setting added

This enables Products to be wagtail_snippets, and thus editable inside the Wagtail admin. Further, it lets you construct a page of type `LandingPage` out of blocks that represent product cards.

The `wagtail_urls` are appended if `WAGTAIL_ENABLE` is true in settings.

To adequately test this, you will need to enable `WAGTAIL_ENABLE` along with `WAGTAIL_ADMIN_ENABLE` in settings. Then log in, then go to `/cms/` and add a page.

What I need most eyes on is the URL flow - is it working like I think, am I cached, etc. I will continue to test locally as well - just wanted to note that I'm no yet 100% that URL are working like I believe they are.