### PR TITLE
add debugging options for GA events

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -944,6 +944,8 @@ GA_ACCOUNT = config(
 )  # Google API Service Account email address
 GA_PROPERTY_ID = config("GA_PROPERTY_ID", default="123456789")
 GTM_CONTAINER_ID = config("GTM_CONTAINER_ID", default="")  # Google container ID
+GA_DEBUG_MODE = config("GA_DEBUG_MODE", default=False, cast=bool)
+GA_CONSOLE_LOGGING = config("GA_CONSOLE_LOGGING", default=False, cast=bool)
 
 REDIS_BACKENDS = {
     # TODO: Make sure that db number is respected

--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -11,7 +11,9 @@
   {% if ga_default_slug %}data-ga-default-slug="{{ ga_default_slug }}"{% endif %}
   {% if ga_article_locale %}data-ga-article-locale="{{ ga_article_locale }}"{% endif %}
   {% if ga_topics %}data-ga-topics="{{ ga_topics }}"{% endif %}
-  {% if ga_products %}data-ga-products="{{ ga_products }}"{% endif %}>
+  {% if ga_products %}data-ga-products="{{ ga_products }}"{% endif %}
+  {% if settings.GA_CONSOLE_LOGGING %}data-ga-console-logging="true"{% endif %}
+  {% if settings.GA_DEBUG_MODE %}data-ga-debug-mode="true"{% endif %}>
 <head>
   {% include "includes/google-analytics.html" %}
 

--- a/kitsune/sumo/static/sumo/js/analytics.js
+++ b/kitsune/sumo/static/sumo/js/analytics.js
@@ -1,5 +1,11 @@
 export default function trackEvent(name, parameters) {
   if (window.gtag) {
+    if (window.gaConsoleLogging) {
+      console.log("------------------------------");
+      console.log(`event: ${name}:`);
+      console.log(`parameters: ${JSON.stringify(parameters, null, 2)}`);
+      console.log("------------------------------");
+    }
     window.gtag('event', name, parameters);
   }
 }

--- a/kitsune/sumo/static/sumo/js/gtm-snippet.js
+++ b/kitsune/sumo/static/sumo/js/gtm-snippet.js
@@ -10,6 +10,8 @@ import dntEnabled from "./libs/dnt-helper";
   let html = document.getElementsByTagName('html')[0];
   let GTM_CONTAINER_ID = html.getAttribute('data-gtm-container-id');
 
+  w.gaConsoleLogging = false;
+
   w.dataLayer = w.dataLayer || [];
 
   w.gtag = function() {
@@ -44,6 +46,18 @@ import dntEnabled from "./libs/dnt-helper";
     }
     if (html.dataset.gaArticleLocale) {
       configParameters.article_locale = html.dataset.gaArticleLocale;
+    }
+    if (html.dataset.gaDebugMode) {
+      configParameters.debug_mode = true;
+    }
+    // Always ensure this block of console-logging code follows all
+    // of the code that modifies the "configParameters" object.
+    if (html.dataset.gaConsoleLogging) {
+      w.gaConsoleLogging = true;
+      console.log("------------------------------");
+      console.log(`config for ${GTM_CONTAINER_ID}:`);
+      console.log(`parameters: ${JSON.stringify(configParameters, null, 2)}`);
+      console.log("------------------------------");
     }
 
     w.gtag('config', GTM_CONTAINER_ID, configParameters);


### PR DESCRIPTION
- Provides the infrastructure to enable/disable debugging options for GA-related QA work, especially for the following PR's currently in the QA pipeline:
  - https://github.com/mozilla/kitsune/pull/6078
  - https://github.com/mozilla/kitsune/pull/6081
  - https://github.com/mozilla/kitsune/pull/6083
- If this is merged, the plan would be to always enable `GA_CONSOLE_LOGGING` on stage, and only occasionally enable `GA_DEBUG_MODE` on stage. These would never be enabled in production.
