### PR TITLE
Expanding playwright coverage over the Explore by topic page

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,6 +35,7 @@ on:
                     - KB Article Translation
                     - recentRevisionsDashboard
                     - kbDashboard
+                    - exploreByTopics
 
 env:
     TEST_ACCOUNT_12: ${{secrets.AUTOMATION_TEST_ACCOUNT_12}}
@@ -97,7 +98,7 @@ jobs:
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
             declare dispatch_test_suite="${{inputs.TestSuite}}"
-            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "messagingSystemCleanup" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "restrictedArticleCreation" "kbRestrictedVisibilitySingleGroup" "whitelistingDifferentGroup" "kbRestrictedVisibilityMultipleGroups" "removingAllArticleRestrictions" "kbRemovedRestrictions" "deleteAllRestrictedTestArticles" "kbArticleTranslation")
+            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "messagingSystemCleanup" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "restrictedArticleCreation" "kbRestrictedVisibilitySingleGroup" "whitelistingDifferentGroup" "kbRestrictedVisibilityMultipleGroups" "removingAllArticleRestrictions" "kbRemovedRestrictions" "deleteAllRestrictedTestArticles" "kbArticleTranslation" "exploreByTopics")
             if [ "$dispatch_test_suite" == "All" ] || [ "${{ github.event_name}}" == "schedule" ] ; then
                 for test in "${all_test_suites[@]}"; do
                     if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then

--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -112,6 +112,12 @@ class BasePage:
         """
         return self.page.text_content(xpath)
 
+    def _get_text_content_of_all_locators(self, locator: Locator) -> list[str]:
+        """
+        This helper function returns a list of text content for the given locator.
+        """
+        return locator.all_text_contents()
+
     def _click(self, element: Union[str, Locator], with_wait=True):
         """
         This helper function clicks on a given element locator.

--- a/playwright_tests/messages/ask_a_question_messages/AAQ_messages/aaq_widget.py
+++ b/playwright_tests/messages/ask_a_question_messages/AAQ_messages/aaq_widget.py
@@ -6,3 +6,4 @@ class AAQWidgetMessages:
                                               "team.")
     FREEMIUM_AAQ_SUBHEADING_TEXT = "Still need help? Continue to ask your question on our forums."
     PREMIUM_AAQ_SUBHEADING_TEXT = "Still need help? Continue to contact our support team."
+    NEUTRAL_AAQ_SUBHEADING_TEXT = "Still need help? Continue to ask your question and get help."

--- a/playwright_tests/pages/explore_help_articles/explore_by_topic_page.py
+++ b/playwright_tests/pages/explore_help_articles/explore_by_topic_page.py
@@ -4,11 +4,29 @@ from playwright.sync_api import Page
 
 from playwright_tests.core.basepage import BasePage
 
+"""
+    This class contains the locators and actions for the /topics/ page.
+"""
+
 
 class ExploreByTopicPage(BasePage):
+    """
+        Locators belonging to the header section.
+    """
     __explore_by_topic_page_header = "//div[@class='documents-product-title']/h1"
+
+    """
+        Locators belonging to the listed KB articles.
+    """
+    __article_metadata_info = "//div[@id='document_metadata']//span[@class='tooltip']"
+
+    """
+        Locators belonging to the side-navbar section.
+    """
+    __filter_by_product_dropdown = "//select[@id='products-topics-dropdown']"
     __filter_by_product_dropdown_selected_option = ("//select[@id='products-topics-dropdown"
                                                     "']/option[@selected]")
+    __filter_by_product_dropdown_options = "//select[@id='products-topics-dropdown']/option"
     __all_topics_side_navbar_options = "//ul[@class='sidebar-nav--list']/li/a"
     __all_topics_selected_option = ("//ul[@class='sidebar-nav--list']/li/a[contains(@class, "
                                     "'selected')]")
@@ -16,17 +34,61 @@ class ExploreByTopicPage(BasePage):
                                     "text-center radius-md']/a")
     __AAQ_widget_text = ("//div[@class='aaq-widget card is-inverse elevation-01 text-center "
                          "radius-md']/p")
