### PR TITLE
Playwright test fixes, restricted visibility suite and wait improvements

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,7 @@ on:
                     - productTopicsPage
                     - AAQ
                     - KB Articles
-                    - KB Restricted Visibility
+                    - kbRestrictedVisibility
                     - KB Article Translation
                     - recentRevisionsDashboard
                     - kbDashboard
@@ -98,7 +98,7 @@ jobs:
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
             declare dispatch_test_suite="${{inputs.TestSuite}}"
-            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "messagingSystemCleanup" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "restrictedArticleCreation" "kbRestrictedVisibilitySingleGroup" "whitelistingDifferentGroup" "kbRestrictedVisibilityMultipleGroups" "removingAllArticleRestrictions" "kbRemovedRestrictions" "deleteAllRestrictedTestArticles" "kbArticleTranslation" "exploreByTopics")
+            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "messagingSystemCleanup" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics")
             if [ "$dispatch_test_suite" == "All" ] || [ "${{ github.event_name}}" == "schedule" ] ; then
                 for test in "${all_test_suites[@]}"; do
                     if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
@@ -119,12 +119,6 @@ jobs:
                 done
             elif [ "$dispatch_test_suite" == "KB Articles" ]; then
                 for test in "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory"; do
-                    if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
-                        any_failures=true
-                    fi
-                done
-            elif [ "$dispatch_test_suite" == "KB Restricted Visibility" ]; then
-                for test in "restrictedArticleCreation" "kbRestrictedVisibilitySingleGroup" "whitelistingDifferentGroup" "kbRestrictedVisibilityMultipleGroups" "removingAllArticleRestrictions" "kbRemovedRestrictions"  "deleteAllRestrictedTestArticles"; do
                     if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
                         any_failures=true
                     fi

--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -14,14 +14,14 @@ class BasePage:
         This helper function returns the element locator from a given xpath.
         """
         if with_wait:
-            self.__wait_for_dom_load_to_finnish()
+            self.page.wait_for_selector(xpath)
         return self.page.locator(xpath)
 
     def _get_elements_locators(self, xpath: str) -> list[Locator]:
         """
         This helper function returns a list of element locators from a given xpath.
         """
-        self.__wait_for_dom_load_to_finnish()
+        self._wait_for_selector(xpath)
         return self.page.locator(xpath).all()
 
     def _get_current_page_url(self) -> str:
@@ -48,11 +48,14 @@ class BasePage:
         """
         return self._get_element_locator(xpath).all_inner_texts()
 
-    def _get_text_of_element(self, xpath: str) -> str:
+    def _get_text_of_element(self, xpath: str, with_wait: bool) -> str:
         """
         This helper function returns the inner text of a given xpath.
         """
