### PR TITLE
Playwright refactor UserGroupFlow and GroupsPage classes

### DIFF
--- a/playwright_tests/flows/user_groups_flows/user_group_flow.py
+++ b/playwright_tests/flows/user_groups_flows/user_group_flow.py
@@ -3,17 +3,18 @@ from playwright_tests.pages.contribute.groups_page import GroupsPage
 from playwright.sync_api import Page
 
 
-class UserGroupFlow(Utilities, GroupsPage):
+class UserGroupFlow:
     def __init__(self, page: Page):
-        super().__init__(page)
+        self.utilities = Utilities(page)
+        self.groups_page = GroupsPage(page)
 
     def remove_a_user_from_group(self, user: str):
-        super()._click_on_edit_group_members()
-        super()._click_on_remove_a_user_from_group_button(user)
-        super()._click_on_remove_member_confirmation_button()
+        self.groups_page.click_on_edit_group_members()
+        self.groups_page.click_on_remove_a_user_from_group_button(user)
+        self.groups_page.click_on_remove_member_confirmation_button()
 
     def add_a_user_to_group(self, user: str):
-        super()._click_on_edit_group_members()
-        super()._type_into_add_member_field(user)
-        super()._group_click_on_a_searched_username(user)
-        super()._click_on_add_member_button()
+        self.groups_page.click_on_edit_group_members()
+        self.groups_page.type_into_add_member_field(user)
+        self.groups_page.group_click_on_a_searched_username(user)
+        self.groups_page.click_on_add_member_button()

--- a/playwright_tests/pages/contribute/groups_page.py
+++ b/playwright_tests/pages/contribute/groups_page.py
@@ -14,33 +14,33 @@ class GroupsPage(BasePage):
         super().__init__(page)
 
     # Add Group member
-    def _get_user_added_successfully_message(self) -> str:
-        return super()._get_text_of_element(self.__user_added_notification)
+    def get_user_added_successfully_message(self) -> str:
+        return self._get_text_of_element(self.__user_added_notification)
 
-    def _get_pm_group_members_button(self) -> Locator:
-        return super()._get_element_locator(self.__private_message_group_members_button)
+    def get_pm_group_members_button(self) -> Locator:
+        return self._get_element_locator(self.__private_message_group_members_button)
 
-    def _click_on_a_particular_group(self, group_name):
-        super()._click(f"//a[text()='{group_name}']")
+    def click_on_a_particular_group(self, group_name):
+        self._click(f"//a[text()='{group_name}']")
 
-    def _click_on_pm_group_members_button(self):
-        super()._click(self.__private_message_group_members_button)
+    def click_on_pm_group_members_button(self):
+        self._click(self.__private_message_group_members_button)
 
-    def _click_on_edit_group_members(self):
-        super()._click(self.__edit_group_members_option)
+    def click_on_edit_group_members(self):
+        self._click(self.__edit_group_members_option)
 
-    def _click_on_remove_a_user_from_group_button(self, username: str):
-        super()._click(f"//div[@class='info']/a[text()='{username}']/../..//a"
-                       f"[@title='Remove user from group']")
+    def click_on_remove_a_user_from_group_button(self, username: str):
+        self._click(f"//div[@class='info']/a[text()='{username}']/../..//a"
+                    f"[@title='Remove user from group']")
 
-    def _click_on_remove_member_confirmation_button(self):
-        super()._click(self.__remove_user_from_group_confirmation_button)
+    def click_on_remove_member_confirmation_button(self):
+        self._click(self.__remove_user_from_group_confirmation_button)
 
-    def _type_into_add_member_field(self, text: str):
-        super()._type(self.__add_group_member_field, text, delay=0)
+    def type_into_add_member_field(self, text: str):
+        self._type(self.__add_group_member_field, text, delay=0)
 
-    def _group_click_on_a_searched_username(self, username: str):
-        super()._click(f"//div[@class='name_search']/b[text()='{username}']")
+    def group_click_on_a_searched_username(self, username: str):
+        self._click(f"//div[@class='name_search']/b[text()='{username}']")
 
-    def _click_on_add_member_button(self):
-        super()._click(self.__add_member_button)
+    def click_on_add_member_button(self):
+        self._click(self.__add_member_button)

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
@@ -298,15 +298,16 @@ def test_unsupported_locales_fallback(page: Page):
                     page
                 ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{value}/")
 