+
+    """
+        Locators belonging to the Volunteer card section.
+    """
     __volunteer_learn_more_option = "//section[@id='get-involved-button']//a"
 
     def __init__(self, page: Page):
         super().__init__(page)
 
+    """
+        Actions against the page header section.
+    """
     def _get_explore_by_topic_page_header(self) -> str:
         return super()._get_text_of_element(self.__explore_by_topic_page_header)
 
+    """
+       Actions against the listed KB articles.
+    """
+    def _get_metadata_of_all_listed_articles(self) -> list[list[str]]:
+        elements = []
+        for metadata in super()._get_elements_locators(self.__article_metadata_info):
+            metadata_elements = super()._get_text_content_of_all_locators(metadata)
+            for item in metadata_elements:
+                split_items = [i.strip() for i in item.strip().split(',')]
+                elements.append(split_items)
+        return elements
+
+    """
+        Actions against the page side-navbar section.
+    """
     def _get_selected_topic_side_navbar_option(self) -> str:
         return super()._get_text_of_element(self.__all_topics_selected_option)
 
-    def _get_current_topic_filter_dropdown_option(self) -> str:
+    def _get_all_topics_side_navbar_options(self) -> list[str]:
+        return super()._get_text_of_elements(self.__all_topics_side_navbar_options)
+
+    def _click_on_a_topic_filter(self, option: str):
+        super()._click(f"//ul[@class='sidebar-nav--list']/li/"
+                       f"a[normalize-space(text())='{option}']")
+
+    def _get_current_product_filter_dropdown_option(self) -> str:
         option = super()._get_text_of_element(self.__filter_by_product_dropdown_selected_option)
         return re.sub(r'\s+', ' ', option).strip()
+
+    def _get_all_filter_by_product_options(self) -> list[str]:
+        return super()._get_text_of_elements(self.__filter_by_product_dropdown_options)
+
+    def _select_a_filter_by_product_option(self, option: str):
+        super()._select_option_by_label(self.__filter_by_product_dropdown, option)
+
+    def _get_text_of_aaq_widget(self) -> str:
+        return super()._get_text_of_element(self.__AAQ_widget_text)
+
+    def _click_on_aaq_continue_button(self):
+        super()._click(self.__AAQ_widget_continue_button)
+
+    def _is_aaq_text_visible(self) -> bool:
+        return super()._is_element_visible(self.__AAQ_widget_text)

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -140,7 +140,7 @@ class SumoPages:
 
         # Explore our help articles products page.
         self.products_page = ProductsPage(page)
-        self.explore_by_product_page = ExploreByTopicPage(page)
+        self.explore_by_topic_page = ExploreByTopicPage(page)
 
         # KB Articles.
         self.kb_submit_kb_article_form_page = SubmitKBArticlePage(page)

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -35,4 +35,5 @@ markers =
     kbArticleTranslation: Tests belonging to kb article translation.
     deleteAllRestrictedTestArticles: Deleting all restricted test articles.
     create_delete_article: Fixture used for creating and deleting test articles.
+    exploreByTopics: Tests belonging to the explore help articles by topics page.
 addopts = --alluredir=./reports/allure_reports --tb=no

--- a/playwright_tests/test_data/aaq_question.json
+++ b/playwright_tests/test_data/aaq_question.json
@@ -35,6 +35,7 @@
     "Firefox Focus": "https://support.allizom.org/en-US/questions/new/focus/form",
     "Mozilla Account": "https://support.allizom.org/en-US/questions/new/mozilla-account/form"
   },
