### PR TITLE
Playwright refactor EditProfileDataFlow, Top Navbar and user_pages classes

### DIFF
--- a/playwright_tests/flows/user_profile_flows/edit_profile_data_flow.py
+++ b/playwright_tests/flows/user_profile_flows/edit_profile_data_flow.py
@@ -9,71 +9,79 @@ from playwright_tests.pages.user_pages.my_profile_edit_settings_page import \
 from playwright_tests.pages.user_pages.my_profile_user_navbar import UserNavbar
 
 
-class EditProfileDataFlow(MyProfileEdit,
-                          Utilities,
-                          MyProfileEditContributionAreasPage,
-                          TopNavbar,
-                          UserNavbar,
-                          MyProfileEditSettingsPage):
+class EditProfileDataFlow:
     def __init__(self, page: Page):
-        super().__init__(page)
+        self.utilities = Utilities(page)
+        self.edit_profile_page = MyProfileEdit(page)
+        self.top_navbar = TopNavbar(page)
+        self.edit_settings_page = MyProfileEditSettingsPage(page)
+        self.profile_navbar = UserNavbar(page)
+        self.profile_contribution_areas = MyProfileEditContributionAreasPage(page)
 
     # Editing a profile with data flow.
     def edit_profile_with_test_data(self):
-        edit_test_data = super().profile_edit_test_data
+        edit_test_data = self.utilities.profile_edit_test_data
 
         self._clear_input_fields()
