### PR TITLE
Playwright refactor flows & classes belonging to AAQ

### DIFF
--- a/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
+++ b/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
@@ -1,15 +1,15 @@
 from playwright.sync_api import Page
 from playwright_tests.core.utilities import Utilities
-from playwright_tests.pages.ask_a_question.product_solutions_pages.product_solutions_page import (
-    ProductSolutionsPage)
-from playwright_tests.pages.top_navbar import TopNavbar
 from playwright_tests.pages.ask_a_question.aaq_pages.aaq_form_page import AAQFormPage
 from playwright_tests.pages.ask_a_question.posted_question_pages.questions_page import QuestionPage
 
 
-class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, Utilities, QuestionPage):
+class AAQFlow:
     def __init__(self, page: Page):
-        super().__init__(page)
+        self.page = page
+        self.aaq_form_page = AAQFormPage(page)
+        self.utilities = Utilities(page)
+        self.question_page = QuestionPage(page)
 
     # Submitting an aaq question for a product flow.
     # Mozilla VPN has an extra optional dropdown menu for choosing an operating system.
@@ -34,13 +34,13 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, Utilities, QuestionP
                 attach_image
             )
         # Submitting the question.
-        super()._click_aaq_form_submit_button()
+        self.aaq_form_page.click_aaq_form_submit_button()
 
         # If the submission was done for freemium products we are retrieving the Question Subject,
         # Question url & Question Body for further test usage.
         if not is_premium:
             # Waiting for submitted question reply button visibility.
-            super()._is_post_reply_button_visible()
+            self.question_page.is_post_reply_button_visible()
             current_page_url = self.page.url
             return {"aaq_subject": question_subject, "question_page_url": current_page_url,
                     "question_body": body}
@@ -52,26 +52,26 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, Utilities, QuestionP
                                                              topic_value: str,
                                                              body_text: str,
                                                              attach_image=False):
-        aaq_subject = subject + super().generate_random_number(min_value=0, max_value=5000)
+        aaq_subject = subject + self.utilities.generate_random_number(min_value=0, max_value=5000)
         # Adding text to subject field.
-        super()._add_text_to_aaq_form_subject_field(aaq_subject)
+        self.aaq_form_page.add_text_to_aaq_form_subject_field(aaq_subject)
         # Selecting a topic.
