### PR TITLE
Decorator to serve prefer CMS pages

### DIFF
--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -9,6 +9,7 @@ from product_details import product_details
 from kitsune.products.models import Product, Topic, TopicSlugHistory
 from kitsune.questions import config as aaq_config
 from kitsune.sumo import NAVIGATION_TOPICS
+from kitsune.sumo.decorators import prefer_cms
 from kitsune.wiki.decorators import check_simple_wiki_locale
 from kitsune.wiki.facets import documents_for, topics_for
 from kitsune.wiki.models import Revision
@@ -33,6 +34,7 @@ def _get_aaq_product_key(slug):
 
 
 @check_simple_wiki_locale
+@prefer_cms
 def product_landing(request, slug):
     """The product landing page."""
     if slug == "firefox-accounts":

--- a/kitsune/urls.py
+++ b/kitsune/urls.py
@@ -4,12 +4,9 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import RedirectView
 from django.views.static import serve as servestatic
 from graphene_django.views import GraphQLView
-from waffle.decorators import waffle_flag
 from waffle.views import wafflejs
 from wagtail.admin.urls import urlpatterns as wagtail_admin_urlpatterns
-from wagtail.urls import serve_pattern
 from wagtail.utils.urlpatterns import decorate_urlpatterns
-from wagtail.views import serve as wagtail_serve
 
 from kitsune.dashboards.api import WikiMetricList
 from kitsune.sumo import views as sumo_views
@@ -49,11 +46,6 @@ urlpatterns = i18n_patterns(
     path("", include("kitsune.users.urls")),
     path("locales", sumo_views.locales, name="sumo.locales"),
     re_path(r"^windows7-support(?:\\/)?$", RedirectView.as_view(url="/home/?as=u")),
-    re_path(
-        rf"wagtail/{serve_pattern.lstrip('^')}",
-        waffle_flag("wagtail_experiments")(wagtail_serve),
-        name="wagtail_serve",
-    ),
 )
 
 if settings.OIDC_ENABLE:


### PR DESCRIPTION
For Wagtail, we needed a way for the system to 'prefer' a CMS page if it was published. This decorator will force a decorated view to check if there is a page to be served in WT, and if so, serve it; if not, fail through to further matching.

Our placeholder/structural pages will return a 404 via the serve method, so will never be served/considered a match.