### PR TITLE
[GA4] fix for invalid article locales when gathering pageview data

### DIFF
--- a/kitsune/sumo/tests/test_googleanalytics.py
+++ b/kitsune/sumo/tests/test_googleanalytics.py
@@ -71,7 +71,7 @@ class GoogleAnalyticsTests(TestCase):
             Row(
                 dimension_values=[
                     DimensionValue(value="/en-US/kb/doc1-slug"),
-                    DimensionValue(value=""),
+                    DimensionValue(value="(not set)"),
                 ],
                 metric_values=[MetricValue(value="1000")],
             ),


### PR DESCRIPTION
mozilla/sumo#1768

## Notes
During QA of https://github.com/mozilla/kitsune/pull/6083, I discovered that GA4 can sometimes return `"(not set)"` as well as an empty string when the `article_locale` dimension has no value, as would be the case for all KB article pageviews prior to this work. This PR resolves that issue.