### PR TITLE
[l10n] Fix missing localization strings inside posted AAQ questions

### DIFF
--- a/kitsune/questions/jinja2/questions/includes/email_subscribe.html
+++ b/kitsune/questions/jinja2/questions/includes/email_subscribe.html
@@ -16,11 +16,11 @@
     <ul id="id_event_type">
       <li class="field radio is-condensed">
         <input type="radio" name="event_type" value="reply" required="" checked="" id="id_event_type_0">
-        <label for="id_event_type_0">when anybody replies.</label>
+        <label for="id_event_type_0">{{ _('when anybody replies') }}.</label>
       </li>
       <li class="field radio is-condensed">
         <input type="radio" name="event_type" value="solution" required="" id="id_event_type_1">
-        <label for="id_event_type_1">when a solution is found.</label>
+        <label for="id_event_type_1">{{ _('when a solution is found') }}.</label>
       </li>
     </ul>
 

--- a/kitsune/questions/jinja2/questions/question_details.html
+++ b/kitsune/questions/jinja2/questions/question_details.html
@@ -422,7 +422,7 @@
                         class="tag-adder">
                     {% csrf_token %}
                     <div class="field is-condensed">
-                      <label for="id_tag_input">Add a tag:</label>
+                      <label for="id_tag_input">{{ _('Add a tag') }}:</label>
                       <input id="id_tag_input" type="text" name="tag-name" size="12" maxlength="100"
                         class="searchbox autocomplete-tags {% if tag_adding_error %} invalid{% endif %}"
                         value="{{ tag_adding_value }}" />


### PR DESCRIPTION
Fix missing localization for strings in question_details.html and email_subscribe.html