### PR TITLE
Update fxa "Use a different account" locator.

### DIFF
--- a/playwright_tests/pages/auth_page.py
+++ b/playwright_tests/pages/auth_page.py
@@ -15,7 +15,7 @@ class AuthPage(BasePage):
     __continue_with_firefox_accounts_button = "//p[@class='login-button-wrap']/a"
 
     # Use a different account option
-    __use_a_different_account_button = "//a[@id='use-different']"
+    __use_a_different_account_button = "//a[text()='Use a different account']"
 
     # Already logged in 'Sign in' button
     __user_logged_in_sign_in_button = "//button[@id='use-logged-in']"


### PR DESCRIPTION
Small fix for playwright being unable to find "Use a different account" option due to some recent changes regarding that locator. (The id is no longer available).