### PR TITLE
Playwright refactor auth flow related classes

### DIFF
--- a/playwright_tests/flows/auth_flows/auth_flow.py
+++ b/playwright_tests/flows/auth_flows/auth_flow.py
@@ -1,47 +1,50 @@
 from playwright_tests.core.utilities import Utilities
 from playwright_tests.pages.auth_page import AuthPage
-from playwright_tests.pages.homepage import Homepage
+from playwright.sync_api import Page
 
 
-class AuthFlowPage(Utilities, AuthPage, Homepage):
+class AuthFlowPage:
+
+    def __init__(self, page: Page):
+        self.utilities = Utilities(page)
+        self.auth_page = AuthPage(page)
+
     # Providing OTP code to FxA auth.
     def __provide_otp_code(self, otp_code: str):
-        super()._add_data_to_otp_code_input_field(otp_code)
-        super()._click_on_otp_code_confirm_button()
+        self.auth_page.add_data_to_otp_code_input_field(otp_code)
+        self.auth_page.click_on_otp_code_confirm_button()
 
     # Providing the needed login credentials to FxA auth.
     def __provide_login_credentials_and_submit(self, username: str, password: str):
-        super()._add_data_to_email_input_field(username)
-        super()._click_on_enter_your_email_submit_button()
+        self.auth_page.add_data_to_email_input_field(username)
+        self.auth_page.click_on_enter_your_email_submit_button()
 
-        if super()._is_logged_in_sign_in_button_displayed():
-            super()._click_on_user_logged_in_sign_in_button()
+        if self.auth_page.is_logged_in_sign_in_button_displayed():
+            self.auth_page.click_on_user_logged_in_sign_in_button()
         else:
-            super()._add_data_to_password_input_field(password)
-            super()._click_on_enter_your_password_submit_button()
+            self.auth_page.add_data_to_password_input_field(password)
+            self.auth_page.click_on_enter_your_password_submit_button()
 
     def login_with_existing_session(self):
-        if super()._is_continue_with_firefox_button_displayed():
-            super()._click_on_continue_with_firefox_accounts_button()
-        super()._click_on_user_logged_in_sign_in_button()
+        if self.auth_page.is_continue_with_firefox_button_displayed():
+            self.auth_page.click_on_continue_with_firefox_accounts_button()
+        self.auth_page.click_on_user_logged_in_sign_in_button()
 
     # Sign in flow.
-    def sign_in_flow(
-        self, username: str, account_password: str
-    ) -> str:
-
+    def sign_in_flow(self, username: str, account_password: str) -> str:
         # Forcing an email clearance
-        super().clear_fxa_email(username)
+        self.utilities.clear_fxa_email(username)
 
-        if super()._is_continue_with_firefox_button_displayed():
-            super()._click_on_continue_with_firefox_accounts_button()
+        if self.auth_page.is_continue_with_firefox_button_displayed():
+            self.auth_page.click_on_continue_with_firefox_accounts_button()
 
-        if super()._is_use_a_different_account_button_displayed():
-            super()._click_on_use_a_different_account_button()
+        if self.auth_page.is_use_a_different_account_button_displayed():
+            self.auth_page.click_on_use_a_different_account_button()
 
         self.__provide_login_credentials_and_submit(username, account_password)
 
-        if super()._is_enter_otp_code_input_field_displayed():
-            self.__provide_otp_code(super().get_fxa_verification_code(fxa_username=username))
+        if self.auth_page.is_enter_otp_code_input_field_displayed():
+            self.__provide_otp_code(self.utilities.get_fxa_verification_code(
+                fxa_username=username))
 
         return username

--- a/playwright_tests/pages/auth_page.py
+++ b/playwright_tests/pages/auth_page.py
@@ -35,53 +35,53 @@ class AuthPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
-    def _click_on_cant_sign_in_to_my_mozilla_account_link(self):
-        super()._click(self.__cant_sign_in_to_my_Mozilla_account_link)
+    def click_on_cant_sign_in_to_my_mozilla_account_link(self):
+        self._click(self.__cant_sign_in_to_my_Mozilla_account_link)
 
-    def _click_on_continue_with_firefox_accounts_button(self):
-        super()._click(self.__continue_with_firefox_accounts_button)
+    def click_on_continue_with_firefox_accounts_button(self):
+        self._click(self.__continue_with_firefox_accounts_button)
 
-    def _click_on_use_a_different_account_button(self):
-        super()._click(self.__use_a_different_account_button)
+    def click_on_use_a_different_account_button(self):
+        self._click(self.__use_a_different_account_button)
 
-    def _click_on_user_logged_in_sign_in_button(self):
-        super()._click(self.__user_logged_in_sign_in_button)
+    def click_on_user_logged_in_sign_in_button(self):
+        self._click(self.__user_logged_in_sign_in_button)
 
-    def _click_on_enter_your_email_submit_button(self):
-        super()._click(self.__enter_your_email_submit_button)
+    def click_on_enter_your_email_submit_button(self):
+        self._click(self.__enter_your_email_submit_button)
 
-    def _click_on_enter_your_password_submit_button(self):
-        super()._click(self.__enter_your_password_submit_button)
+    def click_on_enter_your_password_submit_button(self):
+        self._click(self.__enter_your_password_submit_button)
 
-    def _click_on_otp_code_confirm_button(self):
-        super()._click(self.__enter_otp_code_confirm_button)
+    def click_on_otp_code_confirm_button(self):
+        self._click(self.__enter_otp_code_confirm_button)
 