-        super()._send_text_to_username_field(edit_test_data["valid_user_edit"]["username"])
-        super()._send_text_to_display_name_field(edit_test_data["valid_user_edit"]["display_name"])
-        super()._send_text_to_biography_field(edit_test_data["valid_user_edit"]["biography"])
-        super()._send_text_to_website_field(edit_test_data["valid_user_edit"]["website"])
-        super()._send_text_to_twitter_username_field(
+        self.edit_profile_page.send_text_to_username_field(
+            edit_test_data["valid_user_edit"]["username"]
+        )
+        self.edit_profile_page.send_text_to_display_name_field(
+            edit_test_data["valid_user_edit"]["display_name"]
+        )
+        self.edit_profile_page.send_text_to_biography_field(
+            edit_test_data["valid_user_edit"]["biography"]
+        )
+        self.edit_profile_page.send_text_to_website_field(
+            edit_test_data["valid_user_edit"]["website"]
+        )
+        self.edit_profile_page.send_text_to_twitter_username_field(
             edit_test_data["valid_user_edit"]["twitter_username"]
         )
-        super()._send_text_to_community_portal_field(
+        self.edit_profile_page.send_text_to_community_portal_field(
             edit_test_data["valid_user_edit"]["community_portal_username"]
         )
-        super()._send_text_to_people_directory_username(
+        self.edit_profile_page.send_text_to_people_directory_username(
             edit_test_data["valid_user_edit"]["people_directory_username"]
         )
-        super()._send_text_to_matrix_nickname(
+        self.edit_profile_page.send_text_to_matrix_nickname(
             edit_test_data["valid_user_edit"]["matrix_nickname"]
         )
-        super()._select_country_dropdown_option_by_value(
+        self.edit_profile_page.select_country_dropdown_option_by_value(
             edit_test_data["valid_user_edit"]["country_code"]
         )
-        super()._sent_text_to_city_field(edit_test_data["valid_user_edit"]["city"])
-        super()._select_timezone_dropdown_option_by_value(
+        self.edit_profile_page.sent_text_to_city_field(edit_test_data["valid_user_edit"]["city"])
+        self.edit_profile_page.select_timezone_dropdown_option_by_value(
             edit_test_data["valid_user_edit"]["timezone"]
         )
-        super()._select_preferred_language_dropdown_option_by_value(
+        self.edit_profile_page.select_preferred_language_dropdown_option_by_value(
             edit_test_data["valid_user_edit"]["preferred_language"]
         )
-        super()._select_involved_from_month_option_by_value(
+        self.edit_profile_page.select_involved_from_month_option_by_value(
             edit_test_data["valid_user_edit"]["involved_from_month_number"]
         )
-        super()._select_involved_from_year_option_by_value(
+        self.edit_profile_page.select_involved_from_year_option_by_value(
             edit_test_data["valid_user_edit"]["involved_from_year"]
         )
 
     # Clear all profile edit input fields flow.
     def _clear_input_fields(self):
-        super()._clear_all_input_fields()
-        super()._clear_username_field()
-        super()._clear_biography_textarea_field()
+        self.edit_profile_page.clear_all_input_fields()
+        self.edit_profile_page.clear_username_field()
+        self.edit_profile_page.clear_biography_textarea_field()
 
     def check_all_user_settings(self):
-        super()._click_on_settings_profile_option()
-        super()._click_on_all_settings_checkboxes()
-        super()._click_on_update_button()
+        self.top_navbar.click_on_settings_profile_option()
+        self.edit_settings_page.click_on_all_settings_checkboxes()
+        self.edit_settings_page.click_on_update_button()
 
     def check_all_profile_contribution_areas(self, checked: bool):
-        super()._click_on_settings_profile_option()
-        super()._click_on_edit_contribution_areas_option()
+        self.top_navbar.click_on_settings_profile_option()
+        self.profile_navbar.click_on_edit_contribution_areas_option()
 
         if not checked:
-            super()._click_on_unchecked_cont_areas_checkboxes()
+            self.profile_contribution_areas.click_on_unchecked_cont_areas_checkboxes()
         else:
-            super()._click_on_all_checked_cont_areas_checkboxes()
+            self.profile_contribution_areas.click_on_all_checked_cont_areas_checkboxes()
 
-        super()._click_on_update_contribution_areas_button()
+        self.profile_contribution_areas.click_on_update_contribution_areas_button()

--- a/playwright_tests/pages/top_navbar.py
+++ b/playwright_tests/pages/top_navbar.py
@@ -120,146 +120,146 @@ class TopNavbar(BasePage):
     """
         Actions against the top-navbar logo.
     """
-    def _get_sumo_nav_logo(self) -> ElementHandle:
-        return super()._get_element_handle(self.__sumo_nav_logo)
+    def get_sumo_nav_logo(self) -> ElementHandle:
+        return self._get_element_handle(self.__sumo_nav_logo)
 
-    def _click_on_sumo_nav_logo(self):
-        super()._click(self.__sumo_nav_logo)
+    def click_on_sumo_nav_logo(self):
+        self._click(self.__sumo_nav_logo)
 
     """
         Actions against the 'Explore Help Articles' top-navbar section.
     """
-    def _hover_over_explore_by_product_top_navbar_option(self):
-        super()._hover_over_element(self.__explore_help_articles_top_navbar_option)
+    def hover_over_explore_by_product_top_navbar_option(self):
+        self._hover_over_element(self.__explore_help_articles_top_navbar_option)
 
-    def _get_all_explore_by_product_options_locators(self) -> list[Locator]:
-        self._hover_over_explore_by_product_top_navbar_option()
+    def get_all_explore_by_product_options_locators(self) -> list[Locator]:
+        self.hover_over_explore_by_product_top_navbar_option()
         self.page.wait_for_selector(self.__explore_by_product_top_navbar_header)
-        return super()._get_elements_locators(self.__explore_by_product_top_navbar_options)
+        return self._get_elements_locators(self.__explore_by_product_top_navbar_options)
 
-    def _get_all_explore_by_topic_locators(self) -> list[Locator]:
-        self._hover_over_explore_by_product_top_navbar_option()
+    def get_all_explore_by_topic_locators(self) -> list[Locator]:
+        self.hover_over_explore_by_product_top_navbar_option()
         self.page.wait_for_selector(self.__explore_by_topic_top_navbar_header)
-        return super()._get_elements_locators(self.__explore_by_topic_top_navbar_options)
+        return self._get_elements_locators(self.__explore_by_topic_top_navbar_options)
 
-    def _click_on_explore_our_help_articles_view_all_option(self):
-        super()._hover_over_element(self.__explore_help_articles_top_navbar_option)
-        super()._click(self.__explore_our_help_articles_view_all_option)
+    def click_on_explore_our_help_articles_view_all_option(self):
+        self._hover_over_element(self.__explore_help_articles_top_navbar_option)
+        self._click(self.__explore_our_help_articles_view_all_option)
     """
         Actions against the 'Community Forums' top-navbar section.
     """
-    def _hover_over_community_forums_top_navbar_option(self):
-        super()._hover_over_element(self.__community_forums_top_navbar_option)
+    def hover_over_community_forums_top_navbar_option(self):
+        self._hover_over_element(self.__community_forums_top_navbar_option)
 
-    def _get_all_browse_by_product_options_locators(self) -> list[Locator]:
-        self._hover_over_community_forums_top_navbar_option()
+    def get_all_browse_by_product_options_locators(self) -> list[Locator]:
+        self.hover_over_community_forums_top_navbar_option()
         self.page.wait_for_selector(self.__browse_by_product_top_navbar_header)
-        return super()._get_elements_locators(self.__browse_by_product_top_navbar_options)
+        return self._get_elements_locators(self.__browse_by_product_top_navbar_options)
 
-    def _get_all_browse_all_forum_threads_by_topic_locators(self) -> list[Locator]:
-        self._hover_over_community_forums_top_navbar_option()
+    def get_all_browse_all_forum_threads_by_topic_locators(self) -> list[Locator]:
+        self.hover_over_community_forums_top_navbar_option()
         self.page.wait_for_selector(self.__browse_all_forum_threads_by_topic_top_navbar_header)
-        return super()._get_elements_locators(
+        return self._get_elements_locators(
             self.__browse_all_forum_threads_by_topics_top_navbar_options)
 
     """
         Actions against the 'Ask a Question' top-navbar section.
     """
-    def _hover_over_ask_a_question_top_navbar(self):
-        super()._hover_over_element(self.__ask_a_question_top_navbar)
+    def hover_over_ask_a_question_top_navbar(self):
+        self._hover_over_element(self.__ask_a_question_top_navbar)
 
-    def _get_all_ask_a_question_locators(self) -> list[Locator]:
-        super()._hover_over_element(self.__ask_a_question_top_navbar)
+    def get_all_ask_a_question_locators(self) -> list[Locator]:
+        self._hover_over_element(self.__ask_a_question_top_navbar)
         self.page.wait_for_selector(self.__get_help_with_heading)
-        return super()._get_elements_locators(self.__ask_a_question_top_navbar_options)
+        return self._get_elements_locators(self.__ask_a_question_top_navbar_options)
 
-    def _click_on_browse_all_products_option(self):
-        super()._hover_over_element(self.__ask_a_question_top_navbar)
-        super()._click(self.__browse_all_products_option)
+    def click_on_browse_all_products_option(self):
+        self._hover_over_element(self.__ask_a_question_top_navbar)
+        self._click(self.__browse_all_products_option)
 
     """
         Actions against the 'Contribute' top-navbar section.
     """
-    def _hover_over_contribute_top_navbar(self):
-        super()._hover_over_element(self.__contribute_option)
+    def hover_over_contribute_top_navbar(self):
+        self._hover_over_element(self.__contribute_option)
 
-    def _get_all_contributor_discussions_locators(self) -> list[Locator]:
-        self._hover_over_contribute_top_navbar()
+    def get_all_contributor_discussions_locators(self) -> list[Locator]:
+        self.hover_over_contribute_top_navbar()
         self.page.wait_for_selector(self.__contributor_discussions_top_navbar_header)
-        return super()._get_elements_locators(self.__contributor_discussions_options)
+        return self._get_elements_locators(self.__contributor_discussions_options)
 
-    def _click_on_contribute_top_navbar_option(self):
-        super()._click(self.__contribute_option)
+    def click_on_contribute_top_navbar_option(self):
+        self._click(self.__contribute_option)
 
-    def _click_on_community_discussions_top_navbar_option(self):
-        self._hover_over_contribute_top_navbar()
-        super()._click(self.__contributor_discussions_option)
+    def click_on_community_discussions_top_navbar_option(self):
+        self.hover_over_contribute_top_navbar()
+        self._click(self.__contributor_discussions_option)
 
-    def _click_on_article_discussions_option(self):
-        super()._hover_over_element(self.__contribute_option)
-        super()._click(self.__article_discussions_option)
+    def click_on_article_discussions_option(self):
+        self._hover_over_element(self.__contribute_option)
+        self._click(self.__article_discussions_option)
 
     # Contributor tools
-    def _click_on_moderate_forum_content_option(self):
-        self._hover_over_contribute_top_navbar()
-        super()._click(self.__moderate_forum_content)
+    def click_on_moderate_forum_content_option(self):
+        self.hover_over_contribute_top_navbar()
+        self._click(self.__moderate_forum_content)
 
-    def _click_on_recent_revisions_option(self):
-        self._hover_over_contribute_top_navbar()
-        super()._click(self.__recent_revisions_option)
+    def click_on_recent_revisions_option(self):
+        self.hover_over_contribute_top_navbar()
+        self._click(self.__recent_revisions_option)
 
-    def _click_on_dashboards_option(self):
-        self._hover_over_contribute_top_navbar()
-        super()._click(self.__dashboards_option)
+    def click_on_dashboards_option(self):
+        self.hover_over_contribute_top_navbar()
+        self._click(self.__dashboards_option)
 
-    def _click_on_media_gallery_option(self):
-        self._hover_over_contribute_top_navbar()
-        super()._click(self.__media_gallery_option)
+    def click_on_media_gallery_option(self):
+        self.hover_over_contribute_top_navbar()
+        self._click(self.__media_gallery_option)
 
     """
         Actions against the sign-in/sign-up top-navbar section.
     """
-    def _click_on_signin_signup_button(self):
-        super()._click(self.__signin_signup_button)
+    def click_on_signin_signup_button(self):
+        self._click(self.__signin_signup_button)
 
-    def _click_on_sign_out_button(self):
-        super()._hover_over_element(self.__signed_in_username)
-        super()._click(self.__sign_out_button)
+    def click_on_sign_out_button(self):
+        self._hover_over_element(self.__signed_in_username)
+        self._click(self.__sign_out_button)
 
-    def _sign_in_up_button_displayed_element(self) -> Locator:
-        return super()._get_element_locator(self.__signin_signup_button)
+    def sign_in_up_button_displayed_element(self) -> Locator:
+        return self._get_element_locator(self.__signin_signup_button)
 
     def is_sign_in_up_button_displayed(self) -> bool:
-        return super()._is_element_visible(self.__signin_signup_button)
+        return self._is_element_visible(self.__signin_signup_button)
 
     """
         Actions against the user profile top-navbar section.
     """
-    def _click_on_view_profile_option(self):
-        super()._hover_over_element(self.__signed_in_username)
-        super()._click(self.__signed_in_view_profile_option)
+    def click_on_view_profile_option(self):
+        self._hover_over_element(self.__signed_in_username)
+        self._click(self.__signed_in_view_profile_option)
 
-    def _click_on_edit_profile_option(self):
-        super()._hover_over_element(self.__signed_in_username)
-        super()._click(self.__signed_in_edit_profile_option)
+    def click_on_edit_profile_option(self):
+        self._hover_over_element(self.__signed_in_username)
+        self._click(self.__signed_in_edit_profile_option)
 
-    def _click_on_settings_profile_option(self):
-        super()._hover_over_element(self.__signed_in_username)
-        super()._click(self.__signed_in_settings_option)
+    def click_on_settings_profile_option(self):
+        self._hover_over_element(self.__signed_in_username)
+        self._click(self.__signed_in_settings_option)
 
-    def _click_on_inbox_option(self):
-        super()._hover_over_element(self.__signed_in_username)
-        super()._click(self.__signed_in_inbox_option)
+    def click_on_inbox_option(self):
+        self._hover_over_element(self.__signed_in_username)
+        self._click(self.__signed_in_inbox_option)
 
-    def _click_on_my_questions_profile_option(self):
-        super()._hover_over_element(self.__signed_in_username)
-        super()._click(self.__signed_in_my_questions_option)
+    def click_on_my_questions_profile_option(self):
+        self._hover_over_element(self.__signed_in_username)
+        self._click(self.__signed_in_my_questions_option)
 
-    def _get_text_of_logged_in_username(self) -> str:
-        return super()._get_text_of_element(self.__signed_in_username)
+    def get_text_of_logged_in_username(self) -> str:
+        return self._get_text_of_element(self.__signed_in_username)
 
     """
         General actions against the top-navbar section.
     """
-    def _get_available_menu_titles(self) -> list[str]:
-        return super()._get_text_of_elements(self.__menu_titles)
+    def get_available_menu_titles(self) -> list[str]:
+        return self._get_text_of_elements(self.__menu_titles)

--- a/playwright_tests/pages/user_pages/my_profile_edit.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit.py
@@ -43,172 +43,172 @@ class MyProfileEdit(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
-    def _get_access_denied_header_text(self) -> str:
-        return super()._get_text_of_element(self.__access_denied_main_header)
+    def get_access_denied_header_text(self) -> str:
+        return self._get_text_of_element(self.__access_denied_main_header)
 
-    def _get_access_denied_subheading_text(self) -> str:
-        return super()._get_text_of_element(self.__access_denied_subheading_message)
+    def get_access_denied_subheading_text(self) -> str:
+        return self._get_text_of_element(self.__access_denied_subheading_message)
 
-    def _get_value_of_all_input_fields(self) -> list[str]:
-        elements = super()._get_element_handles(self.__all_input_edit_profile_input_fields)
+    def get_value_of_all_input_fields(self) -> list[str]:
+        elements = self._get_element_handles(self.__all_input_edit_profile_input_fields)
         values = []
         for el in elements:
             values.append(el.input_value())
 
         return values
 
-    def _get_timezone_select_value(self) -> str:
-        return super()._get_element_inner_text_from_page("#id_timezone [selected]")
+    def get_timezone_select_value(self) -> str:
+        return self._get_element_inner_text_from_page("#id_timezone [selected]")
 
-    def _get_preferred_locale_select_value(self) -> str:
-        return super()._get_element_inner_text_from_page('#id_locale [selected]')
+    def get_preferred_locale_select_value(self) -> str:
+        return self._get_element_inner_text_from_page('#id_locale [selected]')
 
     # Above not working trying to find a different solution
 
-    def _get_involved_with_mozilla_month_select_value(self) -> str:
-        return super()._get_text_of_element(self.__involved_with_mozilla_from_month)
+    def get_involved_with_mozilla_month_select_value(self) -> str:
+        return self._get_text_of_element(self.__involved_with_mozilla_from_month)
         # return super()._get_select_chosen_option(self.__involved_with_mozilla_from_month)
 
-    def _get_involved_with_mozilla_year_select_value(self) -> str:
-        return super()._get_text_of_element(self.__involved_with_mozilla_from_year)
+    def get_involved_with_mozilla_year_select_value(self) -> str:
+        return self._get_text_of_element(self.__involved_with_mozilla_from_year)
         # return super()._get_select_chosen_option(self.__involved_with_mozilla_from_year)
 
-    def _get_value_of_all_fields(self) -> list[str]:
+    def get_value_of_all_fields(self) -> list[str]:
         values = [
-            self._get_value_of_all_input_fields(),
-            self._get_timezone_select_value(),
-            self._get_preferred_locale_select_value(),
-            self._get_involved_with_mozilla_month_select_value(),
-            self._get_involved_with_mozilla_year_select_value(),
+            self.get_value_of_all_input_fields(),
+            self.get_timezone_select_value(),
+            self.get_preferred_locale_select_value(),
+            self.get_involved_with_mozilla_month_select_value(),
+            self.get_involved_with_mozilla_year_select_value(),
         ]
         return values
 
-    def _get_username_input_field_value(self) -> str:
-        return super()._get_element_input_value(self.__username_input_field)
+    def get_username_input_field_value(self) -> str:
+        return self._get_element_input_value(self.__username_input_field)
 
-    def _get_username_error_message_text(self) -> str:
-        return super()._get_text_of_element(self.__username_error_message)
+    def get_username_error_message_text(self) -> str:
+        return self._get_text_of_element(self.__username_error_message)
 
-    def _get_display_name_input_field_value(self) -> str:
-        return super()._get_element_input_value(self.__display_name_input_field)
+    def get_display_name_input_field_value(self) -> str:
+        return self._get_element_input_value(self.__display_name_input_field)
 
-    def _get_website_input_field_value(self) -> str:
-        return super()._get_element_input_value(self.__website_input_field)
+    def get_website_input_field_value(self) -> str:
+        return self._get_element_input_value(self.__website_input_field)
 
-    def _get_twitter_input_field_value(self) -> str:
-        return super()._get_element_input_value(self.__twitter_username_field)
+    def get_twitter_input_field_value(self) -> str:
+        return self._get_element_input_value(self.__twitter_username_field)
 
-    def _get_community_portal_field_value(self) -> str:
-        return super()._get_element_input_value(self.__community_portal_username_field)
+    def get_community_portal_field_value(self) -> str:
+        return self._get_element_input_value(self.__community_portal_username_field)
 
-    def _get_people_directory_field_value(self) -> str:
-        return super()._get_element_input_value(self.__people_directory_username_field)
+    def get_people_directory_field_value(self) -> str:
+        return self._get_element_input_value(self.__people_directory_username_field)
 
-    def _get_matrix_username_field_value(self) -> str:
-        return super()._get_element_input_value(self.__matrix_nickname_field)
+    def get_matrix_username_field_value(self) -> str:
+        return self._get_element_input_value(self.__matrix_nickname_field)
 
-    def _get_city_field_value(self) -> str:
-        return super()._get_element_input_value(self.__city_field)
+    def get_city_field_value(self) -> str:
+        return self._get_element_input_value(self.__city_field)
 
-    def _send_text_to_username_field(self, text: str):
-        super()._fill(self.__username_input_field, text)
+    def send_text_to_username_field(self, text: str):
+        self._fill(self.__username_input_field, text)
 
-    def _send_text_to_display_name_field(self, text: str):
-        super()._fill(self.__display_name_input_field, text)
+    def send_text_to_display_name_field(self, text: str):
+        self._fill(self.__display_name_input_field, text)
 
-    def _send_text_to_biography_field(self, text: str):
-        super()._fill(self.__biography_textarea_field, text)
+    def send_text_to_biography_field(self, text: str):
+        self._fill(self.__biography_textarea_field, text)
 
-    def _send_text_to_website_field(self, text: str):
-        super()._fill(self.__website_input_field, text)
+    def send_text_to_website_field(self, text: str):
+        self._fill(self.__website_input_field, text)
 
-    def _send_text_to_twitter_username_field(self, text: str):
-        super()._fill(self.__twitter_username_field, text)
+    def send_text_to_twitter_username_field(self, text: str):
+        self._fill(self.__twitter_username_field, text)
 
-    def _send_text_to_community_portal_field(self, text: str):
-        super()._fill(self.__community_portal_username_field, text)
+    def send_text_to_community_portal_field(self, text: str):
+        self._fill(self.__community_portal_username_field, text)
 
-    def _send_text_to_people_directory_username(self, text: str):
-        super()._fill(self.__people_directory_username_field, text)
+    def send_text_to_people_directory_username(self, text: str):
+        self._fill(self.__people_directory_username_field, text)
 
-    def _send_text_to_matrix_nickname(self, text: str):
+    def send_text_to_matrix_nickname(self, text: str):
         self.page.locator(self.__matrix_nickname_field).fill(text)
 
-    def _sent_text_to_city_field(self, text: str):
-        super()._fill(self.__city_field, text)
+    def sent_text_to_city_field(self, text: str):
+        self._fill(self.__city_field, text)
 
-    def _select_country_dropdown_option_by_value(self, option_value: str):
-        super()._select_option_by_value(self.__country_dropdown, option_value)
+    def select_country_dropdown_option_by_value(self, option_value: str):
+        self._select_option_by_value(self.__country_dropdown, option_value)
 
-    def _select_timezone_dropdown_option_by_value(self, option_value: str):
-        super()._select_option_by_value(self.__timezone_dropdown, option_value)
+    def select_timezone_dropdown_option_by_value(self, option_value: str):
+        self._select_option_by_value(self.__timezone_dropdown, option_value)
 
-    def _select_preferred_language_dropdown_option_by_value(self, option_value: str):
-        super()._select_option_by_value(self.__preferred_locale_dropdown, option_value)
+    def select_preferred_language_dropdown_option_by_value(self, option_value: str):
+        self._select_option_by_value(self.__preferred_locale_dropdown, option_value)
 
-    def _select_involved_from_month_option_by_value(self, option_value: str):
-        super()._select_option_by_value(self.__involved_with_mozilla_from_month, option_value)
+    def select_involved_from_month_option_by_value(self, option_value: str):
+        self._select_option_by_value(self.__involved_with_mozilla_from_month, option_value)
 
-    def _select_involved_from_year_option_by_value(self, option_value: str):
-        super()._select_option_by_value(self.__involved_with_mozilla_from_year, option_value)
+    def select_involved_from_year_option_by_value(self, option_value: str):
+        self._select_option_by_value(self.__involved_with_mozilla_from_year, option_value)
 
-    def _clear_all_input_fields(self):
-        for element in super()._get_element_handles(self.__all_input_edit_profile_input_fields):
+    def clear_all_input_fields(self):
+        for element in self._get_element_handles(self.__all_input_edit_profile_input_fields):
             element.fill("")
 
-    def _clear_biography_textarea_field(self):
-        super()._clear_field(self.__biography_textarea_field)
+    def clear_biography_textarea_field(self):
+        self._clear_field(self.__biography_textarea_field)
 
-    def _clear_username_field(self):
-        super()._clear_field(self.__username_input_field)
+    def clear_username_field(self):
+        self._clear_field(self.__username_input_field)
 
-    def _clear_display_name_field(self):
-        super()._clear_field(self.__display_name_input_field)
+    def clear_display_name_field(self):
+        self._clear_field(self.__display_name_input_field)
 
-    def _clear_website_field(self):
-        super()._clear_field(self.__website_input_field)
+    def clear_website_field(self):
+        self._clear_field(self.__website_input_field)
 
-    def _clear_twitter_field(self):
-        super()._clear_field(self.__twitter_username_field)
+    def clear_twitter_field(self):
+        self._clear_field(self.__twitter_username_field)
 
-    def _clear_community_portal_field(self):
-        super()._clear_field(self.__community_portal_username_field)
+    def clear_community_portal_field(self):
+        self._clear_field(self.__community_portal_username_field)
 
-    def _clear_people_directory_field(self):
-        super()._clear_field(self.__people_directory_username_field)
+    def clear_people_directory_field(self):
+        self._clear_field(self.__people_directory_username_field)
 
-    def _clear_matrix_field(self):
-        super()._clear_field(self.__matrix_nickname_field)
+    def clear_matrix_field(self):
+        self._clear_field(self.__matrix_nickname_field)
 
-    def _clear_country_dropdown_field(self):
-        super()._select_option_by_value(self.__country_dropdown, "")
+    def clear_country_dropdown_field(self):
+        self._select_option_by_value(self.__country_dropdown, "")
 
-    def _clear_city_field(self):
-        super()._clear_field(self.__city_field)
+    def clear_city_field(self):
+        self._clear_field(self.__city_field)
 
-    def _clear_involved_from_month_select_field(self):
-        super()._select_option_by_value(self.__involved_with_mozilla_from_month, "0")
+    def clear_involved_from_month_select_field(self):
+        self._select_option_by_value(self.__involved_with_mozilla_from_month, "0")
 
-    def _clear_involved_from_year_select_field(self):
-        super()._select_option_by_value(self.__involved_with_mozilla_from_year, "0")
+    def clear_involved_from_year_select_field(self):
+        self._select_option_by_value(self.__involved_with_mozilla_from_year, "0")
 
-    def _click_cancel_button(self):
-        super()._click(self.__cancel_button)
+    def click_cancel_button(self):
+        self._click(self.__cancel_button)
 
-    def _click_update_my_profile_button(self):
-        super()._click(self.__update_my_profile_button)
+    def click_update_my_profile_button(self):
+        self._click(self.__update_my_profile_button)
 
-    def _click_close_account_option(self):
-        super()._click(self.__close_account_and_delete_all_profile_information_link)
+    def click_close_account_option(self):
+        self._click(self.__close_account_and_delete_all_profile_information_link)
 
-    def _click_manage_firefox_account_button(self):
-        super()._click(self.__manage_firefox_account_button, with_wait=False)
+    def click_manage_firefox_account_button(self):
+        self._click(self.__manage_firefox_account_button, with_wait=False)
 
-    def _click_make_email_visible_checkbox(self):
-        super()._click(self.__make_email_visible_to_logged_in_users_checkbox)
+    def click_make_email_visible_checkbox(self):
+        self._click(self.__make_email_visible_to_logged_in_users_checkbox)
 
-    def _is_make_email_visible_checkbox_selected(self) -> bool:
-        return super()._is_checkbox_checked(self.__make_email_visible_to_logged_in_users_checkbox)
+    def is_make_email_visible_checkbox_selected(self) -> bool:
+        return self._is_checkbox_checked(self.__make_email_visible_to_logged_in_users_checkbox)
 
-    def _is_my_profile_edit_form_displayed(self) -> Locator:
-        return super()._get_element_locator(self.__edit_my_profile_edit_input_form)
+    def is_my_profile_edit_form_displayed(self) -> Locator:
+        return self._get_element_locator(self.__edit_my_profile_edit_input_form)

--- a/playwright_tests/pages/user_pages/my_profile_edit_contribution_areas_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit_contribution_areas_page.py
@@ -24,16 +24,16 @@ class MyProfileEditContributionAreasPage(BasePage):
         super().__init__(page)
 
     # My profile contribution areas page actions.
-    def _edit_con_areas_pref_banner_txt(self) -> str:
-        return super()._get_text_of_element(
+    def edit_con_areas_pref_banner_txt(self) -> str:
+        return self._get_text_of_element(
             self.__edit_contribution_areas_preferences_saved_banner_text)
 
-    def _get_edit_contribution_areas_page_header(self) -> str:
-        return super()._get_text_of_element(self.__edit_contribution_areas_page_header)
+    def get_edit_contribution_areas_page_header(self) -> str:
+        return self._get_text_of_element(self.__edit_contribution_areas_page_header)
 
-    def _get_contrib_areas_checkbox_labels(self) -> set[str]:
+    def get_contrib_areas_checkbox_labels(self) -> set[str]:
         initial_list = set(
-            super()._get_text_of_elements(self.__edit_contribution_areas_checkbox_labels)
+            self._get_text_of_elements(self.__edit_contribution_areas_checkbox_labels)
         )
         normalized_list = set(
             [
@@ -48,50 +48,50 @@ class MyProfileEditContributionAreasPage(BasePage):
         )
         return normalized_list
 
-    def _click_on_update_contribution_areas_button(self):
-        super()._click(self.__edit_contribution_areas_update_button)
+    def click_on_update_contribution_areas_button(self):
+        self._click(self.__edit_contribution_areas_update_button)
 
-    def _click_on_unchecked_cont_areas_checkboxes(self):
-        for checkbox in super()._get_element_handles(self.__edit_contribution_areas_checkboxes):
+    def click_on_unchecked_cont_areas_checkboxes(self):
+        for checkbox in self._get_element_handles(self.__edit_contribution_areas_checkboxes):
             if not checkbox.is_checked():
                 checkbox.click()
 
-    def _click_on_all_checked_cont_areas_checkboxes(self):
-        for checkbox in super()._get_element_handles(self.__edit_contribution_areas_checkboxes):
+    def click_on_all_checked_cont_areas_checkboxes(self):
+        for checkbox in self._get_element_handles(self.__edit_contribution_areas_checkboxes):
             if checkbox.is_checked():
                 checkbox.click()
 
-    def _click_on_edit_cont_pref_banner_close_button(self):
-        super()._click(self.__edit_contribution_areas_preferences_saved_banner_close_button)
+    def click_on_edit_cont_pref_banner_close_button(self):
+        self._click(self.__edit_contribution_areas_preferences_saved_banner_close_button)
 
-    def _is_edit_cont_pref_banner_displayed(self) -> Locator:
-        return super()._get_element_locator(
+    def is_edit_cont_pref_banner_displayed(self) -> Locator:
+        return self._get_element_locator(
             self.__edit_contribution_areas_preferences_saved_banner)
 
-    def _is_kb_contributors_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__edit_contribution_areas_kb_contributors)
+    def is_kb_contributors_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__edit_contribution_areas_kb_contributors)
 
-    def _is_l10n_contributors_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__edit_contribution_areas_l10n_contributors)
+    def is_l10n_contributors_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__edit_contribution_areas_l10n_contributors)
 
-    def _is_forum_contributors_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__edit_contribution_areas_forum_contributors)
+    def is_forum_contributors_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__edit_contribution_areas_forum_contributors)
 
-    def _is_social_media_contributors_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(
+    def is_social_media_contributors_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(
             self.__edit_contribution_areas_social_media_contributors)
 
-    def _is_mobile_support_contributors_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(
+    def is_mobile_support_contributors_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(
             self.__edit_contribution_areas_mobile_support_contributors)
 
-    def _are_all_cont_pref_checked(self) -> bool:
+    def are_all_cont_pref_checked(self) -> bool:
         is_checked = [
-            self._is_kb_contributors_checkbox_checked(),
-            self._is_l10n_contributors_checkbox_checked(),
-            self._is_forum_contributors_checkbox_checked(),
-            self._is_social_media_contributors_checkbox_checked(),
-            self._is_mobile_support_contributors_checkbox_checked(),
+            self.is_kb_contributors_checkbox_checked(),
+            self.is_l10n_contributors_checkbox_checked(),
+            self.is_forum_contributors_checkbox_checked(),
+            self.is_social_media_contributors_checkbox_checked(),
+            self.is_mobile_support_contributors_checkbox_checked(),
         ]
 
         if False in is_checked:

--- a/playwright_tests/pages/user_pages/my_profile_edit_settings_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit_settings_page.py
@@ -31,77 +31,77 @@ class MyProfileEditSettingsPage(BasePage):
         super().__init__(page)
 
     # My profile edit settings page actions.
-    def _get_edit_settings_page_header(self) -> str:
-        return super()._get_text_of_element(self.__edit_settings_page_header)
+    def get_edit_settings_page_header(self) -> str:
+        return self._get_text_of_element(self.__edit_settings_page_header)
 
-    def _get_text_of_checkbox_options(self) -> list[str]:
-        return super()._get_text_of_elements(self.__edit_settings_checkbox_options_label)
+    def get_text_of_checkbox_options(self) -> list[str]:
+        return self._get_text_of_elements(self.__edit_settings_checkbox_options_label)
 
-    def _settings_saved_notif_banner_txt(self) -> str:
-        return super()._get_text_of_element(
+    def settings_saved_notif_banner_txt(self) -> str:
+        return self._get_text_of_element(
             self.__your_settings_have_been_saved_notification_banner_text)
 
-    def _click_settings_saved_notification_banner(self):
-        super()._click(self.__your_settings_have_been_saved_notification_banner_close_button)
+    def click_settings_saved_notification_banner(self):
+        self._click(self.__your_settings_have_been_saved_notification_banner_close_button)
 
-    def _click_on_all_settings_checkboxes(self):
-        for checkbox in super()._get_element_handles(self.__edit_settings_checkbox_options_label):
+    def click_on_all_settings_checkboxes(self):
+        for checkbox in self._get_element_handles(self.__edit_settings_checkbox_options_label):
             checkbox.click()
 
-    def _click_on_watch_forum_threads_i_start_checkbox(self):
-        super()._click(self.__watch_forum_threads_I_start_checkbox)
+    def click_on_watch_forum_threads_i_start_checkbox(self):
+        self._click(self.__watch_forum_threads_I_start_checkbox)
 
-    def _click_on_watch_forum_threads_i_comment_in_checkbox(self):
-        super()._click(self.__watch_forum_threads_I_comment_in_checkbox)
+    def click_on_watch_forum_threads_i_comment_in_checkbox(self):
+        self._click(self.__watch_forum_threads_I_comment_in_checkbox)
 
-    def _click_on_watch_kb_discussions_threads_i_start_checkbox(self):
-        super()._click(self.__watch_kb_discussions_threads_I_start_checkbox)
+    def click_on_watch_kb_discussions_threads_i_start_checkbox(self):
+        self._click(self.__watch_kb_discussions_threads_I_start_checkbox)
 
-    def _click_on_watch_kb_discussions_threads_i_comment_checkbox(self):
-        super()._click(self.__watch_kb_discussion_threads_I_comment_in_checkbox)
+    def click_on_watch_kb_discussions_threads_i_comment_checkbox(self):
+        self._click(self.__watch_kb_discussion_threads_I_comment_in_checkbox)
 
-    def _click_on_watch_question_threads_i_comment(self):
-        super()._click(self.__watch_question_threads_I_comment_in_checkbox)
+    def click_on_watch_question_threads_i_comment(self):
+        self._click(self.__watch_question_threads_I_comment_in_checkbox)
 
-    def _click_on_send_emails_for_private_messages(self):
-        super()._click(self.__send_emails_for_private_messages_checkbox)
+    def click_on_send_emails_for_private_messages(self):
+        self._click(self.__send_emails_for_private_messages_checkbox)
 
-    def _click_on_update_button(self):
-        super()._click(self.__edit_settings_update_button)
+    def click_on_update_button(self):
+        self._click(self.__edit_settings_update_button)
 
-    def _is_watch_forum_threads_i_start_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__watch_forum_threads_I_start_checkbox)
+    def is_watch_forum_threads_i_start_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__watch_forum_threads_I_start_checkbox)
 
-    def _is_watch_forum_threads_i_comment_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__watch_forum_threads_I_comment_in_checkbox)
+    def is_watch_forum_threads_i_comment_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__watch_forum_threads_I_comment_in_checkbox)
 
-    def _is_watch_kb_discussion_threads_i_start_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__watch_kb_discussions_threads_I_start_checkbox)
+    def is_watch_kb_discussion_threads_i_start_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__watch_kb_discussions_threads_I_start_checkbox)
 
-    def _is_watch_kb_discussion_threads_i_comment_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(
+    def is_watch_kb_discussion_threads_i_comment_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(
             self.__watch_kb_discussion_threads_I_comment_in_checkbox)
 
-    def _is_watch_question_threads_i_comment_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__watch_question_threads_I_comment_in_checkbox)
+    def is_watch_question_threads_i_comment_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__watch_question_threads_I_comment_in_checkbox)
 
-    def _is_send_emails_for_private_messages_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__send_emails_for_private_messages_checkbox)
+    def is_send_emails_for_private_messages_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__send_emails_for_private_messages_checkbox)
 
-    def _notification_banner_element(self) -> Locator:
-        return super()._get_element_locator(
+    def notification_banner_element(self) -> Locator:
+        return self._get_element_locator(
             self.__your_settings_have_been_saved_notification_banner)
 
-    def _are_all_checkbox_checked(self) -> bool:
+    def are_all_checkbox_checked(self) -> bool:
         is_checked = [
-            self._is_watch_forum_threads_i_start_checkbox_checked(),
-            self._is_watch_forum_threads_i_comment_checkbox_checked(),
-            self._is_watch_kb_discussion_threads_i_start_checkbox_checked(),
-            self._is_watch_kb_discussion_threads_i_comment_checkbox_checked(),
-            self._is_watch_question_threads_i_comment_checkbox_checked(),
-            self._is_watch_question_threads_i_comment_checkbox_checked(),
-            self._is_watch_question_threads_i_comment_checkbox_checked(),
-            self._is_send_emails_for_private_messages_checkbox_checked(),
+            self.is_watch_forum_threads_i_start_checkbox_checked(),
+            self.is_watch_forum_threads_i_comment_checkbox_checked(),
+            self.is_watch_kb_discussion_threads_i_start_checkbox_checked(),
+            self.is_watch_kb_discussion_threads_i_comment_checkbox_checked(),
+            self.is_watch_question_threads_i_comment_checkbox_checked(),
+            self.is_watch_question_threads_i_comment_checkbox_checked(),
+            self.is_watch_question_threads_i_comment_checkbox_checked(),
+            self.is_send_emails_for_private_messages_checkbox_checked(),
         ]
 
         if False in is_checked:

--- a/playwright_tests/pages/user_pages/my_profile_user_navbar.py
+++ b/playwright_tests/pages/user_pages/my_profile_user_navbar.py
@@ -19,14 +19,14 @@ class UserNavbar(BasePage):
         super().__init__(page)
 
     # My profile navbar actions.
-    def _click_on_my_profile_option(self):
-        super()._click(self.__my_profile_option)
+    def click_on_my_profile_option(self):
+        self._click(self.__my_profile_option)
 
-    def _click_on_edit_my_profile_option(self):
-        super()._click(self.__edit_my_profile_option)
+    def click_on_edit_my_profile_option(self):
+        self._click(self.__edit_my_profile_option)
 
-    def _click_on_edit_contribution_areas_option(self):
-        super()._click(self.__edit_my_profile_contribution_areas_option)
+    def click_on_edit_contribution_areas_option(self):
+        self._click(self.__edit_my_profile_contribution_areas_option)
 
-    def _click_on_my_questions_option(self):
-        super()._click(self.__edit_my_profile_my_questions_option)
+    def click_on_my_questions_option(self):
+        self._click(self.__edit_my_profile_my_questions_option)

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -210,7 +210,7 @@ def test_aaq_form_cancel_button_freemium_products(page: Page):
 
     with allure.step("Accessing the 'My profile' page via the top-navbar menu and extracting "
                      "the original number of posted questions"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         original_number_of_questions = utilities.number_extraction_from_string(
             sumo_pages.my_profile_page._get_my_profile_questions_text()
         )
@@ -239,7 +239,7 @@ def test_aaq_form_cancel_button_freemium_products(page: Page):
             with check, allure.step("Navigating back to the My Profile page and verifying "
                                     "that the correct number of posted questions is "
                                     "displayed"):
-                sumo_pages.top_navbar._click_on_view_profile_option()
+                sumo_pages.top_navbar.click_on_view_profile_option()
                 new_number = utilities.number_extraction_from_string(
                     sumo_pages.my_profile_page._get_my_profile_questions_text()
                 )
@@ -306,7 +306,7 @@ def test_post_aaq_questions_for_all_freemium_products_topics(page: Page):
 
                 with allure.step("Verifying that the question is no longer displayed inside "
                                  "My Questions page"):
-                    sumo_pages.top_navbar._click_on_my_questions_profile_option()
+                    sumo_pages.top_navbar.click_on_my_questions_profile_option()
                     expect(
                         sumo_pages.my_questions_page._get_listed_question(
                             question_info['aaq_subject'])).to_be_hidden()
@@ -506,7 +506,7 @@ def test_loginless_mozilla_account_aaq(page: Page):
                      "blocked after 3 submissions"):
         i = 1
         while i <= 4:
-            sumo_pages.top_navbar._click_on_signin_signup_button()
+            sumo_pages.top_navbar.click_on_signin_signup_button()
             sumo_pages.auth_page._click_on_cant_sign_in_to_my_mozilla_account_link()
             sumo_pages.aaq_flow.submit_an_aaq_question(
                 subject=utilities.aaq_question_test_data['premium_aaq_question']['subject'],

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -1786,7 +1786,7 @@ def test_report_abuse(page: Page, flagged_content, username):
 
     with allure.step("Navigating to 'Moderate forum content page' and verifying that the "
                      "question exists inside the moderate forum content page"):
-        sumo_pages.top_navbar._click_on_moderate_forum_content_option()
+        sumo_pages.top_navbar.click_on_moderate_forum_content_option()
         expect(
             sumo_pages.moderate_forum_content_page._get_flagged_question_locator(
                 posted_question['question_details']['aaq_subject']

--- a/playwright_tests/tests/ask_a_question_tests/contact_support_page_tests/test_contact_support_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/contact_support_page_tests/test_contact_support_page.py
@@ -18,7 +18,7 @@ def test_contact_support_page_content(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Accessing the contact support page via the top navbar via Ask a "
                      "Question > View All"):
-        sumo_pages.top_navbar._click_on_browse_all_products_option()
+        sumo_pages.top_navbar.click_on_browse_all_products_option()
 
     with check, allure.step("Verifying that the current milestone is the correct one"):
         assert sumo_pages.contact_support_page._get_text_of_current_milestone(
@@ -46,7 +46,7 @@ def test_contact_support_page_cards_redirect(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Accessing the contact support page via the top navbar Ask a Question > "
                      "View All"):
-        sumo_pages.top_navbar._click_on_browse_all_products_option()
+        sumo_pages.top_navbar.click_on_browse_all_products_option()
 
     for card in sumo_pages.contact_support_page._get_all_product_card_titles():
         with allure.step(f"Clicking on {card}"):
@@ -70,7 +70,7 @@ def test_browse_all_product_forums_button_redirect(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Accessing the contact support page via the top navbar Ask a Question > "
                      "View All option"):
-        sumo_pages.top_navbar._click_on_browse_all_products_option()
+        sumo_pages.top_navbar.click_on_browse_all_products_option()
 
     with allure.step("Clicking on browse all product forums button and verifying that we are "
                      "redirected to the correct page"):

--- a/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
@@ -100,4 +100,4 @@ def test_aaq_redirect(page: Page):
                     timeout=30000)
 
             with allure.step("Signing out from SUMO"):
-                sumo_pages.top_navbar._click_on_sign_out_button()
+                sumo_pages.top_navbar.click_on_sign_out_button()

--- a/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
@@ -19,7 +19,7 @@ def test_featured_articles_redirect(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Accessing the contact support page via the top navbar Get Help > "
                      "Browse All products"):
-        sumo_pages.top_navbar._click_on_browse_all_products_option()
+        sumo_pages.top_navbar.click_on_browse_all_products_option()
 
     with allure.step("Clicking on all product cards"):
         for card in sumo_pages.contact_support_page._get_all_product_card_titles():
@@ -55,7 +55,7 @@ def test_popular_topics_redirect(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Accessing the contact support page via the top navbar Get Help > "
                      "Browse All products"):
-        sumo_pages.top_navbar._click_on_browse_all_products_option()
+        sumo_pages.top_navbar.click_on_browse_all_products_option()
 
     for card in sumo_pages.contact_support_page._get_all_product_card_titles():
         sumo_pages.contact_support_page._click_on_a_particular_card(card)
@@ -99,7 +99,7 @@ def test_ask_now_widget_redirect(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Accessing the contact support page via the top navbar Get Help > "
                      "Browse All products"):
-        sumo_pages.top_navbar._click_on_browse_all_products_option()
+        sumo_pages.top_navbar.click_on_browse_all_products_option()
     count = 0
     for freemium_product in utilities.general_test_data["freemium_products"]:
         with allure.step(f"Clicking on the {freemium_product} card "):
@@ -132,8 +132,8 @@ def test_ask_now_widget_redirect(page: Page):
 
         with allure.step("Signing out and accessing the contact support page via the top "
                          "navbar Get Help > Browse All products"):
-            sumo_pages.top_navbar._click_on_sign_out_button()
-            sumo_pages.top_navbar._click_on_browse_all_products_option()
+            sumo_pages.top_navbar.click_on_sign_out_button()
+            sumo_pages.top_navbar.click_on_browse_all_products_option()
 
 
 # C890382
@@ -143,7 +143,7 @@ def test_contact_support_widget_redirect(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Accessing the contact support page via the top navbar Get Help > "
                      "Browse All products"):
-        sumo_pages.top_navbar._click_on_browse_all_products_option()
+        sumo_pages.top_navbar.click_on_browse_all_products_option()
     count = 0
     for premium_product in utilities.general_test_data["premium_products"]:
         with allure.step(f"Clicking on the {premium_product} card"):
@@ -178,5 +178,5 @@ def test_contact_support_widget_redirect(page: Page):
 
         with allure.step("Signing out and access the contact support page via the top navbar "
                          "Get Help > Browse All products"):
-            sumo_pages.top_navbar._click_on_sign_out_button()
-            sumo_pages.top_navbar._click_on_browse_all_products_option()
+            sumo_pages.top_navbar.click_on_sign_out_button()
+            sumo_pages.top_navbar.click_on_browse_all_products_option()

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_page.py
@@ -26,7 +26,7 @@ from playwright_tests.pages.sumo_pages import SumoPages
 def test_contribute_page_text(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Clicking on the Contribute top-navbar option"):
-        sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
+        sumo_pages.top_navbar.click_on_contribute_top_navbar_option()
 
     with check, allure.step("Verifying that the correct page hero header text is displayed"):
         assert sumo_pages.contribute_page._get_page_hero_main_header_text(
@@ -76,7 +76,7 @@ def test_contribute_page_text(page: Page):
 def test_contribute_page_images_are_not_broken(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Clicking on the 'Contribute' top-navbar option"):
-        sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
+        sumo_pages.top_navbar.click_on_contribute_top_navbar_option()
 
     for link in sumo_pages.contribute_page._get_all_page_links():
         image_link = link.get_attribute("src")
@@ -91,7 +91,7 @@ def test_contribute_page_breadcrumbs(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Clicking on the Contribute top-navbar option"):
-        sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
+        sumo_pages.top_navbar.click_on_contribute_top_navbar_option()
 
     breadcrumbs = [
         ContributePageMessages.FIRST_BREADCRUMB,
@@ -112,7 +112,7 @@ def test_way_to_contribute_redirects_to_correct_page(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Clicking on the Contribute top-navbar option"):
-        sumo_pages.top_navbar._click_on_contribute_top_navbar_option()
+        sumo_pages.top_navbar.click_on_contribute_top_navbar_option()
 
     ways_to_contribute_links = [
         ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL,

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
@@ -26,7 +26,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page):
 
     with allure.step("Navigating to the kb dashboards and clicking on the 'Complete "
                      "overview' option"):
-        sumo_pages.top_navbar._click_on_dashboards_option()
+        sumo_pages.top_navbar.click_on_dashboards_option()
         sumo_pages.kb_dashboard_page._click_on_the_complete_overview_link()
 
     with allure.step("Verifying that we are redirected to the correct page"):
@@ -50,7 +50,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page):
 
     with allure.step("Navigating to the homepage and performing the sign in step since the "
                      "kb overview takes quite a bit to refresh/load"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
@@ -65,7 +65,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page):
         ).to_be_hidden()
 
     with allure.step("Signing in with an admin account"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -96,7 +96,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page):
         ).to_be_visible()
 
     with allure.step("Signing in with a non-admin user"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
@@ -112,7 +112,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page):
         ).to_be_visible()
 
     with allure.step("Signing back with an admin account and deleting the article"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
@@ -20,7 +20,7 @@ def test_recent_revisions_revision_availability(page: Page):
             utilities.user_secrets_accounts['TEST_ACCOUNT_12']
         ))
 
-    username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Creating a new kb article"):
         article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
@@ -126,7 +126,7 @@ def test_second_revisions_availability(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
 
-    username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Creating a new revision for the article"):
         second_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
@@ -243,7 +243,7 @@ def test_recent_revisions_dashboard_links(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-    first_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    first_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Creating a new kb article"):
         article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
@@ -255,7 +255,7 @@ def test_recent_revisions_dashboard_links(page: Page):
 
     with allure.step("Navigating to the recent revisions dashboard and verifying that the "
                      "'Show Diff' option is not available for first revisions"):
-        sumo_pages.top_navbar._click_on_recent_revisions_option()
+        sumo_pages.top_navbar.click_on_recent_revisions_option()
         utilities.wait_for_given_timeout(3000)
         expect(
             sumo_pages.recent_revisions_page._get_show_diff_article_locator(
@@ -269,13 +269,13 @@ def test_recent_revisions_dashboard_links(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
-        username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+        username = sumo_pages.top_navbar.get_text_of_logged_in_username()
         second_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
 
     with allure.step("Navigating to the recent revisions dashboard, signing out and clicking "
                      "on the revision date link and verifying that the user is redirected to"
                      "the correct page"):
-        sumo_pages.top_navbar._click_on_recent_revisions_option()
+        sumo_pages.top_navbar.click_on_recent_revisions_option()
         utilities.wait_for_given_timeout(3000)
         utilities.delete_cookies()
         sumo_pages.recent_revisions_page._click_on_revision_date_for_article(
@@ -346,7 +346,7 @@ def test_recent_revisions_dashboard_title_and_username_update(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-    first_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    first_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Creating a new kb article"):
         article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
@@ -363,14 +363,14 @@ def test_recent_revisions_dashboard_title_and_username_update(page: Page):
         )
 
     with allure.step("Editing the username"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
         new_username = utilities.profile_edit_test_data['valid_user_edit']['username']
-        sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.send_text_to_username_field(new_username)
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with allure.step("Navigating to the recent revisions dashboard and verifying that the "
                      "correct new username and article title arte displayed"):
-        sumo_pages.top_navbar._click_on_recent_revisions_option()
+        sumo_pages.top_navbar.click_on_recent_revisions_option()
         utilities.wait_for_given_timeout(3000)
         expect(
             sumo_pages.recent_revisions_page._get_revision_and_username_locator(
@@ -381,9 +381,9 @@ def test_recent_revisions_dashboard_title_and_username_update(page: Page):
         ).to_be_visible()
 
     with allure.step("Changing the username back"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._send_text_to_username_field(first_username)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.send_text_to_username_field(first_username)
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with allure.step("Deleting the article"):
         utilities.navigate_to_link(article_url)

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
@@ -250,7 +250,7 @@ def test_kb_article_contributor_removal(page: Page, create_delete_article):
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
 
-    username_two = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_two = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Creating a new revision for the document and verifying that the 'Edit "
                      "Contributors' option is not displayed for users which don't have the "
@@ -430,7 +430,7 @@ def test_kb_article_contributor_profile_access(page: Page, create_delete_article
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
 
-        username_two = sumo_pages.top_navbar._get_text_of_logged_in_username()
+        username_two = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
         second_revision_info = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
 

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_explore_articles_products_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_explore_articles_products_page.py
@@ -18,7 +18,7 @@ def test_products_page_content(page: Page):
                             "the correct page header is displayed"):
         sumo_pages = SumoPages(page)
         utilities = Utilities(page)
-        sumo_pages.top_navbar._click_on_explore_our_help_articles_view_all_option()
+        sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
         assert sumo_pages.products_page._get_page_header(
         ) == ProductsPageMessages.PRODUCTS_PAGE_HEADER
 
@@ -43,7 +43,7 @@ def test_products_page_card_redirect(page: Page):
     sumo_pages = SumoPages(page)
     utilities = Utilities(page)
     with allure.step("Navigating to products page via top-navbar"):
-        sumo_pages.top_navbar._click_on_explore_our_help_articles_view_all_option()
+        sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
     for card in sumo_pages.products_page._get_all_product_support_titles():
         if card in utilities.general_test_data['product_support']:

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
@@ -696,7 +696,7 @@ def test_kb_article_keywords_and_summary(page: Page, username):
         )
 
     with allure.step("Clicking on the top navbar sumo nav logo"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.wait_for_given_timeout(65000)
 
     if username == 'simple_user':
@@ -846,7 +846,7 @@ def test_kb_article_keyword_and_summary_update(page: Page):
         )
 
     with allure.step("Clicking on the top navbar sumo nav logo"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
 
     with allure.step("Wait for ~1 minute until the kb article is available in search"):
         utilities.wait_for_given_timeout(60000)

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
@@ -178,7 +178,7 @@ def test_restricted_visibility_in_search_results(page: Page, create_delete_artic
         utilities.wait_for_given_timeout(60000)
 
     with allure.step("Clicking on the top-navbar sumo logo"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
 
     with check, allure.step("Verifying that the article is not displayed inside the search "
                             "results"):
@@ -234,7 +234,7 @@ def test_restricted_visibility_in_recent_revisions(page: Page, is_template, crea
 
     with check, allure.step("Navigating to the recent revisions page and verifying that the "
                             "article is displayed"):
-        sumo_pages.top_navbar._click_on_recent_revisions_option()
+        sumo_pages.top_navbar.click_on_recent_revisions_option()
         expect(sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
             article_details['article_title'])).to_be_visible()
 
@@ -270,7 +270,7 @@ def test_restricted_visibility_in_recent_revisions(page: Page, is_template, crea
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
         ))
-        sumo_pages.top_navbar._click_on_recent_revisions_option()
+        sumo_pages.top_navbar.click_on_recent_revisions_option()
 
     with allure.step("Verifying that the article is displayed"):
         expect(sumo_pages.recent_revisions_page._get_recent_revision_based_on_article(
@@ -303,7 +303,7 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
     })[0]
 
     with allure.step("Navigating to the 'Media Gallery' page"):
-        sumo_pages.top_navbar._click_on_media_gallery_option()
+        sumo_pages.top_navbar.click_on_media_gallery_option()
 
     with check, allure.step("Searching for the added image and verifying that the article is "
                             "displayed for admin users inside the 'Articles' image list"):
@@ -355,7 +355,7 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
         )
 
     with allure.step("Navigating to the 'Media Gallery' page"):
-        sumo_pages.top_navbar._click_on_media_gallery_option()
+        sumo_pages.top_navbar.click_on_media_gallery_option()
 
     with check, allure.step("Searching for the added image and verifying that the article is "
                             "displayed for admin users inside the 'Articles' image list"):
@@ -380,7 +380,7 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
 
     with allure.step("Navigating to the media gallery image page and verifying that the "
                      "article is displayed for signed out users"):
-        sumo_pages.top_navbar._click_on_media_gallery_option()
+        sumo_pages.top_navbar.click_on_media_gallery_option()
         utilities.delete_cookies()
         sumo_pages.media_gallery._fill_search_media_gallery_searchbox_input_field(
             utilities.kb_article_test_data['article_image']
@@ -411,7 +411,7 @@ def test_kb_restricted_visibility_discussion(page: Page, is_template, create_del
     thread = _create_discussion_thread(page)
 
     with allure.step("Navigating to the Article Discussions page"):
-        sumo_pages.top_navbar._click_on_article_discussions_option()
+        sumo_pages.top_navbar.click_on_article_discussions_option()
 
     with check, allure.step("Verifying that the the kb article is displayed for admin users"):
         expect(sumo_pages.article_discussions_page
@@ -556,7 +556,7 @@ def test_kb_restricted_visibility_profile_level(page: Page, is_template, create_
     })[0]
 
     with allure.step("Navigating to the user profile page"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
 
     with allure.step("Clicking on the documents link"):
         sumo_pages.my_profile_page._click_on_my_profile_document_link()
@@ -595,7 +595,7 @@ def test_kb_restricted_visibility_profile_level(page: Page, is_template, create_
         )
 
     with allure.step("Navigating to the user profile page"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
 
     with allure.step("Clicking on the documents link"):
         sumo_pages.my_profile_page._click_on_my_profile_document_link()
@@ -613,7 +613,7 @@ def test_kb_restricted_visibility_profile_level(page: Page, is_template, create_
         remove_all_article_restrictions(page)
 
     with allure.step("Navigating to the user profile page"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
 
     with allure.step("Clicking on the documents link"):
         sumo_pages.my_profile_page._click_on_my_profile_document_link()
@@ -703,7 +703,7 @@ def test_kb_restricted_visibility_in_dashboards(page: Page, is_template, create_
 
     with check, allure.step("Verifying that the article is displayed for users belonging to "
                             "the whitelisted group"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
         ))
@@ -714,7 +714,7 @@ def test_kb_restricted_visibility_in_dashboards(page: Page, is_template, create_
 
     with allure.step("Verifying that the article is not displayed for users belonging to "
                      "non-whitelisted groups"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
         ))

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
@@ -20,7 +20,7 @@ def test_product_support_page(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Navigating to products page via top-navbar"):
-        sumo_pages.top_navbar._click_on_explore_our_help_articles_view_all_option()
+        sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
     with allure.step("Clicking on all product cards"):
         for card in sumo_pages.products_page._get_all_product_support_titles():
@@ -109,7 +109,7 @@ def test_product_support_page(page: Page):
                     expect(page).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
 
                 with allure.step("Navigating to products page via top-navbar"):
-                    sumo_pages.top_navbar._click_on_explore_our_help_articles_view_all_option()
+                    sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
 
 # C890929
@@ -118,7 +118,7 @@ def test_product_support_page_frequent_topics_redirect(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Navigating to products page via top-navbar"):
-        sumo_pages.top_navbar._click_on_explore_our_help_articles_view_all_option()
+        sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
     with allure.step("Clicking on all product cards"):
 
@@ -151,7 +151,7 @@ def test_product_support_page_featured_articles_redirect(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Navigating to products page via top-navbar"):
-        sumo_pages.top_navbar._click_on_explore_our_help_articles_view_all_option()
+        sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
     with allure.step("Clicking on all product cards"):
         for card in sumo_pages.products_page._get_all_product_support_titles():
@@ -196,7 +196,7 @@ def test_still_need_help_button_redirect(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Navigating to products page via top-navbar"):
-        sumo_pages.top_navbar._click_on_explore_our_help_articles_view_all_option()
+        sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
     with allure.step("Clicking on all product cards"):
         for card in sumo_pages.products_page._get_all_product_support_titles():
@@ -219,4 +219,4 @@ def test_still_need_help_button_redirect(page: Page):
                     ) == ProductSolutionsMessages.CURRENT_MILESTONE_TEXT
 
                 with allure.step("Navigating to products page via top-navbar"):
-                    sumo_pages.top_navbar._click_on_explore_our_help_articles_view_all_option()
+                    sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -26,7 +26,7 @@ def test_there_are_no_messages_here_text_is_displayed_when_no_messages_are_avail
         ))
 
     with allure.step("Navigating to the inbox page"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
 
     if sumo_pages.inbox_page._are_inbox_messages_displayed():
         with allure.step("Clearing the inbox since there are some existing messages"):
@@ -64,7 +64,7 @@ def test_private_messages_can_be_sent_via_user_profiles(page: Page, is_firefox):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_1"]
         ))
 
-    sumo_pages.top_navbar._get_text_of_logged_in_username()
+    sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Navigating to the profile page for user two"):
         utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username=user_two))
@@ -115,7 +115,7 @@ def test_private_messages_can_be_sent_via_user_profiles(page: Page, is_firefox):
         ))
 
     with allure.step("Accessing the Inbox section"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
 
     with allure.step("Verifying that the inbox contains the previously sent messages"):
         expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_visible()
@@ -148,10 +148,10 @@ def test_private_message_can_be_sent_via_new_message_page(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_3"]
         ))
 
-    sumo_pages.top_navbar._get_text_of_logged_in_username()
+    sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the New Message page and sending a message to another user"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
         sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
             recipient_username=test_user,
@@ -177,7 +177,7 @@ def test_private_message_can_be_sent_via_new_message_page(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
         ))
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
                ).to_be_visible()
 
@@ -199,7 +199,7 @@ def test_navbar_options_redirect_to_the_correct_page_and_options_are_correctly_h
         ))
 
     with allure.step("Accessing the inbox section via the top-navbar"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
 
     with allure.step("Verifying that we are on the correct page and the 'Inbox' navbar "
                      "option is highlighted"):
@@ -258,7 +258,7 @@ def test_new_message_field_validation(page: Page):
         ))
 
     with allure.step("Accessing the New Message page"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
     with allure.step("Trying to submit the form without any data and verifying that we are "
@@ -390,10 +390,10 @@ def test_new_message_cancel_button(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
 
-    sumo_pages.top_navbar._get_text_of_logged_in_username()
+    sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'New Message' section"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
     with allure.step("Filling the new message form with data"):
@@ -424,7 +424,7 @@ def test_new_message_cancel_button(page: Page):
 
     with allure.step("Navigating to the receiver inbox and verifying that no message was "
                      "received"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_hidden()
 
 
@@ -442,10 +442,10 @@ def test_new_message_preview(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
 
-    username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the inbox section and navigating to the new message page"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
     with allure.step("Adding text inside the message content section"):
@@ -508,7 +508,7 @@ def test_new_message_preview(page: Page):
 
     with allure.step("Verifying that the message was no sent by checking the "
                      "'Sent Messages page'"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_sent_messages()
         expect(sumo_pages.sent_message_page._sent_messages(username=test_user)).to_be_hidden()
 
@@ -517,7 +517,7 @@ def test_new_message_preview(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         expect(sumo_pages.inbox_page._inbox_message(username=username)).to_be_hidden()
 
 
@@ -536,11 +536,11 @@ def test_messages_can_be_selected_and_deleted(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
         ))
 
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'New Message' page and sending a message to a different "
                      "user"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
         sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
             recipient_username=test_user,
@@ -606,7 +606,7 @@ def test_messages_can_be_selected_and_deleted(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
         ))
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
 
     with allure.step("Verifying that the messages are displayed inside the inbox section"):
         expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_visible()
@@ -633,7 +633,7 @@ def test_group_messages_cannot_be_sent_by_non_staff_users(page: Page):
         ))
 
     with allure.step("Navigating to the new message page"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
     with allure.step("Typing in a group name inside the To field"):
@@ -679,7 +679,7 @@ def test_staff_users_can_send_group_messages(page: Page):
     targeted_test_group = utilities.user_message_test_data['test_groups'][0]
 
     with allure.step("Navigating to the new messages page"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
     with allure.step("Sending out a message to a test group"):
@@ -706,7 +706,7 @@ def test_staff_users_can_send_group_messages(page: Page):
                 utilities.user_secrets_accounts[user]
             ))
 
-            sumo_pages.top_navbar._click_on_inbox_option()
+            sumo_pages.top_navbar.click_on_inbox_option()
             expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
                    ).to_be_visible()
             sumo_pages.inbox_page._delete_all_inbox_messages_via_delete_selected_button(
@@ -719,7 +719,7 @@ def test_staff_users_can_send_group_messages(page: Page):
                 utilities.user_secrets_accounts[user]
             ))
 
-            sumo_pages.top_navbar._click_on_inbox_option()
+            sumo_pages.top_navbar.click_on_inbox_option()
             expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
                    ).to_be_hidden()
 
@@ -737,7 +737,7 @@ def test_staff_users_can_send_messages_to_multiple_groups(page: Page):
     targeted_test_group = utilities.user_message_test_data['test_groups']
 
     with allure.step("Navigating to the new messages page"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
     with allure.step("Sending out a message to a test group"):
@@ -766,7 +766,7 @@ def test_staff_users_can_send_messages_to_multiple_groups(page: Page):
                 utilities.user_secrets_accounts[user]
             ))
 
-            sumo_pages.top_navbar._click_on_inbox_option()
+            sumo_pages.top_navbar.click_on_inbox_option()
             expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
                    ).to_be_visible()
             sumo_pages.inbox_page._delete_all_inbox_messages_via_delete_selected_button(
@@ -790,7 +790,7 @@ def test_staff_users_can_send_messages_to_both_groups_and_user(page: Page):
             utilities.user_secrets_accounts['TEST_ACCOUNT_12'])]
 
     with allure.step("Navigating to the new messages page"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
     with allure.step("Sending out a message to a test group + user"):
@@ -819,7 +819,7 @@ def test_staff_users_can_send_messages_to_both_groups_and_user(page: Page):
                 utilities.user_secrets_accounts[user]
             ))
 
-            sumo_pages.top_navbar._click_on_inbox_option()
+            sumo_pages.top_navbar.click_on_inbox_option()
             expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
                    ).to_be_visible()
             sumo_pages.inbox_page._delete_all_inbox_messages_via_delete_selected_button(
@@ -850,7 +850,7 @@ def test_removed_group_users_do_not_receive_group_messages(page: Page):
         sumo_pages.user_group_flow.remove_a_user_from_group(targeted_user)
 
     with allure.step("Navigating to the new message page and sending a message to the group"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
         sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
             recipient_username=targeted_test_group,
@@ -868,7 +868,7 @@ def test_removed_group_users_do_not_receive_group_messages(page: Page):
                 utilities.username_extraction_from_email(
                     utilities.user_secrets_accounts[user]
                 ))
-            sumo_pages.top_navbar._click_on_inbox_option()
+            sumo_pages.top_navbar.click_on_inbox_option()
 
             if logged_user == targeted_user:
                 with allure.step("Verifying that the removed user has not received the group "
@@ -901,7 +901,7 @@ def test_unable_to_send_group_messages_to_profiless_groups(page: Page):
         ))
 
     with allure.step("Navigating to the new message page"):
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         sumo_pages.mess_system_user_navbar._click_on_messaging_system_nav_new_message()
 
     with allure.step("Typing in a profiless group name inside the To field"):
@@ -920,7 +920,7 @@ def test_clear_inbox_and_outbox(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts[user]
         ))
-        sumo_pages.top_navbar._click_on_inbox_option()
+        sumo_pages.top_navbar.click_on_inbox_option()
         inbox_and_outbox_deletion(page)
 
     utilities.delete_cookies()

--- a/playwright_tests/tests/test_prerequisites_login.py
+++ b/playwright_tests/tests/test_prerequisites_login.py
@@ -1,7 +1,6 @@
 import pytest
 from playwright_tests.core.utilities import Utilities
 from playwright.sync_api import expect, Page
-from playwright_tests.flows.auth_flows.auth_flow import AuthFlowPage
 from playwright_tests.pages.sumo_pages import SumoPages
 
 
@@ -9,19 +8,18 @@ from playwright_tests.pages.sumo_pages import SumoPages
 def test_create_user_sessions_for_test_accounts(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    auth_flow = AuthFlowPage(page)
 
     i = 0
     keys = list(utilities.user_secrets_accounts.keys())
     tried_once = False
     while i < len(keys):
-        sumo_pages.top_navbar._click_on_signin_signup_button()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
 
         # Also acts as a wait. Introduced in order to avoid flakiness which occurred on some
         # GH runs.
         expect(sumo_pages.auth_page._get_continue_with_firefox_button_locator()).to_be_visible()
 
-        auth_flow.sign_in_flow(
+        sumo_pages.auth_flow_page.sign_in_flow(
             username=utilities.user_secrets_accounts[keys[i]],
             account_password=utilities.user_secrets_pass
         )
@@ -38,9 +36,9 @@ def test_create_user_sessions_for_test_accounts(page: Page):
             username
         )
 
-        if sumo_pages.top_navbar._get_text_of_logged_in_username() != username and not tried_once:
+        if sumo_pages.top_navbar.get_text_of_logged_in_username() != username and not tried_once:
             tried_once = True
-        elif sumo_pages.top_navbar._get_text_of_logged_in_username() != username and tried_once:
+        elif sumo_pages.top_navbar.get_text_of_logged_in_username() != username and tried_once:
             pytest.fail(f"Unable to sign in with {username}")
         else:
             i += 1

--- a/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
+++ b/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
@@ -22,14 +22,14 @@ from playwright_tests.pages.sumo_pages import SumoPages
 def test_number_of_options_not_signed_in(page: Page):
     sumo_pages = SumoPages(page)
     with check, allure.step("Verifying that the SUMO logo is successfully displayed"):
-        image = sumo_pages.top_navbar._get_sumo_nav_logo()
+        image = sumo_pages.top_navbar.get_sumo_nav_logo()
         image_link = image.get_attribute("src")
         response = requests.get(image_link, stream=True)
         assert response.status_code < 400
 
     with allure.step("Verifying that the top-navbar for signed in users contains: Explore "
                      "Help Articles, Community Forums, Ask a Question and Contribute"):
-        top_navbar_items = sumo_pages.top_navbar._get_available_menu_titles()
+        top_navbar_items = sumo_pages.top_navbar.get_available_menu_titles()
         assert top_navbar_items == TopNavbarMessages.TOP_NAVBAR_OPTIONS, (
             "Incorrect elements displayed in top-navbar for signed out state"
         )
@@ -46,14 +46,14 @@ def test_number_of_options_signed_in(page: Page):
         ))
 
     with check, allure.step("Verifying that the SUMO logo is successfully displayed"):
-        image = sumo_pages.top_navbar._get_sumo_nav_logo()
+        image = sumo_pages.top_navbar.get_sumo_nav_logo()
         image_link = image.get_attribute("src")
         response = requests.get(image_link, stream=True)
         assert response.status_code < 400
 
     with allure.step("Verifying that the top-navbar contains: Explore Help Articles, "
                      "Community Forums, Ask a Question, Contribute"):
-        top_navbar_items = sumo_pages.top_navbar._get_available_menu_titles()
+        top_navbar_items = sumo_pages.top_navbar.get_available_menu_titles()
         assert top_navbar_items == TopNavbarMessages.TOP_NAVBAR_OPTIONS, (
             "Incorrect elements displayed in top-navbar for " "signed-in state"
         )
@@ -67,15 +67,15 @@ def test_explore_by_product_redirects(page: Page):
     with allure.step("Clicking on all options from the 'Explore Help Articles' and verifying the "
                      "redirect"):
         for index, option in enumerate(sumo_pages.top_navbar
-                                       ._get_all_explore_by_product_options_locators()):
+                                       .get_all_explore_by_product_options_locators()):
             if index > 0:
-                sumo_pages.top_navbar._hover_over_explore_by_product_top_navbar_option()
+                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option()
             current_option = re.sub(
                 r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
             if sumo_pages.top_navbar._is_locator_visible(option):
                 sumo_pages.top_navbar._click(option)
             else:
-                sumo_pages.top_navbar._hover_over_explore_by_product_top_navbar_option()
+                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option()
                 sumo_pages.top_navbar._click(option)
 
             if current_option == "Firefox desktop":
@@ -95,15 +95,15 @@ def test_explore_by_topic_redirects(page: Page):
     sumo_pages = SumoPages(page)
     with allure.step("Clicking on all options from the 'Explore by topic' and verifying the "
                      "redirect"):
-        for index, option in enumerate(sumo_pages.top_navbar._get_all_explore_by_topic_locators()):
+        for index, option in enumerate(sumo_pages.top_navbar.get_all_explore_by_topic_locators()):
             if index > 0:
-                sumo_pages.top_navbar._hover_over_explore_by_product_top_navbar_option()
+                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option()
             current_option = re.sub(
                 r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
             if sumo_pages.top_navbar._is_locator_visible(option):
                 sumo_pages.top_navbar._click(option)
             else:
-                sumo_pages.top_navbar._hover_over_explore_by_product_top_navbar_option()
+                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option()
                 sumo_pages.top_navbar._click(option)
 
             assert (current_option == sumo_pages.explore_by_topic_page
@@ -131,15 +131,15 @@ def test_browse_by_product_community_forum_redirect(page: Page):
     with allure.step("Clicking on all options from the 'Browse by product' and verifying the "
                      "redirect"):
         for index, option in enumerate(sumo_pages.top_navbar
-                                       ._get_all_browse_by_product_options_locators()):
+                                       .get_all_browse_by_product_options_locators()):
             if index > 0:
-                sumo_pages.top_navbar._hover_over_community_forums_top_navbar_option()
+                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option()
             current_option = re.sub(
                 r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
             if sumo_pages.top_navbar._is_locator_visible(option):
                 sumo_pages.top_navbar._click(option)
             else:
-                sumo_pages.top_navbar._hover_over_community_forums_top_navbar_option()
+                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option()
                 sumo_pages.top_navbar._click(option)
 
             if current_option == "Firefox desktop":
@@ -164,15 +164,15 @@ def test_browse_all_forum_threads_by_topic_redirect(page: Page):
     with allure.step("Clicking on all options from the 'Browse all forum threads by topic' and "
                      "verifying the redirect"):
         for index, option in enumerate(sumo_pages.top_navbar
-                                       ._get_all_browse_all_forum_threads_by_topic_locators()):
+                                       .get_all_browse_all_forum_threads_by_topic_locators()):
             if index > 0:
-                sumo_pages.top_navbar._hover_over_community_forums_top_navbar_option()
+                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option()
             current_option = re.sub(
                 r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
             if sumo_pages.top_navbar._is_locator_visible(option):
                 sumo_pages.top_navbar._click(option)
             else:
-                sumo_pages.top_navbar._hover_over_community_forums_top_navbar_option()
+                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option()
                 sumo_pages.top_navbar._click(option)
 
             assert (sumo_pages.product_support_page._get_product_support_title_text()
@@ -190,15 +190,15 @@ def test_ask_a_question_top_navbar_redirect(page: Page):
     utilities = Utilities(page)
     with allure.step("Clicking on all options from the 'Ask a Question' and verifying the "
                      "redirect"):
-        for index, option in enumerate(sumo_pages.top_navbar._get_all_ask_a_question_locators()):
+        for index, option in enumerate(sumo_pages.top_navbar.get_all_ask_a_question_locators()):
             if index > 0:
-                sumo_pages.top_navbar._hover_over_ask_a_question_top_navbar()
+                sumo_pages.top_navbar.hover_over_ask_a_question_top_navbar()
             current_option = re.sub(
                 r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
             if sumo_pages.top_navbar._is_locator_visible(option):
                 sumo_pages.top_navbar._click(option)
             else:
-                sumo_pages.top_navbar._hover_over_ask_a_question_top_navbar()
+                sumo_pages.top_navbar.hover_over_ask_a_question_top_navbar()
                 sumo_pages.top_navbar._click(option)
 
             if current_option == "Firefox desktop":
@@ -225,22 +225,22 @@ def test_contribute_top_navbar_redirects(page: Page):
 
     with allure.step("Clicking on the 'Contributor discussions' top-navbar option and verifying "
                      "the redirect"):
-        sumo_pages.top_navbar._click_on_community_discussions_top_navbar_option()
+        sumo_pages.top_navbar.click_on_community_discussions_top_navbar_option()
         assert (sumo_pages.contributor_discussions_page._get_contributor_discussions_page_title()
                 == "Contributor Discussions")
 
     with allure.step("Clicking on the 'Contributor discussions' top-navbar options and verifying "
                      "the redirects"):
         for index, option in enumerate(sumo_pages.top_navbar
-                                       ._get_all_contributor_discussions_locators()):
+                                       .get_all_contributor_discussions_locators()):
             if index > 0:
-                sumo_pages.top_navbar._hover_over_contribute_top_navbar()
+                sumo_pages.top_navbar.hover_over_contribute_top_navbar()
             current_option = re.sub(
                 r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
             if sumo_pages.top_navbar._is_locator_visible(option):
                 sumo_pages.top_navbar._click(option)
             else:
-                sumo_pages.top_navbar._hover_over_contribute_top_navbar()
+                sumo_pages.top_navbar.hover_over_contribute_top_navbar()
                 sumo_pages.top_navbar._click(option)
 
             if current_option == "Article discussions":

--- a/playwright_tests/tests/user_page_tests/test_edit_contribution_areas.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_contribution_areas.py
@@ -20,26 +20,26 @@ def test_all_checkboxes_can_be_selected_and_saved(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts['TEST_ACCOUNT_12']
         ))
-    original_user = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    original_user = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Checking all contributor checkboxes"):
         sumo_pages.edit_profile_flow.check_all_profile_contribution_areas(checked=False)
 
     with check, allure.step("Verifying that the correct notification banner text is displayed"):
-        assert sumo_pages.edit_my_profile_con_areas_page._edit_con_areas_pref_banner_txt(
+        assert sumo_pages.edit_my_profile_con_areas_page.edit_con_areas_pref_banner_txt(
         ) == EditContributionAreasPageMessages.PREFERENCES_SAVED_NOTIFICATION_BANNER_TEXT
 
     with allure.step("Verifying that all the checkboxes are checked"):
         assert (
-            sumo_pages.edit_my_profile_con_areas_page._are_all_cont_pref_checked()
+            sumo_pages.edit_my_profile_con_areas_page.are_all_cont_pref_checked()
         ), "Not all checkbox options are checked!"
 
     contribution_options = (sumo_pages.edit_my_profile_con_areas_page
-                            ._get_contrib_areas_checkbox_labels())
+                            .get_contrib_areas_checkbox_labels())
 
     with allure.step("Accessing the my profile page and verifying that the displayed groups are "
                      "the correct ones"):
-        sumo_pages.user_navbar._click_on_my_profile_option()
+        sumo_pages.user_navbar.click_on_my_profile_option()
         assert sumo_pages.my_profile_page._get_my_profile_groups_items_text(
         ) == contribution_options
 
@@ -65,12 +65,12 @@ def test_all_checkboxes_can_be_selected_and_saved(page: Page):
 
     with check, allure.step("Clicking on the update button and verifying that the correct "
                             "notification banner is displayed"):
-        assert sumo_pages.edit_my_profile_con_areas_page._edit_con_areas_pref_banner_txt(
+        assert sumo_pages.edit_my_profile_con_areas_page.edit_con_areas_pref_banner_txt(
         ) == EditContributionAreasPageMessages.PREFERENCES_SAVED_NOTIFICATION_BANNER_TEXT
 
     with allure.step("Verifying that the profile groups section is no longer displayed inside the "
                      "profile section"):
-        sumo_pages.user_navbar._click_on_my_profile_option()
+        sumo_pages.user_navbar.click_on_my_profile_option()
         expect(sumo_pages.my_profile_page._groups_section_element()).to_be_hidden()
 
     with allure.step("Logging in with a different user and accessing the original user profile"):

--- a/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
@@ -21,12 +21,12 @@ def test_username_field_is_automatically_populated(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts['TEST_ACCOUNT_12']
         ))
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
 
     with allure.step("Verifying that username field is automatically populated with the correct "
                      "data"):
-        top_navbar_displayed_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
-        assert (sumo_pages.edit_my_profile_page._get_username_input_field_value(
+        top_navbar_displayed_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
+        assert (sumo_pages.edit_my_profile_page.get_username_input_field_value(
         ) == top_navbar_displayed_username)
 
 
@@ -43,13 +43,13 @@ def test_edit_profile_field_validation_with_symbols(page: Page, is_firefox):
         ))
 
     with allure.step("Navigating to the profile edit page"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
 
-    original_username = sumo_pages.edit_my_profile_page._get_username_input_field_value()
+    original_username = sumo_pages.edit_my_profile_page.get_username_input_field_value()
 
     with allure.step("Clearing the username, display name fields and inserting the new one"):
-        sumo_pages.edit_my_profile_page._clear_username_field()
-        sumo_pages.edit_my_profile_page._clear_display_name_field()
+        sumo_pages.edit_my_profile_page.clear_username_field()
+        sumo_pages.edit_my_profile_page.clear_display_name_field()
         profile_edit_data = utilities.profile_edit_test_data
 
         if not is_firefox:
@@ -60,10 +60,10 @@ def test_edit_profile_field_validation_with_symbols(page: Page, is_firefox):
             new_username = profile_edit_data["valid_user_edit_with_symbols"][
                 "username_with_valid_symbols_firefox"
             ]
-        sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
+        sumo_pages.edit_my_profile_page.send_text_to_username_field(new_username)
 
     with allure.step("Clicking on the 'Update My Profile' button"):
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Verify that the newly set username is successfully applied to the my "
                             "profile section"):
@@ -72,7 +72,7 @@ def test_edit_profile_field_validation_with_symbols(page: Page, is_firefox):
 
     with check, allure.step("Verify that the newly set username is displayed inside the top "
                             "navbar"):
-        assert sumo_pages.top_navbar._get_text_of_logged_in_username() == new_username
+        assert sumo_pages.top_navbar.get_text_of_logged_in_username() == new_username
 
     with check, allure.step("Access a previously posted question and verify that the display name "
                             "has changed"):
@@ -82,10 +82,10 @@ def test_edit_profile_field_validation_with_symbols(page: Page, is_firefox):
 
     with allure.step("Going back to the my profile page and reverting the username back to the "
                      "original one"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_username_field()
-        sumo_pages.edit_my_profile_page._send_text_to_username_field(original_username)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_username_field()
+        sumo_pages.edit_my_profile_page.send_text_to_username_field(original_username)
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Verifying that the username was updated back to the original one"):
         assert sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
@@ -93,7 +93,7 @@ def test_edit_profile_field_validation_with_symbols(page: Page, is_firefox):
 
     with check, allure.step("Verify that the newly set username is displayed inside the top "
                             "navbar"):
-        assert sumo_pages.top_navbar._get_text_of_logged_in_username() == original_username
+        assert sumo_pages.top_navbar.get_text_of_logged_in_username() == original_username
 
     with check, allure.step("Access a previously posted question and verify that the display name "
                             "has changed"):
@@ -113,27 +113,27 @@ def test_username_with_invalid_symbols(page: Page):
         ))
 
     with allure.step("Accessing the edit profile page"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
 
-    original_username = sumo_pages.edit_my_profile_page._get_username_input_field_value()
+    original_username = sumo_pages.edit_my_profile_page.get_username_input_field_value()
 
     with allure.step("Clearing the username input field and adding an invalid user"):
-        sumo_pages.edit_my_profile_page._clear_username_field()
+        sumo_pages.edit_my_profile_page.clear_username_field()
         profile_edit_data = utilities.profile_edit_test_data
         new_username = profile_edit_data["invalid_username_with_symbols"][
             "username_with_invalid_symbols"
         ]
-        sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
+        sumo_pages.edit_my_profile_page.send_text_to_username_field(new_username)
 
     with check, allure.step("Clicking on the 'Update My Profile' button and verifying that "
                             "the correct error message is displayed"):
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
-        assert sumo_pages.edit_my_profile_page._get_username_error_message_text(
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
+        assert sumo_pages.edit_my_profile_page.get_username_error_message_text(
         ) == EditMyProfilePageMessages.USERNAME_INPUT_ERROR_MESSAGE
 
     with allure.step("Accessing the Edit Profile page and verifying that the username was not "
                      "changed"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         assert sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
         ) == original_username
 
@@ -149,17 +149,17 @@ def test_cancel_profile_edit(page: Page):
         ))
 
     with allure.step("Accessing the Edit My Profile page"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
 
-    original_values = sumo_pages.edit_my_profile_page._get_value_of_all_fields()
+    original_values = sumo_pages.edit_my_profile_page.get_value_of_all_fields()
 
     with allure.step("Populating edit profile fields with data"):
         sumo_pages.edit_profile_flow.edit_profile_with_test_data()
 
     with allure.step("Clicking on the 'Cancel' button and verifying that we are on the same "
                      "page and all input field values were reverted back to original"):
-        sumo_pages.edit_my_profile_page._click_cancel_button()
-        assert sumo_pages.edit_my_profile_page._get_value_of_all_fields() == original_values
+        sumo_pages.edit_my_profile_page.click_cancel_button()
+        assert sumo_pages.edit_my_profile_page.get_value_of_all_fields() == original_values
 
 
 #  C946232
@@ -174,8 +174,8 @@ def test_manage_firefox_account_redirects_to_firefox_account_settings_page(page:
 
     with allure.step("Accessing the 'Edit my profile' page and clicking on the 'Manage "
                      "account' button"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._click_manage_firefox_account_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.click_manage_firefox_account_button()
 
     with allure.step("Verifying that the user was redirected to the Mozilla account settings "
                      "page in a new tab"):
@@ -194,33 +194,33 @@ def test_duplicate_usernames_are_not_allowed(page: Page):
             utilities.user_secrets_accounts['TEST_ACCOUNT_12']
         ))
 
-    original_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    original_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Clicking on the 'edit profile' option"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
 
     with allure.step("Clearing the username input field and adding an existing username "
                      "to it"):
-        sumo_pages.edit_my_profile_page._clear_username_field()
-        sumo_pages.edit_my_profile_page._send_text_to_username_field(
+        sumo_pages.edit_my_profile_page.clear_username_field()
+        sumo_pages.edit_my_profile_page.send_text_to_username_field(
             utilities.username_extraction_from_email(
                 utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_6"]
             )
         )
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Verify that the error message is displayed under the username "
                             "input field and is the correct one"):
-        assert sumo_pages.edit_my_profile_page._get_username_error_message_text(
+        assert sumo_pages.edit_my_profile_page.get_username_error_message_text(
         ) == EditMyProfilePageMessages.DUPLICATE_USERNAME_ERROR_MESSAGE
 
     with check, allure.step("Verifying that the username displayed inside the top navbar is "
                             "the correct one"):
-        assert sumo_pages.top_navbar._get_text_of_logged_in_username() == original_username
+        assert sumo_pages.top_navbar.get_text_of_logged_in_username() == original_username
 
     with allure.step("Accessing the my profile page and verifying that the username "
                      "displayed inside the page is the correct one"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         assert sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
         ) == original_username
 
@@ -235,24 +235,24 @@ def test_profile_username_field_cannot_be_left_empty(page: Page):
             utilities.user_secrets_accounts['TEST_ACCOUNT_12']
         ))
 
-    original_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    original_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the Edit My Profile page and clearing the username input "
                      "field"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_username_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_username_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Verifying that we are still on the edit profile page"):
         assert utilities.get_page_url() == EditMyProfilePageMessages.STAGE_EDIT_MY_PROFILE_URL
 
     with allure.step("Verifying that the displayed username inside the top navbar is the "
                      "original one"):
-        assert sumo_pages.top_navbar._get_text_of_logged_in_username() == original_username
+        assert sumo_pages.top_navbar.get_text_of_logged_in_username() == original_username
 
     with allure.step("Accessing the my profile page and verifying that the username is the "
                      "original one"):
-        sumo_pages.user_navbar._click_on_my_profile_option()
+        sumo_pages.user_navbar.click_on_my_profile_option()
         assert sumo_pages.my_profile_page._get_my_profile_display_name_header_text(
         ) == original_username
 
@@ -268,21 +268,21 @@ def test_username_can_contain_uppercase_and_lowercase_letters(page: Page):
             utilities.user_secrets_accounts['TEST_ACCOUNT_MESSAGE_4']
         ))
 
-    original_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    original_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
     new_username = utilities.profile_edit_test_data["uppercase_lowercase_valid_username"][
         "uppercase_lowercase_username"
     ]
 
     with allure.step("Accessing the edit my profile page and updating the username field to "
                      "contain uppercase and lowercase characters"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_username_field()
-        sumo_pages.edit_my_profile_page._send_text_to_username_field(new_username)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_username_field()
+        sumo_pages.edit_my_profile_page.send_text_to_username_field(new_username)
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with allure.step("Verifying that the username displayed inside the top-navbar updates "
                      "successfully"):
-        assert sumo_pages.top_navbar._get_text_of_logged_in_username() == new_username
+        assert sumo_pages.top_navbar.get_text_of_logged_in_username() == new_username
 
     with allure.step("Verifying that the username displayed inside the my profile section is "
                      "the correct one"):
@@ -290,10 +290,10 @@ def test_username_can_contain_uppercase_and_lowercase_letters(page: Page):
         ) == new_username
 
     with allure.step("Reverting the username back to the original one"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_username_field()
-        sumo_pages.edit_my_profile_page._send_text_to_username_field(original_username)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_username_field()
+        sumo_pages.edit_my_profile_page.send_text_to_username_field(original_username)
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 #  C1491463, C1491464
@@ -306,7 +306,7 @@ def test_display_name_replaces_the_username_text(page: Page, is_firefox):
             utilities.user_secrets_accounts['TEST_ACCOUNT_MESSAGE_1']
         ))
 
-    original_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    original_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     if not is_firefox:
         new_display_name = utilities.profile_edit_test_data["valid_user_edit"][
@@ -318,13 +318,13 @@ def test_display_name_replaces_the_username_text(page: Page, is_firefox):
         ]
 
     with allure.step("Accessing the edit profile page and adding a new display name"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_display_name_field()
-        sumo_pages.edit_my_profile_page._send_text_to_display_name_field(new_display_name)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_display_name_field()
+        sumo_pages.edit_my_profile_page.send_text_to_display_name_field(new_display_name)
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with allure.step("Verifying that the top navbar username updates with the display name"):
-        assert sumo_pages.top_navbar._get_text_of_logged_in_username() == new_display_name
+        assert sumo_pages.top_navbar.get_text_of_logged_in_username() == new_display_name
 
     with allure.step(f"Verifying that the 'My profile' display name contains "
                      f"{new_display_name}"):
@@ -332,13 +332,13 @@ def test_display_name_replaces_the_username_text(page: Page, is_firefox):
         ) == f"{new_display_name} ({original_username})"
 
     with allure.step("Reverting back and deleting the display name"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_display_name_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_display_name_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with allure.step(f"Verifying that the displayed name inside the top navbar is reverted "
                      f"back to {original_username}"):
-        assert sumo_pages.top_navbar._get_text_of_logged_in_username() == original_username
+        assert sumo_pages.top_navbar.get_text_of_logged_in_username() == original_username
 
     with allure.step("Verifying that the displayed name inside the main profile page is "
                      "reverted back to the username"):
@@ -359,13 +359,13 @@ def test_biography_field_accepts_html_tags(page: Page):
 
     with allure.step("Accessing the edit profile page via top-navbar and adding data inside "
                      "the biography field"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_biography_textarea_field()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_biography_textarea_field()
         html_test_data = utilities.profile_edit_test_data
-        sumo_pages.edit_my_profile_page._send_text_to_biography_field(
+        sumo_pages.edit_my_profile_page.send_text_to_biography_field(
             html_test_data["biography_field_with_html_data"]["biography_html_data"]
         )
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 #  T5697917
@@ -379,18 +379,18 @@ def test_make_my_email_address_visible_checkbox_checked(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'Edit My Profile' page and checking the 'make email visible "
                      "checkbox'"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        if not sumo_pages.edit_my_profile_page._is_make_email_visible_checkbox_selected():
-            sumo_pages.edit_my_profile_page._click_make_email_visible_checkbox()
-            sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        if not sumo_pages.edit_my_profile_page.is_make_email_visible_checkbox_selected():
+            sumo_pages.edit_my_profile_page.click_make_email_visible_checkbox()
+            sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Returning to My Profile page and verifying that the email is "
                             "displayed"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         assert sumo_pages.my_profile_page._get_text_of_publicly_displayed_username(
         ) == logged_in_email
 
@@ -424,18 +424,18 @@ def test_make_my_email_address_visible_checkbox_unchecked(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'Edit My Profile' page and unchecking the make email "
                      "visible checkbox"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        if sumo_pages.edit_my_profile_page._is_make_email_visible_checkbox_selected():
-            sumo_pages.edit_my_profile_page._click_make_email_visible_checkbox()
-            sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        if sumo_pages.edit_my_profile_page.is_make_email_visible_checkbox_selected():
+            sumo_pages.edit_my_profile_page.click_make_email_visible_checkbox()
+            sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with allure.step("Returning to My Profile page and verifying that the email is not "
                      "displayed"):
-        sumo_pages.user_navbar._click_on_my_profile_option()
+        sumo_pages.user_navbar.click_on_my_profile_option()
         expect(sumo_pages.my_profile_page._publicly_displayed_email_element()).to_be_hidden()
 
     with allure.step("Signing in with a different non-admin user"):
@@ -459,14 +459,14 @@ def test_website_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'Edit My Profile' page and updating the website field"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
         website_field_test_data = utilities.profile_edit_test_data["valid_user_edit"]["website"]
-        sumo_pages.edit_my_profile_page._clear_website_field()
-        sumo_pages.edit_my_profile_page._send_text_to_website_field(website_field_test_data)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.clear_website_field()
+        sumo_pages.edit_my_profile_page.send_text_to_website_field(website_field_test_data)
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Verify that the correct website is displayed"):
         assert sumo_pages.my_profile_page._get_my_profile_website_text() == website_field_test_data
@@ -502,9 +502,9 @@ def test_website_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_website_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_website_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 # T5697919
@@ -516,22 +516,22 @@ def test_twitter_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the Edit My Profile' page, clearing and adding data inside the "
                      "twitter input field"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
         twitter_field_test_data = utilities.profile_edit_test_data["valid_user_edit"][
             "twitter_username"
         ]
-        sumo_pages.edit_my_profile_page._clear_twitter_field()
-        sumo_pages.edit_my_profile_page._send_text_to_twitter_username_field(
+        sumo_pages.edit_my_profile_page.clear_twitter_field()
+        sumo_pages.edit_my_profile_page.send_text_to_twitter_username_field(
             twitter_field_test_data)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Navigating back to the My Profile page and verify that the correct "
                             "twitter is displayed"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         assert sumo_pages.my_profile_page._get_my_profile_twitter_text() == twitter_field_test_data
 
     with check, allure.step("Signing in with a different user and verifying that the correct "
@@ -569,9 +569,9 @@ def test_twitter_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_twitter_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_twitter_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 # T5697921
@@ -583,21 +583,21 @@ def test_community_portal_username_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside the "
                      "'Community Portal' input field"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
         community_portal_field_test_data = (
             utilities.profile_edit_test_data["valid_user_edit"]["community_portal_username"])
-        sumo_pages.edit_my_profile_page._clear_community_portal_field()
-        sumo_pages.edit_my_profile_page._send_text_to_community_portal_field(
+        sumo_pages.edit_my_profile_page.clear_community_portal_field()
+        sumo_pages.edit_my_profile_page.send_text_to_community_portal_field(
             community_portal_field_test_data)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Navigating back to the My Profile page and verify that the correct "
                             "Community portal information is displayed"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         assert sumo_pages.my_profile_page._get_my_profile_community_portal_text(
         ) == community_portal_field_test_data
 
@@ -635,9 +635,9 @@ def test_community_portal_username_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_community_portal_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_community_portal_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 # T5697920
@@ -649,22 +649,22 @@ def test_people_directory_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside the "
                      "'People Directory' input field"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
         people_directory_field_test_data = (
             utilities.profile_edit_test_data["valid_user_edit"]["people_directory_username"])
-        sumo_pages.edit_my_profile_page._clear_people_directory_field()
-        sumo_pages.edit_my_profile_page._send_text_to_people_directory_username(
+        sumo_pages.edit_my_profile_page.clear_people_directory_field()
+        sumo_pages.edit_my_profile_page.send_text_to_people_directory_username(
             people_directory_field_test_data
         )
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Navigating back to the My Profile page and verify that the correct "
                             "People Directory information is displayed"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         assert sumo_pages.my_profile_page._get_my_profile_people_directory_text(
         ) == people_directory_field_test_data
 
@@ -688,9 +688,9 @@ def test_people_directory_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_people_directory_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_people_directory_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 # T5697922
@@ -702,21 +702,21 @@ def test_matrix_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside the "
                      "Matrix input field"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
         matrix_field_test_data = utilities.profile_edit_test_data["valid_user_edit"][
             "matrix_nickname"
         ]
-        sumo_pages.edit_my_profile_page._clear_matrix_field()
-        sumo_pages.edit_my_profile_page._send_text_to_matrix_nickname(matrix_field_test_data)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.clear_matrix_field()
+        sumo_pages.edit_my_profile_page.send_text_to_matrix_nickname(matrix_field_test_data)
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Navigating back to the My Profile page and verify that the correct "
                             "Matrix information is displayed"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         assert matrix_field_test_data in sumo_pages.my_profile_page._get_my_profile_matrix_text()
 
     with check, allure.step("Signing in with a different user and verifying that the correct "
@@ -738,9 +738,9 @@ def test_matrix_information_is_displayed(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
 
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_matrix_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_matrix_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 # T5697923
@@ -752,21 +752,21 @@ def test_country_location_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside the "
                      "country input field"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
         country_field_test_data_code = utilities.profile_edit_test_data["valid_user_edit"][
             "country_code"
         ]
         country_field_test_data_value = utilities.profile_edit_test_data["valid_user_edit"][
             "country_value"
         ]
-        sumo_pages.edit_my_profile_page._clear_country_dropdown_field()
-        sumo_pages.edit_my_profile_page._select_country_dropdown_option_by_value(
+        sumo_pages.edit_my_profile_page.clear_country_dropdown_field()
+        sumo_pages.edit_my_profile_page.select_country_dropdown_option_by_value(
             country_field_test_data_code)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Verify that the correct Country information is displayed"):
         assert (country_field_test_data_value in sumo_pages.my_profile_page.
@@ -793,9 +793,9 @@ def test_country_location_information_is_displayed(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
 
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_country_dropdown_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_country_dropdown_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 # T5697924
@@ -807,17 +807,17 @@ def test_city_location_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'Edit' My profile page, clearing and adding data inside "
                      "the City input field"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
         city_field_test_data_value = (
             utilities.profile_edit_test_data["valid_user_edit"]["city"])
-        sumo_pages.edit_my_profile_page._clear_city_field()
-        sumo_pages.edit_my_profile_page._sent_text_to_city_field(
+        sumo_pages.edit_my_profile_page.clear_city_field()
+        sumo_pages.edit_my_profile_page.sent_text_to_city_field(
             city_field_test_data_value)
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Verify that the correct City information is displayed"):
         assert (city_field_test_data_value in sumo_pages.my_profile_page
@@ -843,9 +843,9 @@ def test_city_location_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_city_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_city_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 # T5697925
@@ -857,26 +857,26 @@ def test_involved_since_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-    username_one = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    username_one = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'Edit My Profile' page, clearing and adding data inside "
                      "the involved since input fields"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
         involved_since_month_number_test_data = (
             utilities.profile_edit_test_data["valid_user_edit"]["involved_from_month_number"])
         involved_since_month_test_data_value = (
             utilities.profile_edit_test_data["valid_user_edit"]["involved_from_month_value"])
         involved_since_year_test_data_value = (
             utilities.profile_edit_test_data["valid_user_edit"]["involved_from_year"])
-        sumo_pages.edit_my_profile_page._clear_involved_from_month_select_field()
-        sumo_pages.edit_my_profile_page._clear_involved_from_year_select_field()
-        sumo_pages.edit_my_profile_page._select_involved_from_month_option_by_value(
+        sumo_pages.edit_my_profile_page.clear_involved_from_month_select_field()
+        sumo_pages.edit_my_profile_page.clear_involved_from_year_select_field()
+        sumo_pages.edit_my_profile_page.select_involved_from_month_option_by_value(
             involved_since_month_number_test_data
         )
-        sumo_pages.edit_my_profile_page._select_involved_from_year_option_by_value(
+        sumo_pages.edit_my_profile_page.select_involved_from_year_option_by_value(
             involved_since_year_test_data_value
         )
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with check, allure.step("Verify that the correct involved from information is displayed"):
         assert (involved_since_month_test_data_value and involved_since_year_test_data_value in
@@ -902,10 +902,10 @@ def test_involved_since_information_is_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._clear_involved_from_month_select_field()
-        sumo_pages.edit_my_profile_page._clear_involved_from_year_select_field()
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.clear_involved_from_month_select_field()
+        sumo_pages.edit_my_profile_page.clear_involved_from_year_select_field()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
 
 # T5697906, T5697929
@@ -934,11 +934,11 @@ def test_edit_user_profile_button_is_not_displayed_for_non_admin_users(page: Pag
         assert (
             sumo_pages.auth_page._is_continue_with_firefox_button_displayed()
         ), "The auth page is not displayed! It should be!"
-        expect(sumo_pages.edit_my_profile_page._is_my_profile_edit_form_displayed()).to_be_hidden()
+        expect(sumo_pages.edit_my_profile_page.is_my_profile_edit_form_displayed()).to_be_hidden()
 
     with allure.step("Signing in with another non-admin account and accessing another user "
                      "account"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
@@ -953,11 +953,11 @@ def test_edit_user_profile_button_is_not_displayed_for_non_admin_users(page: Pag
         utilities.navigate_to_link(
             EditMyProfilePageMessages.get_url_of_other_profile_edit_page(target_username)
         )
-        assert sumo_pages.edit_my_profile_page._get_access_denied_header_text(
+        assert sumo_pages.edit_my_profile_page.get_access_denied_header_text(
         ) == EditMyProfilePageMessages.PROFILE_ACCESS_DENIED_HEADING
-        assert sumo_pages.edit_my_profile_page._get_access_denied_subheading_text(
+        assert sumo_pages.edit_my_profile_page.get_access_denied_subheading_text(
         ) == EditMyProfilePageMessages.PROFILE_ACCESS_DENIED_SUBHEADING
-        expect(sumo_pages.edit_my_profile_page._is_my_profile_edit_form_displayed()).to_be_hidden()
+        expect(sumo_pages.edit_my_profile_page.is_my_profile_edit_form_displayed()).to_be_hidden()
 
 
 # T5697928
@@ -1047,7 +1047,7 @@ def test_deactivate_this_user_buttons_are_displayed_only_for_admin_users(page: P
                ).to_be_hidden()
 
     with allure.step("Signing in with a non-admin account"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
@@ -1063,7 +1063,7 @@ def test_deactivate_this_user_buttons_are_displayed_only_for_admin_users(page: P
                ).to_be_hidden()
 
     with allure.step("Signing in with an admin account"):
-        sumo_pages.top_navbar._click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
         utilities.delete_cookies()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]

--- a/playwright_tests/tests/user_page_tests/test_edit_my_settings.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_settings.py
@@ -22,18 +22,18 @@ def test_all_checkboxes_can_be_selected_and_saved(page: Page):
     with check, allure.step("Checking all user settings and verifying that the correct "
                             "notification banner is displayed and all checkboxes are checked"):
         sumo_pages.edit_profile_flow.check_all_user_settings()
-        assert sumo_pages.edit_my_profile_settings_page._settings_saved_notif_banner_txt(
+        assert sumo_pages.edit_my_profile_settings_page.settings_saved_notif_banner_txt(
         ) == EditSettingsPageMessages.MODIFIED_SETTINGS_NOTIFICATION_BANNER_MESSAGE
         assert (
-            sumo_pages.edit_my_profile_settings_page._are_all_checkbox_checked()
+            sumo_pages.edit_my_profile_settings_page.are_all_checkbox_checked()
         ), "Not all checkboxes are checked!"
 
     with check, allure.step("Unchecking all the checkboxes and verifying that the correct "
                             "notification banner is displayed and all checkboxes are "
                             "unchecked"):
         sumo_pages.edit_profile_flow.check_all_user_settings()
-        assert sumo_pages.edit_my_profile_settings_page._settings_saved_notif_banner_txt(
+        assert sumo_pages.edit_my_profile_settings_page.settings_saved_notif_banner_txt(
         ) == EditSettingsPageMessages.MODIFIED_SETTINGS_NOTIFICATION_BANNER_MESSAGE
         assert not (
-            sumo_pages.edit_my_profile_settings_page._are_all_checkbox_checked()
+            sumo_pages.edit_my_profile_settings_page.are_all_checkbox_checked()
         ), "Not all checkboxes are unchecked!"

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -21,11 +21,11 @@ def test_my_profile_page_can_be_accessed_via_top_navbar(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts['TEST_ACCOUNT_12']
         ))
-    original_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    original_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'My profile' page and verifying that we are redirected "
                      "to the correct profile"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         expect(page).to_have_url(MyProfileMessages.get_my_profile_stage_url(
             username=original_username))
 
@@ -44,7 +44,7 @@ def test_my_profile_sign_out_button_functionality(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Signing in with a non-admin account"):
-        sumo_pages.top_navbar._click_on_signin_signup_button()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
 
         sumo_pages.auth_flow_page.sign_in_flow(
             username=utilities.user_special_chars,
@@ -53,12 +53,12 @@ def test_my_profile_sign_out_button_functionality(page: Page):
 
     with allure.step("Accessing the my profile page, clicking on the sign out button and "
                      "verifying that the user is redirected to the homepage"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         sumo_pages.my_profile_page._click_my_profile_page_sign_out_button()
         expect(page).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
 
     with allure.step("Verify that the 'Sign in/Up' button from the page header is displayed"):
-        expect(sumo_pages.top_navbar._sign_in_up_button_displayed_element()).to_be_visible()
+        expect(sumo_pages.top_navbar.sign_in_up_button_displayed_element()).to_be_visible()
 
 
 # C2108828
@@ -70,7 +70,7 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-    repliant_username = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    repliant_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Navigating to the Firefox AAQ form and posting a new AAQ question for "
                      "the Firefox product"):
@@ -87,7 +87,7 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page):
 
     with allure.step("Navigating to the user profile page and extracting the original number "
                      "of posted question solutions"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         original_number_of_solutions = utilities.number_extraction_from_string(
             sumo_pages.my_profile_page._get_my_profile_solutions_text()
         )
@@ -108,7 +108,7 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page):
     with allure.step("Accessing the 'My profile' page of the account which provided the "
                      "solution and verifying that the original number of solutions has "
                      "incremented"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         utilities.number_extraction_from_string(
             sumo_pages.my_profile_page._get_my_profile_solutions_text()
         )
@@ -133,11 +133,11 @@ def test_number_of_my_profile_answers_is_successfully_displayed(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-    repliant_user = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    repliant_user = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'My profile' page and extracting the number of posted "
                      "answers"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         original_number_of_answers = utilities.number_extraction_from_string(
             sumo_pages.my_profile_page._get_my_profile_answers_text()
         )
@@ -202,7 +202,7 @@ def test_number_of_posted_articles_is_successfully_displayed(page: Page):
         ))
 
     with allure.step("Accessing the profile page and extracting the number of documents"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         original_number_of_documents = utilities.number_extraction_from_string(
             sumo_pages.my_profile_page._get_my_profile_documents_text()
         )
@@ -212,7 +212,7 @@ def test_number_of_posted_articles_is_successfully_displayed(page: Page):
 
     with allure.step("Accessing the profile page and verifying that the number of posted "
                      "documents has incremented"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         assert (
             utilities.number_extraction_from_string(
                 sumo_pages.my_profile_page._get_my_profile_documents_text()
@@ -241,7 +241,7 @@ def test_accounts_with_symbols_are_getting_a_corresponding_valid_username(page: 
     sumo_pages = SumoPages(page)
     with allure.step("Signing in with an account that contains SUMO-supported and "
                      "unsupported characters"):
-        sumo_pages.top_navbar._click_on_signin_signup_button()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
 
         username = utilities.username_extraction_from_email(
             utilities.remove_character_from_string(
@@ -254,14 +254,14 @@ def test_accounts_with_symbols_are_getting_a_corresponding_valid_username(page: 
 
     with allure.step("Verifying that the username contains the supported characters and "
                      "doesn't contain the unsupported ones in top navbar"):
-        assert sumo_pages.top_navbar._get_text_of_logged_in_username() == username
+        assert sumo_pages.top_navbar.get_text_of_logged_in_username() == username
 
     with allure.step("Verifying that the username contains the supported characters and "
                      "doesn't contain the unsupported ones in My Profile page"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         assert sumo_pages.my_profile_page._get_my_profile_display_name_header_text() == username
 
     with allure.step("Verifying that the username contains the supported characters and "
                      "doesn't contain the unsupported ones in Edit my Profile page"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        assert sumo_pages.edit_my_profile_page._get_username_input_field_value() == username
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        assert sumo_pages.edit_my_profile_page.get_username_input_field_value() == username

--- a/playwright_tests/tests/user_page_tests/test_my_questions.py
+++ b/playwright_tests/tests/user_page_tests/test_my_questions.py
@@ -20,7 +20,7 @@ def test_number_of_questions_is_incremented_when_posting_a_question(page: Page):
 
     with allure.step("Accessing the 'My profile' page and extracting the original number of "
                      "posted questions"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         original_number_of_questions = utilities.number_extraction_from_string(
             sumo_pages.my_profile_page._get_my_profile_questions_text()
         )
@@ -41,7 +41,7 @@ def test_number_of_questions_is_incremented_when_posting_a_question(page: Page):
 
     with allure.step("Navigating back to the profile page and verifying that the number of "
                      "questions has incremented"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         new_number = utilities.number_extraction_from_string(
             sumo_pages.my_profile_page._get_my_profile_questions_text()
         )
@@ -70,7 +70,7 @@ def test_my_contributions_questions_reflects_my_questions_page_numbers(page: Pag
 
     with allure.step("Accessing the 'My profile' and extracting the number of questions "
                      "listed inside the my profile page"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
         number_of_questions = utilities.number_extraction_from_string(
             sumo_pages.my_profile_page._get_my_profile_questions_text()
         )
@@ -88,18 +88,18 @@ def test_correct_messages_is_displayed_if_user_has_no_posted_questions(page: Pag
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Signing in with a user which has no posted questions"):
-        sumo_pages.top_navbar._click_on_signin_signup_button()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
         sumo_pages.auth_flow_page.sign_in_flow(
             username=utilities.user_special_chars,
             account_password=utilities.user_secrets_pass
         )
 
-    original_user = sumo_pages.top_navbar._get_text_of_logged_in_username()
+    original_user = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Accessing the 'My questions' page and verifying that the correct "
                      "message is displayed"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
-        sumo_pages.user_navbar._click_on_my_questions_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
+        sumo_pages.user_navbar.click_on_my_questions_option()
         assert (
             sumo_pages.my_questions_page._get_text_of_no_question_message()
             == MyQuestionsPageMessages.NO_POSTED_QUESTIONS_MESSAGE
@@ -123,12 +123,12 @@ def test_correct_messages_is_displayed_if_user_has_no_posted_questions(page: Pag
 
     with allure.step("Accessing the my questions page and verifying that the no question "
                      "message is no longer displayed"):
-        sumo_pages.top_navbar._click_on_view_profile_option()
-        sumo_pages.user_navbar._click_on_my_questions_option()
+        sumo_pages.top_navbar.click_on_view_profile_option()
+        sumo_pages.user_navbar.click_on_my_questions_option()
         expect(sumo_pages.my_questions_page._is_no_question_message_displayed()).to_be_hidden()
 
     with allure.step("Signing in with an admin account and deleting the posted question"):
-        sumo_pages.top_navbar._click_on_sign_out_button()
+        sumo_pages.top_navbar.click_on_sign_out_button()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -149,9 +149,9 @@ def test_correct_messages_is_displayed_if_user_has_no_posted_questions(page: Pag
     with allure.step("Signing in with the original user and verifying that the correct "
                      "message and the question list is no longer displayed"):
         utilities.delete_cookies()
-        sumo_pages.top_navbar._click_on_signin_signup_button()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
         sumo_pages.auth_flow_page.login_with_existing_session()
-        sumo_pages.user_navbar._click_on_my_questions_option()
+        sumo_pages.user_navbar.click_on_my_questions_option()
         assert (
             sumo_pages.my_questions_page._get_text_of_no_question_message()
             == MyQuestionsPageMessages.NO_POSTED_QUESTIONS_MESSAGE
@@ -184,7 +184,7 @@ def test_my_question_page_reflects_posted_questions_and_redirects_to_the_correct
 
     with allure.step("Navigating to my questions profile page and verifying that the first "
                      "element from the My Questions page is the recently posted question"):
-        sumo_pages.top_navbar._click_on_my_questions_profile_option()
+        sumo_pages.top_navbar.click_on_my_questions_profile_option()
         assert sumo_pages.my_questions_page._get_text_of_first_listed_question().replace(
             " ", "") == question_info["aaq_subject"].replace(" ", "")
 


### PR DESCRIPTION
- Mark the protected page functions as public.
- Replace super() with self in page classes.
- Use composition instead of multiple inheritance for the edit_profile_data_flow.py