+  "product_without_aaq_url" : "https://support.allizom.org/en-US/kb/get-community-support?exit_aaq=1",
   "aaq_topic_tags": {
     "Firefox": {
       "Install and update": "install-and-update",

--- a/playwright_tests/tests/explore_help_articles_tests/explore_by_topic_tests/test_explore_by_topics.py
+++ b/playwright_tests/tests/explore_help_articles_tests/explore_by_topic_tests/test_explore_by_topics.py
@@ -1,0 +1,136 @@
+import time
+
+import allure
+import pytest
+from playwright.sync_api import Page
+
+from playwright_tests.core.utilities import Utilities
+from playwright_tests.messages.ask_a_question_messages.AAQ_messages.aaq_widget import (
+    AAQWidgetMessages)
+from playwright_tests.messages.ask_a_question_messages.contact_support_messages import (
+    ContactSupportMessages)
+from playwright_tests.pages.sumo_pages import SumoPages
+
+troubleshooting_topic_url = ("https://support.allizom.org/en-US/topics/customize-settings-and"
+                             "-preferences")
+
+
+#  C2663958, C2663959
+@pytest.mark.exploreByTopics
+def test_explore_by_topic_product_filter(page: Page):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    with allure.step("Navigating to the /topics/  Customize settings and preferences  page"):
+        utilities.navigate_to_link(troubleshooting_topic_url)
+    for topic in sumo_pages.explore_by_topic_page._get_all_topics_side_navbar_options():
+        topic = topic.strip()
+        if topic != "Customize settings and preferences":
+            sumo_pages.explore_by_topic_page._click_on_a_topic_filter(topic)
+        with allure.step("Verifying that the correct page header is displayed"):
+            assert topic == (sumo_pages.explore_by_topic_page
+                             ._get_explore_by_topic_page_header().strip())
+        for product in sumo_pages.explore_by_topic_page._get_all_filter_by_product_options():
+            product = product.strip()
+            if product.strip() == "All Products":
+                continue
+            else:
+                sumo_pages.explore_by_topic_page._select_a_filter_by_product_option(
+                    product.strip())
+                time.sleep(2)
+                # This currently fails due to https://github.com/mozilla/sumo/issues/1901.
+                # Uncommenting after the issue is fixed.
+                # if not sumo_pages.explore_by_topic_page._get_metadata_of_all_listed_articles():
+                #     pytest.fail(f"There is no sublist for {product}")
+
+                for sublist in (sumo_pages.explore_by_topic_page
+                                ._get_metadata_of_all_listed_articles()):
+                    assert product in sublist
+
+
+# C2462867
+@pytest.mark.exploreByTopics
+def test_explore_by_topic_aaq_widget_text(page: Page):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+
+    with allure.step("Signing in to SUMO"):
+        utilities.start_existing_session(utilities.username_extraction_from_email(
+            utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
+        ))
+
+    with allure.step("Navigating to the /topics/  Customize settings and preferences  page"):
+        utilities.navigate_to_link(troubleshooting_topic_url)
+    for topic in sumo_pages.explore_by_topic_page._get_all_topics_side_navbar_options():
+        topic = topic.strip()
+        if topic != "Customize settings and preferences":
+            sumo_pages.explore_by_topic_page._click_on_a_topic_filter(topic)
+        for product in sumo_pages.explore_by_topic_page._get_all_filter_by_product_options():
+            product = product.strip()
+            sumo_pages.explore_by_topic_page._select_a_filter_by_product_option(product)
+            time.sleep(2)
+            with allure.step("Verifying the correct AAQ widget text is displayed for products"):
+                if product == "All Products":
+                    assert (sumo_pages.explore_by_topic_page
+                            ._get_text_of_aaq_widget() == AAQWidgetMessages
+                            .NEUTRAL_AAQ_SUBHEADING_TEXT)
+                elif product in utilities.general_test_data['freemium_products']:
+                    assert (sumo_pages.explore_by_topic_page
+                            ._get_text_of_aaq_widget() == AAQWidgetMessages
+                            .FREEMIUM_AAQ_SUBHEADING_TEXT)
+                elif product in utilities.general_test_data['premium_products']:
+                    assert (sumo_pages.explore_by_topic_page
+                            ._get_text_of_aaq_widget() == AAQWidgetMessages
+                            .PREMIUM_AAQ_SUBHEADING_TEXT)
+                else:
+                    assert not sumo_pages.explore_by_topic_page._is_aaq_text_visible()
+
+
+# C2663960
+@pytest.mark.exploreByTopics
+def test_explore_by_topic_aaq_widget_redirect(page: Page):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+
+    with allure.step("Signing in to SUMO"):
+        utilities.start_existing_session(utilities.username_extraction_from_email(
+            utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
+        ))
+
+    with allure.step("Navigating to the /topics/  Customize settings and preferences  page"):
+        utilities.navigate_to_link(troubleshooting_topic_url)
+
+    for topic in sumo_pages.explore_by_topic_page._get_all_topics_side_navbar_options():
+        topic = topic.strip()
+        if topic != "Customize settings and preferences":
+            sumo_pages.explore_by_topic_page._click_on_a_topic_filter(topic)
+        for product in sumo_pages.explore_by_topic_page._get_all_filter_by_product_options():
+            product = product.strip()
+            current_url = utilities.get_page_url()
+            sumo_pages.explore_by_topic_page._select_a_filter_by_product_option(product)
+            print(f"This is the product: {product}")
+            time.sleep(2)
+            with page.expect_navigation() as navigation_info:
+                sumo_pages.explore_by_topic_page._click_on_aaq_continue_button()
+            response = navigation_info.value
+            assert response.status == 200
+            if product == "All Products":
+                assert ContactSupportMessages.PAGE_URL == utilities.get_page_url()
+            elif product not in utilities.aaq_question_test_data['products_aaq_url']:
+                assert (utilities.aaq_question_test_data['product_without_aaq_url'] == utilities.
+                        get_page_url())
+            else:
+                assert (utilities.
+                        aaq_question_test_data['products_aaq_url'][product] == utilities.
+                        get_page_url())
+
+            utilities.navigate_to_link(current_url)
+
+
+# C2663961
+@pytest.mark.exploreByTopics
+def test_incorrect_kb_topic_listing_redirect(page: Page):
+    utilities = Utilities(page)
+    with page.expect_navigation() as navigation_info:
+        utilities.navigate_to_link("https://support.allizom.org/en-US/topics/get-started")
+    response = navigation_info.value
+    assert response.status == 404

--- a/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
+++ b/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
@@ -89,7 +89,7 @@ def test_explore_by_product_redirects(page: Page):
                         PRODUCTS_PAGE_HEADER)
 
 
-# C2462867
+# C2462867, C2663957
 @pytest.mark.topNavbarTests
 def test_explore_by_topic_redirects(page: Page):
     sumo_pages = SumoPages(page)
@@ -106,18 +106,18 @@ def test_explore_by_topic_redirects(page: Page):
                 sumo_pages.top_navbar._hover_over_explore_by_product_top_navbar_option()
                 sumo_pages.top_navbar._click(option)
 
-            assert (current_option == sumo_pages.explore_by_product_page
+            assert (current_option == sumo_pages.explore_by_topic_page
                     ._get_explore_by_topic_page_header())
 
             with allure.step("Verifying that the correct option is selected inside the 'All "
                              "Topics' side navbar"):
-                assert (current_option == sumo_pages.explore_by_product_page
+                assert (current_option == sumo_pages.explore_by_topic_page
                         ._get_selected_topic_side_navbar_option())
 
             with allure.step("Verifying that the 'All Products' option is displayed inside the "
                              "'Filter by product' dropdown"):
-                assert (sumo_pages.explore_by_product_page
-                        ._get_current_topic_filter_dropdown_option()) == 'All Products'
+                assert (sumo_pages.explore_by_topic_page
+                        ._get_current_product_filter_dropdown_option()) == 'All Products'
 
 
 # C2462868


### PR DESCRIPTION
- Adding a new helper function in BasePage to extract the list of text content for a given locator.
- Adding the https://support.allizom.org/en-US/kb/get-community-support?exit_aaq=1 page to test data.
- Adding the AAQ widget text which is displayed when the "All Products" filter is applied to AAQWidgetMessage for further usage in tests.
- Expanding the locators & actions for the ExploreByTopicsPage class.
- Adding playwright coverage for the "Explore By Topic" page:
  - Verifying that the correct explore by topic page header is displayed when changing the topic via the "All Topics" side navbar.
  - Verifying that the "Filter by product" successfully updates the displayed list of articles with articles that belong to the chosen product from the "Filter by product" dropdown (by verifying the displayed metadata for each listed article)
  - Verifying that the correct AAQ widget text is displayed for each filtered product.
  - Verifying the correct AAQ widget redirect for each filtered product.
  - Added playwright coverage for the https://github.com/mozilla/sumo/issues/1876 case
- Adding the new test suite to playwright.yml