-        super()._select_aaq_form_topic_value(
+        self.aaq_form_page.select_aaq_form_topic_value(
             topic_value
         )
         # Adding text to question body.
-        super()._add_text_to_aaq_textarea_field(
+        self.aaq_form_page.add_text_to_aaq_textarea_field(
             body_text
         )
 
         if attach_image:
             # Uploading an image to the aaq question form.
-            super()._get_upload_image_button_locator().set_input_files(
-                super().aaq_question_test_data["valid_firefox_question"]["image_path"]
+            self.aaq_form_page.get_upload_image_button_locator().set_input_files(
+                self.utilities.aaq_question_test_data["valid_firefox_question"]["image_path"]
             )
 
             # Waiting for the image preview to be displayed.
-            super()._uploaded_image_locator()
+            self.aaq_form_page.uploaded_image_locator()
 
         # Returning the entered question subject for further usage.
         return aaq_subject
@@ -82,55 +82,55 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, Utilities, QuestionP
     def add_valid_data_to_all_premium_products_aaq_fields(self, subject: str, body: str,
                                                           is_loginless: bool, email: str):
         if is_loginless:
-            super()._fill_contact_email_field(email)
-        super()._select_random_topic_by_value()
-        if super()._is_os_dropdown_menu_visible():
-            super()._select_random_os_by_value()
-        super()._add_text_to_premium_aaq_form_subject_field(subject)
-        super()._add_text_to_premium_aaq_textarea_body_field(body)
+            self.aaq_form_page.fill_contact_email_field(email)
+        self.aaq_form_page.select_random_topic_by_value()
+        if self.aaq_form_page.is_os_dropdown_menu_visible():
+            self.aaq_form_page.select_random_os_by_value()
+        self.aaq_form_page.add_text_to_premium_aaq_form_subject_field(subject)
+        self.aaq_form_page.add_text_to_premium_aaq_textarea_body_field(body)
 
     # Adding an image to the aaq form.
     def adding_an_image_to_aaq_form(self):
-        super()._get_upload_image_button_locator().set_input_files(
-            super().aaq_question_test_data["valid_firefox_question"]["image_path"]
+        self.aaq_form_page.get_upload_image_button_locator().set_input_files(
+            self.utilities.aaq_question_test_data["valid_firefox_question"]["image_path"]
         )
 
     def deleting_question_flow(self):
-        super()._click_delete_this_question_question_tools_option()
-        super()._click_delete_this_question_button()
+        self.question_page.click_delete_this_question_question_tools_option()
+        self.question_page.click_delete_this_question_button()
 
     def editing_question_flow(self, subject='', body='', troubleshoot='', submit_edit=True):
-        if subject != '':
-            super()._clear_subject_input_field()
-            super()._add_text_to_aaq_form_subject_field(subject)
+        if subject:
+            self.aaq_form_page.clear_subject_input_field()
+            self.aaq_form_page.add_text_to_aaq_form_subject_field(subject)
 
-        if body != '':
-            super()._clear_the_question_body_textarea_field()
-            super()._add_text_to_aaq_textarea_field(body)
+        if body:
+            self.aaq_form_page.clear_the_question_body_textarea_field()
+            self.aaq_form_page.add_text_to_aaq_textarea_field(body)
 
-        if troubleshoot != '':
-            super()._add_text_to_troubleshooting_information_textarea(troubleshoot)
+        if troubleshoot:
+            self.aaq_form_page.add_text_to_troubleshooting_information_textarea(troubleshoot)
 
         if submit_edit:
-            super()._click_aaq_edit_submit_button()
+            self.aaq_form_page.click_aaq_edit_submit_button()
 
     def editing_reply_flow(self, reply_body: str, submit_reply=True):
-        super()._clear_the_question_body_textarea_field()
-        super()._add_text_to_aaq_textarea_field(reply_body)
+        self.aaq_form_page.clear_the_question_body_textarea_field()
+        self.aaq_form_page.add_text_to_aaq_textarea_field(reply_body)
 
         if submit_reply:
-            super()._click_on_update_answer_button()
+            self.aaq_form_page.click_on_update_answer_button()
         else:
-            super()._click_aaq_form_cancel_button()
+            self.aaq_form_page.click_aaq_form_cancel_button()
 
     def delete_question_reply(self, answer_id: str, delete_reply: bool):
-        super()._click_on_reply_more_options_button(answer_id)
-        super()._click_on_delete_this_post_for_a_certain_reply(answer_id)
+        self.question_page.click_on_reply_more_options_button(answer_id)
+        self.question_page.click_on_delete_this_post_for_a_certain_reply(answer_id)
 
         if delete_reply:
-            super()._click_delete_this_question_button()
+            self.question_page.click_delete_this_question_button()
         else:
-            super()._click_on_cancel_delete_button()
+            self.question_page.click_on_cancel_delete_button()
 
     def post_question_reply_flow(self,
                                  repliant_username: str,
@@ -139,27 +139,27 @@ class AAQFlow(AAQFormPage, ProductSolutionsPage, TopNavbar, Utilities, QuestionP
                                  quoted_reply=False,
                                  reply_for_id='') -> str:
         if quoted_reply:
-            super()._click_on_reply_more_options_button(reply_for_id)
-            super()._click_on_quote_for_a_certain_reply(reply_for_id)
+            self.question_page.click_on_reply_more_options_button(reply_for_id)
+            self.question_page.click_on_quote_for_a_certain_reply(reply_for_id)
 
-        if reply != '' and quoted_reply:
-            super()._type_inside_the_post_a_reply_textarea(reply)
-        elif reply != '' and not quoted_reply:
-            super()._add_text_to_post_a_reply_textarea(reply)
+        if reply and quoted_reply:
+            self.question_page.type_inside_the_post_a_reply_textarea(reply)
+        elif reply and not quoted_reply:
+            self.question_page.add_text_to_post_a_reply_textarea(reply)
 
         if submit_reply:
-            return super()._click_on_post_reply_button(repliant_username)
+            return self.question_page.click_on_post_reply_button(repliant_username)
 
     def report_question_abuse(self, answer_id: str, text=''):
-        super()._click_on_reply_more_options_button(answer_id)
-        super()._click_on_report_abuse_for_a_certain_reply(answer_id)
+        self.question_page.click_on_reply_more_options_button(answer_id)
+        self.question_page.click_on_report_abuse_for_a_certain_reply(answer_id)
 
-        if text != '':
-            super()._add_text_to_report_abuse_textarea(text)
+        if text:
+            self.question_page.add_text_to_report_abuse_textarea(text)
 
-        super()._click_on_report_abuse_submit_button()
-        super()._click_abuse_modal_close_button()
+        self.question_page.click_on_report_abuse_submit_button()
+        self.question_page.click_abuse_modal_close_button()
 
     def spam_marking_a_reply(self, reply_id: str):
-        super()._click_on_reply_more_options_button(reply_id)
-        super()._click_on_mark_as_spam_for_a_certain_reply(reply_id)
+        self.question_page.click_on_reply_more_options_button(reply_id)
+        self.question_page.click_on_mark_as_spam_for_a_certain_reply(reply_id)

--- a/playwright_tests/pages/ask_a_question/aaq_pages/aaq_form_page.py
+++ b/playwright_tests/pages/ask_a_question/aaq_pages/aaq_form_page.py
@@ -73,153 +73,153 @@ class AAQFormPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
-    def _fill_contact_email_field(self, text: str):
-        super()._fill(self.__loginless_contact_email_input_field, text)
+    def fill_contact_email_field(self, text: str):
+        self._fill(self.__loginless_contact_email_input_field, text)
 
-    def _get_premium_card_submission_message(self) -> str:
-        return super()._get_text_of_element(self.__premium_ticket_message)
+    def get_premium_card_submission_message(self) -> str:
+        return self._get_text_of_element(self.__premium_ticket_message)
 
     # Breadcrumb actions.
-    def _get_in_progress_item_label(self) -> str:
-        return super()._get_text_of_element(self.__in_progress_item_label)
+    def get_in_progress_item_label(self) -> str:
+        return self._get_text_of_element(self.__in_progress_item_label)
 
-    def _click_on_a_particular_completed_milestone(self, milestone_name: str):
-        super()._click(f'//span[@class="progress--label" and text()="{milestone_name}"]/../..')
+    def click_on_a_particular_completed_milestone(self, milestone_name: str):
+        self._click(f'//span[@class="progress--label" and text()="{milestone_name}"]/../..')
 
     # Question subject actions.
-    def _get_value_of_subject_input_field(self) -> str:
-        return super()._get_element_input_value(self.__aaq_subject_input_field)
+    def get_value_of_subject_input_field(self) -> str:
+        return self._get_element_input_value(self.__aaq_subject_input_field)
 
-    def _clear_subject_input_field(self):
-        super()._clear_field(self.__aaq_subject_input_field)
+    def clear_subject_input_field(self):
+        self._clear_field(self.__aaq_subject_input_field)
 
-    def _get_aaq_form_subject_error(self) -> str:
-        return super()._get_text_of_element(self.__aaq_subject_input_field_error_message)
+    def get_aaq_form_subject_error(self) -> str:
+        return self._get_text_of_element(self.__aaq_subject_input_field_error_message)
 
-    def _add_text_to_aaq_form_subject_field(self, text: str):
-        super()._fill(self.__aaq_subject_input_field, text)
+    def add_text_to_aaq_form_subject_field(self, text: str):
+        self._fill(self.__aaq_subject_input_field, text)
 
-    def _add_text_to_premium_aaq_form_subject_field(self, text: str):
-        super()._fill(self.__premium_aaq_subject_input_field, text)
+    def add_text_to_premium_aaq_form_subject_field(self, text: str):
+        self._fill(self.__premium_aaq_subject_input_field, text)
 
-    def _add_text_to_premium_aaq_textarea_body_field(self, text: str):
-        super()._fill(self.__tell_us_more_premium_product_textarea, text)
+    def add_text_to_premium_aaq_textarea_body_field(self, text: str):
+        self._fill(self.__tell_us_more_premium_product_textarea, text)
 
     # Question body actions.
-    def _get_value_of_question_body_textarea_field(self) -> str:
-        return super()._get_element_input_value(self.__how_can_we_help_textarea)
+    def get_value_of_question_body_textarea_field(self) -> str:
+        return self._get_element_input_value(self.__how_can_we_help_textarea)
 
-    def _clear_the_question_body_textarea_field(self):
-        super()._clear_field(self.__how_can_we_help_textarea)
+    def clear_the_question_body_textarea_field(self):
+        self._clear_field(self.__how_can_we_help_textarea)
 
-    def _get_aaq_form_body_error(self) -> str:
-        return super()._get_text_of_element(self.__how_can_we_help_textarea_error_field)
+    def get_aaq_form_body_error(self) -> str:
+        return self._get_text_of_element(self.__how_can_we_help_textarea_error_field)
 
-    def _add_text_to_aaq_textarea_field(self, text: str):
-        super()._fill(self.__how_can_we_help_textarea, text)
+    def add_text_to_aaq_textarea_field(self, text: str):
+        self._fill(self.__how_can_we_help_textarea, text)
 
     # Question image actions.
-    def _image_preview_element(self) -> ElementHandle:
-        return super()._get_element_handle(self.__uploaded_test_image_preview)
+    def image_preview_element(self) -> ElementHandle:
+        return self._get_element_handle(self.__uploaded_test_image_preview)
 
-    def _uploaded_image_locator(self) -> Locator:
+    def uploaded_image_locator(self) -> Locator:
         try:
-            super()._wait_for_selector(self.__uploaded_image)
+            self._wait_for_selector(self.__uploaded_image)
         except TimeoutError:
             print("Uploaded image not displayed")
-        return super()._get_element_locator(self.__uploaded_image)
+        return self._get_element_locator(self.__uploaded_image)
 
-    def _uploaded_images_handles(self) -> list[ElementHandle]:
-        return super()._get_element_handles(self.__uploaded_image)
+    def uploaded_images_handles(self) -> list[ElementHandle]:
+        return self._get_element_handles(self.__uploaded_image)
 
-    def _get_upload_image_button_locator(self) -> Locator:
-        return super()._get_element_locator(self.__add_image_browse_button)
+    def get_upload_image_button_locator(self) -> Locator:
+        return self._get_element_locator(self.__add_image_browse_button)
 
     # Page content actions.
-    def _get_product_image_locator(self) -> Locator:
-        return super()._get_element_locator(self.__aaq_page_logo)
+    def get_product_image_locator(self) -> Locator:
+        return self._get_element_locator(self.__aaq_page_logo)
 
-    def _get_aaq_form_page_heading(self) -> str:
-        return super()._get_text_of_element(self.__aaq_page_product_heading)
+    def get_aaq_form_page_heading(self) -> str:
+        return self._get_text_of_element(self.__aaq_page_product_heading)
 
-    def _get_aaq_form_page_intro_text(self) -> str:
-        return super()._get_text_of_element(self.__aaq_page_intro_text)
+    def get_aaq_form_page_intro_text(self) -> str:
+        return self._get_text_of_element(self.__aaq_page_intro_text)
 
-    def _get_aaq_form_info_card_text(self) -> str:
-        return super()._get_text_of_element(self.__aaq_page_info_card)
+    def get_aaq_form_info_card_text(self) -> str:
+        return self._get_text_of_element(self.__aaq_page_info_card)
 
-    def _get_learn_more_button_locator(self) -> Locator:
-        return super()._get_element_locator(self.__learn_more_button)
+    def get_learn_more_button_locator(self) -> Locator:
+        return self._get_element_locator(self.__learn_more_button)
 
-    def _get_helpful_tip_locator(self) -> Locator:
-        return super()._get_element_locator(self.__helpful_tip_section)
+    def get_helpful_tip_locator(self) -> Locator:
+        return self._get_element_locator(self.__helpful_tip_section)
 
     # Question topic actions.
-    def _get_aaq_form_topic_select_error(self) -> str:
-        return super()._get_text_of_element(self.__product_topic_select_dropdown_error_message)
+    def get_aaq_form_topic_select_error(self) -> str:
+        return self._get_text_of_element(self.__product_topic_select_dropdown_error_message)
 
     # Returns all the non-default selectable topic options.
-    def _get_aaq_form_topic_options(self) -> list[str]:
-        return super()._get_text_of_elements(self.__product_topic_options_without_default_none)
+    def get_aaq_form_topic_options(self) -> list[str]:
+        return self._get_text_of_elements(self.__product_topic_options_without_default_none)
 
-    def _select_aaq_form_topic_value(self, value: str):
-        super()._select_option_by_value(self.__product_topic_select_dropdown, value)
+    def select_aaq_form_topic_value(self, value: str):
+        self._select_option_by_value(self.__product_topic_select_dropdown, value)
 
-    def _add_text_to_product_version_field(self, text: str):
-        super()._fill(self.__product_version_input, text)
+    def add_text_to_product_version_field(self, text: str):
+        self._fill(self.__product_version_input, text)
 
-    def _add_text_to_os_field(self, text: str):
-        super()._fill(self.__product_os, text)
+    def add_text_to_os_field(self, text: str):
+        self._fill(self.__product_os, text)
 
-    def _select_aaq_form_os_value(self, value: str):
-        super()._select_option_by_value(self.__product_os_select_dropdown_options, value)
+    def select_aaq_form_os_value(self, value: str):
+        self._select_option_by_value(self.__product_os_select_dropdown_options, value)
 
     # Troubleshooting information actions.
-    def _add_text_to_troubleshooting_information_textarea(self, text: str):
-        super()._fill(self.__troubleshooting_information_textarea, text)
+    def add_text_to_troubleshooting_information_textarea(self, text: str):
+        self._fill(self.__troubleshooting_information_textarea, text)
 
-    def _click_on_learn_more_button(self):
-        super()._click(self.__learn_more_button)
+    def click_on_learn_more_button(self):
+        self._click(self.__learn_more_button)
 
-    def _is_os_dropdown_menu_visible(self) -> bool:
-        return super()._is_element_visible(self.__product_os_select_dropdown)
+    def is_os_dropdown_menu_visible(self) -> bool:
+        return self._is_element_visible(self.__product_os_select_dropdown)
 
-    def _select_random_os_by_value(self):
-        super()._select_random_option_by_value(self.__product_os_select_dropdown,
-                                               self.__product_os_select_dropdown_options)
+    def select_random_os_by_value(self):
+        self._select_random_option_by_value(self.__product_os_select_dropdown,
+                                            self.__product_os_select_dropdown_options)
 
-    def _select_random_topic_by_value(self):
-        super()._select_random_option_by_value(self.__product_topic_select_dropdown,
-                                               self.__product_topic_options)
+    def select_random_topic_by_value(self):
+        self._select_random_option_by_value(self.__product_topic_select_dropdown,
+                                            self.__product_topic_options)
 
-    def _click_on_share_data_button(self):
-        super()._click(self.__share_data_button)
+    def click_on_share_data_button(self):
+        self._click(self.__share_data_button)
 
-    def _click_on_show_details_option(self):
-        super()._click(self.__show_details_option)
+    def click_on_show_details_option(self):
+        self._click(self.__show_details_option)
 
     # Instead of clicking on the 'Try these manual steps' button we are going to perform the
     # assertion by checking that the element has the correct href value. Navigating to prod can
     # yield a 429 error which we want to avoid.
-    def _get_try_these_manual_steps_link(self) -> str:
-        return super()._get_element_attribute_value(
+    def get_try_these_manual_steps_link(self) -> str:
+        return self._get_element_attribute_value(
             self.__try_these_manual_steps_link,
             "href"
         )
 
     # Email me when someone answers the thread section actions.
-    def _click_on_email_me_when_someone_answers_the_thread_checkbox(self):
-        super()._click(self.__email_me_checkbox)
+    def click_on_email_me_when_someone_answers_the_thread_checkbox(self):
+        self._click(self.__email_me_checkbox)
 
-    def _click_aaq_form_cancel_button(self):
-        super()._click(self.__form_cancel_option)
+    def click_aaq_form_cancel_button(self):
+        self._click(self.__form_cancel_option)
 
-    def _click_aaq_form_submit_button(self):
-        super()._click(self.__form_submit_button)
+    def click_aaq_form_submit_button(self):
+        self._click(self.__form_submit_button)
 
     # Edit question form actions.
-    def _click_aaq_edit_submit_button(self):
-        super()._click(self.__save_edit_question_button)
+    def click_aaq_edit_submit_button(self):
+        self._click(self.__save_edit_question_button)
 
-    def _click_on_update_answer_button(self):
-        super()._click(self.__form_update_answer_button)
+    def click_on_update_answer_button(self):
+        self._click(self.__form_update_answer_button)

--- a/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
+++ b/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
@@ -141,438 +141,437 @@ class QuestionPage(BasePage):
         super().__init__(page)
 
     # Report abuse actions.
-    def _click_abuse_modal_close_button(self):
-        super()._click(self.__report_abuse_modal_close_button)
+    def click_abuse_modal_close_button(self):
+        self._click(self.__report_abuse_modal_close_button)
 
-    def _get_successful_flagged_this_content_text(self) -> str:
-        return super()._get_text_of_element(self.__report_abuse_flagged_this_content_message)
+    def get_successful_flagged_this_content_text(self) -> str:
+        return self._get_text_of_element(self.__report_abuse_flagged_this_content_message)
 
-    def _add_text_to_report_abuse_textarea(self, text: str):
-        super()._fill(self.__report_abuse_textarea, text)
+    def add_text_to_report_abuse_textarea(self, text: str):
+        self._fill(self.__report_abuse_textarea, text)
 
-    def _click_on_report_abuse_submit_button(self):
-        super()._click(self.__report_abuse_submit_button)
+    def click_on_report_abuse_submit_button(self):
+        self._click(self.__report_abuse_submit_button)
 
     # Breadcrumbs actions.
-    def _get_current_breadcrumb_locator(self, question_title: str) -> Locator:
-        return super()._get_element_locator(f"//ol[@id='breadcrumbs']/li[text()='{question_title}'"
-                                            f"]")
+    def get_current_breadcrumb_locator(self, question_title: str) -> Locator:
+        return self._get_element_locator(f"//ol[@id='breadcrumbs']/li[text()='{question_title}'"
+                                         f"]")
 
-    def _click_on_breadcrumb(self, breadcrumb_xpath: str):
-        super()._click(breadcrumb_xpath)
+    def click_on_breadcrumb(self, breadcrumb_xpath: str):
+        self._click(breadcrumb_xpath)
 
     # Get email updates actions.
-    def _get_email_updates_option(self) -> Locator:
-        return super()._get_element_locator(self.__stop_email_updates_option)
+    def get_email_updates_option(self) -> Locator:
+        return self._get_element_locator(self.__stop_email_updates_option)
 
     # Problem solved actions.
-    def _get_problem_solved_section_header_text(self) -> str:
-        return super()._get_text_of_element(self.__problem_solved_reply_section_header)
+    def get_problem_solved_section_header_text(self) -> str:
+        return self._get_text_of_element(self.__problem_solved_reply_section_header)
 
-    def _click_on_undo_button(self):
-        super()._click(self.__undo_solves_problem)
+    def click_on_undo_button(self):
+        self._click(self.__undo_solves_problem)
 
-    def _get_undo_button_locator(self) -> Locator:
-        return super()._get_element_locator(self.__undo_solves_problem)
+    def get_undo_button_locator(self) -> Locator:
+        return self._get_element_locator(self.__undo_solves_problem)
 
-    def _click_read_this_answer_in_context_link(self):
-        super()._click(self.__problem_solved_reply_reply_link)
+    def click_read_this_answer_in_context_link(self):
+        self._click(self.__problem_solved_reply_reply_link)
 
-    def _get_chosen_solution_text(self) -> str:
-        return super()._get_text_of_element(self.__problem_solved_reply_text)
+    def get_chosen_solution_text(self) -> str:
+        return self._get_text_of_element(self.__problem_solved_reply_text)
 
-    def _get_chosen_solution_section_locator(self) -> Locator:
-        return super()._get_element_locator(self.__problem_solved_reply_section)
+    def get_chosen_solution_section_locator(self) -> Locator:
+        return self._get_element_locator(self.__problem_solved_reply_section)
 
-    def _get_solved_problem_banner_text(self) -> str:
-        return super()._get_text_of_element(self.__problem_solved_banner_text)
+    def get_solved_problem_banner_text(self) -> str:
+        return self._get_text_of_element(self.__problem_solved_banner_text)
 
-    def _get_solved_the_problem_button_locator(self, target_reply_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{target_reply_id}']/"
-                                            f"following-sibling::aside//input[@type='submit']")
+    def get_solved_the_problem_button_locator(self, target_reply_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{target_reply_id}']/"
+                                         f"following-sibling::aside//input[@type='submit']")
 
-    def _get_chosen_solution_reply_message(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//h3[@class='is-solution']")
+    def get_chosen_solution_reply_message(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//h3[@class='is-solution']")
 
-    def _get_chosen_solution_reply_message_locator(self, reply_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{reply_id}']//h3[@class='is-solution']")
+    def get_chosen_solution_reply_message_locator(self, reply_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{reply_id}']//h3[@class='is-solution']")
 
     # I have this problem too actions.
-    def _get_i_have_this_problem_too_locator(self) -> Locator:
-        return super()._get_element_locator(self.__i_have_this_problem_too_button)
+    def get_i_have_this_problem_too_locator(self) -> Locator:
+        return self._get_element_locator(self.__i_have_this_problem_too_button)
 
-    def _click_i_have_this_problem_too_button(self):
-        super()._click(self.__i_have_this_problem_too_button)
+    def click_i_have_this_problem_too_button(self):
+        self._click(self.__i_have_this_problem_too_button)
 
-    def _get_i_have_this_problem_too_counter(self) -> int:
-        return int(super()._get_text_of_element(self.__i_have_this_problem_too_counter))
+    def get_i_have_this_problem_too_counter(self) -> int:
+        return int(self._get_text_of_element(self.__i_have_this_problem_too_counter))
 
-    def _get_last_reply_by_text(self) -> str:
-        return super()._get_text_of_element(self.__last_reply_by)
+    def get_last_reply_by_text(self) -> str:
+        return self._get_text_of_element(self.__last_reply_by)
 
     # Page content actions.
-    def _get_question_header(self) -> str:
-        return super()._get_text_of_element(self.__questions_header)
+    def get_question_header(self) -> str:
+        return self._get_text_of_element(self.__questions_header)
 
-    def _click_last_reply_by(self):
-        super()._click(self.__last_reply_by)
+    def click_last_reply_by(self):
+        self._click(self.__last_reply_by)
 
-    def _get_question_body(self) -> str:
-        return super()._get_text_of_element(self.__question_body)
+    def get_question_body(self) -> str:
+        return self._get_text_of_element(self.__question_body)
 
-    def _get_question_author_name(self) -> str:
-        return super()._get_text_of_element(self.__question_author)
+    def get_question_author_name(self) -> str:
+        return self._get_text_of_element(self.__question_author)
 
-    def _get_question_id(self) -> str:
-        return super()._get_element_attribute_value(self.__question_section, 'id')
+    def get_question_id(self) -> str:
+        return self._get_element_attribute_value(self.__question_section, 'id')
 
-    def _get_modified_question_locator(self) -> Locator:
-        return super()._get_element_locator(self.__modified_question_section)
+    def get_modified_question_locator(self) -> Locator:
+        return self._get_element_locator(self.__modified_question_section)
 
-    def _get_modified_by_text(self) -> str:
-        return super()._get_text_of_element(self.__modified_question_section)
+    def get_modified_by_text(self) -> str:
+        return self._get_text_of_element(self.__modified_question_section)
 
-    def _get_add_image_section_locator(self) -> Locator:
-        return super()._get_element_locator(self.__add_image_button)
+    def get_add_image_section_locator(self) -> Locator:
+        return self._get_element_locator(self.__add_image_button)
 
-    def _click_on_my_questions_banner_option(self):
-        super()._click(self.__posted_questions_success_banner_my_questions_link)
+    def click_on_my_questions_banner_option(self):
+        self._click(self.__posted_questions_success_banner_my_questions_link)
 
-    def _click_on_solves_the_problem_button(self, target_reply_id: str):
-        super()._click(f"//div[@id='{target_reply_id}']/following-sibling::aside//"
-                       f"input[@type='submit']")
+    def click_on_solves_the_problem_button(self, target_reply_id: str):
+        self._click(f"//div[@id='{target_reply_id}']/following-sibling::aside//"
+                    f"input[@type='submit']")
 
-    def _is_post_reply_button_visible(self) -> ElementHandle:
-        super()._wait_for_selector(self.__post_reply_button)
-        return super()._get_element_handle(self.__post_reply_button)
+    def is_post_reply_button_visible(self) -> ElementHandle:
+        self._wait_for_selector(self.__post_reply_button)
+        return self._get_element_handle(self.__post_reply_button)
 
-    def _click_on_the_reply_author(self, reply_id: str):
-        super()._click(f"//div[@id='{reply_id}']//a[@class='author-name']")
+    def click_on_the_reply_author(self, reply_id: str):
+        self._click(f"//div[@id='{reply_id}']//a[@class='author-name']")
 
-    def _get_text_content_of_reply(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//div[@class='content']")
+    def get_text_content_of_reply(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//div[@class='content']")
 
-    def _get_display_name_of_question_reply_author(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//a[@class='author-name']/"
-                                            f"span[@class='display-name']")
+    def get_display_name_of_question_reply_author(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//a[@class='author-name']/"
+                                         f"span[@class='display-name']")
 
-    def _get_displayed_user_title_of_question_reply_locator(self, reply_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{reply_id}']//a[@class='author-name']/"
-                                            f"span[@class='user-title']")
+    def get_displayed_user_title_of_question_reply_locator(self, reply_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{reply_id}']//a[@class='author-name']/"
+                                         f"span[@class='user-title']")
 
-    def _get_displayed_user_title_of_question_reply(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//a[@class='author-name']/"
-                                            f"span[@class='user-title']")
+    def get_displayed_user_title_of_question_reply(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//a[@class='author-name']/"
+                                         f"span[@class='user-title']")
 
     # Question tag actions.
-    def _get_question_tag_options(self) -> list[str]:
-        return super()._get_text_of_elements(self.__question_tags_options)
+    def get_question_tag_options(self) -> list[str]:
+        return self._get_text_of_elements(self.__question_tags_options)
 
-    def _get_remove_tag_button_locator(self, tag_name: str) -> Locator:
-        return super()._get_element_locator(f"//ul[@class='tag-list cf']//a[text()='{tag_name}']/"
-                                            f"following-sibling::button[@class='remover']")
+    def get_remove_tag_button_locator(self, tag_name: str) -> Locator:
+        return self._get_element_locator(f"//ul[@class='tag-list cf']//a[text()='{tag_name}']/"
+                                         f"following-sibling::button[@class='remover']")
 
-    def _add_text_to_add_a_tag_input_field(self, text: str):
-        super()._fill(self.__add_a_tag_input_field, text)
-        super()._click(f"//li[@class='ui-menu-item']/div[text()='{text}']")
+    def add_text_to_add_a_tag_input_field(self, text: str):
+        self._fill(self.__add_a_tag_input_field, text)
+        self._click(f"//li[@class='ui-menu-item']/div[text()='{text}']")
 
-    def _get_add_a_tag_input_field(self) -> Locator:
-        return super()._get_element_locator(self.__add_a_tag_input_field)
+    def get_add_a_tag_input_field(self) -> Locator:
+        return self._get_element_locator(self.__add_a_tag_input_field)
 
-    def _get_add_a_tag_button(self) -> Locator:
-        return super()._get_element_locator(self.__add_a_tab_button)
+    def get_add_a_tag_button(self) -> Locator:
+        return self._get_element_locator(self.__add_a_tab_button)
 
-    def _click_on_add_a_tag_button(self):
-        super()._click(self.__add_a_tab_button)
+    def click_on_add_a_tag_button(self):
+        self._click(self.__add_a_tab_button)
 
-    def _click_on_a_certain_tag(self, tag_name: str):
-        super()._click(f"//li[@class='tag']//a[text()='{tag_name}']")
+    def click_on_a_certain_tag(self, tag_name: str):
+        self._click(f"//li[@class='tag']//a[text()='{tag_name}']")
 
-    def _get_a_certain_tag(self, tag_name: str) -> Locator:
-        return super()._get_element_locator(f"//li[@class='tag']//a[text()='{tag_name}']")
+    def get_a_certain_tag(self, tag_name: str) -> Locator:
+        return self._get_element_locator(f"//li[@class='tag']//a[text()='{tag_name}']")
 
-    def _click_on_tag_remove_button(self, tag_name: str):
-        super()._click(f"//li[@class='tag']//a[text()='{tag_name}']/"
-                       f"following-sibling::button[@class='remover']")
+    def click_on_tag_remove_button(self, tag_name: str):
+        self._click(f"//li[@class='tag']//a[text()='{tag_name}']/"
+                    f"following-sibling::button[@class='remover']")
 
     # Attached image actions.
-    def _get_attached_image(self) -> Locator:
-        return super()._get_element_locator(self.__attached_image)
+    def get_attached_image(self) -> Locator:
+        return self._get_element_locator(self.__attached_image)
 
     # Question more information actions.
-    def _get_more_information_with_text_locator(self, text: str) -> Locator:
-        return super()._get_element_locator(f"//div[@class='about-support']/p[text()='{text}']")
+    def get_more_information_with_text_locator(self, text: str) -> Locator:
+        return self._get_element_locator(f"//div[@class='about-support']/p[text()='{text}']")
 
-    def _get_question_details_button_locator(self) -> Locator:
-        return super()._get_element_locator(self.__question_details_button)
+    def get_question_details_button_locator(self) -> Locator:
+        return self._get_element_locator(self.__question_details_button)
 
-    def _get_more_information_locator(self) -> Locator:
-        return super()._get_element_locator(self.__more_information_panel_header)
+    def get_more_information_locator(self) -> Locator:
+        return self._get_element_locator(self.__more_information_panel_header)
 
-    def _get_user_agent_information(self) -> str:
-        super()._wait_for_selector(self.__more_system_details_modal)
-        return super()._get_text_of_element(self.__user_agent_information)
+    def get_user_agent_information(self) -> str:
+        self._wait_for_selector(self.__more_system_details_modal)
+        return self._get_text_of_element(self.__user_agent_information)
 
-    def _get_system_details_information(self) -> list[str]:
-        return super()._get_text_of_elements(self.__system_details_options)
+    def get_system_details_information(self) -> list[str]:
+        return self._get_text_of_elements(self.__system_details_options)
 
-    def _click_on_question_details_button(self):
-        super()._click(self.__question_details_button)
+    def click_on_question_details_button(self):
+        self._click(self.__question_details_button)
 
-    def _click_on_more_system_details_option(self):
-        super()._click(self.__more_system_details_option)
+    def click_on_more_system_details_option(self):
+        self._click(self.__more_system_details_option)
 
-    def _click_on_the_additional_system_panel_close(self):
-        super()._click(self.__close_additional_system_details_button)
+    def click_on_the_additional_system_panel_close(self):
+        self._click(self.__close_additional_system_details_button)
 
-    def _get_reply_section_locator(self, answer_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{answer_id}']")
+    def get_reply_section_locator(self, answer_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{answer_id}']")
 
-    def _click_on_reply_more_options_button(self, answer_id: str):
-        super()._click(f"//div[@id='{answer_id}']//button[text()='more options']")
+    def click_on_reply_more_options_button(self, answer_id: str):
+        self._click(f"//div[@id='{answer_id}']//button[text()='more options']")
 
-    def _click_on_report_abuse_for_a_certain_reply(self, answer_id: str):
-        super()._click(f"//div[@id='{answer_id}']//a[text()='Report Abuse']")
+    def click_on_report_abuse_for_a_certain_reply(self, answer_id: str):
+        self._click(f"//div[@id='{answer_id}']//a[text()='Report Abuse']")
 
-    def _get_click_on_report_abuse_reply_locator(self, answer_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{answer_id}']//a[text()='Report Abuse']")
+    def get_click_on_report_abuse_reply_locator(self, answer_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{answer_id}']//a[text()='Report Abuse']")
 
-    def _click_on_quote_for_a_certain_reply(self, answer_id: str):
-        super()._click(f"//div[@id='{answer_id}']//a[text()='Quote']")
+    def click_on_quote_for_a_certain_reply(self, answer_id: str):
+        self._click(f"//div[@id='{answer_id}']//a[text()='Quote']")
 
-    def _get_quote_reply_locator(self, answer_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{answer_id}']//a[text()='Quote']")
+    def get_quote_reply_locator(self, answer_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{answer_id}']//a[text()='Quote']")
 
-    def _click_on_mark_as_spam_for_a_certain_reply(self, answer_id: str):
-        super()._click(f"//div[@id='{answer_id}']//form[@class='spam-form cf']/a")
+    def click_on_mark_as_spam_for_a_certain_reply(self, answer_id: str):
+        self._click(f"//div[@id='{answer_id}']//form[@class='spam-form cf']/a")
 
-    def _get_mark_as_spam_reply_locator(self, answer_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{answer_id}']//"
-                                            f"form[@class='spam-form cf']/a")
+    def get_mark_as_spam_reply_locator(self, answer_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{answer_id}']//"
+                                         f"form[@class='spam-form cf']/a")
 
-    def _get_marked_as_spam_locator(self, answer_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{answer_id}']//h3[@class='is-spam']")
+    def get_marked_as_spam_locator(self, answer_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{answer_id}']//h3[@class='is-spam']")
 
-    def _get_marked_as_spam_text(self, answer_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{answer_id}']//h3[@class='is-spam']")
+    def get_marked_as_spam_text(self, answer_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{answer_id}']//h3[@class='is-spam']")
 
-    def _click_on_edit_this_post_for_a_certain_reply(self, answer_id: str):
-        super()._click(f"//div[@id='{answer_id}']//a[text()='Edit this post']")
+    def click_on_edit_this_post_for_a_certain_reply(self, answer_id: str):
+        self._click(f"//div[@id='{answer_id}']//a[text()='Edit this post']")
 
-    def _get_edit_this_post_reply_locator(self, answer_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{answer_id}']//"
-                                            f"a[text()='Edit this post']")
+    def get_edit_this_post_reply_locator(self, answer_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{answer_id}']//"
+                                         f"a[text()='Edit this post']")
 
-    def _click_on_delete_this_post_for_a_certain_reply(self, answer_id: str):
-        super()._click(f"//div[@id='{answer_id}']//a[text()='Delete this post']")
+    def click_on_delete_this_post_for_a_certain_reply(self, answer_id: str):
+        self._click(f"//div[@id='{answer_id}']//a[text()='Delete this post']")
 
-    def _get_delete_this_post_reply_locator(self, answer_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{answer_id}']//"
-                                            f"a[text()='Delete this post']")
+    def get_delete_this_post_reply_locator(self, answer_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{answer_id}']//"
+                                         f"a[text()='Delete this post']")
 
-    def _click_on_cancel_delete_button(self):
-        super()._click(self.__delete_question_cancel_button)
+    def click_on_cancel_delete_button(self):
+        self._click(self.__delete_question_cancel_button)
 
     # Post a reply actions.
-    def _add_text_to_post_a_reply_textarea(self, text: str):
-        super()._fill(self.__post_a_reply_textarea, text)
+    def add_text_to_post_a_reply_textarea(self, text: str):
+        self._fill(self.__post_a_reply_textarea, text)
 
-    def _type_inside_the_post_a_reply_textarea(self, text: str):
-        super()._type(self.__post_a_reply_textarea, text, 100)
+    def type_inside_the_post_a_reply_textarea(self, text: str):
+        self._type(self.__post_a_reply_textarea, text, 100)
 
-    def _get_post_a_reply_textarea_locator(self) -> Locator:
-        return super()._get_element_locator(self.__post_a_reply_textarea)
+    def get_post_a_reply_textarea_locator(self) -> Locator:
+        return self._get_element_locator(self.__post_a_reply_textarea)
 
-    def _get_post_a_reply_textarea_text(self) -> str:
-        return super()._get_text_of_element(self.__post_a_reply_textarea)
+    def get_post_a_reply_textarea_text(self) -> str:
+        return self._get_text_of_element(self.__post_a_reply_textarea)
 
-    def _get_post_a_reply_textarea_value(self) -> str:
-        return super()._get_element_input_value(self.__post_a_reply_textarea)
+    def get_post_a_reply_textarea_value(self) -> str:
+        return self._get_element_input_value(self.__post_a_reply_textarea)
 
-    def _get_posted_reply_locator(self, question_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{question_id}']")
+    def get_posted_reply_locator(self, question_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{question_id}']")
 
-    def _get_posted_reply_text(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//div[@class='content']/p")
+    def get_posted_reply_text(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//div[@class='content']/p")
 
-    def _get_posted_quote_reply_username_text(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//div[@class='content']/em/p")
+    def get_posted_quote_reply_username_text(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//div[@class='content']/em/p")
 
-    def _click_posted_reply_said_link(self, reply_id: str):
-        super()._click(f"//div[@id='{reply_id}']//div[@class='content']//a")
+    def click_posted_reply_said_link(self, reply_id: str):
+        self._click(f"//div[@id='{reply_id}']//div[@class='content']//a")
 
-    def _get_blockquote_reply_text(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//div[@class='content']//"
-                                            f"blockquote")
+    def get_blockquote_reply_text(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//div[@class='content']//"
+                                         f"blockquote")
 
-    def _get_posted_reply_modified_by_text(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//"
-                                            f"p[@class='edited text-body-sm']/em")
+    def get_posted_reply_modified_by_text(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//"
+                                         f"p[@class='edited text-body-sm']/em")
 
-    def _get_posted_reply_modified_by_locator(self, reply_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{reply_id}']//"
-                                            f"p[@class='edited text-body-sm']/em")
+    def get_posted_reply_modified_by_locator(self, reply_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{reply_id}']//"
+                                         f"p[@class='edited text-body-sm']/em")
 
-    def _click_on_post_reply_button(self, repliant_username) -> str:
-        super()._click(self.__post_reply_button)
-        super()._wait_for_selector(f"//span[@class='display-name' and contains"
-                                   f"(text(), '{repliant_username}')]")
-        return super()._get_element_attribute_value(f"//span[@class='display-name' and "
-                                                    f"contains(text(), '{repliant_username}')]/"
-                                                    f"ancestor::div[@class='answer ']",
-                                                    "id")
+    def click_on_post_reply_button(self, repliant_username) -> str:
+        self._click(self.__post_reply_button)
+        self._wait_for_selector(f"//span[@class='display-name' and contains"
+                                f"(text(), '{repliant_username}')]")
+        return self._get_element_attribute_value(f"//span[@class='display-name' and "
+                                                 f"contains(text(), '{repliant_username}')]/"
+                                                 f"ancestor::div[@class='answer ']",
+                                                 "id")
 
     # Question Tools actions.
-    def _get_edit_this_question_option_locator(self) -> Locator:
-        return super()._get_element_locator(self.__edit_this_question_option)
+    def get_edit_this_question_option_locator(self) -> Locator:
+        return self._get_element_locator(self.__edit_this_question_option)
 
-    def _get_delete_this_question_locator(self) -> Locator:
-        return super()._get_element_locator(self.__delete_this_question_option)
+    def get_delete_this_question_locator(self) -> Locator:
+        return self._get_element_locator(self.__delete_this_question_option)
 
-    def _get_lock_this_question_locator(self) -> Locator:
-        return super()._get_element_locator(self.__lock_this_question_option)
+    def get_lock_this_question_locator(self) -> Locator:
+        return self._get_element_locator(self.__lock_this_question_option)
 
     # Stands for archived banner as well
-    def _get_thread_locked_text(self) -> str:
-        return super()._get_text_of_element(self.__lock_this_thread_banner)
+    def get_thread_locked_text(self) -> str:
+        return self._get_text_of_element(self.__lock_this_thread_banner)
 
-    def _get_thread_locked_locator(self) -> Locator:
-        return super()._get_element_locator(self.__lock_this_thread_banner)
+    def get_thread_locked_locator(self) -> Locator:
+        return self._get_element_locator(self.__lock_this_thread_banner)
 
-    def _get_archive_this_question_locator(self) -> Locator:
-        return super()._get_element_locator(self.__archive_this_question_option)
+    def get_archive_this_question_locator(self) -> Locator:
+        return self._get_element_locator(self.__archive_this_question_option)
 
-    def _get_needs_more_information_checkbox_locator(self) -> Locator:
-        return super()._get_element_locator(self.__needs_more_information_from_the_user_checkbox)
+    def get_needs_more_information_checkbox_locator(self) -> Locator:
+        return self._get_element_locator(self.__needs_more_information_from_the_user_checkbox)
 
-    def _get_mark_as_spam_locator(self) -> Locator:
-        return super()._get_element_locator(self.__mark_as_spam_option)
+    def get_mark_as_spam_locator(self) -> Locator:
+        return self._get_element_locator(self.__mark_as_spam_option)
 
-    def _get_marked_as_spam_banner_locator(self) -> Locator:
-        return super()._get_element_locator(self.__marked_as_spam_banner)
+    def get_marked_as_spam_banner_locator(self) -> Locator:
+        return self._get_element_locator(self.__marked_as_spam_banner)
 
-    def _get_marked_as_spam_banner_text(self) -> str:
-        return super()._get_text_of_element(self.__marked_as_spam_banner)
+    def get_marked_as_spam_banner_text(self) -> str:
+        return self._get_text_of_element(self.__marked_as_spam_banner)
 
-    def _click_on_thread_locked_link(self):
-        super()._click(self.__lock_this_thread_banner_link)
+    def click_on_thread_locked_link(self):
+        self._click(self.__lock_this_thread_banner_link)
 
-    def _click_on_lock_this_question_locator(self):
-        super()._click(self.__lock_this_question_option)
+    def click_on_lock_this_question_locator(self):
+        self._click(self.__lock_this_question_option)
 
-    def _click_on_subscribe_to_feed_option(self):
-        super()._click(self.__subscribe_to_feed_option)
+    def click_on_subscribe_to_feed_option(self):
+        self._click(self.__subscribe_to_feed_option)
 
-    def _click_on_mark_as_spam_option(self):
-        super()._click(self.__mark_as_spam_option)
+    def click_on_mark_as_spam_option(self):
+        self._click(self.__mark_as_spam_option)
 
-    def _click_on_edit_this_question_question_tools_option(self):
-        super()._click(self.__edit_this_question_option)
+    def click_on_edit_this_question_question_tools_option(self):
+        self._click(self.__edit_this_question_option)
 
-    def _click_delete_this_question_question_tools_option(self):
-        super()._click(self.__delete_this_question_option)
+    def click_delete_this_question_question_tools_option(self):
+        self._click(self.__delete_this_question_option)
 
-    def _click_on_archive_this_question_option(self):
-        super()._click(self.__archive_this_question_option)
+    def click_on_archive_this_question_option(self):
+        self._click(self.__archive_this_question_option)
 
-    def _click_delete_this_question_button(self):
-        super()._click(self.__delete_question_delete_button)
+    def click_delete_this_question_button(self):
+        self._click(self.__delete_question_delete_button)
 
     # Votes reply section
-    def _get_reply_votes_section_locator(self, reply_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{reply_id}']//"
-                                            f"form[@class='document-vote--form helpful']")
+    def get_reply_votes_section_locator(self, reply_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{reply_id}']//"
+                                         f"form[@class='document-vote--form helpful']")
 
-    def _get_reply_vote_heading(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//"
-                                            f"h4[@class='document-vote--heading']")
+    def get_reply_vote_heading(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//"
+                                         f"h4[@class='document-vote--heading']")
 
-    def _click_reply_vote_thumbs_up_button(self, reply_id: str):
-        return super()._click(f"//div[@id='{reply_id}']//button[@name='helpful']")
+    def click_reply_vote_thumbs_up_button(self, reply_id: str):
+        return self._click(f"//div[@id='{reply_id}']//button[@name='helpful']")
 
-    def _get_thumbs_up_vote_message(self, reply_id: str) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//"
-                                            f"p[@class='msg document-vote--heading']")
+    def get_thumbs_up_vote_message(self, reply_id: str) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//"
+                                         f"p[@class='msg document-vote--heading']")
 
-    def _get_thumbs_up_button_locator(self, reply_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{reply_id}']//button[@name='helpful']")
+    def get_thumbs_up_button_locator(self, reply_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{reply_id}']//button[@name='helpful']")
 
-    def _get_thumbs_down_button_locator(self, reply_id: str) -> Locator:
-        return super()._get_element_locator(f"//div[@id='{reply_id}']//"
-                                            f"button[@name='not-helpful']")
+    def get_thumbs_down_button_locator(self, reply_id: str) -> Locator:
+        return self._get_element_locator(f"//div[@id='{reply_id}']//"
+                                         f"button[@name='not-helpful']")
 
-    def _click_reply_vote_thumbs_down_button(self, reply_id):
-        super()._click(f"//div[@id='{reply_id}']//button[@name='not-helpful']")
+    def click_reply_vote_thumbs_down_button(self, reply_id):
+        self._click(f"//div[@id='{reply_id}']//button[@name='not-helpful']")
 
-    def _get_helpful_count(self, reply_id) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//"
-                                            f"button[@name='helpful']//"
-                                            f"strong[@class='helpful-count']")
+    def get_helpful_count(self, reply_id) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//"
+                                         f"button[@name='helpful']//"
+                                         f"strong[@class='helpful-count']")
 
-    def _get_not_helpful_count(self, reply_id) -> str:
-        return super()._get_text_of_element(f"//div[@id='{reply_id}']//"
-                                            f"button[@name='not-helpful']//"
-                                            f"strong[@class='helpful-count']")
+    def get_not_helpful_count(self, reply_id) -> str:
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//"
+                                         f"button[@name='not-helpful']//"
+                                         f"strong[@class='helpful-count']")
 
     # Signed out card actions.
-    def _click_on_log_in_to_your_account_signed_out_card_link(self):
-        super()._click(self.__log_in_to_your_account_signed_out_card_option)
+    def click_on_log_in_to_your_account_signed_out_card_link(self):
+        self._click(self.__log_in_to_your_account_signed_out_card_option)
 
-    def _click_on_start_a_new_question_signed_out_card_link(self):
-        super()._click(self.__start_a_new_question_signed_out_card_option)
+    def click_on_start_a_new_question_signed_out_card_link(self):
+        self._click(self.__start_a_new_question_signed_out_card_option)
 
-    def _click_on_ask_a_question_signed_out_card_option(self):
-        super()._click(self.__ask_a_question_signed_out_card_option)
+    def click_on_ask_a_question_signed_out_card_option(self):
+        self._click(self.__ask_a_question_signed_out_card_option)
 
-    def _ask_a_question_signed_out_card_option_locator(self) -> Locator:
-        return super()._get_element_locator(self.__ask_a_question_signed_out_card_option)
+    def ask_a_question_signed_out_card_option_locator(self) -> Locator:
+        return self._get_element_locator(self.__ask_a_question_signed_out_card_option)
 
-    def _click_on_i_have_this_problem_too_signed_out_card_option(self):
-        super()._click(self.__i_have_this_problem_too_signed_out_card_option)
+    def click_on_i_have_this_problem_too_signed_out_card_option(self):
+        self._click(self.__i_have_this_problem_too_signed_out_card_option)
 
-    def _get_i_have_this_problem_too_signed_out_card_locator(self) -> Locator:
-        return super()._get_element_locator(self.__i_have_this_problem_too_signed_out_card_option)
+    def get_i_have_this_problem_too_signed_out_card_locator(self) -> Locator:
+        return self._get_element_locator(self.__i_have_this_problem_too_signed_out_card_option)
 
     # Common responses actions.
 
-    def _click_on_common_responses_option(self):
-        super()._click(self.__common_responses_option)
+    def click_on_common_responses_option(self):
+        self._click(self.__common_responses_option)
 
-    def _type_into_common_responses_search_field(self, text: str):
-        super()._type(self.__common_responses_search_field, text, 100)
+    def type_into_common_responses_search_field(self, text: str):
+        self._type(self.__common_responses_search_field, text, 100)
 
-    def _get_text_of_no_cat_responses(self) -> str:
-        return super()._get_text_of_element(self.__common_responses_no_cat_selected)
+    def get_text_of_no_cat_responses(self) -> str:
+        return self._get_text_of_element(self.__common_responses_no_cat_selected)
 
-    def _get_list_of_categories(self) -> list[str]:
-        return super()._get_text_of_elements(self.__common_responses_categories_options)
+    def get_list_of_categories(self) -> list[str]:
+        return self._get_text_of_elements(self.__common_responses_categories_options)
 
-    def _get_list_of_responses(self) -> list[str]:
-        return super()._get_text_of_elements(self.__common_responses_responses_options)
+    def get_list_of_responses(self) -> list[str]:
+        return self._get_text_of_elements(self.__common_responses_responses_options)
 
-    def _click_on_a_particular_category_option(self, option: str):
-        super()._click(f"//ul[@class='category-list']/li[text()='{option}']",
-                       with_wait=True)
+    def click_on_a_particular_category_option(self, option: str):
+        self._click(f"//ul[@class='category-list']/li[text()='{option}']", with_wait=True)
 
-    def _click_on_a_particular_response_option(self, option: str):
-        super()._click(f"//ul[@class='sidebar-nav']/li[text()='{option}']")
+    def click_on_a_particular_response_option(self, option: str):
+        self._click(f"//ul[@class='sidebar-nav']/li[text()='{option}']")
 
     # Removing both newline characters and link syntax format.
-    def _get_text_of_response_editor_textarea_field(self) -> str:
-        return (super()._get_element_input_value(self.__common_responses_textarea_field)
+    def get_text_of_response_editor_textarea_field(self) -> str:
+        return (self._get_element_input_value(self.__common_responses_textarea_field)
                 .replace("\n", "")
                 .replace("[", "")
                 .replace("]", "")
                 )
 
-    def _get_text_of_response_preview(self) -> str:
-        return super()._get_text_of_element(self.__common_responses_response_preview)
+    def get_text_of_response_preview(self) -> str:
+        return self._get_text_of_element(self.__common_responses_response_preview)
 
-    def _click_on_switch_to_mode(self):
-        super()._click(self.__common_responses_switch_to_mode, with_wait=True)
+    def click_on_switch_to_mode(self):
+        self._click(self.__common_responses_switch_to_mode, with_wait=True)
 
-    def _click_on_common_responses_cancel_button(self):
-        super()._click(self.__common_responses_cancel_button, with_wait=True)
+    def click_on_common_responses_cancel_button(self):
+        self._click(self.__common_responses_cancel_button, with_wait=True)
 
-    def _click_on_common_responses_insert_response_button(self):
-        super()._click(self.__common_responses_insert_response_button)
+    def click_on_common_responses_insert_response_button(self):
+        self._click(self.__common_responses_insert_response_button)

--- a/playwright_tests/pages/contribute/contribute_pages/ways_to_contribute_pages.py
+++ b/playwright_tests/pages/contribute/contribute_pages/ways_to_contribute_pages.py
@@ -30,53 +30,53 @@ class WaysToContributePages(BasePage):
         super().__init__(page)
 
     # Breadcrumbs
-    def _get_text_of_all_breadcrumbs(self) -> list[str]:
-        return super()._get_text_of_elements(self.__all_breadcrumbs)
+    def get_text_of_all_breadcrumbs(self) -> list[str]:
+        return self._get_text_of_elements(self.__all_breadcrumbs)
 
-    def _get_interactable_breadcrumbs(self) -> list[ElementHandle]:
-        return super()._get_element_handles(self.__interactable_breadcrumbs)
+    def get_interactable_breadcrumbs(self) -> list[ElementHandle]:
+        return self._get_element_handles(self.__interactable_breadcrumbs)
 
-    def _click_on_breadcrumb(self, element: ElementHandle):
+    def click_on_breadcrumb(self, element: ElementHandle):
         element.click()
 
     # Page content
-    def _get_hero_main_header_text(self) -> str:
-        return super()._get_text_of_element(self.__hero_main_header)
+    def get_hero_main_header_text(self) -> str:
+        return self._get_text_of_element(self.__hero_main_header)
 
-    def _get_hero_second_header(self) -> str:
-        return super()._get_text_of_element(self.__hero_second_header)
+    def get_hero_second_header(self) -> str:
+        return self._get_text_of_element(self.__hero_second_header)
 
-    def _get_hero_text(self) -> str:
-        return super()._get_text_of_element(self.__hero_text)
+    def get_hero_text(self) -> str:
+        return self._get_text_of_element(self.__hero_text)
 
-    def _get_all_page_image_links(self) -> list[ElementHandle]:
-        return super()._get_element_handles(self.__all_page_images)
+    def get_all_page_image_links(self) -> list[ElementHandle]:
+        return self._get_element_handles(self.__all_page_images)
 
     # How to contribute_messages section
-    def _get_how_to_contribute_header_text(self) -> str:
-        return super()._get_text_of_element(self.__how_to_contribute_header)
+    def get_how_to_contribute_header_text(self) -> str:
+        return self._get_text_of_element(self.__how_to_contribute_header)
 
-    def _get_how_to_contribute_link_options(self) -> list[str]:
-        return super()._get_text_of_elements(self.__all_how_to_contribute_option_links)
+    def get_how_to_contribute_link_options(self) -> list[str]:
+        return self._get_text_of_elements(self.__all_how_to_contribute_option_links)
 
-    def _get_how_to_contribute_option_four(self) -> str:
-        return super()._get_text_of_element(self.__start_answering_how_to_contribute_option_text)
+    def get_how_to_contribute_option_four(self) -> str:
+        return self._get_text_of_element(self.__start_answering_how_to_contribute_option_text)
 
-    def _get_first_fact_text(self) -> str:
-        return super()._get_text_of_element(self.__first_fact_text)
+    def get_first_fact_text(self) -> str:
+        return self._get_text_of_element(self.__first_fact_text)
 
-    def _get_second_fact_text(self) -> str:
-        return super()._get_text_of_element(self.__second_fact_text)
+    def get_second_fact_text(self) -> str:
+        return self._get_text_of_element(self.__second_fact_text)
 
     # Other ways to contribute_messages section
-    def _get_other_ways_to_contribute_header(self) -> str:
-        return super()._get_text_of_element(self.__other_ways_to_contribute_header)
+    def get_other_ways_to_contribute_header(self) -> str:
+        return self._get_text_of_element(self.__other_ways_to_contribute_header)
 
-    def _get_other_ways_to_contribute_cards(self) -> list[str]:
-        return super()._get_text_of_elements(self.__other_ways_to_contribute_card_titles)
+    def get_other_ways_to_contribute_cards(self) -> list[str]:
+        return self._get_text_of_elements(self.__other_ways_to_contribute_card_titles)
 
-    def _get_other_ways_to_contribute_card_list(self) -> list[ElementHandle]:
-        return super()._get_element_handles(self.__other_ways_to_contribute_card_list)
+    def get_other_ways_to_contribute_card_list(self) -> list[ElementHandle]:
+        return self._get_element_handles(self.__other_ways_to_contribute_card_list)
 
-    def _click_on_other_way_to_contribute_card(self, card_item: ElementHandle):
+    def click_on_other_way_to_contribute_card(self, card_item: ElementHandle):
         card_item.click()

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -33,11 +33,11 @@ def test_community_card_and_helpful_tip_are_displayed_for_freemium_product(page:
 
             with allure.step(f"Verifying that the helpful tip card is displayed for the "
                              f"{freemium_product} product"):
-                expect(sumo_pages.aaq_form_page._get_helpful_tip_locator()).to_be_visible()
+                expect(sumo_pages.aaq_form_page.get_helpful_tip_locator()).to_be_visible()
 
             with allure.step("Clicking on the 'Learn More' button from the community help "
                              "card and verifying that we are on the contribute messages page"):
-                sumo_pages.aaq_form_page._click_on_learn_more_button()
+                sumo_pages.aaq_form_page.click_on_learn_more_button()
                 expect(page).to_have_url(ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL)
 
 
@@ -59,11 +59,11 @@ def test_community_card_and_helpful_tip_not_displayed_for_premium_products(page:
 
             with allure.step(f"Verifying that the helpful tip options is displayed for the "
                              f"{premium_product}"):
-                expect(sumo_pages.aaq_form_page._get_helpful_tip_locator()).to_be_hidden()
+                expect(sumo_pages.aaq_form_page.get_helpful_tip_locator()).to_be_hidden()
 
             with allure.step("Verifying that the 'Learn More' button from the community help "
                              "banner is not displayed"):
-                expect(sumo_pages.aaq_form_page._get_learn_more_button_locator()).to_be_hidden()
+                expect(sumo_pages.aaq_form_page.get_learn_more_button_locator()).to_be_hidden()
 
 
 # C1511570
@@ -151,14 +151,14 @@ def test_corresponding_aaq_product_name_and_image_are_displayed(page: Page):
             # This needs to change when we add the Mozilla Account icon/product.
             if product != "Mozilla Account":
                 with allure.step("Verifying that the product image is displayed"):
-                    expect(sumo_pages.aaq_form_page._get_product_image_locator()).to_be_visible()
+                    expect(sumo_pages.aaq_form_page.get_product_image_locator()).to_be_visible()
             else:
                 with allure.step("Verifying that the product image is hidden for Mozilla "
                                  "Account product"):
-                    expect(sumo_pages.aaq_form_page._get_product_image_locator()).to_be_visible()
+                    expect(sumo_pages.aaq_form_page.get_product_image_locator()).to_be_visible()
 
             with check, allure.step("Verifying that the correct product header is displayed"):
-                assert sumo_pages.aaq_form_page._get_aaq_form_page_heading() == product
+                assert sumo_pages.aaq_form_page.get_aaq_form_page_heading() == product
 
 
 # T5696594, T5696595
@@ -178,13 +178,13 @@ def test_progress_milestone_redirect(page: Page):
 
             with check, allure.step("Verifying that the correct in progress milestone is "
                                     "displayed"):
-                assert sumo_pages.aaq_form_page._get_in_progress_item_label(
+                assert sumo_pages.aaq_form_page.get_in_progress_item_label(
                 ) == AAQFormMessages.IN_PROGRESS_MILESTONE
 
             with allure.step(f"Clicking on the {AAQFormMessages.COMPLETED_MILESTONE_TWO} "
                              f"milestone and verifying that we are on the correct product "
                              f"solutions page"):
-                sumo_pages.aaq_form_page._click_on_a_particular_completed_milestone(
+                sumo_pages.aaq_form_page.click_on_a_particular_completed_milestone(
                     AAQFormMessages.COMPLETED_MILESTONE_TWO)
                 expect(page).to_have_url(
                     utilities.general_test_data["product_solutions"][product])
@@ -193,7 +193,7 @@ def test_progress_milestone_redirect(page: Page):
                              f"{AAQFormMessages.COMPLETED_MILESTONE_ONE} milestone"):
                 utilities.navigate_to_link(
                     utilities.aaq_question_test_data["products_aaq_url"][product])
-                sumo_pages.aaq_form_page._click_on_a_particular_completed_milestone(
+                sumo_pages.aaq_form_page.click_on_a_particular_completed_milestone(
                     AAQFormMessages.COMPLETED_MILESTONE_ONE)
                 expect(page).to_have_url(ContactSupportMessages.PAGE_URL_CHANGE_PRODUCT_REDIRECT)
 
@@ -225,11 +225,11 @@ def test_aaq_form_cancel_button_freemium_products(page: Page):
                 sumo_pages.aaq_flow.add__valid_data_to_all_aaq_fields_without_submitting(
                     subject=utilities.aaq_question_test_data["valid_firefox_question"]
                     ["subject"],
-                    topic_value=sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                    topic_value=sumo_pages.aaq_form_page.get_aaq_form_topic_options()[0],
                     body_text=utilities.aaq_question_test_data["valid_firefox_question"]
                     ["question_body"]
                 )
-                sumo_pages.aaq_form_page._click_aaq_form_cancel_button()
+                sumo_pages.aaq_form_page.click_aaq_form_cancel_button()
 
             with allure.step("Verifying that we are redirected back to the correct product "
                              "solutions page"):
@@ -261,7 +261,7 @@ def test_post_aaq_questions_for_all_freemium_products_topics(page: Page):
             utilities.navigate_to_link(
                 utilities.aaq_question_test_data["products_aaq_url"][product])
 
-            for topic in sumo_pages.aaq_form_page._get_aaq_form_topic_options():
+            for topic in sumo_pages.aaq_form_page.get_aaq_form_topic_options():
                 with allure.step(f"Submitting question for {product} product"):
                     question_info = sumo_pages.aaq_flow.submit_an_aaq_question(
                         subject=utilities.aaq_question_test_data["valid_firefox_question"]
@@ -287,14 +287,14 @@ def test_post_aaq_questions_for_all_freemium_products_topics(page: Page):
                         )
                     assert (
                         all(map(
-                            lambda x: x in sumo_pages.question_page._get_question_tag_options(),
+                            lambda x: x in sumo_pages.question_page.get_question_tag_options(),
                             slugs))
                     )
 
                 with allure.step("Clicking on the 'My Questions' banner option and Verifying "
                                  "that the posted question is displayed inside the 'My "
                                  "Questions page"):
-                    sumo_pages.question_page._click_on_my_questions_banner_option()
+                    sumo_pages.question_page.click_on_my_questions_banner_option()
                     expect(sumo_pages.my_questions_page._get_listed_question(
                         question_info['aaq_subject'])).to_be_visible()
 
@@ -330,39 +330,39 @@ def test_share_firefox_data_functionality(page: Page):
                      "Data' option"):
         utilities.navigate_to_link(
             utilities.aaq_question_test_data["products_aaq_url"]["Firefox"])
-        sumo_pages.aaq_form_page._click_on_share_data_button()
+        sumo_pages.aaq_form_page.click_on_share_data_button()
 
     with check, allure.step("Verifying that the 'try these manual steps' contains the "
                             "correct link"):
-        assert sumo_pages.aaq_form_page._get_try_these_manual_steps_link(
+        assert sumo_pages.aaq_form_page.get_try_these_manual_steps_link(
         ) == QuestionPageMessages.TRY_THESE_MANUAL_STEPS_LINK
 
     with allure.step("Adding data inside AAQ form fields without submitting the form"):
         sumo_pages.aaq_flow.add__valid_data_to_all_aaq_fields_without_submitting(
             subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_value=sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+            topic_value=sumo_pages.aaq_form_page.get_aaq_form_topic_options()[0],
             body_text=utilities.aaq_question_test_data["valid_firefox_question"]
             ["question_body"]
         )
 
     with allure.step("Adding text inside the troubleshooting information field and "
                      "submitting the AAQ question"):
-        sumo_pages.aaq_form_page._add_text_to_troubleshooting_information_textarea(
+        sumo_pages.aaq_form_page.add_text_to_troubleshooting_information_textarea(
             utilities.aaq_question_test_data["troubleshooting_information"]
         )
-        sumo_pages.aaq_form_page._click_aaq_form_submit_button()
+        sumo_pages.aaq_form_page.click_aaq_form_submit_button()
 
     with allure.step("Verifying that the troubleshooting information is displayed"):
-        sumo_pages.question_page._click_on_question_details_button()
-        sumo_pages.question_page._click_on_more_system_details_option()
+        sumo_pages.question_page.click_on_question_details_button()
+        sumo_pages.question_page.click_on_more_system_details_option()
         expect(
-            sumo_pages.question_page._get_more_information_with_text_locator(
+            sumo_pages.question_page.get_more_information_with_text_locator(
                 utilities.aaq_question_test_data["troubleshooting_information"]
             )
         ).to_be_visible()
 
     with allure.step("Closing the additional details panel and deleting the posted question"):
-        sumo_pages.question_page._click_on_the_additional_system_panel_close()
+        sumo_pages.question_page.click_on_the_additional_system_panel_close()
         sumo_pages.aaq_flow.deleting_question_flow()
 
 
@@ -384,7 +384,7 @@ def test_additional_system_details_user_agent_information(page: Page):
                 sumo_pages.aaq_flow.submit_an_aaq_question(
                     subject=utilities.aaq_question_test_data["valid_firefox_question"]
                     ["subject"],
-                    topic_name=sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                    topic_name=sumo_pages.aaq_form_page.get_aaq_form_topic_options()[0],
                     body=utilities.aaq_question_test_data["valid_firefox_question"]
                     ["question_body"],
                     attach_image=True
@@ -392,14 +392,14 @@ def test_additional_system_details_user_agent_information(page: Page):
 
             with check, allure.step("Verifying that the correct user-agent information is "
                                     "displayed"):
-                sumo_pages.question_page._click_on_question_details_button()
-                sumo_pages.question_page._click_on_more_system_details_option()
+                sumo_pages.question_page.click_on_question_details_button()
+                sumo_pages.question_page.click_on_more_system_details_option()
                 assert "User Agent: " + utilities.get_user_agent(
-                ) == sumo_pages.question_page._get_user_agent_information()
+                ) == sumo_pages.question_page.get_user_agent_information()
 
             with allure.step("Closing the additional details panel and deleting the posted "
                              "questions"):
-                sumo_pages.question_page._click_on_the_additional_system_panel_close()
+                sumo_pages.question_page.click_on_the_additional_system_panel_close()
                 sumo_pages.aaq_flow.deleting_question_flow()
 
 
@@ -427,19 +427,19 @@ def test_system_details_information(page: Page):
                     utilities.aaq_question_test_data["products_aaq_url"][product])
                 sumo_pages.aaq_flow.add__valid_data_to_all_aaq_fields_without_submitting(
                     subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-                    topic_value=sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+                    topic_value=sumo_pages.aaq_form_page.get_aaq_form_topic_options()[0],
                     body_text=utilities.aaq_question_test_data["valid_firefox_question"][
                         "question_body"]
                 )
 
                 with allure.step("Clicking on the 'Show details' option and adding data to "
                                  "product version and OS fields"):
-                    sumo_pages.aaq_form_page._click_on_show_details_option()
-                    sumo_pages.aaq_form_page._add_text_to_product_version_field(
+                    sumo_pages.aaq_form_page.click_on_show_details_option()
+                    sumo_pages.aaq_form_page.add_text_to_product_version_field(
                         utilities.aaq_question_test_data[
                             "troubleshoot_product_and_os_versions"][1]
                     )
-                    sumo_pages.aaq_form_page._add_text_to_os_field(
+                    sumo_pages.aaq_form_page.add_text_to_os_field(
                         utilities.aaq_question_test_data[
                             "troubleshoot_product_and_os_versions"][0]
                     )
@@ -447,9 +447,9 @@ def test_system_details_information(page: Page):
                 with check, allure.step("Submitting the AAQ question and verifying that the "
                                         "correct provided troubleshooting information is "
                                         "displayed"):
-                    sumo_pages.aaq_form_page._click_aaq_form_submit_button()
-                    sumo_pages.question_page._click_on_question_details_button()
-                    assert sumo_pages.question_page._get_system_details_information(
+                    sumo_pages.aaq_form_page.click_aaq_form_submit_button()
+                    sumo_pages.question_page.click_on_question_details_button()
+                    assert sumo_pages.question_page.get_system_details_information(
                     ) == troubleshooting_info
 
                 with allure.step("Deleting the posted question"):
@@ -487,10 +487,10 @@ def test_premium_products_aaq(page: Page):
                     is_premium=True
                 )
                 if utilities.get_page_url() == premium_form_link:
-                    sumo_pages.aaq_form_page._click_aaq_form_submit_button()
+                    sumo_pages.aaq_form_page.click_aaq_form_submit_button()
 
         with allure.step("Verifying that the correct success message is displayed"):
-            assert sumo_pages.aaq_form_page._get_premium_card_submission_message(
+            assert sumo_pages.aaq_form_page.get_premium_card_submission_message(
             ) == aaq_form_messages.get_premium_ticket_submission_success_message(
                 utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             )
@@ -517,12 +517,12 @@ def test_loginless_mozilla_account_aaq(page: Page):
             )
             if i <= 3:
                 with allure.step("Verifying that the correct success message is displayed"):
-                    assert sumo_pages.aaq_form_page._get_premium_card_submission_message(
+                    assert sumo_pages.aaq_form_page.get_premium_card_submission_message(
                     ) == aaq_form_messages.get_premium_ticket_submission_success_message(
                         utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
                     )
             else:
                 with allure.step("Verifying that submission error message is displayed"):
-                    assert sumo_pages.aaq_form_page._get_premium_card_submission_message(
+                    assert sumo_pages.aaq_form_page.get_premium_card_submission_message(
                     ) == aaq_form_messages.LOGINLESS_RATELIMIT_REACHED_MESSAGE
             i += 1

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -75,7 +75,7 @@ def test_edit_this_question_functionality_not_signed_in(page: Page):
     with allure.step("Deleting user session and verifying that the 'edit this question' nav "
                      "option is not available"):
         utilities.delete_cookies()
-        expect(sumo_pages.question_page._get_edit_this_question_option_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_edit_this_question_option_locator()).to_be_hidden()
 
     with allure.step("Navigating to the edit endpoint and verifying that the user is "
                      "redirected to the auth page"):
@@ -116,12 +116,12 @@ def test_cancel_edit_this_question_functionality(page: Page, username):
                             "question' option and verifying that the subject field contains "
                             "the correct value"):
         utilities.navigate_to_link(posted_question['question_details']['question_page_url'])
-        sumo_pages.question_page._click_on_edit_this_question_question_tools_option()
-        assert sumo_pages.aaq_form_page._get_value_of_subject_input_field(
+        sumo_pages.question_page.click_on_edit_this_question_question_tools_option()
+        assert sumo_pages.aaq_form_page.get_value_of_subject_input_field(
         ) == posted_question['question_details']['aaq_subject']
 
     with check, allure.step("Verifying that the question body contains the correct value"):
-        assert sumo_pages.aaq_form_page._get_value_of_question_body_textarea_field(
+        assert sumo_pages.aaq_form_page.get_value_of_question_body_textarea_field(
         ) == posted_question['question_details']['question_body']
 
     with allure.step("Editing the question with new data"):
@@ -135,25 +135,25 @@ def test_cancel_edit_this_question_functionality(page: Page, username):
 
     with check, allure.step("Clicking on the 'Cancel' button and verifying that the modified "
                             "text is not displayed"):
-        sumo_pages.aaq_form_page._click_aaq_form_cancel_button()
-        expect(sumo_pages.question_page._get_modified_question_locator()).to_be_hidden()
-        assert sumo_pages.question_page._get_question_header(
+        sumo_pages.aaq_form_page.click_aaq_form_cancel_button()
+        expect(sumo_pages.question_page.get_modified_question_locator()).to_be_hidden()
+        assert sumo_pages.question_page.get_question_header(
         ) == posted_question['question_details']['aaq_subject']
-        assert sumo_pages.question_page._get_question_body(
+        assert sumo_pages.question_page.get_question_body(
         ) == posted_question['question_details']['question_body'] + '\n'
 
     if username == 'TEST_ACCOUNT_12':
         with allure.step("Verifying that the additional question details option is hidden"):
-            expect(sumo_pages.question_page._get_question_details_button_locator()).to_be_hidden()
+            expect(sumo_pages.question_page.get_question_details_button_locator()).to_be_hidden()
     elif username == "TEST_ACCOUNT_MODERATOR":
         with allure.step("Verifying that the more information section from the 'More System "
                          "Details' is not displayed"):
-            sumo_pages.question_page._click_on_question_details_button()
-            sumo_pages.question_page._click_on_more_system_details_option()
-            expect(sumo_pages.question_page._get_more_information_locator()).to_be_hidden()
+            sumo_pages.question_page.click_on_question_details_button()
+            sumo_pages.question_page.click_on_more_system_details_option()
+            expect(sumo_pages.question_page.get_more_information_locator()).to_be_hidden()
 
         with allure.step("Closing the more information panel and deleting the question"):
-            sumo_pages.question_page._click_on_the_additional_system_panel_close()
+            sumo_pages.question_page.click_on_the_additional_system_panel_close()
 
             if username != 'TEST_ACCOUNT_MODERATOR':
                 utilities.start_existing_session(
@@ -178,7 +178,7 @@ def test_edit_other_user_question_non_admin(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.question_page._get_edit_this_question_option_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_edit_this_question_option_locator()).to_be_hidden()
 
     with check, allure.step("Manually navigating to the '/edit' endpoint and verifying that "
                             "403 is returned"):
@@ -220,10 +220,10 @@ def test_edit_this_question_functionality(page: Page, username):
     with check, allure.step("Clicking on the 'Edit this question' option and verifying that "
                             "the subject and body fields contain the correct value"):
         utilities.navigate_to_link(posted_question['question_details']['question_page_url'])
-        sumo_pages.question_page._click_on_edit_this_question_question_tools_option()
-        assert sumo_pages.aaq_form_page._get_value_of_subject_input_field(
+        sumo_pages.question_page.click_on_edit_this_question_question_tools_option()
+        assert sumo_pages.aaq_form_page.get_value_of_subject_input_field(
         ) == posted_question['question_details']['aaq_subject']
-        assert sumo_pages.aaq_form_page._get_value_of_question_body_textarea_field(
+        assert sumo_pages.aaq_form_page.get_value_of_question_body_textarea_field(
         ) == posted_question['question_details']['question_body']
 
     with check, allure.step("Editing the question with new data and verifying that the "
@@ -235,28 +235,28 @@ def test_edit_this_question_functionality(page: Page, username):
             body=utilities.aaq_question_test_data['valid_firefox_question']['body_updated'],
             troubleshoot=utilities.aaq_question_test_data['troubleshooting_information']
         )
-        expect(sumo_pages.question_page._get_modified_question_locator()).to_be_visible()
+        expect(sumo_pages.question_page.get_modified_question_locator()).to_be_visible()
 
-        assert user in sumo_pages.question_page._get_modified_by_text()
-        assert sumo_pages.question_page._get_question_header(
+        assert user in sumo_pages.question_page.get_modified_by_text()
+        assert sumo_pages.question_page.get_question_header(
         ) == utilities.aaq_question_test_data['valid_firefox_question']['subject_updated']
-        assert sumo_pages.question_page._get_question_body(
+        assert sumo_pages.question_page.get_question_body(
         ) == utilities.aaq_question_test_data['valid_firefox_question']['body_updated'] + '\n'
 
     if username == 'TEST_ACCOUNT_12':
         with allure.step("Verifying that the additional question details option is hidden"):
-            expect(sumo_pages.question_page._get_question_details_button_locator()).to_be_hidden()
+            expect(sumo_pages.question_page.get_question_details_button_locator()).to_be_hidden()
     elif username == "TEST_ACCOUNT_MODERATOR":
         with allure.step("Verifying that the more information section displays the updated "
                          "information"):
-            sumo_pages.question_page._click_on_question_details_button()
-            sumo_pages.question_page._click_on_more_system_details_option()
-            expect(sumo_pages.question_page._get_more_information_with_text_locator(
+            sumo_pages.question_page.click_on_question_details_button()
+            sumo_pages.question_page.click_on_more_system_details_option()
+            expect(sumo_pages.question_page.get_more_information_with_text_locator(
                 utilities.aaq_question_test_data['troubleshooting_information']
             )
             ).to_be_visible()
 
-        sumo_pages.question_page._click_on_the_additional_system_panel_close()
+        sumo_pages.question_page.click_on_the_additional_system_panel_close()
 
     with allure.step("Deleting the posted question"):
         if username != 'TEST_ACCOUNT_MODERATOR':
@@ -283,7 +283,7 @@ def test_delete_question_cancel_button(page: Page):
     with allure.step("Navigating to the posted question by a different user an verifying "
                      "that the 'Delete this question' option is not available"):
         utilities.navigate_to_link(posted_question_one['question_details']['question_page_url'])
-        expect(sumo_pages.question_page._get_delete_this_question_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_delete_this_question_locator()).to_be_hidden()
 
     with check, allure.step("Manually navigating to the delete endpoint and verifying that "
                             "403 is returned"):
@@ -297,7 +297,7 @@ def test_delete_question_cancel_button(page: Page):
     with allure.step("Navigating to the posted question by self and verifying that the "
                      "'Delete this question' option is not available"):
         utilities.navigate_to_link(posted_question_two['question_details']['question_page_url'])
-        expect(sumo_pages.question_page._get_delete_this_question_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_delete_this_question_locator()).to_be_hidden()
 
     with check, allure.step("Manually navigating to the delete endpoint and verifying that "
                             "403 is returned"):
@@ -314,8 +314,8 @@ def test_delete_question_cancel_button(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-        sumo_pages.question_page._click_delete_this_question_question_tools_option()
-        sumo_pages.aaq_form_page._click_aaq_form_cancel_button()
+        sumo_pages.question_page.click_delete_this_question_question_tools_option()
+        sumo_pages.aaq_form_page.click_aaq_form_cancel_button()
 
     with allure.step("Verifying that the question is not deleted"):
         expect(page).to_have_url(posted_question_two['question_details']['question_page_url'])
@@ -346,7 +346,7 @@ def test_lock_and_archive_this_question(page: Page, status):
 
         question_info_two = sumo_pages.aaq_flow.submit_an_aaq_question(
             subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_name=sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+            topic_name=sumo_pages.aaq_form_page.get_aaq_form_topic_options()[0],
             body=utilities.aaq_question_test_data["valid_firefox_question"]
             ["simple_body_text"],
             attach_image=False
@@ -358,11 +358,11 @@ def test_lock_and_archive_this_question(page: Page, status):
     if status == "locked":
         with allure.step("Verifying that the 'Lock this question' option is not available for "
                          "other posted questions"):
-            expect(sumo_pages.question_page._get_lock_this_question_locator()).to_be_hidden()
+            expect(sumo_pages.question_page.get_lock_this_question_locator()).to_be_hidden()
     elif status == "archived":
         with allure.step("Verifying that the 'Archive this question' option is not available "
                          "for other posted questions"):
-            expect(sumo_pages.question_page._get_archive_this_question_locator()).to_be_hidden()
+            expect(sumo_pages.question_page.get_archive_this_question_locator()).to_be_hidden()
 
     with allure.step("Navigating to the question posted by self"):
         utilities.navigate_to_link(question_info_two['question_page_url'])
@@ -370,11 +370,11 @@ def test_lock_and_archive_this_question(page: Page, status):
     if status == "locked":
         with allure.step("Verifying that the 'Lock this question is not available for self "
                          "posted questions"):
-            expect(sumo_pages.question_page._get_lock_this_question_locator()).to_be_hidden()
+            expect(sumo_pages.question_page.get_lock_this_question_locator()).to_be_hidden()
     elif status == "archived":
         with allure.step("Verifying that the 'Archive this question' is not available for "
                          "self posted questions"):
-            expect(sumo_pages.question_page._get_archive_this_question_locator()).to_be_hidden()
+            expect(sumo_pages.question_page.get_archive_this_question_locator()).to_be_hidden()
 
     with allure.step("Signing in with an admin account"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -383,10 +383,10 @@ def test_lock_and_archive_this_question(page: Page, status):
 
     if status == "locked":
         with allure.step("Clicking on the 'Lock this question' option"):
-            sumo_pages.question_page._click_on_lock_this_question_locator()
+            sumo_pages.question_page.click_on_lock_this_question_locator()
     elif status == "archived":
         with allure.step("Clicking on the 'Archive this question' option"):
-            sumo_pages.question_page._click_on_archive_this_question_option()
+            sumo_pages.question_page.click_on_archive_this_question_option()
 
     with allure.step("Signing in with a different non admin user account"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -396,17 +396,17 @@ def test_lock_and_archive_this_question(page: Page, status):
     if status == "locked":
         with check, allure.step("Verifying that correct locked thread banner text is "
                                 "displayed"):
-            assert sumo_pages.question_page._get_thread_locked_text(
+            assert sumo_pages.question_page.get_thread_locked_text(
             ) == QuestionPageMessages.LOCKED_THREAD_BANNER
     elif status == "archived":
         with check, allure.step("Verifying that correct archived thread banner text is "
                                 "displayed"):
-            assert sumo_pages.question_page._get_thread_locked_text(
+            assert sumo_pages.question_page.get_thread_locked_text(
             ) == QuestionPageMessages.ARCHIVED_THREAD_BANNER
 
     with allure.step("Clicking on the locked thread link and verifying that we are "
                      "redirected to the correct page"):
-        sumo_pages.question_page._click_on_thread_locked_link()
+        sumo_pages.question_page.click_on_thread_locked_link()
         expect(page).to_have_url(ContactSupportMessages.PAGE_URL)
 
     with allure.step("Navigating back to the question page"):
@@ -414,22 +414,22 @@ def test_lock_and_archive_this_question(page: Page, status):
 
     if status == "locked":
         with allure.step("Verifying that the 'Unlock this question option' is not available'"):
-            expect(sumo_pages.question_page._get_lock_this_question_locator()).to_be_hidden()
+            expect(sumo_pages.question_page.get_lock_this_question_locator()).to_be_hidden()
     elif status == "archived":
         with allure.step("Verifying that the 'Archive this question' options is not "
                          "available"):
-            expect(sumo_pages.question_page._get_archive_this_question_locator()).to_be_hidden()
+            expect(sumo_pages.question_page.get_archive_this_question_locator()).to_be_hidden()
 
     with allure.step("Verifying that the post a reply textarea field is not displayed"):
-        expect(sumo_pages.question_page._get_post_a_reply_textarea_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_post_a_reply_textarea_locator()).to_be_hidden()
 
     with allure.step("Verifying that the 'needs more information from the user' checkbox is "
                      "not displayed"):
-        expect(sumo_pages.question_page._get_needs_more_information_checkbox_locator()
+        expect(sumo_pages.question_page.get_needs_more_information_checkbox_locator()
                ).to_be_hidden()
 
     with allure.step("Verifying that the 'Add images section is not displayed'"):
-        expect(sumo_pages.question_page._get_add_image_section_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_add_image_section_locator()).to_be_hidden()
 
     with allure.step("Signing in with an admin account and verifying that the 'needs more "
                      "information from the user' checkbox is available"):
@@ -439,11 +439,11 @@ def test_lock_and_archive_this_question(page: Page, status):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-        expect(sumo_pages.question_page._get_needs_more_information_checkbox_locator()
+        expect(sumo_pages.question_page.get_needs_more_information_checkbox_locator()
                ).to_be_visible()
 
     with allure.step("Verifying that the 'Add images' section is available"):
-        expect(sumo_pages.question_page._get_add_image_section_locator()).to_be_visible()
+        expect(sumo_pages.question_page.get_add_image_section_locator()).to_be_visible()
 
     with allure.step("Submitting a reply to the question and verifying that the posted reply "
                      "is visible"):
@@ -451,14 +451,14 @@ def test_lock_and_archive_this_question(page: Page, status):
             repliant_username=repliant_username,
             reply=utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
         )
-        expect(sumo_pages.question_page._get_posted_reply_locator(reply_id)).to_be_visible()
+        expect(sumo_pages.question_page.get_posted_reply_locator(reply_id)).to_be_visible()
 
     with allure.step("Signing in with a normal user account and verifying that the admin's "
                      "reply is visible"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.question_page._get_posted_reply_locator(reply_id)).to_be_visible()
+        expect(sumo_pages.question_page.get_posted_reply_locator(reply_id)).to_be_visible()
 
     with allure.step("Signing in with an admin account"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -467,10 +467,10 @@ def test_lock_and_archive_this_question(page: Page, status):
 
     if status == "locked":
         with allure.step("Unlocking the question"):
-            sumo_pages.question_page._click_on_lock_this_question_locator()
+            sumo_pages.question_page.click_on_lock_this_question_locator()
     elif status == "archived":
         with allure.step("Clicking on the 'Archive this question' option"):
-            sumo_pages.question_page._click_on_archive_this_question_option()
+            sumo_pages.question_page.click_on_archive_this_question_option()
 
     with allure.step("Signing in with a non-admin account and verifying that the 'Thread "
                      "locked' banner is not displayed"):
@@ -480,7 +480,7 @@ def test_lock_and_archive_this_question(page: Page, status):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.question_page._get_thread_locked_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_thread_locked_locator()).to_be_hidden()
 
     with allure.step("Submitting a reply to the question and verifying that the posted reply "
                      "is visible"):
@@ -488,7 +488,7 @@ def test_lock_and_archive_this_question(page: Page, status):
             repliant_username=second_repliant,
             reply=utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
         )
-        expect(sumo_pages.question_page._get_posted_reply_locator(reply_id_two)).to_be_visible()
+        expect(sumo_pages.question_page.get_posted_reply_locator(reply_id_two)).to_be_visible()
 
     with allure.step("Signing in with an admin account and deleting both questions"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -516,7 +516,7 @@ def test_subscribe_to_feed_option(page: Page, is_firefox):
 
         question_info_one = sumo_pages.aaq_flow.submit_an_aaq_question(
             subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_name=sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+            topic_name=sumo_pages.aaq_form_page.get_aaq_form_topic_options()[0],
             body=utilities.aaq_question_test_data["valid_firefox_question"]
             ["simple_body_text"],
             attach_image=False
@@ -531,7 +531,7 @@ def test_subscribe_to_feed_option(page: Page, is_firefox):
 
         question_info_two = sumo_pages.aaq_flow.submit_an_aaq_question(
             subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_name=sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+            topic_name=sumo_pages.aaq_form_page.get_aaq_form_topic_options()[0],
             body=utilities.aaq_question_test_data["valid_firefox_question"]
             ["simple_body_text"],
             attach_image=False
@@ -543,13 +543,13 @@ def test_subscribe_to_feed_option(page: Page, is_firefox):
         utilities.navigate_to_link(question_info_one['question_page_url'])
 
         if not is_firefox:
-            sumo_pages.question_page._click_on_subscribe_to_feed_option()
+            sumo_pages.question_page.click_on_subscribe_to_feed_option()
             expect(page).to_have_url(
                 question_info_one['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
             )
         else:
             with page.expect_download() as download_info:
-                sumo_pages.question_page._click_on_subscribe_to_feed_option()
+                sumo_pages.question_page.click_on_subscribe_to_feed_option()
             download = download_info.value
 
             with allure.step("Verifying that the received file contains the correct name"):
@@ -565,14 +565,14 @@ def test_subscribe_to_feed_option(page: Page, is_firefox):
                      "Chrome) or has the correct download info (Firefox)"):
         utilities.navigate_to_link(question_info_two['question_page_url'])
         if not is_firefox:
-            sumo_pages.question_page._click_on_subscribe_to_feed_option()
+            sumo_pages.question_page.click_on_subscribe_to_feed_option()
             expect(page).to_have_url(
                 question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
             )
             utilities.navigate_back()
         else:
             with page.expect_download() as download_info:
-                sumo_pages.question_page._click_on_subscribe_to_feed_option()
+                sumo_pages.question_page.click_on_subscribe_to_feed_option()
             download = download_info.value
 
             with check, allure.step("Verifying that the received file contains the correct "
@@ -590,14 +590,14 @@ def test_subscribe_to_feed_option(page: Page, is_firefox):
         utilities.delete_cookies()
 
         if not is_firefox:
-            sumo_pages.question_page._click_on_subscribe_to_feed_option()
+            sumo_pages.question_page.click_on_subscribe_to_feed_option()
             expect(page).to_have_url(
                 question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
             )
             utilities.navigate_back()
         else:
             with page.expect_download() as download_info:
-                sumo_pages.question_page._click_on_subscribe_to_feed_option()
+                sumo_pages.question_page.click_on_subscribe_to_feed_option()
             download = download_info.value
 
             with check, allure.step("Verifying that the received file contains the correct "
@@ -618,14 +618,14 @@ def test_subscribe_to_feed_option(page: Page, is_firefox):
         ))
 
         if not is_firefox:
-            sumo_pages.question_page._click_on_subscribe_to_feed_option()
+            sumo_pages.question_page.click_on_subscribe_to_feed_option()
             expect(page).to_have_url(
                 question_info_two['question_page_url'] + QuestionPageMessages.FEED_FILE_PATH
             )
             utilities.navigate_back()
         else:
             with page.expect_download() as download_info:
-                sumo_pages.question_page._click_on_subscribe_to_feed_option()
+                sumo_pages.question_page.click_on_subscribe_to_feed_option()
             download = download_info.value
 
             with check, allure.step("Verifying that the received file contains the correct "
@@ -656,14 +656,14 @@ def test_mark_as_spam_functionality(page: Page):
     with allure.step("Deleting user session and verifying that the 'Mark as spam' option is "
                      "not displayed"):
         utilities.delete_cookies()
-        expect(sumo_pages.question_page._get_mark_as_spam_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_mark_as_spam_locator()).to_be_hidden()
 
     with allure.step("Signing in with a non admin user account and verifying that the 'Mark "
                      "as spam' option is not displayed"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.question_page._get_mark_as_spam_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_mark_as_spam_locator()).to_be_hidden()
 
     with check, allure.step("Signing in with an admin account, clicking on the 'mark as "
                             "spam' option and verifying that the correct spam banner message"
@@ -672,9 +672,9 @@ def test_mark_as_spam_functionality(page: Page):
             utilities.username_extraction_from_email(
                 utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
             ))
-        sumo_pages.question_page._click_on_mark_as_spam_option()
+        sumo_pages.question_page.click_on_mark_as_spam_option()
         assert (QuestionPageMessages.MARKED_AS_SPAM_BANNER + username in sumo_pages.question_page.
-                _get_marked_as_spam_banner_text())
+                get_marked_as_spam_banner_text())
 
     with check, allure.step("Deleting the user session, navigating to the posted question "
                             "and verifying that the 404 is returned"):
@@ -699,20 +699,20 @@ def test_mark_as_spam_functionality(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-        sumo_pages.question_page._click_on_mark_as_spam_option()
-        expect(sumo_pages.question_page._get_marked_as_spam_banner_locator()).to_be_hidden()
+        sumo_pages.question_page.click_on_mark_as_spam_option()
+        expect(sumo_pages.question_page.get_marked_as_spam_banner_locator()).to_be_hidden()
 
     with allure.step("Deleting the user session and verifying that the 'Marked as spam' "
                      "banner is not displayed"):
         utilities.delete_cookies()
-        expect(sumo_pages.question_page._get_marked_as_spam_banner_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_marked_as_spam_banner_locator()).to_be_hidden()
 
     with allure.step("Signing in with a non admin user account and verifying that the "
                      "'Marked as spam' banner is not displayed"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.question_page._get_marked_as_spam_banner_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_marked_as_spam_banner_locator()).to_be_hidden()
 
     with allure.step("Signing in with an admin account and deleting the question"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -732,10 +732,10 @@ def test_question_topics(page: Page, username):
         posted_question = post_firefox_product_question_flow(page, 'TEST_ACCOUNT_12')
 
     with allure.step("Verifying that the 'Add a tag' input field is not displayed for OP"):
-        expect(sumo_pages.question_page._get_add_a_tag_input_field()).to_be_hidden()
+        expect(sumo_pages.question_page.get_add_a_tag_input_field()).to_be_hidden()
 
     with allure.step("Verifying that the 'Add' topic section button is not displayed for OP"):
-        expect(sumo_pages.question_page._get_add_a_tag_button()).to_be_hidden()
+        expect(sumo_pages.question_page.get_add_a_tag_button()).to_be_hidden()
 
     with allure.step("Deleting user session"):
         utilities.delete_cookies()
@@ -747,24 +747,24 @@ def test_question_topics(page: Page, username):
             ))
 
     with allure.step("Verifying that the 'Add a tag' input field is not displayed"):
-        expect(sumo_pages.question_page._get_add_a_tag_input_field()).to_be_hidden()
+        expect(sumo_pages.question_page.get_add_a_tag_input_field()).to_be_hidden()
 
     with allure.step("Verifying that the 'Add' topic section button is not displayed"):
-        expect(sumo_pages.question_page._get_add_a_tag_button()).to_be_hidden()
+        expect(sumo_pages.question_page.get_add_a_tag_button()).to_be_hidden()
 
     with allure.step("Verifying that the remove tag button is not displayed"):
-        for tag in sumo_pages.question_page._get_question_tag_options():
-            expect(sumo_pages.question_page._get_remove_tag_button_locator(tag)).to_be_hidden()
+        for tag in sumo_pages.question_page.get_question_tag_options():
+            expect(sumo_pages.question_page.get_remove_tag_button_locator(tag)).to_be_hidden()
 
     with allure.step("Signing in with a admin user account, adding data inside the 'Add a "
                      "tag' input field"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-        sumo_pages.question_page._add_text_to_add_a_tag_input_field(
+        sumo_pages.question_page.add_text_to_add_a_tag_input_field(
             utilities.aaq_question_test_data['valid_firefox_question']['custom_tag']
         )
-        sumo_pages.question_page._click_on_add_a_tag_button()
+        sumo_pages.question_page.click_on_add_a_tag_button()
 
     with allure.step("Deleting user session"):
         utilities.delete_cookies()
@@ -778,14 +778,14 @@ def test_question_topics(page: Page, username):
     with check, allure.step("Verifying that the tag is available for all users"):
         page.reload()
         assert (utilities.aaq_question_test_data['valid_firefox_question']
-                ['custom_tag'] in sumo_pages.question_page._get_question_tag_options())
+                ['custom_tag'] in sumo_pages.question_page.get_question_tag_options())
 
     with allure.step("Verifying that the question tags are acting as filters"):
-        for question in sumo_pages.question_page._get_question_tag_options():
+        for question in sumo_pages.question_page.get_question_tag_options():
             with check, allure.step(f"Clicking on the {question} tag and verifying tha the "
                                     f"filter is applied to the clicked tag"):
                 time.sleep(1)
-                sumo_pages.question_page._click_on_a_certain_tag(question)
+                sumo_pages.question_page.click_on_a_certain_tag(question)
                 assert (question == sumo_pages.product_support_forum.
                         _get_text_of_selected_tag_filter_option())
 
@@ -804,14 +804,14 @@ def test_question_topics(page: Page, username):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
         page.reload()
-        sumo_pages.question_page._click_on_tag_remove_button(
+        sumo_pages.question_page.click_on_tag_remove_button(
             utilities.aaq_question_test_data['valid_firefox_question']['custom_tag']
         )
         # Adding a custom wait to avoid test flakiness.
         utilities.wait_for_given_timeout(1000)
 
     with allure.step("Verifying that the tag was removed"):
-        expect(sumo_pages.question_page._get_a_certain_tag(
+        expect(sumo_pages.question_page.get_a_certain_tag(
             utilities.aaq_question_test_data['valid_firefox_question']['custom_tag']
         )
         ).to_be_hidden()
@@ -826,7 +826,7 @@ def test_question_topics(page: Page, username):
             ))
 
     with allure.step("Verifying that the tag was removed"):
-        expect(sumo_pages.question_page._get_a_certain_tag(
+        expect(sumo_pages.question_page.get_a_certain_tag(
             utilities.aaq_question_test_data['valid_firefox_question']['custom_tag']
         )
         ).to_be_hidden()
@@ -851,21 +851,21 @@ def test_email_updates_option_visibility(page: Page):
     with allure.step("Deleting user session and verifying that the 'Get  email updates' "
                      "option is displayed"):
         utilities.delete_cookies()
-        expect(sumo_pages.question_page._get_email_updates_option()).to_be_visible()
+        expect(sumo_pages.question_page.get_email_updates_option()).to_be_visible()
 
     with allure.step("Signing in with another non admin user account and verifying that the "
                      "'Get email updates' option is displayed"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.question_page._get_email_updates_option()).to_be_visible()
+        expect(sumo_pages.question_page.get_email_updates_option()).to_be_visible()
 
     with allure.step("Signing in with an admin account and verifying that the 'Get email "
                      "updated' options is displayed"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-        expect(sumo_pages.question_page._get_email_updates_option()).to_be_visible()
+        expect(sumo_pages.question_page.get_email_updates_option()).to_be_visible()
 
     with allure.step("Deleting the posted question"):
         sumo_pages.aaq_flow.deleting_question_flow()
@@ -899,17 +899,17 @@ def test_mark_reply_as_spam(page: Page):
 
     with allure.step("Clicking on the self reply menu and verifying that the 'mark as spam' "
                      "option is not displayed for non-admin users"):
-        sumo_pages.question_page._click_on_reply_more_options_button(reply_id_two)
-        expect(sumo_pages.question_page._get_mark_as_spam_reply_locator(reply_id_two)
+        sumo_pages.question_page.click_on_reply_more_options_button(reply_id_two)
+        expect(sumo_pages.question_page.get_mark_as_spam_reply_locator(reply_id_two)
                ).to_be_hidden()
-        sumo_pages.question_page._click_on_reply_more_options_button(reply_id_two)
+        sumo_pages.question_page.click_on_reply_more_options_button(reply_id_two)
 
     with allure.step("Clicking on other user posted reply menu and verifying that the 'mark "
                      "as spam' option is not displayed for non-admin users"):
-        sumo_pages.question_page._click_on_reply_more_options_button(reply_id_one)
-        expect(sumo_pages.question_page._get_mark_as_spam_reply_locator(reply_id_one)
+        sumo_pages.question_page.click_on_reply_more_options_button(reply_id_one)
+        expect(sumo_pages.question_page.get_mark_as_spam_reply_locator(reply_id_one)
                ).to_be_hidden()
-        sumo_pages.question_page._click_on_reply_more_options_button(reply_id_one)
+        sumo_pages.question_page.click_on_reply_more_options_button(reply_id_one)
 
     with check, allure.step("Signing in with an admin account, clicking on the 'Marks as "
                             "Spam' option for one of the replies and verifying that the "
@@ -918,27 +918,27 @@ def test_mark_reply_as_spam(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
         sumo_pages.aaq_flow.spam_marking_a_reply(reply_id_one)
-        assert sumo_pages.question_page._get_marked_as_spam_text(
+        assert sumo_pages.question_page.get_marked_as_spam_text(
             reply_id_one) == QuestionPageMessages.REPLY_MARKED_AS_SPAM_MESSAGE
 
     with allure.step("Deleting user session and verifying that the reply marked as spam is "
                      "no longer displayed"):
         utilities.delete_cookies()
-        expect(sumo_pages.question_page._get_reply_section_locator(reply_id_one)).to_be_hidden()
+        expect(sumo_pages.question_page.get_reply_section_locator(reply_id_one)).to_be_hidden()
 
     with allure.step("Signing in with a user account and verifying that reply marked as spam "
                      "is no longer displayed"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
-        expect(sumo_pages.question_page._get_reply_section_locator(reply_id_one)).to_be_hidden()
+        expect(sumo_pages.question_page.get_reply_section_locator(reply_id_one)).to_be_hidden()
 
     with allure.step("Signing in with the reply OP user account and verifying that the reply "
                      "marked as spam is no longer displayed"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.question_page._get_reply_section_locator(reply_id_one)).to_be_hidden()
+        expect(sumo_pages.question_page.get_reply_section_locator(reply_id_one)).to_be_hidden()
 
     with allure.step("Signing in with the admin account, unmarking the reply from spam and "
                      "verifying that the 'Marked as spam' message is no longer displayed"):
@@ -946,35 +946,35 @@ def test_mark_reply_as_spam(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
         sumo_pages.aaq_flow.spam_marking_a_reply(reply_id_one)
-        expect(sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)).to_be_hidden()
+        expect(sumo_pages.question_page.get_marked_as_spam_locator(reply_id_one)).to_be_hidden()
 
     with allure.step("Deleting the user session and verifying that the reply is visible to "
                      "the logged out users"):
         utilities.delete_cookies()
-        expect(sumo_pages.question_page._get_reply_section_locator(reply_id_one)).to_be_visible()
+        expect(sumo_pages.question_page.get_reply_section_locator(reply_id_one)).to_be_visible()
 
     with allure.step("Verifying that the 'Marked as spam' message is no longer displayed"):
-        expect(sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)).to_be_hidden()
+        expect(sumo_pages.question_page.get_marked_as_spam_locator(reply_id_one)).to_be_hidden()
 
     with allure.step("Signing in with a different user and verifying that the reply is "
                      "visible again"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
-        expect(sumo_pages.question_page._get_reply_section_locator(reply_id_one)).to_be_visible()
+        expect(sumo_pages.question_page.get_reply_section_locator(reply_id_one)).to_be_visible()
 
     with allure.step("Verifying that the 'Marked as spam' message is no longer displayed"):
-        expect(sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)).to_be_hidden()
+        expect(sumo_pages.question_page.get_marked_as_spam_locator(reply_id_one)).to_be_hidden()
 
     with allure.step("Signing in with the reply OP and verifying that the reply is visible "
                      "again"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.question_page._get_reply_section_locator(reply_id_one)).to_be_visible()
+        expect(sumo_pages.question_page.get_reply_section_locator(reply_id_one)).to_be_visible()
 
     with allure.step("Verifying that the 'Marked as spam' message is no longer displayed"):
-        expect(sumo_pages.question_page._get_marked_as_spam_locator(reply_id_one)).to_be_hidden()
+        expect(sumo_pages.question_page.get_marked_as_spam_locator(reply_id_one)).to_be_hidden()
 
     with allure.step("Signing in with an admin account and deleting the posted question"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -1005,9 +1005,9 @@ def test_edit_reply(page: Page, username):
 
     with check, allure.step("Verifying that the reply contains the correct name and user "
                             "status"):
-        assert sumo_pages.question_page._get_display_name_of_question_reply_author(
+        assert sumo_pages.question_page.get_display_name_of_question_reply_author(
             reply_id) == posted_question['username_one']
-        assert sumo_pages.question_page._get_displayed_user_title_of_question_reply(
+        assert sumo_pages.question_page.get_displayed_user_title_of_question_reply(
             reply_id) == QuestionPageMessages.QUESTION_REPLY_OWNER
 
     if username == 'TEST_ACCOUNT_13':
@@ -1019,8 +1019,8 @@ def test_edit_reply(page: Page, username):
 
         with allure.step("Clicking on the more options for the reply posted by another user "
                          "and verifying that the 'edit this post' option is not displayed"):
-            sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
-            expect(sumo_pages.question_page._get_edit_this_post_reply_locator(reply_id)
+            sumo_pages.question_page.click_on_reply_more_options_button(reply_id)
+            expect(sumo_pages.question_page.get_edit_this_post_reply_locator(reply_id)
                    ).to_be_hidden()
 
         with check, allure.step("Manually navigating to edit reply endpoint and verifying "
@@ -1041,11 +1041,11 @@ def test_edit_reply(page: Page, username):
                 reply=utilities.aaq_question_test_data['valid_firefox_question']
                 ['question_reply']
             )
-            assert sumo_pages.question_page._get_display_name_of_question_reply_author(
+            assert sumo_pages.question_page.get_display_name_of_question_reply_author(
                 reply_id
             ) == username_two
             expect(
-                sumo_pages.question_page._get_displayed_user_title_of_question_reply_locator(
+                sumo_pages.question_page.get_displayed_user_title_of_question_reply_locator(
                     reply_id
                 )
             ).to_be_hidden()
@@ -1057,9 +1057,9 @@ def test_edit_reply(page: Page, username):
 
     with check, allure.step("Clicking on the 'Edit this post option' and verifying that the "
                             "textarea contains the original reply"):
-        sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
-        sumo_pages.question_page._click_on_edit_this_post_for_a_certain_reply(reply_id)
-        assert sumo_pages.question_page._get_post_a_reply_textarea_text().strip(
+        sumo_pages.question_page.click_on_reply_more_options_button(reply_id)
+        sumo_pages.question_page.click_on_edit_this_post_for_a_certain_reply(reply_id)
+        assert sumo_pages.question_page.get_post_a_reply_textarea_text().strip(
         ) in utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
 
     with allure.step("Editing the question reply"):
@@ -1070,19 +1070,19 @@ def test_edit_reply(page: Page, username):
         )
 
     with check, allure.step("Verifying that the question reply is the original one"):
-        assert sumo_pages.question_page._get_posted_reply_text(reply_id).strip(
+        assert sumo_pages.question_page.get_posted_reply_text(reply_id).strip(
         ) == utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
 
     with allure.step("Verifying that the 'Modified by' message is not displayed for the "
                      "reply"):
-        expect(sumo_pages.question_page._get_posted_reply_modified_by_locator(reply_id)
+        expect(sumo_pages.question_page.get_posted_reply_modified_by_locator(reply_id)
                ).to_be_hidden()
 
     with check, allure.step("Clicking on the 'Edit this post option' and verifying that the "
                             "textarea contains the original reply"):
-        sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
-        sumo_pages.question_page._click_on_edit_this_post_for_a_certain_reply(reply_id)
-        assert sumo_pages.question_page._get_post_a_reply_textarea_text(
+        sumo_pages.question_page.click_on_reply_more_options_button(reply_id)
+        sumo_pages.question_page.click_on_edit_this_post_for_a_certain_reply(reply_id)
+        assert sumo_pages.question_page.get_post_a_reply_textarea_text(
         ) in utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
 
     with check, allure.step("Editing the reply and verifying that the reply contains the "
@@ -1091,12 +1091,12 @@ def test_edit_reply(page: Page, username):
             reply_body=utilities.aaq_question_test_data['valid_firefox_question']
             ['updated_reply']
         )
-        assert sumo_pages.question_page._get_posted_reply_text(reply_id).strip(
+        assert sumo_pages.question_page.get_posted_reply_text(reply_id).strip(
         ) == utilities.aaq_question_test_data['valid_firefox_question']['updated_reply']
 
     with check, allure.step("Verifying that the 'Modified by' message is displayed for the "
                             "reply"):
-        assert username_two in sumo_pages.question_page._get_posted_reply_modified_by_text(
+        assert username_two in sumo_pages.question_page.get_posted_reply_modified_by_text(
             reply_id)
 
     with allure.step("Deleting the posted question"):
@@ -1125,7 +1125,7 @@ def test_delete_reply(page: Page, username):
             repliant_username=posted_question['username_one'],
             reply=utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
         )
-        expect(sumo_pages.question_page._get_delete_this_post_reply_locator(reply_id)
+        expect(sumo_pages.question_page.get_delete_this_post_reply_locator(reply_id)
                ).to_be_hidden()
 
     with check, allure.step("Verifying that manually navigating to the delete page for the "
@@ -1154,8 +1154,8 @@ def test_delete_reply(page: Page, username):
 
             with allure.step("Verifying that the 'Delete this post' option is not available "
                              "for replies posted by others"):
-                sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
-                expect(sumo_pages.question_page._get_delete_this_post_reply_locator(reply_id)
+                sumo_pages.question_page.click_on_reply_more_options_button(reply_id)
+                expect(sumo_pages.question_page.get_delete_this_post_reply_locator(reply_id)
                        ).to_be_hidden()
 
             with check, allure.step("Verifying that manually navigating to the delete page "
@@ -1176,11 +1176,11 @@ def test_delete_reply(page: Page, username):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
         sumo_pages.aaq_flow.delete_question_reply(reply_id, delete_reply=False)
-        expect(sumo_pages.question_page._get_posted_reply_locator(reply_id)).to_be_visible()
+        expect(sumo_pages.question_page.get_posted_reply_locator(reply_id)).to_be_visible()
 
     with allure.step("Deleting the reply and verifying that the reply is no longer displayed"):
         sumo_pages.aaq_flow.delete_question_reply(reply_id, delete_reply=True)
-        expect(sumo_pages.question_page._get_posted_reply_locator(reply_id)).to_be_hidden()
+        expect(sumo_pages.question_page.get_posted_reply_locator(reply_id)).to_be_hidden()
 
     with allure.step("Deleting the posted question"):
         sumo_pages.aaq_flow.deleting_question_flow()
@@ -1198,17 +1198,17 @@ def test_i_have_this_problem_too(page: Page):
 
     with allure.step("Verifying that the 'I have this problem too' button is not displayed "
                      "for self posted questions"):
-        problem_counter = sumo_pages.question_page._get_i_have_this_problem_too_counter()
-        expect(sumo_pages.question_page._get_i_have_this_problem_too_locator()).to_be_hidden()
+        problem_counter = sumo_pages.question_page.get_i_have_this_problem_too_counter()
+        expect(sumo_pages.question_page.get_i_have_this_problem_too_locator()).to_be_hidden()
 
     with check, allure.step("Deleting the user session, clicking on the 'I have this problem "
                             "too' button and verifying tha the 'have this problem' counter "
                             "was successfully incremented"):
         utilities.delete_cookies()
         problem_counter += 1
-        sumo_pages.question_page._click_i_have_this_problem_too_button()
+        sumo_pages.question_page.click_i_have_this_problem_too_button()
         page.reload()
-        assert problem_counter == sumo_pages.question_page._get_i_have_this_problem_too_counter()
+        assert problem_counter == sumo_pages.question_page.get_i_have_this_problem_too_counter()
 
     with check, allure.step("Signing in with a different non-admin user account, clicking on "
                             "the 'I have this problem too' and verifying that the 'have this "
@@ -1216,14 +1216,14 @@ def test_i_have_this_problem_too(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
-        sumo_pages.question_page._click_i_have_this_problem_too_button()
+        sumo_pages.question_page.click_i_have_this_problem_too_button()
         page.reload()
         problem_counter += 1
-        assert problem_counter == sumo_pages.question_page._get_i_have_this_problem_too_counter()
+        assert problem_counter == sumo_pages.question_page.get_i_have_this_problem_too_counter()
 
     with allure.step("Verifying that the 'I have this problem too' button is no longer "
                      "displayed"):
-        expect(sumo_pages.question_page._get_i_have_this_problem_too_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_i_have_this_problem_too_locator()).to_be_hidden()
 
     with check, allure.step("Signing in with an admin account, clicking on the 'I have this "
                             "problem too' and verifying that the 'have this problem' counter "
@@ -1232,13 +1232,13 @@ def test_i_have_this_problem_too(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
         problem_counter += 1
-        sumo_pages.question_page._click_i_have_this_problem_too_button()
+        sumo_pages.question_page.click_i_have_this_problem_too_button()
         page.reload()
-        assert problem_counter == sumo_pages.question_page._get_i_have_this_problem_too_counter()
+        assert problem_counter == sumo_pages.question_page.get_i_have_this_problem_too_counter()
 
     with allure.step("Verifying that the 'I have this problem too' button is no longer "
                      "displayed"):
-        expect(sumo_pages.question_page._get_i_have_this_problem_too_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_i_have_this_problem_too_locator()).to_be_hidden()
 
     with allure.step("Deleting the posted question"):
         sumo_pages.aaq_flow.deleting_question_flow()
@@ -1262,7 +1262,7 @@ def test_solves_this_problem(page: Page):
     with allure.step("Deleting user session and verifying that the 'Solved the problem' "
                      "button is not displayed"):
         utilities.delete_cookies()
-        expect(sumo_pages.question_page._get_solved_the_problem_button_locator(reply_id)
+        expect(sumo_pages.question_page.get_solved_the_problem_button_locator(reply_id)
                ).to_be_hidden()
 
     with allure.step("Signing in with a different user account and verifying that the "
@@ -1270,7 +1270,7 @@ def test_solves_this_problem(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
-        expect(sumo_pages.question_page._get_solved_the_problem_button_locator(reply_id)
+        expect(sumo_pages.question_page.get_solved_the_problem_button_locator(reply_id)
                ).to_be_hidden()
 
     with check, allure.step("Signing in with the first username, clicking on the 'Solved the "
@@ -1279,26 +1279,26 @@ def test_solves_this_problem(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        sumo_pages.question_page._click_on_solves_the_problem_button(reply_id)
-        assert sumo_pages.question_page._get_solved_problem_banner_text(
+        sumo_pages.question_page.click_on_solves_the_problem_button(reply_id)
+        assert sumo_pages.question_page.get_solved_problem_banner_text(
         ) == QuestionPageMessages.CHOSEN_SOLUTION_BANNER
 
     with check, allure.step("Verifying that the 'Chosen solution is displayed for the reply'"):
-        assert sumo_pages.question_page._get_chosen_solution_reply_message(
+        assert sumo_pages.question_page.get_chosen_solution_reply_message(
             reply_id) == QuestionPageMessages.CHOSEN_SOLUTION_REPLY_CARD
 
     with check, allure.step("Verifying that the chosen solution reply section has the "
                             "correct header"):
-        assert sumo_pages.question_page._get_problem_solved_section_header_text(
+        assert sumo_pages.question_page.get_problem_solved_section_header_text(
         ) == QuestionPageMessages.CHOSEN_SOLUTION_CARD
 
     with check, allure.step("Verifying the chosen solution text"):
-        assert sumo_pages.question_page._get_chosen_solution_text(
+        assert sumo_pages.question_page.get_chosen_solution_text(
         ) == utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
 
     with allure.step("Clicking on the 'Read this answer in context' link and verifying that "
                      "the page url updates to point out to the posted reply"):
-        sumo_pages.question_page._click_read_this_answer_in_context_link()
+        sumo_pages.question_page.click_read_this_answer_in_context_link()
         expect(page).to_have_url(
             posted_question['question_details']['question_page_url'] + "#" + reply_id
         )
@@ -1306,28 +1306,28 @@ def test_solves_this_problem(page: Page):
     with check, allure.step("Navigating back, clicking on the undo button and verifying that "
                             "the correct banner is displayed"):
         utilities.navigate_back()
-        sumo_pages.question_page._click_on_undo_button()
-        assert sumo_pages.question_page._get_solved_problem_banner_text(
+        sumo_pages.question_page.click_on_undo_button()
+        assert sumo_pages.question_page.get_solved_problem_banner_text(
         ) == QuestionPageMessages.UNDOING_A_SOLUTION
 
     with allure.step("Verifying that the 'Solved the problem' option is not displayed"):
-        expect(sumo_pages.question_page._get_chosen_solution_section_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_chosen_solution_section_locator()).to_be_hidden()
 
     with allure.step("Verifying that the 'Chosen solution' banner is not displayed for the "
                      "previously provided solution"):
-        expect(sumo_pages.question_page._get_chosen_solution_reply_message_locator(reply_id)
+        expect(sumo_pages.question_page.get_chosen_solution_reply_message_locator(reply_id)
                ).to_be_hidden()
 
     with allure.step("Verifying that the 'Undo' option is not available"):
-        expect(sumo_pages.question_page._get_undo_button_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_undo_button_locator()).to_be_hidden()
 
     with check, allure.step("Signing in with an admin account, clicking on the 'solved this "
                             "problem option' and verifying the chosen solution text"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-        sumo_pages.question_page._click_on_solves_the_problem_button(reply_id)
-        assert sumo_pages.question_page._get_chosen_solution_text(
+        sumo_pages.question_page.click_on_solves_the_problem_button(reply_id)
+        assert sumo_pages.question_page.get_chosen_solution_text(
         ) == utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
 
     with allure.step("Deleting the posted question"):
@@ -1347,7 +1347,7 @@ def test_quote_reply_functionality(page: Page, quote_on):
                      "question"):
         posted_question = post_firefox_product_question_flow(page,
                                                              "TEST_ACCOUNT_MESSAGE_3")
-    question_id = sumo_pages.question_page._get_question_id()
+    question_id = sumo_pages.question_page.get_question_id()
 
     if quote_on == "reply":
         with allure.step("Posting a reply to the question"):
@@ -1384,28 +1384,28 @@ def test_quote_reply_functionality(page: Page, quote_on):
     with check, allure.step("Verifying that the original repliant is displayed inside the "
                             "quote"):
         assert (posted_question['username_one'] in sumo_pages.question_page
-                ._get_posted_quote_reply_username_text(quote_id))
+                .get_posted_quote_reply_username_text(quote_id))
 
     if quote_on == "reply":
         with check, allure.step("Verifying that the original reply is displayed inside the "
                                 "quote"):
             assert (utilities.aaq_question_test_data['valid_firefox_question']
                     ['question_reply'] == sumo_pages.question_page
-                    ._get_blockquote_reply_text(quote_id).strip())
+                    .get_blockquote_reply_text(quote_id).strip())
     else:
         with check, allure.step("Verifying that the question details is displayed inside the "
                                 "quote"):
             assert (utilities.aaq_question_test_data['valid_firefox_question']
                     ['simple_body_text'] == sumo_pages.question_page
-                    ._get_blockquote_reply_text(quote_id).strip())
+                    .get_blockquote_reply_text(quote_id).strip())
 
     with check, allure.step("Verifying that the new reply text is also displayed"):
         assert (utilities
                 .aaq_question_test_data['valid_firefox_question']['updated_reply'] in sumo_pages.
-                question_page._get_posted_reply_text(quote_id).strip())
+                question_page.get_posted_reply_text(quote_id).strip())
 
     with allure.step("Clicking on the 'said' link"):
-        sumo_pages.question_page._click_posted_reply_said_link(quote_id)
+        sumo_pages.question_page.click_posted_reply_said_link(quote_id)
 
     if quote_on == "reply":
         with check, allure.step("Verifying that the correct url is displayed"):
@@ -1445,27 +1445,27 @@ def test_quote_reply_functionality(page: Page, quote_on):
     with check, allure.step("Verifying that the original repliant is displayed inside the "
                             "quote"):
         assert (posted_question['username_one'] in sumo_pages.question_page
-                ._get_posted_quote_reply_username_text(quote_id))
+                .get_posted_quote_reply_username_text(quote_id))
 
     if quote_on == "reply":
         with check, allure.step("Verifying that the original reply is displayed inside the "
                                 "quote"):
             assert (utilities.aaq_question_test_data['valid_firefox_question']
                     ['question_reply'] == sumo_pages.question_page
-                    ._get_blockquote_reply_text(quote_id).strip())
+                    .get_blockquote_reply_text(quote_id).strip())
     else:
         with check, allure.step("Verifying that the question is displayed inside the quote"):
             assert (utilities.aaq_question_test_data['valid_firefox_question']
                     ['simple_body_text'] == sumo_pages.question_page
-                    ._get_blockquote_reply_text(quote_id).strip())
+                    .get_blockquote_reply_text(quote_id).strip())
 
     with check, allure.step("Verifying that the new reply text is also displayed"):
         assert (utilities.aaq_question_test_data['valid_firefox_question']
                 ['updated_reply'] == sumo_pages.question_page
-                ._get_posted_reply_text(quote_id).strip())
+                .get_posted_reply_text(quote_id).strip())
 
     with allure.step("Clicking on the 'said' link"):
-        sumo_pages.question_page._click_posted_reply_said_link(quote_id)
+        sumo_pages.question_page.click_posted_reply_said_link(quote_id)
 
     if quote_on == "reply":
         with allure.step("Verifying that the correct url is displayed"):
@@ -1491,31 +1491,31 @@ def test_quote_reply_functionality_signed_out(page: Page):
     with allure.step("Signing in with a non admin user account and posting a Firefox product "
                      "question"):
         posted_question = post_firefox_product_question_flow(page, 'TEST_ACCOUNT_12')
-    question_id = sumo_pages.question_page._get_question_id()
+    question_id = sumo_pages.question_page.get_question_id()
 
     with allure.step("Deleting user session, clicking on the 'Quote' option for the question "
                      "and verifying that the url has updated to contain the correct fragment"
                      " identifier"):
         utilities.delete_cookies()
-        sumo_pages.question_page._click_on_reply_more_options_button(question_id)
-        sumo_pages.question_page._click_on_quote_for_a_certain_reply(question_id)
+        sumo_pages.question_page.click_on_reply_more_options_button(question_id)
+        sumo_pages.question_page.click_on_quote_for_a_certain_reply(question_id)
         expect(page).to_have_url(
             posted_question['question_details']['question_page_url'] + "#question-reply")
 
     with allure.step("Verifying that the reply textarea field is not displayed"):
-        expect(sumo_pages.question_page._get_post_a_reply_textarea_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_post_a_reply_textarea_locator()).to_be_hidden()
 
     with allure.step("Verifying that the 'Ask a question' signed out card is not displayed"):
-        expect(sumo_pages.question_page._ask_a_question_signed_out_card_option_locator()
+        expect(sumo_pages.question_page.ask_a_question_signed_out_card_option_locator()
                ).to_be_hidden()
 
     with allure.step("Verifying that the 'I have this problem, too' option is not displayed"):
-        expect(sumo_pages.question_page._get_i_have_this_problem_too_signed_out_card_locator()
+        expect(sumo_pages.question_page.get_i_have_this_problem_too_signed_out_card_locator()
                ).to_be_hidden()
 
     with allure.step("Clicking on the 'start a new question' signed out card link and "
                      "verifying that we are redirected to the Contact Support page"):
-        sumo_pages.question_page._click_on_start_a_new_question_signed_out_card_link()
+        sumo_pages.question_page.click_on_start_a_new_question_signed_out_card_link()
         expect(page).to_have_url(ContactSupportMessages.PAGE_URL)
 
     with allure.step("Navigating back to the question page,signing in back with the op and "
@@ -1533,32 +1533,32 @@ def test_quote_reply_functionality_signed_out(page: Page):
                      "verifying that the url has updated to contain the correct fragment "
                      "identifier"):
         utilities.delete_cookies()
-        sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
-        sumo_pages.question_page._click_on_quote_for_a_certain_reply(reply_id)
+        sumo_pages.question_page.click_on_reply_more_options_button(reply_id)
+        sumo_pages.question_page.click_on_quote_for_a_certain_reply(reply_id)
         expect(page).to_have_url(
             posted_question['question_details']['question_page_url'] + "#question-reply"
         )
 
     with allure.step("Verifying that the reply textarea field is not displayed"):
-        expect(sumo_pages.question_page._get_post_a_reply_textarea_locator()).to_be_hidden()
+        expect(sumo_pages.question_page.get_post_a_reply_textarea_locator()).to_be_hidden()
 
     with allure.step("Verifying that the 'Ask a question' signed out card is displayed"):
-        expect(sumo_pages.question_page._ask_a_question_signed_out_card_option_locator()
+        expect(sumo_pages.question_page.ask_a_question_signed_out_card_option_locator()
                ).to_be_visible()
 
     with allure.step("Verifying that the 'I have this problem, too' option is displayed"):
-        expect(sumo_pages.question_page._get_i_have_this_problem_too_signed_out_card_locator()
+        expect(sumo_pages.question_page.get_i_have_this_problem_too_signed_out_card_locator()
                ).to_be_visible()
 
     with allure.step("Clicking on the 'Ask a question' and verifying that we are redirected "
                      "to the contact support page"):
-        sumo_pages.question_page._click_on_ask_a_question_signed_out_card_option()
+        sumo_pages.question_page.click_on_ask_a_question_signed_out_card_option()
         expect(page).to_have_url(ContactSupportMessages.PAGE_URL)
 
     with allure.step("Navigating back to the question page, clicking on the 'log in to your "
                      "account' link and proceeding with the auth flow with an admin account"):
         utilities.navigate_back()
-        sumo_pages.question_page._click_on_log_in_to_your_account_signed_out_card_link()
+        sumo_pages.question_page.click_on_log_in_to_your_account_signed_out_card_link()
         sumo_pages.auth_flow_page.sign_in_flow(
             username=utilities.user_special_chars,
             account_password=utilities.user_secrets_pass,
@@ -1568,7 +1568,7 @@ def test_quote_reply_functionality_signed_out(page: Page):
         expect(page).to_have_url(posted_question['question_details']['question_page_url'])
 
     with allure.step("Verifying that the textarea field is displayed"):
-        expect(sumo_pages.question_page._get_post_a_reply_textarea_locator()).to_be_visible()
+        expect(sumo_pages.question_page.get_post_a_reply_textarea_locator()).to_be_visible()
 
     with allure.step("Signing in with an admin account and deleting the posted question"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -1589,118 +1589,118 @@ def test_question_reply_votes(page: Page):
     with allure.step("Signing in with a non admin user account and posting a Firefox product "
                      "question"):
         posted_question = post_firefox_product_question_flow(page, 'TEST_ACCOUNT_12')
-    sumo_pages.question_page._get_question_id()
+    sumo_pages.question_page.get_question_id()
 
     with allure.step("Posting a reply to the question"):
-        sumo_pages.question_page._add_text_to_post_a_reply_textarea(
+        sumo_pages.question_page.add_text_to_post_a_reply_textarea(
             utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
         )
-        reply_id = sumo_pages.question_page._click_on_post_reply_button(
+        reply_id = sumo_pages.question_page.click_on_post_reply_button(
             posted_question['username_one']
         )
 
     with allure.step("Verifying the vote reply is not available for self posted questions"):
-        expect(sumo_pages.question_page._get_reply_votes_section_locator(reply_id)).to_be_hidden()
+        expect(sumo_pages.question_page.get_reply_votes_section_locator(reply_id)).to_be_hidden()
 
     with check, allure.step("Signing in a different user and verifying that the correct vote "
                             "header is displayed"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts['TEST_ACCOUNT_13']
         ))
-        assert sumo_pages.question_page._get_reply_vote_heading(
+        assert sumo_pages.question_page.get_reply_vote_heading(
             reply_id) == QuestionPageMessages.HELPFUL_VOTE_HEADER
 
     with allure.step("Clicking on the 'thumbs up' button and verifying that the correct "
                      "message is displayed"):
-        sumo_pages.question_page._click_reply_vote_thumbs_up_button(reply_id)
+        sumo_pages.question_page.click_reply_vote_thumbs_up_button(reply_id)
         number_of_thumbs_up_votes += 1
-        assert sumo_pages.question_page._get_thumbs_up_vote_message(
+        assert sumo_pages.question_page.get_thumbs_up_vote_message(
             reply_id) == QuestionPageMessages.THUMBS_UP_VOTE_MESSAGE
 
     with check, allure.step("Refreshing the page and verifying that the correct number of "
                             "thumbs up votes is displayed"):
         utilities.refresh_page()
-        assert int(sumo_pages.question_page._get_helpful_count(reply_id
-                                                               )) == number_of_thumbs_up_votes
+        assert int(sumo_pages.question_page.get_helpful_count(reply_id
+                                                              )) == number_of_thumbs_up_votes
 
     with check, allure.step("Verifying that the correct number of thumbs down votes is "
                             "displayed"):
-        assert int(sumo_pages.question_page._get_not_helpful_count(reply_id)
+        assert int(sumo_pages.question_page.get_not_helpful_count(reply_id)
                    ) == number_of_thumbs_down_votes
 
     with allure.step("Verifying that the thumbs up button contains the disabled attribute"):
-        expect(sumo_pages.question_page._get_thumbs_up_button_locator(reply_id)
+        expect(sumo_pages.question_page.get_thumbs_up_button_locator(reply_id)
                ).to_have_attribute("disabled", "")
 
     with allure.step("Verifying that the thumbs down button contains the disabled attribute"):
-        expect(sumo_pages.question_page._get_thumbs_down_button_locator(reply_id)
+        expect(sumo_pages.question_page.get_thumbs_down_button_locator(reply_id)
                ).to_have_attribute("disabled", "")
 
     with check, allure.step("Refreshing the page and verifying that the correct number of "
                             "thumbs up votes is displayed"):
         utilities.refresh_page()
-        assert int(sumo_pages.question_page._get_helpful_count(reply_id)
+        assert int(sumo_pages.question_page.get_helpful_count(reply_id)
                    ) == number_of_thumbs_up_votes
 
     with check, allure.step("Verifying that the correct number of thumbs down votes is "
                             "displayed"):
-        assert int(sumo_pages.question_page._get_not_helpful_count(reply_id)
+        assert int(sumo_pages.question_page.get_not_helpful_count(reply_id)
                    ) == number_of_thumbs_down_votes
 
     with allure.step("Deleting the user session and clicking on the 'thumbs up' button"):
         utilities.delete_cookies()
-        sumo_pages.question_page._click_reply_vote_thumbs_up_button(reply_id)
+        sumo_pages.question_page.click_reply_vote_thumbs_up_button(reply_id)
         number_of_thumbs_up_votes += 1
 
     with check, allure.step("Refreshing the page and verifying that the correct number of "
                             "thumbs up votes is displayed"):
         utilities.refresh_page()
-        assert int(sumo_pages.question_page._get_helpful_count(reply_id)
+        assert int(sumo_pages.question_page.get_helpful_count(reply_id)
                    ) == number_of_thumbs_up_votes
 
     with check, allure.step("Verifying that the correct number of thumbs down votes is "
                             "displayed"):
-        assert int(sumo_pages.question_page._get_not_helpful_count(reply_id)
+        assert int(sumo_pages.question_page.get_not_helpful_count(reply_id)
                    ) == number_of_thumbs_down_votes
 
     with allure.step("Verifying that the thumbs up button contains the disabled attribute"):
-        expect(sumo_pages.question_page._get_thumbs_up_button_locator(reply_id)
+        expect(sumo_pages.question_page.get_thumbs_up_button_locator(reply_id)
                ).to_have_attribute("disabled", "")
 
     with allure.step("Verifying that the thumbs down button contains the disabled attribute"):
-        expect(sumo_pages.question_page._get_thumbs_down_button_locator(reply_id)
+        expect(sumo_pages.question_page.get_thumbs_down_button_locator(reply_id)
                ).to_have_attribute("disabled", "")
 
     with check, allure.step("Refreshing the page and verifying that the correct number of "
                             "thumbs up votes is displayed"):
         utilities.refresh_page()
-        assert int(sumo_pages.question_page._get_helpful_count(reply_id
-                                                               )) == number_of_thumbs_up_votes
+        assert int(sumo_pages.question_page.get_helpful_count(reply_id
+                                                              )) == number_of_thumbs_up_votes
 
     check.equal(
-        int(sumo_pages.question_page._get_not_helpful_count(reply_id)), number_of_thumbs_down_votes
+        int(sumo_pages.question_page.get_not_helpful_count(reply_id)), number_of_thumbs_down_votes
     )
 
     with allure.step("Signing in with an admin account and clicking on the vote down button"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts['TEST_ACCOUNT_MODERATOR']
         ))
-        sumo_pages.question_page._click_reply_vote_thumbs_down_button(reply_id)
+        sumo_pages.question_page.click_reply_vote_thumbs_down_button(reply_id)
         number_of_thumbs_down_votes += 1
 
     with check, allure.step("Verifying that the correct message is displayed"):
-        assert sumo_pages.question_page._get_thumbs_up_vote_message(
+        assert sumo_pages.question_page.get_thumbs_up_vote_message(
             reply_id) == QuestionPageMessages.THUMBS_DOWN_VOTE_MESSAGE
 
     with check, allure.step("Refreshing the page and verifying that the correct number of "
                             "thumbs up votes is displayed"):
         utilities.refresh_page()
-        assert int(sumo_pages.question_page._get_helpful_count(reply_id
-                                                               )) == number_of_thumbs_up_votes
+        assert int(sumo_pages.question_page.get_helpful_count(reply_id
+                                                              )) == number_of_thumbs_up_votes
 
     with check, allure.step("Verifying that the correct number of thumbs down votes is "
                             "displayed"):
-        assert int(sumo_pages.question_page._get_not_helpful_count(reply_id)
+        assert int(sumo_pages.question_page.get_not_helpful_count(reply_id)
                    ) == number_of_thumbs_down_votes
 
     with allure.step("Deleting the posted question"):
@@ -1736,20 +1736,20 @@ def test_report_abuse(page: Page, flagged_content, username):
     if flagged_content == "question_content":
         with allure.step("Clicking on the more options for the question and verifying that "
                          "the report abuse option is not displayed for signed out users"):
-            sumo_pages.question_page._click_on_reply_more_options_button(
-                sumo_pages.question_page._get_question_id()
+            sumo_pages.question_page.click_on_reply_more_options_button(
+                sumo_pages.question_page.get_question_id()
             )
             expect(
-                sumo_pages.question_page._get_click_on_report_abuse_reply_locator(
-                    sumo_pages.question_page._get_question_id()
+                sumo_pages.question_page.get_click_on_report_abuse_reply_locator(
+                    sumo_pages.question_page.get_question_id()
                 )
             ).to_be_hidden()
 
     else:
         with allure.step("Clicking on the more options for the reply and verifying that the "
                          "report abuse options is not displayed for signed out users"):
-            sumo_pages.question_page._click_on_reply_more_options_button(reply_id)
-            expect(sumo_pages.question_page._get_click_on_report_abuse_reply_locator(
+            sumo_pages.question_page.click_on_reply_more_options_button(reply_id)
+            expect(sumo_pages.question_page.get_click_on_report_abuse_reply_locator(
                 reply_id)).to_be_hidden()
 
     if username == "TEST_ACCOUNT_MODERATOR":
@@ -1766,7 +1766,7 @@ def test_report_abuse(page: Page, flagged_content, username):
     if flagged_content == "question_content":
         with allure.step("Reporting the question as abusive"):
             sumo_pages.aaq_flow.report_question_abuse(
-                answer_id=sumo_pages.question_page._get_question_id(),
+                answer_id=sumo_pages.question_page.get_question_id(),
                 text=utilities.aaq_question_test_data['valid_firefox_question']
                 ['report_abuse_text']
             )
@@ -1831,68 +1831,68 @@ def test_common_responses(page: Page):
             utilities.username_extraction_from_email(
                 utilities.user_secrets_accounts['TEST_ACCOUNT_13']
             ))
-        sumo_pages.question_page._click_on_common_responses_option()
-        sumo_pages.question_page._click_on_a_particular_category_option(
+        sumo_pages.question_page.click_on_common_responses_option()
+        sumo_pages.question_page.click_on_a_particular_category_option(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_category"]
         )
-        sumo_pages.question_page._type_into_common_responses_search_field(
+        sumo_pages.question_page.type_into_common_responses_search_field(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
         )
         utilities.wait_for_given_timeout(3000)
 
     with allure.step("Verifying that the only item in the category field is the searched "
                      "option"):
-        response_options = sumo_pages.question_page._get_list_of_responses()
+        response_options = sumo_pages.question_page.get_list_of_responses()
         assert (
             len(response_options) == 1 and response_options[0] == utilities.
             aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
         )
 
     with allure.step("Clicking on the response option and on the 'Cancel' panel button"):
-        sumo_pages.question_page._click_on_a_particular_response_option(
+        sumo_pages.question_page.click_on_a_particular_response_option(
             utilities.aaq_question_test_data["valid_firefox_question"]
             ["common_responses_response"]
         )
-        sumo_pages.question_page._click_on_common_responses_cancel_button()
+        sumo_pages.question_page.click_on_common_responses_cancel_button()
 
     with check, allure.step("Verifying that the form textarea does not contain the common "
                             "response"):
-        assert sumo_pages.question_page._get_post_a_reply_textarea_value() == ""
+        assert sumo_pages.question_page.get_post_a_reply_textarea_value() == ""
 
     with allure.step("Clicking on the 'Common Responses' option and selecting a response "
                      "from the list"):
-        sumo_pages.question_page._click_on_common_responses_option()
-        sumo_pages.question_page._click_on_a_particular_category_option(
+        sumo_pages.question_page.click_on_common_responses_option()
+        sumo_pages.question_page.click_on_a_particular_category_option(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_category"]
         )
-        sumo_pages.question_page._type_into_common_responses_search_field(
+        sumo_pages.question_page.type_into_common_responses_search_field(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
         )
         utilities.wait_for_given_timeout(3000)
 
     with allure.step("Verifying that the only item in the category field is the searched "
                      "option"):
-        response_options = sumo_pages.question_page._get_list_of_responses()
+        response_options = sumo_pages.question_page.get_list_of_responses()
         assert (
             len(response_options) == 1 and response_options[0] == utilities
             .aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
         )
 
     with allure.step("Clicking on the response option"):
-        sumo_pages.question_page._click_on_a_particular_response_option(
+        sumo_pages.question_page.click_on_a_particular_response_option(
             utilities.aaq_question_test_data["valid_firefox_question"]["common_responses_response"]
         )
-        sumo_pages.question_page._click_on_switch_to_mode()
-        response = sumo_pages.question_page._get_text_of_response_preview()
+        sumo_pages.question_page.click_on_switch_to_mode()
+        response = sumo_pages.question_page.get_text_of_response_preview()
 
     with check, allure.step("Clicking on the Insert Response, post reply and verifying that "
                             "the reply was successfully posted and contains the correct data"):
-        sumo_pages.question_page._click_on_common_responses_insert_response_button()
+        sumo_pages.question_page.click_on_common_responses_insert_response_button()
         try:
-            reply_id = sumo_pages.question_page._click_on_post_reply_button(username)
+            reply_id = sumo_pages.question_page.click_on_post_reply_button(username)
         except TimeoutError:
-            reply_id = sumo_pages.question_page._click_on_post_reply_button(username)
-        assert sumo_pages.question_page._get_text_content_of_reply(
+            reply_id = sumo_pages.question_page.click_on_post_reply_button(username)
+        assert sumo_pages.question_page.get_text_content_of_reply(
             reply_id).strip() in response.strip()
 
     with allure.step("Signing in  with an admin account and deleting the posted question"):
@@ -1915,7 +1915,7 @@ def post_firefox_product_question_flow(page: Page, username: str):
 
         question_details = sumo_pages.aaq_flow.submit_an_aaq_question(
             subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_name=sumo_pages.aaq_form_page._get_aaq_form_topic_options()[0],
+            topic_name=sumo_pages.aaq_form_page.get_aaq_form_topic_options()[0],
             body=utilities.aaq_question_test_data["valid_firefox_question"]
             ["simple_body_text"],
             attach_image=False

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_article_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_article_page.py
@@ -33,22 +33,22 @@ def test_contribute_article_page_text(page: Page):
 
     with check, allure.step("Verifying that the page header is successfully displayed and "
                             "contains the correct strings"):
-        assert sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_main_header_text(
         ) == ContributeHelpArticlesMessages.HERO_PAGE_TITLE
 
     with check, allure.step("Verifying that the h2 is successfully displayed and contains "
                             "the correct strings"):
-        assert sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_second_header(
         ) == ContributeHelpArticlesMessages.HERO_SECOND_TITLE
 
     with check, allure.step("Verifying tha the paragraph under h2 is successfully displayed "
                             "and contains the correct strings"):
-        assert sumo_pages.ways_to_contribute_pages._get_hero_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_text(
         ) == ContributeHelpArticlesMessages.HERO_TEXT
 
     with check, allure.step("Verifying that the 'How you can contribute_messages' header is "
                             "successfully displayed and contains the correct strings"):
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_header_text(
         ) == ContributeHelpArticlesMessages.HOW_TO_CONTRIBUTE_HEADER
 
     # Need to add a check for the logged in state as well.
@@ -63,7 +63,7 @@ def test_contribute_article_page_text(page: Page):
 
     with check, allure.step("Verifying that the 'How you can contribute_messages' cards are "
                             "successfully expected"):
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_link_options(
         ) == card_titles
 
     with check, allure.step("Signing up with a FxA contributor account and Verifying that "
@@ -71,22 +71,22 @@ def test_contribute_article_page_text(page: Page):
                             "contains the expected string"):
         # We need to add here the check for when the user is signed in with a contributor
         # account
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_option_four(
         ) == ContributeHelpArticlesMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
 
     with check, allure.step("Verifying that the first line from the fact text is "
                             "successfully displayed and contains the expected string"):
-        assert sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_first_fact_text(
         ) == ContributeHelpArticlesMessages.FACT_FIRST_LINE
 
     with check, allure.step("Verifying that the second line from the fact section text is "
                             "successfully displayed and contains the expected string"):
-        assert sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_second_fact_text(
         ) == ContributeHelpArticlesMessages.FACT_SECOND_LINE
 
     with check, allure.step("Verifying that the 'Other ways to contribute_messages' header "
                             "is successfully displayed and contains the expected string"):
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_header(
         ) == ContributeHelpArticlesMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
     other_ways_to_contribute_card_titles = [
@@ -98,7 +98,7 @@ def test_contribute_article_page_text(page: Page):
 
     with check, allure.step("Verifying that the 'Other ways to contribute_messages' are "
                             "successfully displayed and in the correct order"):
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_cards(
         ) == other_ways_to_contribute_card_titles
 
 
@@ -112,7 +112,7 @@ def test_contribute_article_page_images_are_not_broken(page: Page):
             ContributeHelpArticlesMessages.STAGE_CONTRIBUTE_HELP_ARTICLES_PAGE_URL
         )
 
-    for link in sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
+    for link in sumo_pages.ways_to_contribute_pages.get_all_page_image_links():
         image_link = link.get_attribute("src")
         response = requests.get(image_link, stream=True)
         with check, allure.step(f"Verifying that {image_link} is not broken"):
@@ -136,14 +136,14 @@ def test_contribute_article_page_breadcrumbs(page: Page):
     ]
 
     with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs() == breadcrumbs
+        assert sumo_pages.ways_to_contribute_pages.get_text_of_all_breadcrumbs() == breadcrumbs
 
     counter = 1
-    for breadcrumb in sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
+    for breadcrumb in sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs():
         breadcrumb_to_click = (
-            sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs()[counter]
+            sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
+        sumo_pages.ways_to_contribute_pages.click_on_breadcrumb(breadcrumb_to_click)
 
         if counter == 1:
             with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
@@ -177,11 +177,11 @@ def test_contribute_article_other_ways_to_contribute_redirect_to_the_correct_pag
     ]
 
     counter = 0
-    for element in sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list():
+    for element in sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list():
         card = (
-            sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list()[counter]
+            sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
+        sumo_pages.ways_to_contribute_pages.click_on_other_way_to_contribute_card(card)
         with check, allure.step(f"Verifying that the {ways_to_contribute_links[counter]} "
                                 f"redirects to the correct page"):
             assert ways_to_contribute_links[counter] == utilities.get_page_url()

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_forum_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_forum_page.py
@@ -30,13 +30,13 @@ def test_contribute_forum_page_text(page: Page):
         utilities.navigate_to_link(ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL)
     with check, allure.step("Verifying that the Contribute Forum page contains the correct "
                             "strings"):
-        assert sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_main_header_text(
         ) == ContributeForumMessages.HERO_PAGE_TITLE
-        assert sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_second_header(
         ) == ContributeForumMessages.HERO_SECOND_TITLE
-        assert sumo_pages.ways_to_contribute_pages._get_hero_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_text(
         ) == ContributeForumMessages.HERO_TEXT
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_header_text(
         ) == ContributeForumMessages.HOW_TO_CONTRIBUTE_HEADER
 
         # Need to add a check for the logged in state as well.
@@ -49,18 +49,18 @@ def test_contribute_forum_page_text(page: Page):
             ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
         ]
 
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_link_options(
         ) == card_titles
 
         # We need to add here the check for when the user is signed in with a contributor
         # account
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_option_four(
         ) == ContributeForumMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
-        assert sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_first_fact_text(
         ) == ContributeForumMessages.FACT_FIRST_LINE
-        assert sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_second_fact_text(
         ) == ContributeForumMessages.FACT_SECOND_LINE
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_header(
         ) == ContributeForumMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
         other_ways_to_contribute_card_titles = [
@@ -69,7 +69,7 @@ def test_contribute_forum_page_text(page: Page):
             ContributeForumMessages.PROVIDE_SUPPORT_ON_SOCIAL_CHANNELS_CARD_TITLE,
             ContributeForumMessages.RESPOND_TO_MOBILE_STORE_REVIEWS_CARD_TITLE,
         ]
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_cards(
         ) == other_ways_to_contribute_card_titles
 
 
@@ -81,7 +81,7 @@ def test_contribute_forum_page_images_are_not_broken(page: Page):
     with allure.step("Accessing the Contribute Forum page"):
         utilities.navigate_to_link(ContributeForumMessages.STAGE_CONTRIBUTE_FORUM_PAGE_URL)
 
-    for link in sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
+    for link in sumo_pages.ways_to_contribute_pages.get_all_page_image_links():
         image_link = link.get_attribute("src")
         response = requests.get(image_link, stream=True)
         with check, allure.step(f"Verifying that the {image_link} link is not broken"):
@@ -103,14 +103,14 @@ def test_contribute_forum_page_breadcrumbs(page: Page):
     ]
 
     with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs() == breadcrumbs
+        assert sumo_pages.ways_to_contribute_pages.get_text_of_all_breadcrumbs() == breadcrumbs
 
     counter = 1
-    for breadcrumb in sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
+    for breadcrumb in sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs():
         breadcrumb_to_click = (
-            sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs()[counter]
+            sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
+        sumo_pages.ways_to_contribute_pages.click_on_breadcrumb(breadcrumb_to_click)
 
         if counter == 1:
             with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
@@ -142,11 +142,11 @@ def test_contribute_forum_other_ways_to_contribute_redirect_to_the_correct_page(
     ]
 
     counter = 0
-    for element in sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list():
+    for element in sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list():
         card = (
-            sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list()[counter]
+            sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
+        sumo_pages.ways_to_contribute_pages.click_on_other_way_to_contribute_card(card)
         with check, allure.step("Verifying that the 'other ways to contribute_messages' "
                                 "cards are redirecting to the correct SUMO page"):
             assert ways_to_contribute_links[counter] == utilities.get_page_url()

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_localization_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_localization_page.py
@@ -33,13 +33,13 @@ def test_contribute_localization_page_text(page: Page):
 
     with check, allure.step("Verifying that the Contribute localization page contains the "
                             "correct strings"):
-        assert sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_main_header_text(
         ) == ContributeLocalizationMessages.HERO_PAGE_TITLE
-        assert sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_second_header(
         ) == ContributeLocalizationMessages.HERO_SECOND_TITLE
-        assert sumo_pages.ways_to_contribute_pages._get_hero_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_text(
         ) == ContributeLocalizationMessages.HERO_TEXT
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_header_text(
         ) == ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_HEADER
 
         # Need to add a check for the logged in state as well.
@@ -51,15 +51,15 @@ def test_contribute_localization_page_text(page: Page):
             ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_THREE,
             ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
         ]
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_link_options(
         ) == card_titles
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_option_four(
         ) == ContributeLocalizationMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
-        assert sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_first_fact_text(
         ) == ContributeLocalizationMessages.FACT_FIRST_LINE
-        assert sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_second_fact_text(
         ) == ContributeLocalizationMessages.FACT_SECOND_LINE
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_header(
         ) == ContributeLocalizationMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
         other_ways_to_contribute_card_titles = [
@@ -68,7 +68,7 @@ def test_contribute_localization_page_text(page: Page):
             ContributeLocalizationMessages.PROVIDE_SUPPORT_ON_SOCIAL_CHANNELS_CARD_TITLE,
             ContributeLocalizationMessages.RESPOND_TO_MOBILE_STORE_REVIEWS_CARD_TITLE,
         ]
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_cards(
         ) == other_ways_to_contribute_card_titles
 
 
@@ -82,7 +82,7 @@ def test_contribute_localization_page_images_are_not_broken(page: Page):
             ContributeLocalizationMessages.STAGE_CONTRIBUTE_LOCALIZATION_PAGE_URL
         )
 
-    for link in sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
+    for link in sumo_pages.ways_to_contribute_pages.get_all_page_image_links():
         image_link = link.get_attribute("src")
         response = requests.get(image_link, stream=True)
         with check, allure.step(f"Verifying that the {image_link} is not broken"):
@@ -105,14 +105,14 @@ def test_contribute_localization_page_breadcrumbs(page: Page):
             ContributeLocalizationMessages.SECOND_BREADCRUMB,
             ContributeLocalizationMessages.THIRD_BREADCRUMB,
         ]
-        assert sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs() == breadcrumbs
+        assert sumo_pages.ways_to_contribute_pages.get_text_of_all_breadcrumbs() == breadcrumbs
 
     counter = 1
-    for breadcrumb in sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
+    for breadcrumb in sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs():
         breadcrumb_to_click = (
-            sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs()[counter]
+            sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
+        sumo_pages.ways_to_contribute_pages.click_on_breadcrumb(breadcrumb_to_click)
 
         if counter == 1:
             with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
@@ -148,11 +148,11 @@ def test_contribute_localization_other_ways_to_contribute_redirect_to_the_correc
     ]
 
     counter = 0
-    for element in sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list():
+    for element in sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list():
         card = (
-            sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list()[counter]
+            sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
+        sumo_pages.ways_to_contribute_pages.click_on_other_way_to_contribute_card(card)
         with check, allure.step("Verifying that the 'other ways to contribute_messages' "
                                 "cards are redirecting to the correct SUMO page"):
             assert ways_to_contribute_links[counter] == utilities.get_page_url()

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_mobile_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_mobile_page.py
@@ -33,13 +33,13 @@ def test_contribute_mobile_page_text(page: Page):
 
     with check, allure.step("Verifying that the Contribute Mobile Store page contains the "
                             "correct strings"):
-        assert sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_main_header_text(
         ) == ContributeMobileSupportMessages.HERO_PAGE_TITLE
-        assert sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_second_header(
         ) == ContributeMobileSupportMessages.HERO_SECOND_TITLE
-        assert sumo_pages.ways_to_contribute_pages._get_hero_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_text(
         ) == ContributeMobileSupportMessages.HERO_TEXT
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_header_text(
         ) == ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_HEADER
 
         # Need to add a check for the logged in state as well.
@@ -51,15 +51,15 @@ def test_contribute_mobile_page_text(page: Page):
             ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_THREE,
             ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FIVE,
         ]
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_link_options(
         ) == card_titles
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_option_four(
         ) == ContributeMobileSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
-        assert sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_first_fact_text(
         ) == ContributeMobileSupportMessages.FACT_FIRST_LINE
-        assert sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_second_fact_text(
         ) == ContributeMobileSupportMessages.FACT_SECOND_LINE
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_header(
         ) == ContributeMobileSupportMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
         other_ways_to_contribute_card_titles = [
@@ -68,7 +68,7 @@ def test_contribute_mobile_page_text(page: Page):
             ContributeMobileSupportMessages.LOCALIZE_CONTENT_CARD_TITLE,
             ContributeMobileSupportMessages.PROVIDE_SUPPORT_ON_SOCIAL_CHANNELS_CARD_TITLE,
         ]
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_cards(
         ) == other_ways_to_contribute_card_titles
 
 
@@ -82,7 +82,7 @@ def test_contribute_mobile_page_images_are_not_broken(page: Page):
             ContributeMobileSupportMessages.STAGE_CONTRIBUTE_MOBILE_SUPPORT_PAGE_URL
         )
 
-    for link in sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
+    for link in sumo_pages.ways_to_contribute_pages.get_all_page_image_links():
         image_link = link.get_attribute("src")
         response = requests.get(image_link, stream=True)
         with check, allure.step(f"Verifying that the {image_link} image is not broken"):
@@ -106,15 +106,15 @@ def test_contribute_mobile_page_breadcrumbs(page: Page):
     ]
 
     with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs(
+        assert sumo_pages.ways_to_contribute_pages.get_text_of_all_breadcrumbs(
         ) == breadcrumbs
 
     counter = 1
-    for breadcrumb in sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
+    for breadcrumb in sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs():
         breadcrumb_to_click = (
-            sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs()[counter]
+            sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
+        sumo_pages.ways_to_contribute_pages.click_on_breadcrumb(breadcrumb_to_click)
 
         if counter == 1:
             with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
@@ -149,11 +149,11 @@ def test_contribute_mobile_other_ways_to_contribute_redirect_to_the_correct_page
     ]
 
     counter = 0
-    for element in sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list():
+    for element in sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list():
         card = (
-            sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list()[counter]
+            sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
+        sumo_pages.ways_to_contribute_pages.click_on_other_way_to_contribute_card(card)
         with check, allure.step("Verifying that the 'other ways to contribute_messages' "
                                 "cards are redirecting to the correct SUMO page"):
             assert ways_to_contribute_links[counter] == utilities.get_page_url()

--- a/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_social_media_page.py
+++ b/playwright_tests/tests/contribute_tests/contribute_pages_tests/test_contribute_social_media_page.py
@@ -32,20 +32,20 @@ def test_contribute_social_page_text(page: Page):
         )
 
     with check, allure.step("Verifying that the correct hero main header is displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_hero_main_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_main_header_text(
         ) == ContributeSocialSupportMessages.HERO_PAGE_TITLE
 
     with check, allure.step("Verifying that the correct hero second header is displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_hero_second_header(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_second_header(
         ) == ContributeSocialSupportMessages.HERO_SECOND_TITLE
 
     with check, allure.step("Verifying that the correct get hero text is displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_hero_text(
+        assert sumo_pages.ways_to_contribute_pages.get_hero_text(
         ) == ContributeSocialSupportMessages.HERO_TEXT
 
     with check, allure.step("Verifying that the correct how to contribute_messages header "
                             "text is displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_header_text(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_header_text(
         ) == ContributeSocialSupportMessages.HOW_TO_CONTRIBUTE_HEADER
 
     # Need to add a check for the logged in state as well.
@@ -60,24 +60,24 @@ def test_contribute_social_page_text(page: Page):
 
     with check, allure.step("Verifying that the correct how to contribute_messages link "
                             "option are displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_link_options(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_link_options(
         ) == card_titles
 
     with check, allure.step("Verifying that the correct option four text is displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_how_to_contribute_option_four(
+        assert sumo_pages.ways_to_contribute_pages.get_how_to_contribute_option_four(
         ) == ContributeSocialSupportMessages.HOW_TO_CONTRIBUTE_OPTION_FOUR
 
     with check, allure.step("Verifying that the correct page first fact text is displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_first_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_first_fact_text(
         ) == ContributeSocialSupportMessages.FACT_FIRST_LINE
 
     with check, allure.step("Verifying that the correct second fact text is displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_second_fact_text(
+        assert sumo_pages.ways_to_contribute_pages.get_second_fact_text(
         ) == ContributeSocialSupportMessages.FACT_SECOND_LINE
 
     with check, allure.step("Verifying that the correct get other ways to "
                             "contribute_messages header is displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_header(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_header(
         ) == ContributeSocialSupportMessages.OTHER_WAYS_TO_CONTRIBUTE_HEADER
 
     other_ways_to_contribute_card_titles = [
@@ -89,7 +89,7 @@ def test_contribute_social_page_text(page: Page):
 
     with check, allure.step("Verifying that the other ways to contribute_messages card "
                             "titles are the correct ones"):
-        assert sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_cards(
+        assert sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_cards(
         ) == other_ways_to_contribute_card_titles
 
 
@@ -103,7 +103,7 @@ def test_contribute_social_page_images_are_not_broken(page: Page):
             ContributeSocialSupportMessages.STAGE_CONTRIBUTE_SOCIAL_SUPPORT_PAGE_URL
         )
 
-    for link in sumo_pages.ways_to_contribute_pages._get_all_page_image_links():
+    for link in sumo_pages.ways_to_contribute_pages.get_all_page_image_links():
         image_link = link.get_attribute("src")
         response = requests.get(image_link, stream=True)
         with check, allure.step(f"Verifying that the {image_link} image is not broken"):
@@ -127,14 +127,14 @@ def test_contribute_social_page_breadcrumbs(page: Page):
     ]
 
     with check, allure.step("Verifying that the correct breadcrumbs are displayed"):
-        assert sumo_pages.ways_to_contribute_pages._get_text_of_all_breadcrumbs() == breadcrumbs
+        assert sumo_pages.ways_to_contribute_pages.get_text_of_all_breadcrumbs() == breadcrumbs
 
     counter = 1
-    for breadcrumb in sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs():
+    for breadcrumb in sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs():
         breadcrumb_to_click = (
-            sumo_pages.ways_to_contribute_pages._get_interactable_breadcrumbs()[counter]
+            sumo_pages.ways_to_contribute_pages.get_interactable_breadcrumbs()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_breadcrumb(breadcrumb_to_click)
+        sumo_pages.ways_to_contribute_pages.click_on_breadcrumb(breadcrumb_to_click)
 
         if counter == 1:
             with check, allure.step("Verifying that the Contribute breadcrumb redirects to "
@@ -168,11 +168,11 @@ def test_contribute_social_other_ways_to_contribute_redirect_to_the_correct_page
     ]
 
     counter = 0
-    for element in sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list():
+    for element in sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list():
         card = (
-            sumo_pages.ways_to_contribute_pages._get_other_ways_to_contribute_card_list()[counter]
+            sumo_pages.ways_to_contribute_pages.get_other_ways_to_contribute_card_list()[counter]
         )
-        sumo_pages.ways_to_contribute_pages._click_on_other_way_to_contribute_card(card)
+        sumo_pages.ways_to_contribute_pages.click_on_other_way_to_contribute_card(card)
         with check, allure.step("Verifying that the 'other ways to contribute_messages'n "
                                 "cards are redirecting to the correct SUMO page"):
             assert ways_to_contribute_links[counter] == utilities.get_page_url()

--- a/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
@@ -78,7 +78,7 @@ def test_edit_profile_field_validation_with_symbols(page: Page, is_firefox):
                             "has changed"):
         sumo_pages.my_profile_page._click_on_my_profile_questions_link()
         sumo_pages.my_questions_page._click_on_a_question_by_index(1)
-        assert sumo_pages.question_page._get_question_author_name() == new_username
+        assert sumo_pages.question_page.get_question_author_name() == new_username
 
     with allure.step("Going back to the my profile page and reverting the username back to the "
                      "original one"):
@@ -99,7 +99,7 @@ def test_edit_profile_field_validation_with_symbols(page: Page, is_firefox):
                             "has changed"):
         sumo_pages.my_profile_page._click_on_my_profile_questions_link()
         sumo_pages.my_questions_page._click_on_a_question_by_index(1)
-        assert sumo_pages.question_page._get_question_author_name() == original_username
+        assert sumo_pages.question_page.get_question_author_name() == original_username
 
 
 # C1491017

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -95,15 +95,15 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page):
     with allure.step("Navigating to the previously posted question and posting a reply to it"):
         utilities.navigate_to_link(question_info["question_page_url"])
         question_test_data = utilities.question_test_data
-        sumo_pages.question_page._add_text_to_post_a_reply_textarea(
+        sumo_pages.question_page.add_text_to_post_a_reply_textarea(
             question_test_data["question_reply_solution"]
         )
-        answer_id = sumo_pages.question_page._click_on_post_reply_button(
+        answer_id = sumo_pages.question_page.click_on_post_reply_button(
             repliant_username=repliant_username
         )
 
     with allure.step("Marking the reply as the question solution"):
-        sumo_pages.question_page._click_on_solves_the_problem_button(target_reply_id=answer_id)
+        sumo_pages.question_page.click_on_solves_the_problem_button(target_reply_id=answer_id)
 
     with allure.step("Accessing the 'My profile' page of the account which provided the "
                      "solution and verifying that the original number of solutions has "
@@ -119,8 +119,8 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page):
     with allure.step("Deleting the posted question and verifying that we are redirected to "
                      "the product support forum page after deletion"):
         utilities.navigate_to_link(question_info["question_page_url"])
-        sumo_pages.question_page._click_delete_this_question_question_tools_option()
-        sumo_pages.question_page._click_delete_this_question_button()
+        sumo_pages.question_page.click_delete_this_question_question_tools_option()
+        sumo_pages.question_page.click_delete_this_question_button()
         expect(sumo_pages.product_support_page._product_product_title_element()).to_be_visible()
 
 
@@ -159,14 +159,14 @@ def test_number_of_my_profile_answers_is_successfully_displayed(page: Page):
     with allure.step("Posting a reply for the question"):
         question_test_data = utilities.question_test_data
         reply_text = question_test_data["non_solution_reply"]
-        sumo_pages.question_page._add_text_to_post_a_reply_textarea(reply_text)
-        answer_id = sumo_pages.question_page._click_on_post_reply_button(
+        sumo_pages.question_page.add_text_to_post_a_reply_textarea(reply_text)
+        answer_id = sumo_pages.question_page.click_on_post_reply_button(
             repliant_username=repliant_user
         )
 
     with allure.step("Accessing the 'My profile' page and verifying that the number of "
                      "answers has incremented successfully"):
-        sumo_pages.question_page._click_on_the_reply_author(answer_id)
+        sumo_pages.question_page.click_on_the_reply_author(answer_id)
         utilities.number_extraction_from_string(
             sumo_pages.my_profile_page._get_my_profile_answers_text()
         )
@@ -186,8 +186,8 @@ def test_number_of_my_profile_answers_is_successfully_displayed(page: Page):
     with allure.step("Deleting the posted question and verifying that the user is redirected "
                      "to the product support forum page"):
         utilities.navigate_to_link(question_info["question_page_url"])
-        sumo_pages.question_page._click_delete_this_question_question_tools_option()
-        sumo_pages.question_page._click_delete_this_question_button()
+        sumo_pages.question_page.click_delete_this_question_question_tools_option()
+        sumo_pages.question_page.click_delete_this_question_button()
         expect(sumo_pages.product_support_page._product_product_title_element()).to_be_visible()
 
 

--- a/playwright_tests/tests/user_page_tests/test_my_questions.py
+++ b/playwright_tests/tests/user_page_tests/test_my_questions.py
@@ -49,8 +49,8 @@ def test_number_of_questions_is_incremented_when_posting_a_question(page: Page):
 
     with allure.step("Deleting the posted question"):
         utilities.navigate_to_link(question_info["question_page_url"])
-        sumo_pages.question_page._click_delete_this_question_question_tools_option()
-        sumo_pages.question_page._click_delete_this_question_button()
+        sumo_pages.question_page.click_delete_this_question_question_tools_option()
+        sumo_pages.question_page.click_delete_this_question_button()
 
     with allure.step("Verifying that we are on the product support forum page after deletion"):
         expect(sumo_pages.product_support_page._product_product_title_element()).to_be_visible()
@@ -133,8 +133,8 @@ def test_correct_messages_is_displayed_if_user_has_no_posted_questions(page: Pag
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
         utilities.navigate_to_link(question_info["question_page_url"])
-        sumo_pages.question_page._click_delete_this_question_question_tools_option()
-        sumo_pages.question_page._click_delete_this_question_button()
+        sumo_pages.question_page.click_delete_this_question_question_tools_option()
+        sumo_pages.question_page.click_delete_this_question_button()
 
     with allure.step("Accessing the original user and verifying that the correct message is "
                      "displayed"):


### PR DESCRIPTION
- Mark the aaq_form_page, questions_page, ways_to_contribute_pages page classes functions as public and replace super() with self.
- Use composition instead of inheritance for the aaq_flow.py class.
- Updating modified function calls in tests.