### PR TITLE
[l10n] Fix the unlocalized "More" option from the product topic listing page

### DIFF
--- a/kitsune/sumo/static/sumo/js/sumo-tabs.js
+++ b/kitsune/sumo/static/sumo/js/sumo-tabs.js
@@ -17,7 +17,7 @@ export default function tabsInit() {
     primary.insertAdjacentHTML('beforeend', `
     <li class="tabs--item-more">
       <button class="tabs--button" type="button" aria-haspopup="true" aria-expanded="false">
-        More
+        {{ _('More') }}
       </button>
       <ul class="tabs--dropdown elevation-01">
         ${primary.innerHTML}


### PR DESCRIPTION
Fix the "More" unlocalized string from the topics listing page (example: https://support.allizom.org/de/products/firefox/troubleshooting). 
![image](https://github.com/user-attachments/assets/0177411a-88ef-433b-8c52-ffd3033cb6b4)