-    def _add_data_to_email_input_field(self, text: str):
-        super()._fill(self.__enter_your_email_input_field, text)
+    def add_data_to_email_input_field(self, text: str):
+        self._fill(self.__enter_your_email_input_field, text)
 
-    def _add_data_to_password_input_field(self, text: str):
-        super()._fill(self.__enter_your_password_input_field, text)
+    def add_data_to_password_input_field(self, text: str):
+        self._fill(self.__enter_your_password_input_field, text)
 
-    def _add_data_to_otp_code_input_field(self, text: str):
-        super()._fill(self.__enter_otp_code_input_field, text)
+    def add_data_to_otp_code_input_field(self, text: str):
+        self._fill(self.__enter_otp_code_input_field, text)
 
-    def _clear_email_input_field(self):
-        super()._clear_field(self.__enter_your_email_input_field)
+    def clear_email_input_field(self):
+        self._clear_field(self.__enter_your_email_input_field)
 
-    def _is_use_a_different_account_button_displayed(self) -> bool:
-        super()._wait_for_selector(self.__use_a_different_account_button)
-        return super()._is_element_visible(self.__use_a_different_account_button)
+    def is_use_a_different_account_button_displayed(self) -> bool:
+        self._wait_for_selector(self.__use_a_different_account_button)
+        return self._is_element_visible(self.__use_a_different_account_button)
 
-    def _is_logged_in_sign_in_button_displayed(self) -> bool:
-        return super()._is_element_visible(self.__user_logged_in_sign_in_button)
+    def is_logged_in_sign_in_button_displayed(self) -> bool:
+        return self._is_element_visible(self.__user_logged_in_sign_in_button)
 
-    def _is_enter_otp_code_input_field_displayed(self) -> bool:
-        super()._wait_for_selector(self.__continue_with_firefox_accounts_button)
-        return super()._is_element_visible(self.__enter_otp_code_input_field)
+    def is_enter_otp_code_input_field_displayed(self) -> bool:
+        self._wait_for_selector(self.__continue_with_firefox_accounts_button)
+        return self._is_element_visible(self.__enter_otp_code_input_field)
 
-    def _is_continue_with_firefox_button_displayed(self) -> bool:
-        super()._wait_for_selector(self.__continue_with_firefox_accounts_button)
-        return super()._is_element_visible(self.__continue_with_firefox_accounts_button)
+    def is_continue_with_firefox_button_displayed(self) -> bool:
+        self._wait_for_selector(self.__continue_with_firefox_accounts_button)
+        return self._is_element_visible(self.__continue_with_firefox_accounts_button)
 
-    def _get_continue_with_firefox_button_locator(self) -> Locator:
-        return super()._get_element_locator(self.__continue_with_firefox_accounts_button)
+    def get_continue_with_firefox_button_locator(self) -> Locator:
+        return self._get_element_locator(self.__continue_with_firefox_accounts_button)

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -507,7 +507,7 @@ def test_loginless_mozilla_account_aaq(page: Page):
         i = 1
         while i <= 4:
             sumo_pages.top_navbar.click_on_signin_signup_button()
-            sumo_pages.auth_page._click_on_cant_sign_in_to_my_mozilla_account_link()
+            sumo_pages.auth_page.click_on_cant_sign_in_to_my_mozilla_account_link()
             sumo_pages.aaq_flow.submit_an_aaq_question(
                 subject=utilities.aaq_question_test_data['premium_aaq_question']['subject'],
                 body=utilities.aaq_question_test_data['premium_aaq_question']['body'],

--- a/playwright_tests/tests/test_prerequisites_login.py
+++ b/playwright_tests/tests/test_prerequisites_login.py
@@ -17,7 +17,7 @@ def test_create_user_sessions_for_test_accounts(page: Page):
 
         # Also acts as a wait. Introduced in order to avoid flakiness which occurred on some
         # GH runs.
-        expect(sumo_pages.auth_page._get_continue_with_firefox_button_locator()).to_be_visible()
+        expect(sumo_pages.auth_page.get_continue_with_firefox_button_locator()).to_be_visible()
 
         sumo_pages.auth_flow_page.sign_in_flow(
             username=utilities.user_secrets_accounts[keys[i]],

--- a/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
@@ -932,7 +932,7 @@ def test_edit_user_profile_button_is_not_displayed_for_non_admin_users(page: Pag
             EditMyProfilePageMessages.get_url_of_other_profile_edit_page(target_username)
         )
         assert (
-            sumo_pages.auth_page._is_continue_with_firefox_button_displayed()
+            sumo_pages.auth_page.is_continue_with_firefox_button_displayed()
         ), "The auth page is not displayed! It should be!"
         expect(sumo_pages.edit_my_profile_page.is_my_profile_edit_form_displayed()).to_be_hidden()
 
@@ -1021,7 +1021,7 @@ def test_private_message_button_redirects_non_signed_in_users_to_the_fxa_login_f
                      "in user is redirected to the fxa page"):
         sumo_pages.my_profile_page._click_on_private_message_button()
         assert (
-            sumo_pages.auth_page._is_continue_with_firefox_button_displayed()
+            sumo_pages.auth_page.is_continue_with_firefox_button_displayed()
         ), "The auth page is not displayed! It should be!"
 
 


### PR DESCRIPTION
- Mark the auth_page class functions as public and replace super() with self.
- Use composition instead of inheritance for the auth_flow.py class.
- Updating modified function calls in tests.