### PR TITLE
Expand playwright coverage over the new top-navbar options

### DIFF
--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -54,6 +54,12 @@ class BasePage:
         """
         return self._get_element_locator(xpath).inner_text()
 
+    def _get_text_of_locator(self, locator: Locator) -> str:
+        """
+        This helper function returns the inner text of a given locator.
+        """
+        return locator.inner_text()
+
     def _is_element_empty(self, xpath: str) -> bool:
         """
         This helper function returns checks if the given xpath has an inner text.
@@ -192,9 +198,15 @@ class BasePage:
 
     def _is_element_visible(self, xpath: str) -> bool:
         """
-        This helper function checks if a given element locator is visible.
+        This helper function finds the locator of the given xpath and checks if it is visible.
         """
         return self._get_element_locator(xpath).is_visible()
+
+    def _is_locator_visible(self, locator: Locator) -> bool:
+        """
+        This helper function checks if the given locator is visible.
+        """
+        return locator.is_visible()
 
     def _is_checkbox_checked(self, xpath: str) -> bool:
         """

--- a/playwright_tests/pages/community_forums/forums_pages/product_support_forum.py
+++ b/playwright_tests/pages/community_forums/forums_pages/product_support_forum.py
@@ -1,3 +1,5 @@
+import re
+
 from playwright.sync_api import Page
 from playwright_tests.core.basepage import BasePage
 
@@ -15,6 +17,7 @@ class ProductSupportForum(BasePage):
 
     # Side navbar filter options
     __side_navbar_filter_options = "//ul[@class='sidebar-nav--list']//a"
+    __topic_dropdown_selected_option = "//select[@id='products-topics-dropdown']/option[@selected]"
 
     # Question list
     __all_question_list_tags = "//li[@class='tag']"
@@ -26,6 +29,10 @@ class ProductSupportForum(BasePage):
     # Ask the Community actions
     def _click_on_the_ask_the_community_button(self):
         super()._click(self.__ask_the_community_button)
+
+    def _get_selected_topic_option(self) -> str:
+        option = super()._get_text_of_element(self.__topic_dropdown_selected_option)
+        return re.sub(r'\s+', ' ', option).strip()
 
     # Showing Questions Tagged section actions
     def _get_text_of_selected_tag_filter_option(self) -> str:

--- a/playwright_tests/pages/contribute/contribute_pages/contributor_discussions_pages/contributor_discussions_page.py
+++ b/playwright_tests/pages/contribute/contribute_pages/contributor_discussions_pages/contributor_discussions_page.py
@@ -1,0 +1,16 @@
+from playwright.sync_api import Page
+from playwright_tests.core.basepage import BasePage
+
+"""
+    This class contains the locators and actions for the general "Contributor Discussions" page.
+"""
+
+
+class ContributorDiscussionPage(BasePage):
+    __contributor_discussions_page_title = "//div[@id='forums']/h1"
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def _get_contributor_discussions_page_title(self) -> str:
+        return super()._get_text_of_element(self.__contributor_discussions_page_title)

--- a/playwright_tests/pages/contribute/contribute_pages/contributor_discussions_pages/discussions_page.py
+++ b/playwright_tests/pages/contribute/contribute_pages/contributor_discussions_pages/discussions_page.py
@@ -1,0 +1,24 @@
+import re
+from playwright.sync_api import Page
+from playwright_tests.core.basepage import BasePage
+
+"""
+    This class contains the locators and actions for the {x} discussions page.
+"""
+
+
+class DiscussionsPage(BasePage):
+    __discussions_page_title = "//article[@id='threads']/h1"
+    __contributor_discussions_side_nav_selected_option = ("//nav[@id='for-contributors-sidebar']//"
+                                                          "a[@class='selected']")
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def _get_contributor_discussions_page_title(self) -> str:
+        return super()._get_text_of_element(self.__discussions_page_title)
+
+    def _get_contributor_discussions_side_nav_selected_option(self) -> str:
+        option = super()._get_text_of_element(
+            self.__contributor_discussions_side_nav_selected_option)
+        return re.sub(r'\s+', ' ', option).strip()

--- a/playwright_tests/pages/explore_help_articles/explore_by_topic_page.py
+++ b/playwright_tests/pages/explore_help_articles/explore_by_topic_page.py
@@ -1,0 +1,32 @@
+import re
+
+from playwright.sync_api import Page
+
+from playwright_tests.core.basepage import BasePage
+
+
+class ExploreByTopicPage(BasePage):
+    __explore_by_topic_page_header = "//div[@class='documents-product-title']/h1"
+    __filter_by_product_dropdown_selected_option = ("//select[@id='products-topics-dropdown"
+                                                    "']/option[@selected]")
+    __all_topics_side_navbar_options = "//ul[@class='sidebar-nav--list']/li/a"
+    __all_topics_selected_option = ("//ul[@class='sidebar-nav--list']/li/a[contains(@class, "
+                                    "'selected')]")
+    __AAQ_widget_continue_button = ("//div[@class='aaq-widget card is-inverse elevation-01 "
+                                    "text-center radius-md']/a")
+    __AAQ_widget_text = ("//div[@class='aaq-widget card is-inverse elevation-01 text-center "
+                         "radius-md']/p")
+    __volunteer_learn_more_option = "//section[@id='get-involved-button']//a"
+
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+    def _get_explore_by_topic_page_header(self) -> str:
+        return super()._get_text_of_element(self.__explore_by_topic_page_header)
+
+    def _get_selected_topic_side_navbar_option(self) -> str:
+        return super()._get_text_of_element(self.__all_topics_selected_option)
+
+    def _get_current_topic_filter_dropdown_option(self) -> str:
+        option = super()._get_text_of_element(self.__filter_by_product_dropdown_selected_option)
+        return re.sub(r'\s+', ' ', option).strip()

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -19,6 +19,10 @@ from playwright_tests.flows.messaging_system_flows.messaging_system_flow import 
 from playwright_tests.flows.user_groups_flows.user_group_flow import UserGroupFlow
 from playwright_tests.flows.user_profile_flows.edit_profile_data_flow import EditProfileDataFlow
 from playwright_tests.pages.ask_a_question.aaq_pages.aaq_form_page import AAQFormPage
+from playwright_tests.pages.contribute.contribute_pages.contributor_discussions_pages.\
+    contributor_discussions_page import ContributorDiscussionPage
+from playwright_tests.pages.contribute.contribute_pages.contributor_discussions_pages.\
+    discussions_page import DiscussionsPage
 from playwright_tests.pages.contribute.contributor_tools_pages.article_discussions_page import \
     ArticleDiscussionsPage
 from playwright_tests.pages.contribute.contributor_tools_pages.kb_dashboard_page import KBDashboard
@@ -59,6 +63,7 @@ from playwright_tests.pages.ask_a_question.contact_support_pages.contact_support
 from playwright_tests.pages.contribute.contribute_pages.contribute_page import ContributePage
 from playwright_tests.pages.contribute.contribute_pages.ways_to_contribute_pages import (
     WaysToContributePages)
+from playwright_tests.pages.explore_help_articles.explore_by_topic_page import ExploreByTopicPage
 from playwright_tests.pages.footer import FooterSection
 from playwright_tests.pages.community_forums.forums_pages.product_support_forum import (
     ProductSupportForum)
@@ -135,6 +140,7 @@ class SumoPages:
 
         # Explore our help articles products page.
         self.products_page = ProductsPage(page)
+        self.explore_by_product_page = ExploreByTopicPage(page)
 
         # KB Articles.
         self.kb_submit_kb_article_form_page = SubmitKBArticlePage(page)
@@ -182,6 +188,10 @@ class SumoPages:
 
         # Moderate Forum Page
         self.moderate_forum_content_page = ModerateForumContent(page)
+
+        # Discussions pages
+        self.contributor_discussions_page = ContributorDiscussionPage(page)
+        self.discussions_page = DiscussionsPage(page)
 
         # Auth flow Page.
         self.auth_flow_page = AuthFlowPage(page)

--- a/playwright_tests/pages/top_navbar.py
+++ b/playwright_tests/pages/top_navbar.py
@@ -4,16 +4,19 @@ from playwright_tests.core.basepage import BasePage
 
 
 class TopNavbar(BasePage):
+    """
+        General page locators
+    """
     __menu_titles = "//div[@id='main-navigation']//a[contains(@class,'mzp-c-menu-title')]"
     __sumo_nav_logo = "//div[@class='sumo-nav--logo']/a/img"
 
-    # Get Help option
-    __ask_a_question_top_navbar = (
-        "//li[@class='mzp-c-menu-category mzp-has-drop-down "
-        "mzp-js-expandable']/a[contains(text(), 'Ask a Question')]"
-    )
-
-    # Explore our help articles locator.
+    """
+        Locators belonging to the 'Explore Help Articles' top-navbar section".
+    """
+    __explore_by_topic_top_navbar_header = ("//h4[@class='mzp-c-menu-item-title' and text("
+                                            ")='Explore by topic']")
+    __explore_by_product_top_navbar_header = ("//h4[@class='mzp-c-menu-item-title' and text("
+                                              ")='Explore by product']")
     __explore_help_articles_top_navbar_option = (
         "//a[@class='mzp-c-menu-title sumo-nav--link' "
         "and normalize-space(text())='Explore Help "
@@ -24,8 +27,23 @@ class TopNavbar(BasePage):
         "sumo-nav--sublist']/li/a[normalize-space("
         "text())='View all products']"
     )
+    __explore_by_product_top_navbar_options = ("//h4[text()='Explore by "
+                                               "product']/../following-sibling::ul/li/a")
+    __explore_by_topic_top_navbar_options = ("//h4[text()='Explore by "
+                                             "topic']/../following-sibling::ul/li/a")
 
-    # Sub menu items ask a Question section
+    """
+        Locators belonging to the 'Ask a Question' top-navbar section.
+    """
+    __ask_a_question_top_navbar = (
+        "//li[@class='mzp-c-menu-category mzp-has-drop-down "
+        "mzp-js-expandable']/a[contains(text(), 'Ask a Question')]"
+    )
+    __get_help_with_heading = "//h4[@class='mzp-c-menu-item-title' and text()='Get help with']"
+
+    __ask_a_question_top_navbar_options = ("//a[text()='Ask a Question']/following-sibling::div"
+                                           "//li/a")
+
     __aaq_firefox_browser_option = (
         "//div[@id='main-navigation']//h4[contains(text(), 'Ask a "
         "Question')]/../..//a[contains(text(),'Firefox desktop')]"
@@ -34,10 +52,34 @@ class TopNavbar(BasePage):
         "//div[@id='main-navigation']//a[normalize-space(text(" "))='View all']"
     )
 
-    # Contribute Tools
+    """
+        Locators belonging to the 'Community Forums' top-navbar section.
+    """
+    __browse_by_product_top_navbar_header = ("//h4[@class='mzp-c-menu-item-title' and text("
+                                             ")='Browse by product']")
+    __browse_all_forum_threads_by_topic_top_navbar_header = ("//h4[@class='mzp-c-menu-item-title' "
+                                                             "and text()='Browse all forum "
+                                                             "threads by topic']")
+    __community_forums_top_navbar_option = ("//a[@class='mzp-c-menu-title sumo-nav--link' "
+                                            "and normalize-space(text())='Community Forums']")
+    __browse_by_product_top_navbar_options = ("//h4[text()='Browse by "
+                                              "product']/../following-sibling::ul/li/a")
+    __browse_all_forum_threads_by_topics_top_navbar_options = ("//h4[text()='Browse all forum "
+                                                               "threads by topic']/../"
+                                                               "following-sibling::ul/li/a")
+
+    """
+        Locators belonging to the 'Contribute' top-navbar section.
+    """
     __contribute_option = "//a[contains(text(),'Contribute')]"
 
     # Contributor Discussions
+    __contributor_discussions_top_navbar_header = ("//h4[@class='mzp-c-menu-item-title' and text("
+                                                   ")='Contributor discussions']")
+    __contributor_discussions_options = ("//h4[text()='Contributor "
+                                         "discussions']/../following-sibling::ul/li/a")
+    __contributor_discussions_option = ("//h4[@class='mzp-c-menu-item-title' and text() "
+                                        "='Contributor discussions']")
     __article_discussions_option = (
         "//div[@id='main-navigation']//a[normalize-space(text(" "))='Article discussions']"
     )
@@ -58,10 +100,10 @@ class TopNavbar(BasePage):
         "normalize-space(text())='Media gallery']"
     )
 
-    # Sign in button
+    """
+        Locators belonging to the username section of the top-navbar.
+    """
     __signin_signup_button = "//div[@id='profile-navigation']//a[contains(text(), 'Sign In/Up')]"
-
-    # Signed in options
     __signed_in_username = "//span[@class='sumo-nav--username']"
     __signed_in_view_profile_option = "//h4[contains(text(), 'View Profile')]/parent::a"
     __signed_in_edit_profile_option = "//a[contains(text(),'Edit Profile')]"
@@ -75,19 +117,83 @@ class TopNavbar(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
-    # Support logo
+    """
+        Actions against the top-navbar logo.
+    """
     def _get_sumo_nav_logo(self) -> ElementHandle:
         return super()._get_element_handle(self.__sumo_nav_logo)
 
     def _click_on_sumo_nav_logo(self):
         super()._click(self.__sumo_nav_logo)
 
-    def _get_available_menu_titles(self) -> list[str]:
-        return super()._get_text_of_elements(self.__menu_titles)
+    """
+        Actions against the 'Explore Help Articles' top-navbar section.
+    """
+    def _hover_over_explore_by_product_top_navbar_option(self):
+        super()._hover_over_element(self.__explore_help_articles_top_navbar_option)
 
-    # Contribute Tools
+    def _get_all_explore_by_product_options_locators(self) -> list[Locator]:
+        self._hover_over_explore_by_product_top_navbar_option()
+        self.page.wait_for_selector(self.__explore_by_product_top_navbar_header)
+        return super()._get_elements_locators(self.__explore_by_product_top_navbar_options)
+
+    def _get_all_explore_by_topic_locators(self) -> list[Locator]:
+        self._hover_over_explore_by_product_top_navbar_option()
+        self.page.wait_for_selector(self.__explore_by_topic_top_navbar_header)
+        return super()._get_elements_locators(self.__explore_by_topic_top_navbar_options)
+
+    def _click_on_explore_our_help_articles_view_all_option(self):
+        super()._hover_over_element(self.__explore_help_articles_top_navbar_option)
+        super()._click(self.__explore_our_help_articles_view_all_option)
+    """
+        Actions against the 'Community Forums' top-navbar section.
+    """
+    def _hover_over_community_forums_top_navbar_option(self):
+        super()._hover_over_element(self.__community_forums_top_navbar_option)
+
+    def _get_all_browse_by_product_options_locators(self) -> list[Locator]:
+        self._hover_over_community_forums_top_navbar_option()
+        self.page.wait_for_selector(self.__browse_by_product_top_navbar_header)
+        return super()._get_elements_locators(self.__browse_by_product_top_navbar_options)
+
+    def _get_all_browse_all_forum_threads_by_topic_locators(self) -> list[Locator]:
+        self._hover_over_community_forums_top_navbar_option()
+        self.page.wait_for_selector(self.__browse_all_forum_threads_by_topic_top_navbar_header)
+        return super()._get_elements_locators(
+            self.__browse_all_forum_threads_by_topics_top_navbar_options)
+
+    """
+        Actions against the 'Ask a Question' top-navbar section.
+    """
+    def _hover_over_ask_a_question_top_navbar(self):
+        super()._hover_over_element(self.__ask_a_question_top_navbar)
+
+    def _get_all_ask_a_question_locators(self) -> list[Locator]:
+        super()._hover_over_element(self.__ask_a_question_top_navbar)
+        self.page.wait_for_selector(self.__get_help_with_heading)
+        return super()._get_elements_locators(self.__ask_a_question_top_navbar_options)
+
+    def _click_on_browse_all_products_option(self):
+        super()._hover_over_element(self.__ask_a_question_top_navbar)
+        super()._click(self.__browse_all_products_option)
+
+    """
+        Actions against the 'Contribute' top-navbar section.
+    """
+    def _hover_over_contribute_top_navbar(self):
+        super()._hover_over_element(self.__contribute_option)
+
+    def _get_all_contributor_discussions_locators(self) -> list[Locator]:
+        self._hover_over_contribute_top_navbar()
+        self.page.wait_for_selector(self.__contributor_discussions_top_navbar_header)
+        return super()._get_elements_locators(self.__contributor_discussions_options)
+
     def _click_on_contribute_top_navbar_option(self):
         super()._click(self.__contribute_option)
+
+    def _click_on_community_discussions_top_navbar_option(self):
+        self._hover_over_contribute_top_navbar()
+        super()._click(self.__contributor_discussions_option)
 
     def _click_on_article_discussions_option(self):
         super()._hover_over_element(self.__contribute_option)
@@ -95,31 +201,40 @@ class TopNavbar(BasePage):
 
     # Contributor tools
     def _click_on_moderate_forum_content_option(self):
-        super()._hover_over_element(self.__contribute_option)
+        self._hover_over_contribute_top_navbar()
         super()._click(self.__moderate_forum_content)
 
     def _click_on_recent_revisions_option(self):
-        super()._hover_over_element(self.__contribute_option)
+        self._hover_over_contribute_top_navbar()
         super()._click(self.__recent_revisions_option)
 
     def _click_on_dashboards_option(self):
-        super()._hover_over_element(self.__contribute_option)
+        self._hover_over_contribute_top_navbar()
         super()._click(self.__dashboards_option)
 
     def _click_on_media_gallery_option(self):
-        super()._hover_over_element(self.__contribute_option)
+        self._hover_over_contribute_top_navbar()
         super()._click(self.__media_gallery_option)
 
-    # Explore our Help Articles actions.
-    def _click_on_explore_our_help_articles_view_all_option(self):
-        super()._hover_over_element(self.__explore_help_articles_top_navbar_option)
-        super()._click(self.__explore_our_help_articles_view_all_option)
-
-    # Sign in option
+    """
+        Actions against the sign-in/sign-up top-navbar section.
+    """
     def _click_on_signin_signup_button(self):
         super()._click(self.__signin_signup_button)
 
-    # Profile options
+    def _click_on_sign_out_button(self):
+        super()._hover_over_element(self.__signed_in_username)
+        super()._click(self.__sign_out_button)
+
+    def _sign_in_up_button_displayed_element(self) -> Locator:
+        return super()._get_element_locator(self.__signin_signup_button)
+
+    def is_sign_in_up_button_displayed(self) -> bool:
+        return super()._is_element_visible(self.__signin_signup_button)
+
+    """
+        Actions against the user profile top-navbar section.
+    """
     def _click_on_view_profile_option(self):
         super()._hover_over_element(self.__signed_in_username)
         super()._click(self.__signed_in_view_profile_option)
@@ -136,31 +251,15 @@ class TopNavbar(BasePage):
         super()._hover_over_element(self.__signed_in_username)
         super()._click(self.__signed_in_inbox_option)
 
-    def _click_on_sign_out_button(self):
-        super()._hover_over_element(self.__signed_in_username)
-        super()._click(self.__sign_out_button)
-
     def _click_on_my_questions_profile_option(self):
         super()._hover_over_element(self.__signed_in_username)
         super()._click(self.__signed_in_my_questions_option)
 
-    def _click_on_ask_a_question_option(self):
-        super()._hover_over_element(self.__ask_a_question_top_navbar)
-        super()._click(self.__ask_a_question_option)
-
-    def _click_on_ask_a_question_firefox_browser_option(self):
-        super()._hover_over_element(self.__ask_a_question_top_navbar)
-        super()._click(self.__aaq_firefox_browser_option)
-
-    def _click_on_browse_all_products_option(self):
-        super()._hover_over_element(self.__ask_a_question_top_navbar)
-        super()._click(self.__browse_all_products_option)
-
     def _get_text_of_logged_in_username(self) -> str:
         return super()._get_text_of_element(self.__signed_in_username)
 
-    def _sign_in_up_button_displayed_element(self) -> Locator:
-        return super()._get_element_locator(self.__signin_signup_button)
-
-    def is_sign_in_up_button_displayed(self) -> bool:
-        return super()._is_element_visible(self.__signin_signup_button)
+    """
+        General actions against the top-navbar section.
+    """
+    def _get_available_menu_titles(self) -> list[str]:
+        return super()._get_text_of_elements(self.__menu_titles)

--- a/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
+++ b/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
@@ -1,3 +1,5 @@
+import re
+
 import allure
 import pytest
 from playwright.sync_api import Page
@@ -5,6 +7,12 @@ from pytest_check import check
 import requests
 
 from playwright_tests.core.utilities import Utilities
+from playwright_tests.messages.ask_a_question_messages.contact_support_messages import \
+    ContactSupportMessages
+from playwright_tests.messages.contribute_messages.con_discussions.support_forums_messages import \
+    SupportForumsPageMessages
+from playwright_tests.messages.explore_help_articles.products_page_messages import \
+    ProductsPageMessages
 from playwright_tests.messages.top_navbar_messages import TopNavbarMessages
 from playwright_tests.pages.sumo_pages import SumoPages
 
@@ -49,3 +57,210 @@ def test_number_of_options_signed_in(page: Page):
         assert top_navbar_items == TopNavbarMessages.TOP_NAVBAR_OPTIONS, (
             "Incorrect elements displayed in top-navbar for " "signed-in state"
         )
+
+
+# C2462866
+@pytest.mark.topNavbarTests
+def test_explore_by_product_redirects(page: Page):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    with allure.step("Clicking on all options from the 'Explore Help Articles' and verifying the "
+                     "redirect"):
+        for index, option in enumerate(sumo_pages.top_navbar
+                                       ._get_all_explore_by_product_options_locators()):
+            if index > 0:
+                sumo_pages.top_navbar._hover_over_explore_by_product_top_navbar_option()
+            current_option = re.sub(
+                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
+            if sumo_pages.top_navbar._is_locator_visible(option):
+                sumo_pages.top_navbar._click(option)
+            else:
+                sumo_pages.top_navbar._hover_over_explore_by_product_top_navbar_option()
+                sumo_pages.top_navbar._click(option)
+
+            if current_option == "Firefox desktop":
+                current_option = utilities.remove_character_from_string(current_option, 'desktop')
+
+            if current_option != "View all products":
+                support_page = sumo_pages.product_support_page._get_product_support_title_text()
+                assert current_option in support_page
+            else:
+                assert (sumo_pages.products_page._get_page_header() == ProductsPageMessages.
+                        PRODUCTS_PAGE_HEADER)
+
+
+# C2462867
+@pytest.mark.topNavbarTests
+def test_explore_by_topic_redirects(page: Page):
+    sumo_pages = SumoPages(page)
+    with allure.step("Clicking on all options from the 'Explore by topic' and verifying the "
+                     "redirect"):
+        for index, option in enumerate(sumo_pages.top_navbar._get_all_explore_by_topic_locators()):
+            if index > 0:
+                sumo_pages.top_navbar._hover_over_explore_by_product_top_navbar_option()
+            current_option = re.sub(
+                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
+            if sumo_pages.top_navbar._is_locator_visible(option):
+                sumo_pages.top_navbar._click(option)
+            else:
+                sumo_pages.top_navbar._hover_over_explore_by_product_top_navbar_option()
+                sumo_pages.top_navbar._click(option)
+
+            assert (current_option == sumo_pages.explore_by_product_page
+                    ._get_explore_by_topic_page_header())
+
+            with allure.step("Verifying that the correct option is selected inside the 'All "
+                             "Topics' side navbar"):
+                assert (current_option == sumo_pages.explore_by_product_page
+                        ._get_selected_topic_side_navbar_option())
+
+            with allure.step("Verifying that the 'All Products' option is displayed inside the "
+                             "'Filter by product' dropdown"):
+                assert (sumo_pages.explore_by_product_page
+                        ._get_current_topic_filter_dropdown_option()) == 'All Products'
+
+
+# C2462868
+@pytest.mark.topNavbarTests
+def test_browse_by_product_community_forum_redirect(page: Page):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    utilities.start_existing_session(utilities.username_extraction_from_email(
+        utilities.user_secrets_accounts['TEST_ACCOUNT_12']
+    ))
+    with allure.step("Clicking on all options from the 'Browse by product' and verifying the "
+                     "redirect"):
+        for index, option in enumerate(sumo_pages.top_navbar
+                                       ._get_all_browse_by_product_options_locators()):
+            if index > 0:
+                sumo_pages.top_navbar._hover_over_community_forums_top_navbar_option()
+            current_option = re.sub(
+                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
+            if sumo_pages.top_navbar._is_locator_visible(option):
+                sumo_pages.top_navbar._click(option)
+            else:
+                sumo_pages.top_navbar._hover_over_community_forums_top_navbar_option()
+                sumo_pages.top_navbar._click(option)
+
+            if current_option == "Firefox desktop":
+                current_option = utilities.remove_character_from_string(
+                    current_option, 'desktop').rstrip()
+
+            if current_option != "View all forums":
+                assert (f"{current_option} Community Forum" == sumo_pages.product_support_page
+                        ._get_product_support_title_text())
+            else:
+                assert utilities.get_page_url() == SupportForumsPageMessages.PAGE_URL
+
+
+# C2462869
+@pytest.mark.topNavbarTests
+def test_browse_all_forum_threads_by_topic_redirect(page: Page):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    utilities.start_existing_session(utilities.username_extraction_from_email(
+        utilities.user_secrets_accounts['TEST_ACCOUNT_12']
+    ))
+    with allure.step("Clicking on all options from the 'Browse all forum threads by topic' and "
+                     "verifying the redirect"):
+        for index, option in enumerate(sumo_pages.top_navbar
+                                       ._get_all_browse_all_forum_threads_by_topic_locators()):
+            if index > 0:
+                sumo_pages.top_navbar._hover_over_community_forums_top_navbar_option()
+            current_option = re.sub(
+                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
+            if sumo_pages.top_navbar._is_locator_visible(option):
+                sumo_pages.top_navbar._click(option)
+            else:
+                sumo_pages.top_navbar._hover_over_community_forums_top_navbar_option()
+                sumo_pages.top_navbar._click(option)
+
+            assert (sumo_pages.product_support_page._get_product_support_title_text()
+                    == "All Products Community Forum")
+
+            with allure.step("Verifying that the correct default topic filter is selected"):
+                assert (sumo_pages.product_support_forum._get_selected_topic_option()
+                        == current_option)
+
+
+# C2462870
+@pytest.mark.topNavbarTests
+def test_ask_a_question_top_navbar_redirect(page: Page):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    with allure.step("Clicking on all options from the 'Ask a Question' and verifying the "
+                     "redirect"):
+        for index, option in enumerate(sumo_pages.top_navbar._get_all_ask_a_question_locators()):
+            if index > 0:
+                sumo_pages.top_navbar._hover_over_ask_a_question_top_navbar()
+            current_option = re.sub(
+                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
+            if sumo_pages.top_navbar._is_locator_visible(option):
+                sumo_pages.top_navbar._click(option)
+            else:
+                sumo_pages.top_navbar._hover_over_ask_a_question_top_navbar()
+                sumo_pages.top_navbar._click(option)
+
+            if current_option == "Firefox desktop":
+                current_option = utilities.remove_character_from_string(
+                    current_option, 'desktop').rstrip()
+            elif current_option == "Monitor":
+                current_option = f"Mozilla {current_option}"
+
+            if current_option != "View all":
+                assert (f"{current_option} Solutions" == sumo_pages.product_solutions_page
+                        ._get_product_solutions_heading())
+            else:
+                assert utilities.get_page_url() == ContactSupportMessages.PAGE_URL
+
+
+# C2462871
+@pytest.mark.topNavbarTests
+def test_contribute_top_navbar_redirects(page: Page):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    utilities.start_existing_session(utilities.username_extraction_from_email(
+        utilities.user_secrets_accounts['TEST_ACCOUNT_13']
+    ))
+
+    with allure.step("Clicking on the 'Contributor discussions' top-navbar option and verifying "
+                     "the redirect"):
+        sumo_pages.top_navbar._click_on_community_discussions_top_navbar_option()
+        assert (sumo_pages.contributor_discussions_page._get_contributor_discussions_page_title()
+                == "Contributor Discussions")
+
+    with allure.step("Clicking on the 'Contributor discussions' top-navbar options and verifying "
+                     "the redirects"):
+        for index, option in enumerate(sumo_pages.top_navbar
+                                       ._get_all_contributor_discussions_locators()):
+            if index > 0:
+                sumo_pages.top_navbar._hover_over_contribute_top_navbar()
+            current_option = re.sub(
+                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
+            if sumo_pages.top_navbar._is_locator_visible(option):
+                sumo_pages.top_navbar._click(option)
+            else:
+                sumo_pages.top_navbar._hover_over_contribute_top_navbar()
+                sumo_pages.top_navbar._click(option)
+
+            if current_option == "Article discussions":
+                assert (sumo_pages.discussions_page._get_contributor_discussions_page_title()
+                        .lower()
+                        == "english knowledge base discussions")
+                with allure.step("Verifying that the correct option is highlighted inside the "
+                                 "'Contributor discussions' side navbar"):
+                    assert (sumo_pages.discussions_page
+                            ._get_contributor_discussions_side_nav_selected_option()
+                            == current_option)
+            elif current_option == "View all discussions":
+                assert (sumo_pages.contributor_discussions_page
+                        ._get_contributor_discussions_page_title(
+                        ).lower() == "contributor discussions")
+            else:
+                assert (sumo_pages.discussions_page._get_contributor_discussions_page_title()
+                        .lower() == current_option.lower())
+                with allure.step("Verifying that the correct option is highlighted inside the "
+                                 "'Contributor discussions' side navbar"):
+                    assert (sumo_pages.discussions_page
+                            ._get_contributor_discussions_side_nav_selected_option()
+                            == current_option)


### PR DESCRIPTION
- Adding new helper functions inside BasePage.
- Creating the contributor_discussions_page.py page (for /forums SUMO page), discussions_page.py (for /forums/{forumName}/ page) and explore_by_topic_page.py page (for /topics/ SUMO page).
- Instantiating the newly created pages inside sumo_pages.py
- Updating the top-navbar.py with several new locators (for the new top-navbar) & action functions against them.
- Expanding playwright coverage over the top-navbar section by verifying:
  - `Explore Help Articles > Explore by product` top-navbar options redirects.
  - `Explore Help Articles > Explore by topic` top-navbar options redirects + the default "Filter by product" & "All Topics" filter when accessing the page.
  - `Community Forums > Browse by product` top-navbar options redirects.
  - `Community Forums > Browse all forum threads by topic` top-navbar options redirects + the filter displayed inside the "Topics" dropdown.
  - `Ask a Question` top-navbar option redirects.
  - `Contribute > Contributor Discussions` top-navbar redirects + the highlighted option inside the "Contributor discussions" side-navbar