### PR TITLE
fix relevant topics widget for docs

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/product_topics_widget.html
+++ b/kitsune/wiki/jinja2/wiki/includes/product_topics_widget.html
@@ -1,20 +1,20 @@
 <section id="accordion" class="mzp-c-details products">
-  {% for product_title, topics in topics_by_product.items() %}
-  <h3 class="sumo-card-heading">{{ product_title }}</h3>
+  {% for product, topics in topics_by_product.items() %}
+  <h3 class="sumo-card-heading">{{ product.title }}</h3>
   <ul class="checkbox-list">
     {% for topic in topics %}
     <li>
     <div class="field checkbox is-condensed">
-      <input type="checkbox" name="{{ name }}" id="id_{{ topic.id }}" value="{{ topic.id }}"{% if topic.checked %} checked{% endif %}/>
-      <label for="id_{{ topic.id }}">{{ topic.title }}</label>
+      <input type="checkbox" name="{{ name }}" id="id_{{ product.id }}_{{ topic.id }}" value="{{ topic.id }}"{% if topic.checked %} checked{% endif %}/>
+      <label for="id_{{ product.id }}_{{ topic.id }}">{{ topic.title }}</label>
     </div>
       {% if topic.my_subtopics %}
         <ul class="checkbox-list--sublist">
           {% for subtopic in topic.my_subtopics %}
             <li>
               <div class="field checkbox is-condensed">
-                <input type="checkbox" name="{{ name }}" id="id_sub_{{ subtopic.id }}" value="{{ subtopic.id }}"{% if subtopic.checked %} checked{% endif %}/>
-                <label for="id_sub_{{ subtopic.id }}">{{ subtopic.title }}</label>
+                <input type="checkbox" name="{{ name }}" id="id_sub_{{ product.id }}_{{ subtopic.id }}" value="{{ subtopic.id }}"{% if subtopic.checked %} checked{% endif %}/>
+                <label for="id_sub_{{ product.id }}_{{ subtopic.id }}">{{ subtopic.title }}</label>
               </div>
             </li>
           {% endfor %}

--- a/kitsune/wiki/widgets.py
+++ b/kitsune/wiki/widgets.py
@@ -27,7 +27,7 @@ class ProductTopicsAndSubtopicsWidget(forms.widgets.SelectMultiple):
                 for subtopic in topic.my_subtopics:
                     self.process_topic(value, subtopic)
 
-            topics_by_product[product.title] = topics
+            topics_by_product[product] = topics
 
         return render_to_string(
             "wiki/includes/product_topics_widget.html",


### PR DESCRIPTION
mozilla/sumo#1937

This PR fixes the issue above, but it doesn't address improving the interface for how products and topics are associated with an article. That can be done in a separate PR.