-        return self._get_element_locator(xpath).inner_text()
+        if with_wait:
+            self._get_element_locator(xpath, with_wait=with_wait).inner_text()
+        else:
+            return self._get_element_locator(xpath).inner_text()
 
     def _get_text_of_locator(self, locator: Locator) -> str:
         """

--- a/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
+++ b/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
@@ -551,7 +551,8 @@ class QuestionPage(BasePage):
         return super()._get_text_of_elements(self.__common_responses_responses_options)
 
     def _click_on_a_particular_category_option(self, option: str):
-        super()._click(f"//ul[@class='category-list']/li[text()='{option}']")
+        super()._click(f"//ul[@class='category-list']/li[text()='{option}']",
+                       with_wait=True)
 
     def _click_on_a_particular_response_option(self, option: str):
         super()._click(f"//ul[@class='sidebar-nav']/li[text()='{option}']")
@@ -568,10 +569,10 @@ class QuestionPage(BasePage):
         return super()._get_text_of_element(self.__common_responses_response_preview)
 
     def _click_on_switch_to_mode(self):
-        super()._click(self.__common_responses_switch_to_mode)
+        super()._click(self.__common_responses_switch_to_mode, with_wait=True)
 
     def _click_on_common_responses_cancel_button(self):
-        super()._click(self.__common_responses_cancel_button)
+        super()._click(self.__common_responses_cancel_button, with_wait=True)
 
     def _click_on_common_responses_insert_response_button(self):
         super()._click(self.__common_responses_insert_response_button)

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -26,12 +26,7 @@ markers =
     kbArticleShowHistory: Tests belonging to the kb article show history section.
     recentRevisionsDashboard: Tests belonging to the recent revisions dashboard.
     kbDashboard: Tests belonging to the KB dashboard.
-    restrictedArticleCreation: Prerequisite for restricted visibility kb tests.
-    kbRestrictedVisibilitySingleGroup: Tests belonging to the kb article restriction with one group.
-    whitelistingDifferentGroup: Whitelisting a different group action.
-    kbRestrictedVisibilityMultipleGroups: Tests belonging to the kb article restriction with multiple restricted groups.
-    removingAllArticleRestrictions: Removing all restrictions action.
-    kbRemovedRestrictions: Tests belonging to the kb article restriction with all restrictions removed.
+    kbRestrictedVisibility: Tests belonging to the KB article restriction functionality.
     kbArticleTranslation: Tests belonging to kb article translation.
     deleteAllRestrictedTestArticles: Deleting all restricted test articles.
     create_delete_article: Fixture used for creating and deleting test articles.

--- a/playwright_tests/test_data/aaq_question.json
+++ b/playwright_tests/test_data/aaq_question.json
@@ -29,6 +29,7 @@
     "Firefox for Enterprise": "https://support.allizom.org/en-US/questions/new/firefox-enterprise/form",
     "MDN Plus": "https://support.allizom.org/en-US/questions/new/mdn-plus/form",
     "Mozilla VPN": "https://support.allizom.org/en-US/questions/new/firefox-private-network-vpn/form",
+    "Mozilla Monitor": "https://support.allizom.org/en-US/questions/new/monitor/form",
     "Firefox Relay": "https://support.allizom.org/en-US/questions/new/relay/form",
     "Pocket": "https://support.allizom.org/en-US/questions/new/pocket/form",
     "Thunderbird": "https://support.allizom.org/en-US/questions/new/thunderbird/form",

--- a/playwright_tests/test_data/add_kb_article.json
+++ b/playwright_tests/test_data/add_kb_article.json
@@ -7,7 +7,7 @@
   "category_options": "Troubleshooting",
   "relevant_to_option": "Firefox",
   "selected_parent_topic": "Firefox",
-  "selected_child_topic": "Bookmarks and tabs",
+  "selected_child_topic": "Troubleshooting",
   "related_documents": "Stage test owl",
   "keywords": "auto test keywordv1",
   "updated_keywords": "auto updated keyword",

--- a/playwright_tests/test_data/general_data.json
+++ b/playwright_tests/test_data/general_data.json
@@ -12,7 +12,8 @@
     "Mozilla VPN",
     "Firefox Relay",
     "Pocket",
-    "Mozilla Account"
+    "Mozilla Account",
+    "Mozilla Monitor"
   ],
   "kb_article_categories": [
     "Troubleshooting",
@@ -56,6 +57,7 @@
     "Firefox for Enterprise": "https://support.allizom.org/en-US/questions/new/firefox-enterprise",
     "MDN Plus": "https://support.allizom.org/en-US/questions/new/mdn-plus",
     "Mozilla VPN": "https://support.allizom.org/en-US/questions/new/firefox-private-network-vpn",
+    "Mozilla Monitor": "https://support.allizom.org/en-US/questions/new/monitor",
     "Firefox Relay": "https://support.allizom.org/en-US/questions/new/relay",
     "Pocket": "https://support.allizom.org/en-US/questions/new/pocket",
     "Thunderbird": "https://support.allizom.org/en-US/questions/new/thunderbird",

--- a/playwright_tests/test_data/restricted_visibility_articles.json
+++ b/playwright_tests/test_data/restricted_visibility_articles.json
@@ -1,1 +1,0 @@
-{"restricted_kb_article_title": "", "restricted_kb_article_url": "", "restricted_kb_article_thread": "", "restricted_kb_article_child_topic": "", "restricted_kb_template_title": "", "restricted_kb_template_url": "", "restricted_kb_template_thread": "", "simple_article_url": "", "simple_article_template_url": ""}

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -1827,14 +1827,13 @@ def test_common_responses(page: Page):
                 utilities.user_secrets_accounts['TEST_ACCOUNT_13']
             ))
         sumo_pages.question_page._click_on_common_responses_option()
-        utilities.wait_for_networkidle()
         sumo_pages.question_page._click_on_a_particular_category_option(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_category"]
         )
         sumo_pages.question_page._type_into_common_responses_search_field(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
         )
-        utilities.wait_for_networkidle()
+        utilities.wait_for_given_timeout(3000)
 
     with allure.step("Verifying that the only item in the category field is the searched "
                      "option"):
@@ -1849,7 +1848,6 @@ def test_common_responses(page: Page):
             utilities.aaq_question_test_data["valid_firefox_question"]
             ["common_responses_response"]
         )
-        utilities.wait_for_networkidle()
         sumo_pages.question_page._click_on_common_responses_cancel_button()
 
     with check, allure.step("Verifying that the form textarea does not contain the common "
@@ -1859,14 +1857,13 @@ def test_common_responses(page: Page):
     with allure.step("Clicking on the 'Common Responses' option and selecting a response "
                      "from the list"):
         sumo_pages.question_page._click_on_common_responses_option()
-        utilities.wait_for_networkidle()
         sumo_pages.question_page._click_on_a_particular_category_option(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_category"]
         )
         sumo_pages.question_page._type_into_common_responses_search_field(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
         )
-        utilities.wait_for_networkidle()
+        utilities.wait_for_given_timeout(3000)
 
     with allure.step("Verifying that the only item in the category field is the searched "
                      "option"):
@@ -1880,9 +1877,7 @@ def test_common_responses(page: Page):
         sumo_pages.question_page._click_on_a_particular_response_option(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
         )
-        utilities.wait_for_networkidle()
         sumo_pages.question_page._click_on_switch_to_mode()
-        utilities.wait_for_networkidle()
         response = sumo_pages.question_page._get_text_of_response_preview()
 
     with check, allure.step("Clicking on the Insert Response, post reply and verifying that "

--- a/playwright_tests/tests/conftest.py
+++ b/playwright_tests/tests/conftest.py
@@ -12,6 +12,7 @@ def navigate_to_homepage(page: Page):
     This fixture is used in all functions. It navigates to the SuMo homepage and returns the page
     object.
     """
