### PR TITLE
Update docs workflow caching

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,15 +27,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+          cache: pip
       - id: pages
-        uses: actions/configure-pages@v4
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
+        uses: actions/configure-pages@v5
       - run: pip install mkdocs-material 
       - run: mkdocs build -d dist
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Following up from https://github.com/mozilla/kitsune/pull/5943#pullrequestreview-1984069258 — this caches built wheels and downloaded packages for later reuse via implicit action machinery.

_(Also bumps configure-pages action that fixes vague error reporting et al.)_

Workflow [run for `43de721`](https://github.com/janbrasna/kitsune/actions/runs/10342670412) and cache priming & hit shown:

1. Storing cache: [actions/runs/10342358161/job/28625206900#step:5:115](https://github.com/janbrasna/kitsune/actions/runs/10342358161/job/28625206900#step:5:115)
2. Restoring cache: [actions/runs/10342670412/job/28625892130#step:3:15](https://github.com/janbrasna/kitsune/actions/runs/10342670412/job/28625892130#step:3:15)