### PR TITLE
update switching-devices topic

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -1298,9 +1298,7 @@ LEGACY_CONTRIBUTOR_GROUPS = [
 FIREFOX_SWITCHING_DEVICES_ARTICLES = config(
     "FIREFOX_SWITCHING_DEVICES_ARTICLES", default="switching-devices", cast=Csv()
 )
-FIREFOX_SWITCHING_DEVICES_TOPIC = config(
-    "FIREFOX_SWITCHING_DEVICES_TOPIC", default="back-up-your-data"
-)
+FIREFOX_SWITCHING_DEVICES_TOPIC = config("FIREFOX_SWITCHING_DEVICES_TOPIC", default="backup-data")
 
 # Slugs of articles that have a special CTA for Mozilla account
 MOZILLA_ACCOUNT_ARTICLES = [


### PR DESCRIPTION
mozilla/sumo#1940

I think all of the articles associated with the old topic of slug `back-up-your-data` have been moved to the new topic of slug `backup-data`, so the `FIREFOX_SWITCHING_DEVICES_TOPIC` setting has to be updated accordingly.