### PR TITLE
fix contributor tools menus on mobile

### DIFF
--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -701,13 +701,11 @@
 </li>
 {% endmacro %}
 
-{% macro for_contributors_sidebar(user, default_language, li_only=False, active=None, menu="contributor-discussions", locale=None, is_collapsible=False) -%}
+{% macro for_contributors_sidebar(user, default_language, active=None, menu="contributor-discussions", locale=None, is_collapsible=False) -%}
 {% if user.is_authenticated %}
 <nav class="sidebar-nav" id="for-contributors-sidebar">
   <span class="details-heading"></span>
-  {% if not li_only %}
     <ul class="sidebar-nav--list">
-  {% endif %}
     {% if menu == "contributor-tools" %}
       <li class="sidebar-subheading sidebar-nav--heading-item hide-on-mobile">{{ _('Contributor tools') }}</li>
       {{ _tools_nav_links(user, default_language, active, context="sidebar-menu", locale=locale, is_collapsible=is_collapsible) }}
@@ -715,10 +713,7 @@
       <li class="sidebar-subheading sidebar-nav--heading-item">{{ _('Contributor discussions') }}</li>
       {{ _discussion_nav_links(user, default_language, active, context="sidebar-menu") }}
     {% endif %}
-
-  {% if not li_only %}
     </ul>
-  {% endif %}
 </nav>
 {% endif %}
 {%- endmacro %}

--- a/kitsune/sumo/static/sumo/js/protocol-details-init.js
+++ b/kitsune/sumo/static/sumo/js/protocol-details-init.js
@@ -40,7 +40,6 @@ export default function detailsInit() {
     if (sidebarList && mq.matches) {
       window.Mzp.Details.init('.details-heading');
       swapMobileSubnavText();
-
     } else {
       window.Mzp.Details.destroy('.details-heading');
     }

--- a/kitsune/wiki/jinja2/wiki/new_document.html
+++ b/kitsune/wiki/jinja2/wiki/new_document.html
@@ -85,7 +85,7 @@
 {% block side_top %}
   <nav id="doc-tools">
     <ul class="sidebar-nav sidebar-folding">
-      {{ for_contributors_sidebar(user, settings.WIKI_DEFAULT_LANGUAGE, True) }}
+      {{ for_contributors_sidebar(user, settings.WIKI_DEFAULT_LANGUAGE) }}
     </ul>
   </nav>
 {% endblock %}

--- a/kitsune/wiki/jinja2/wiki/recent_revisions.html
+++ b/kitsune/wiki/jinja2/wiki/recent_revisions.html
@@ -10,7 +10,7 @@
 {% block side_top %}
   <nav id="doc-tools">
     <ul class="sidebar-nav sidebar-folding">
-      {{ for_contributors_sidebar(user, settings.WIKI_DEFAULT_LANGUAGE, True, menu="contributor-tools", locale=locale, is_collapsible=True, active="wiki.revisions") }}
+      {{ for_contributors_sidebar(user, settings.WIKI_DEFAULT_LANGUAGE, menu="contributor-tools", locale=locale, is_collapsible=True, active="wiki.revisions") }}
     </ul>
   </nav>
 {% endblock %}


### PR DESCRIPTION
mozilla/sumo#1783

## QA Notes
@emilghittasv Just FYI, that all of the contributor tools menus seemed to be working on mobile except on the pages `/kb/revisions` and `kb/new`, both of which this PR fixes.