### PR TITLE
remove firefox download button when navigating by topic

### DIFF
--- a/kitsune/products/jinja2/products/includes/topic_documents.html
+++ b/kitsune/products/jinja2/products/includes/topic_documents.html
@@ -2,7 +2,6 @@
   <div class="sumo-article-header--text">
 
     <div class="documents-product-title">
-      {{ download_firefox() }}
       <h1 class="topic-title is-subtopic sumo-page-heading">
         {{ pgettext('DB: products.Topic.title', topic.title) }}
       </h1>


### PR DESCRIPTION
mozilla/sumo#1954

When navigating by topic, the Firefox download button is already shown in the profile on non-Firefox browsers, so there's no need to show it within the topics page.