### PR TITLE
[Playwright] Update how we are fetching the current browser name in tests

### DIFF
--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -501,7 +501,7 @@ def test_lock_and_archive_this_question(page: Page, status):
 
 # C2191267, C2191116, C2134136, C2191091
 @pytest.mark.postedQuestions
-def test_subscribe_to_feed_option(page: Page):
+def test_subscribe_to_feed_option(page: Page, is_firefox):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Signing in with a non admin user account"):
@@ -540,7 +540,7 @@ def test_subscribe_to_feed_option(page: Page):
                      "Chrome) or has the correct download info (Firefox)"):
         utilities.navigate_to_link(question_info_one['question_page_url'])
 
-        if page.context.browser.browser_type.name == "chromium":
+        if not is_firefox:
             sumo_pages.question_page._click_on_subscribe_to_feed_option()
             expect(page).to_have_url(
                 question_info_one['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
@@ -562,7 +562,7 @@ def test_subscribe_to_feed_option(page: Page):
                      "option and verifying that the url is updated to the feed endpoint ("
                      "Chrome) or has the correct download info (Firefox)"):
         utilities.navigate_to_link(question_info_two['question_page_url'])
-        if page.context.browser.browser_type.name == "chromium":
+        if not is_firefox:
             sumo_pages.question_page._click_on_subscribe_to_feed_option()
             expect(page).to_have_url(
                 question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
@@ -587,7 +587,7 @@ def test_subscribe_to_feed_option(page: Page):
                      "the feed endpoint (Chrome) or has the correct download info (Firefox)"):
         utilities.delete_cookies()
 
-        if page.context.browser.browser_type.name == "chromium":
+        if not is_firefox:
             sumo_pages.question_page._click_on_subscribe_to_feed_option()
             expect(page).to_have_url(
                 question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
@@ -615,7 +615,7 @@ def test_subscribe_to_feed_option(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
 
-        if page.context.browser.browser_type.name == "chromium":
+        if not is_firefox:
             sumo_pages.question_page._click_on_subscribe_to_feed_option()
             expect(page).to_have_url(
                 question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -51,7 +51,7 @@ def test_there_are_no_messages_here_text_is_displayed_when_no_messages_are_avail
 # C2094292
 # This test needs to be updated to fetch the username from a different place
 @pytest.mark.messagingSystem
-def test_private_messages_can_be_sent_via_user_profiles(page: Page):
+def test_private_messages_can_be_sent_via_user_profiles(page: Page, is_firefox):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     message_body = "Test1"
@@ -75,7 +75,7 @@ def test_private_messages_can_be_sent_via_user_profiles(page: Page):
     with allure.step("Verifying that the receiver is automatically added inside the 'To' "
                      "field"):
         # Firefox GH runner fails here. We are running this assertion only in Chrome for now
-        if page.context.browser.browser_type.name == "chromium":
+        if not is_firefox:
             assert sumo_pages.new_message_page._get_user_to_text() == user_two, (
                 f"Incorrect 'To' receiver. Expected: {user_two}. "
                 f"Received: {sumo_pages.new_message_page._get_user_to_text()}"

--- a/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
@@ -34,7 +34,7 @@ def test_username_field_is_automatically_populated(page: Page):
 # This test is currently covering the: my profile section, top navbar, and posted questions.
 # Might want to extend the coverage
 @pytest.mark.editUserProfileTests
-def test_edit_profile_field_validation_with_symbols(page: Page):
+def test_edit_profile_field_validation_with_symbols(page: Page, is_firefox):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Signing in with a non-admin account"):
@@ -52,11 +52,11 @@ def test_edit_profile_field_validation_with_symbols(page: Page):
         sumo_pages.edit_my_profile_page._clear_display_name_field()
         profile_edit_data = utilities.profile_edit_test_data
 
-        if page.context.browser.browser_type.name == "chromium":
+        if not is_firefox:
             new_username = profile_edit_data["valid_user_edit_with_symbols"][
                 "username_with_valid_symbols_chrome"
             ]
-        elif page.context.browser.browser_type.name == "firefox":
+        else:
             new_username = profile_edit_data["valid_user_edit_with_symbols"][
                 "username_with_valid_symbols_firefox"
             ]
@@ -298,7 +298,7 @@ def test_username_can_contain_uppercase_and_lowercase_letters(page: Page):
 
 #  C1491463, C1491464
 @pytest.mark.editUserProfileTests
-def test_display_name_replaces_the_username_text(page: Page):
+def test_display_name_replaces_the_username_text(page: Page, is_firefox):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Signing in with a non-admin account"):
@@ -308,11 +308,11 @@ def test_display_name_replaces_the_username_text(page: Page):
 
     original_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
 
-    if page.context.browser.browser_type.name == "chromium":
+    if not is_firefox:
         new_display_name = utilities.profile_edit_test_data["valid_user_edit"][
             "display_name_chrome"
         ]
-    elif page.context.browser.browser_type.name == "firefox":
+    else:
         new_display_name = utilities.profile_edit_test_data["valid_user_edit"][
             "display_name_firefox"
         ]


### PR DESCRIPTION
- Playwright pytest provides the is_chromium, is_webkit and is_firefox fixtures to determine the current browser used for testing. Modifying tests to use those.