### PR TITLE
fix products.js and convert to vanilla JS

### DIFF
--- a/kitsune/sumo/static/sumo/js/products.js
+++ b/kitsune/sumo/static/sumo/js/products.js
@@ -1,17 +1,22 @@
 import UITour from "./libs/uitour";
 import compareVersions from "./compare_versions";
 
-(function($) {
-  'use strict';
+// The "DOMContentLoaded" event is guaranteed not to have been
+// called by the time the following code is run, because it always
+// waits until all deferred scripts have been loaded, and the code
+// in this file is always bundled into a script that is deferred.
+document.addEventListener("DOMContentLoaded", () => {
+  let downloadButton = document.querySelector(".download-firefox .download-button");
 
-  $(function() {
-    var latestVersion = $('.download-firefox .download-button').data('latest-version');
-
-    UITour.getConfiguration('appinfo', function(info) {
-      if (compareVersions(info.version, latestVersion) === 0) {
-        $('.refresh-firefox').show();
-        $('.download-firefox').hide();
-      }
-    });
-  });
-})(jQuery);
+  if (downloadButton) {
+    let latestVersion = downloadButton.dataset.latestVersion;
+    if (latestVersion) {
+      UITour.getConfiguration("appinfo", function(info) {
+        if (compareVersions(info.version, latestVersion) === 0) {
+          document.querySelector(".refresh-firefox").hidden = false;
+          document.querySelector(".download-firefox").hidden = true;
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
mozilla/sumo#1716

This PR is a fix for this issue, but at the immediate, surface level. It fixes `products.js` to handle the cases when things don't exist in the DOM, and also converts it to vanilla JS (removes its reliance on jQuery). The PR that addresses the deeper problem that this issue manifests is https://github.com/mozilla/kitsune/pull/6136. Only one of the two PR's should be merged. This PR should be favored over the other one if we'd like to remain open to making the `Refresh Firefox` button (the one included by the `download_firefox()` Jinja macro) work as intended sometime in the future.