### PR TITLE
Fix test failure in

### DIFF
--- a/kitsune/wiki/tests/test_parser.py
+++ b/kitsune/wiki/tests/test_parser.py
@@ -501,7 +501,7 @@ class TestWikiVideo(TestCase):
         """Video does not exist."""
         p = WikiParser()
         doc = pq(p.parse("[[V:404]]", locale="fr"))
-        self.assertEqual("La vidéo « 404 » n’existe pas.", doc.text())
+        self.assertEqual("La vidéo « 404 » n’existe pas.", doc.text().replace("\xa0", " "))
 
     def test_video_modal(self):
         """Video modal defaults for plcaeholder and text."""


### PR DESCRIPTION
`wiki/tests/test_parser/TestWikiVideo/test_video_not_exist`

- In returned doc.text, replace unicode non-breaking-space with regular space 