-    # C2625000
-    @pytest.mark.kbArticleTranslation
-    def test_fallback_languages(self):
-        with allure.step("Verifying the language fallback"):
-            for key, value in FALLBACK_LANGUAGES.items():
-                self.navigate_to_link(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{value}/")
-                expect(
-                    self.page
-                ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{key}/")
+
+# C2625000
+@pytest.mark.kbArticleTranslation
+def test_fallback_languages(self):
+    with allure.step("Verifying the language fallback"):
+        for key, value in FALLBACK_LANGUAGES.items():
+            self.navigate_to_link(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{value}/")
+            expect(
+                self.page
+            ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{key}/")
 
 
 # C2316347
@@ -339,9 +340,9 @@ def test_sumo_locale_priority(page: Page):
         ))
 
     with allure.step("Accessing the edit profile page and changing the language to ro"):
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._select_preferred_language_dropdown_option_by_value("ro")
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.select_preferred_language_dropdown_option_by_value("ro")
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
 
     with allure.step("Navigating to the SUMO homepage without specifying the path in the "
                      "locale and verifying that the preferred locale is set"):
@@ -368,10 +369,10 @@ def test_sumo_locale_priority(page: Page):
 
     with allure.step("Changing the preferred language back to english and signing out"):
         utilities.navigate_to_link(HomepageMessages.STAGE_HOMEPAGE_URL + '/en-US/')
-        sumo_pages.top_navbar._click_on_edit_profile_option()
-        sumo_pages.edit_my_profile_page._select_preferred_language_dropdown_option_by_value(
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.select_preferred_language_dropdown_option_by_value(
             "en-US")
-        sumo_pages.edit_my_profile_page._click_update_my_profile_button()
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
         utilities.delete_cookies()
 
     with allure.step("Sending the request with the modified 'Accept-Language' header set to "

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -646,16 +646,16 @@ def test_group_messages_cannot_be_sent_by_non_staff_users(page: Page):
 
     with allure.step("Navigating to the groups page"):
         utilities.navigate_to_link(utilities.general_test_data['groups'])
-        sumo_pages.user_groups._click_on_a_particular_group(
+        sumo_pages.user_groups.click_on_a_particular_group(
             utilities.user_message_test_data['test_groups'][0])
 
     with allure.step("Verifying that the pm group members button is not displayed"):
-        expect(sumo_pages.user_groups._get_pm_group_members_button()).to_be_hidden()
+        expect(sumo_pages.user_groups.get_pm_group_members_button()).to_be_hidden()
 
     with allure.step("Deleting the user session and verifying that the pm group members "
                      "button is not displayed"):
         utilities.delete_cookies()
-        expect(sumo_pages.user_groups._get_pm_group_members_button()).to_be_hidden()
+        expect(sumo_pages.user_groups.get_pm_group_members_button()).to_be_hidden()
 
     # The PM group members button was removed for staff members as well.
     with allure.step("Signing in with a staff account and verifying that the pm group "
@@ -663,7 +663,7 @@ def test_group_messages_cannot_be_sent_by_non_staff_users(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
         ))
-        expect(sumo_pages.user_groups._get_pm_group_members_button()).to_be_hidden()
+        expect(sumo_pages.user_groups.get_pm_group_members_button()).to_be_hidden()
 
 
 # C2566115, C2566116, C2566119
@@ -846,7 +846,7 @@ def test_removed_group_users_do_not_receive_group_messages(page: Page):
         )
 
         utilities.navigate_to_link(utilities.general_test_data['groups'])
-        sumo_pages.user_groups._click_on_a_particular_group(targeted_test_group)
+        sumo_pages.user_groups.click_on_a_particular_group(targeted_test_group)
         sumo_pages.user_group_flow.remove_a_user_from_group(targeted_user)
 
     with allure.step("Navigating to the new message page and sending a message to the group"):
@@ -886,7 +886,7 @@ def test_removed_group_users_do_not_receive_group_messages(page: Page):
             utilities.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
         ))
         utilities.navigate_to_link(utilities.general_test_data['groups'])
-        sumo_pages.user_groups._click_on_a_particular_group(targeted_test_group)
+        sumo_pages.user_groups.click_on_a_particular_group(targeted_test_group)
         sumo_pages.user_group_flow.add_a_user_to_group(targeted_user)
 
 


### PR DESCRIPTION
- Mark the group page functions as public.
- Replace super() with self in group_page class.
- Use composition instead of inheritance for the user_group_flow.py