### PR TITLE
Playwright fix failing product topics test failures & enable zh-Hant fallback test

### DIFF
--- a/playwright_tests/messages/ask_a_question_messages/contact_support_messages.py
+++ b/playwright_tests/messages/ask_a_question_messages/contact_support_messages.py
@@ -10,14 +10,10 @@ class ContactSupportMessages:
         "Firefox for iOS": "Firefox for iPhone, iPad and iPod touch devices",
         "Firefox for Enterprise": "Firefox Quantum for businesses",
         "MDN Plus": "MDN Plus provides a custom experience for MDN supporters.",
-        "Firefox Reality": "Firefox for Virtual Reality headsets",
         "Mozilla VPN": "VPN for Windows 10, Android and iOS devices",
-        "Firefox Private Network": "Browse securely on public Wi-Fi",
         "Firefox Relay": "Service that lets you create aliases to hide your real email",
         "Mozilla Monitor": "Stay informed and take back control of your exposed data",
         "Pocket": "The web’s most intriguing articles",
-        "Hubs": "Virtual 3D meeting spaces for collaborating with friends, family, "
-                "and colleagues on your browser or VR headset",
         "Thunderbird": "Email software for Windows, Mac and Linux",
         "Firefox Focus": "Automatic privacy browser and content blocker",
         "Mozilla Account": "Mozilla account is the account system for Mozilla"

--- a/playwright_tests/messages/explore_help_articles/products_page_messages.py
+++ b/playwright_tests/messages/explore_help_articles/products_page_messages.py
@@ -11,8 +11,6 @@ class ProductsPageMessages:
                            "data breach.",
         "Pocket": "Discover and save stories for later.",
         "MDN Plus": "MDN Plus provides a custom user experience for MDN supporters.",
-        "Hubs": "Collaborate and engage with each other through spatialized audio and with media "
-                "from around the web.",
         "Firefox Focus": "Automatic privacy browser and content blocker",
         "Firefox for Enterprise": "Firefox Quantum for businesses",
         "Thunderbird": "Email software for Windows, Mac and Linux"

--- a/playwright_tests/test_data/general_data.json
+++ b/playwright_tests/test_data/general_data.json
@@ -29,11 +29,9 @@
     "Firefox for iOS": "https://support.allizom.org/en-US/products/ios/install-and-update",
     "Firefox for Enterprise": "https://support.allizom.org/en-US/products/firefox-enterprise/install-and-update",
     "MDN Plus": "https://support.allizom.org/en-US/products/mdn-plus/getting-started",
-    "Firefox Reality": "https://support.allizom.org/en-US/products/firefox-reality/get-started",
-    "Mozilla VPN": "https://support.allizom.org/en-US/products/firefox-private-network-vpn/download-setup",
+    "Mozilla VPN": "https://support.allizom.org/en-US/products/firefox-private-network-vpn/accounts",
     "Firefox Relay": "https://support.allizom.org/en-US/products/relay/technical",
     "Pocket": "https://support.allizom.org/en-US/products/pocket/pocket-for-ios",
-    "Hubs": "https://support.allizom.org/en-US/products/hubs/hubs-get-started",
     "Thunderbird": "https://support.allizom.org/en-US/products/thunderbird/protect-your-privacy",
     "Firefox Focus": "https://support.allizom.org/en-US/products/focus-firefox/Focus-ios",
     "Mozilla Account": "https://support.allizom.org/en-US/products/mozilla-account/passwords-recovery"

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -409,7 +409,7 @@ class TestAAQPage(TestUtilities, AAQFormMessages):
                          "submitting the form"):
             for product in super().general_test_data["freemium_products"]:
                 self.logger.info(product)
-                if product == 'Firefox Reality' or product == "Thunderbird":
+                if product == "Thunderbird":
                     continue
                 else:
                     self.navigate_to_link(super().aaq_question_test_data["products_aaq_url"]

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
@@ -329,8 +329,7 @@ class TestArticleTranslation(TestUtilities, KbTranslationMessages):
                     ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{value}/")
 
     # C2625000
-    # Skipping this test for now due to the https://github.com/mozilla/sumo/issues/1820 failure
-    @pytest.mark.skip
+    @pytest.mark.kbArticleTranslation
     def test_fallback_languages(self):
         with allure.step("Verifying the language fallback"):
             for key, value in FALLBACK_LANGUAGES.items():


### PR DESCRIPTION
- Enabling test_fallback_languages test since https://github.com/mozilla/sumo/issues/1820 is now fixed.
- Removed some other Firefox Reality, FPN and Hubs mentions inside the playwright framework.