+    page.set_default_navigation_timeout(120000)
     page.goto(HomepageMessages.STAGE_HOMEPAGE_URL)
     return page
 

--- a/playwright_tests/tests/explore_help_articles_tests/articles/conftest.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/conftest.py
@@ -7,14 +7,12 @@ from playwright_tests.flows.explore_articles_flows.article_flows.add_kb_article_
     AddKbArticleFlow
 from playwright_tests.flows.explore_articles_flows.article_flows.delete_kb_article_flow import \
     DeleteKbArticleFlow
-from playwright_tests.pages.auth_page import AuthPage
 
 
 @pytest.fixture
 def create_delete_article(request, page: Page):
     utilities = Utilities(page)
     submit_kb_article_flow = AddKbArticleFlow(page)
-    auth_page = AuthPage(page)
     kb_article_deletion_flow = DeleteKbArticleFlow(page)
     auto_close = True
     marker = request.node.get_closest_marker("create_delete_article")
@@ -57,11 +55,11 @@ def create_delete_article(request, page: Page):
     yield _create_delete_article
 
     if auto_close:
+        utilities.delete_cookies()
         for article_link in created_articles_url:
             utilities.navigate_to_link(article_link)
-            if auth_page._is_logged_in_sign_in_button_displayed():
-                utilities.start_existing_session(
-                    utilities.username_extraction_from_email(
-                        utilities.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
-                    ))
+            utilities.start_existing_session(
+                utilities.username_extraction_from_email(
+                    utilities.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
+                ))
             kb_article_deletion_flow.delete_kb_article()

--- a/playwright_tests/tests/explore_help_articles_tests/explore_by_topic_tests/test_explore_by_topics.py
+++ b/playwright_tests/tests/explore_help_articles_tests/explore_by_topic_tests/test_explore_by_topics.py
@@ -131,6 +131,6 @@ def test_explore_by_topic_aaq_widget_redirect(page: Page):
 def test_incorrect_kb_topic_listing_redirect(page: Page):
     utilities = Utilities(page)
     with page.expect_navigation() as navigation_info:
-        utilities.navigate_to_link("https://support.allizom.org/en-US/topics/get-started")
+        utilities.navigate_to_link("https://support.allizom.org/en-US/topics/testt")
     response = navigation_info.value
     assert response.status == 404


### PR DESCRIPTION
- Adding Mozilla Monitor to playwright coverage.
- Fixing some failures caused by the recent taxonomy work.
- Isolating the restricted visibility kb articles to avoid flakiness (no longer using a single kb article for multiple tests. Making use of the create_delete_article fixture to create a fresh kb article before each test & delete when done)
- Removing unused playwright.yml and pytest.ini markers.
- Reworking the waits.