### PR TITLE
Playwright refactor kb article related flows and classes

### DIFF
--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
@@ -16,11 +16,17 @@ from playwright_tests.pages.explore_help_articles.articles.submit_kb_article_pag
     SubmitKBArticlePage)
 
 
-class AddKbArticleFlow(Utilities, SubmitKBArticlePage, AddKbMediaFlow, KBArticlePage,
-                       KBArticleShowHistoryPage, KBArticleReviewRevisionPage, EditKBArticlePage):
+class AddKbArticleFlow:
 
     def __init__(self, page: Page):
-        super().__init__(page)
+        self.page = page
+        self.utilities = Utilities(page)
+        self.submit_kb_article_page = SubmitKBArticlePage(page)
+        self.add_media_flow = AddKbMediaFlow(page)
+        self.kb_article_page = KBArticlePage(page)
+        self.kb_article_show_history_page = KBArticleShowHistoryPage(page)
+        self.kb_article_review_revision_page = KBArticleReviewRevisionPage(page)
+        self.edit_kb_article_page = EditKBArticlePage(page)
 
     def submit_simple_kb_article(self,
                                  article_title=None,
@@ -44,53 +50,51 @@ class AddKbArticleFlow(Utilities, SubmitKBArticlePage, AddKbMediaFlow, KBArticle
                                  ) -> dict[str, Any]:
         self.page.goto(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
 
-        kb_article_test_data = super().kb_article_test_data
+        kb_article_test_data = self.utilities.kb_article_test_data
 
         if restricted_to_groups is not None:
             for group in restricted_to_groups:
-                super()._add_and_select_restrict_visibility_group(group)
+                self.submit_kb_article_page.add_and_select_restrict_visibility_group(group)
         if single_group != "":
-            super()._add_and_select_restrict_visibility_group(single_group)
+            self.submit_kb_article_page.add_and_select_restrict_visibility_group(single_group)
 
         if article_title is None:
             if is_template:
-                kb_article_title = (kb_article_test_data["kb_template_title"] + self.
+                kb_article_title = (kb_article_test_data["kb_template_title"] + self.utilities.
                                     generate_random_number(0, 5000))
             else:
-                kb_article_title = (kb_article_test_data["kb_article_title"] + self.
+                kb_article_title = (kb_article_test_data["kb_article_title"] + self.utilities.
                                     generate_random_number(0, 5000))
         else:
             kb_article_title = article_title
 
         if kb_article_title != "":
-            super()._add_text_to_article_form_title_field(
+            self.submit_kb_article_page.add_text_to_article_form_title_field(
                 kb_article_title
             )
 
         if (article_slug is not None) and (article_slug != ""):
             kb_article_slug = article_slug
-            super()._add_text_to_article_slug_field(kb_article_slug)
+            self.submit_kb_article_page.add_text_to_article_slug_field(kb_article_slug)
 
         if article_category is None:
             if is_template:
                 article_category = kb_article_test_data["kb_template_category"]
-                super()._select_category_option_by_text(
+                self.submit_kb_article_page.select_category_option_by_text(
                     article_category
                 )
             else:
                 article_category = kb_article_test_data["category_options"]
-                super()._select_category_option_by_text(article_category)
+                self.submit_kb_article_page.select_category_option_by_text(article_category)
         else:
-            super()._select_category_option_by_text(article_category)
+            self.submit_kb_article_page.select_category_option_by_text(article_category)
 
         if not allow_translations:
-            super()._check_allow_translations_checkbox()
+            self.submit_kb_article_page.check_allow_translations_checkbox()
 
         product = kb_article_test_data["relevant_to_product"]
         if selected_product is True:
-            super()._click_on_a_particular_product(
-                product
-            )
+            self.submit_kb_article_page.click_on_a_particular_product(product)
 
         article_topic = [
             kb_article_test_data["selected_parent_topic"],
@@ -99,59 +103,64 @@ class AddKbArticleFlow(Utilities, SubmitKBArticlePage, AddKbMediaFlow, KBArticle
 
         # Adding Article topic
         if selected_topics is True:
-            super()._click_on_a_particular_parent_topic_checkbox(
+            self.submit_kb_article_page.click_on_a_particular_parent_topic_checkbox(
                 article_topic[0]
             )
-            super()._click_on_a_particular_child_topic_checkbox(
+            self.submit_kb_article_page.click_on_a_particular_child_topic_checkbox(
                 article_topic[0],
                 article_topic[1],
             )
 
         # Interacting with Allow Discussion checkbox
-        if (allow_discussion is True) and (super(
-        )._is_allow_discussion_on_article_checkbox_checked() is False):
-            super()._check_allow_discussion_on_article_checkbox()
-        elif (allow_discussion is False) and (super(
-        )._is_allow_discussion_on_article_checkbox_checked() is True):
-            super()._check_allow_discussion_on_article_checkbox()
+        if (allow_discussion is True) and (
+            self.submit_kb_article_page
+                .is_allow_discussion_on_article_checkbox_checked() is False):
+            self.submit_kb_article_page.check_allow_discussion_on_article_checkbox()
+        elif (allow_discussion is False) and (
+            self.submit_kb_article_page
+                .is_allow_discussion_on_article_checkbox_checked() is True):
+            self.submit_kb_article_page.check_allow_discussion_on_article_checkbox()
 
-        super()._add_text_to_related_documents_field(kb_article_test_data["related_documents"])
+        self.submit_kb_article_page.add_text_to_related_documents_field(
+            kb_article_test_data["related_documents"])
 
         keyword = None
         if article_keyword is None:
-            super()._add_text_to_keywords_field(kb_article_test_data["keywords"])
+            self.submit_kb_article_page.add_text_to_keywords_field(
+                kb_article_test_data["keywords"])
             keyword = kb_article_test_data["keywords"]
         else:
-            super()._add_text_to_keywords_field(article_keyword)
+            self.submit_kb_article_page.add_text_to_keywords_field(article_keyword)
             keyword = article_keyword
 
         summary = None
         if search_summary is None:
-            super()._add_text_to_search_result_summary_field(
+            self.submit_kb_article_page.add_text_to_search_result_summary_field(
                 kb_article_test_data["search_result_summary"]
             )
             summary = kb_article_test_data["search_result_summary"]
         else:
-            super()._add_text_to_search_result_summary_field(
+            self.submit_kb_article_page.add_text_to_search_result_summary_field(
                 search_summary
             )
             summary = search_summary
 
-        if not super()._is_content_textarea_displayed():
-            super()._click_on_toggle_syntax_highlight_option()
+        if not self.submit_kb_article_page.is_content_textarea_displayed():
+            self.submit_kb_article_page.click_on_toggle_syntax_highlight_option()
 
         if article_content is None:
-            super()._add_text_to_content_textarea(kb_article_test_data["article_content"])
+            self.submit_kb_article_page.add_text_to_content_textarea(
+                kb_article_test_data["article_content"])
 
         if article_content_image != '':
-            super()._click_on_insert_media_button()
-            super().add_media_to_kb_article(
+            self.submit_kb_article_page.click_on_insert_media_button()
+            self.add_media_flow.add_media_to_kb_article(
                 file_type="Image",
                 file_name=article_content_image
             )
 
         if expiry_date is not None:
-            super()._add_text_to_expiry_date_field(expiry_date)
+            self.submit_kb_article_page.add_text_to_expiry_date_field(expiry_date)
 
         # We need to evaluate in order to fetch the slug field value
         slug = self.page.evaluate(
@@ -163,22 +172,22 @@ class AddKbArticleFlow(Utilities, SubmitKBArticlePage, AddKbMediaFlow, KBArticle
             # If title and slug are empty we are not reaching the description field.
             if ((article_title != '') and (article_slug != '') and (
                     search_summary != "") and (article_content != "")):
-                super()._click_on_submit_for_review_button()
-                super()._add_text_to_changes_description_field(
+                self.submit_kb_article_page.click_on_submit_for_review_button()
+                self.submit_kb_article_page.add_text_to_changes_description_field(
                     kb_article_test_data["changes_description"]
                 )
-                super()._click_on_changes_submit_button()
+                self.submit_kb_article_page.click_on_changes_submit_button()
                 try:
-                    first_revision_id = super()._get_last_revision_id()
+                    first_revision_id = self.kb_article_show_history_page.get_last_revision_id()
                 except IndexError:
                     print("Chances are that the form was not submitted successfully")
             else:
-                super()._click_on_submit_for_review_button()
+                self.submit_kb_article_page.click_on_submit_for_review_button()
 
-        article_url = super()._get_article_page_url()
+        article_url = self.submit_kb_article_page.get_article_page_url()
 
         if approve_first_revision:
-            super()._click_on_show_history_option()
+            self.kb_article_page.click_on_show_history_option()
             if ready_for_localization:
                 self.approve_kb_revision(first_revision_id, ready_for_l10n=True)
             else:
@@ -205,33 +214,33 @@ class AddKbArticleFlow(Utilities, SubmitKBArticlePage, AddKbMediaFlow, KBArticle
                             ready_for_l10n=False,
                             significance_type=''):
         if (KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT not in
-                super()._get_current_page_url()):
-            super()._click_on_show_history_option()
+                self.utilities.get_page_url()):
+            self.kb_article_page.click_on_show_history_option()
 
-        super()._click_on_review_revision(
+        self.kb_article_show_history_page.click_on_review_revision(
             revision_id
         )
-        super()._click_on_approve_revision_button()
+        self.kb_article_review_revision_page.click_on_approve_revision_button()
 
         if revision_needs_change:
-            if not super()._is_needs_change_checkbox_checked():
-                super()._click_on_needs_change_checkbox()
-            super()._add_text_to_needs_change_comment(
-                super().kb_revision_test_data['needs_change_message']
+            if not self.kb_article_review_revision_page.is_needs_change_checkbox_checked():
+                self.kb_article_review_revision_page.click_on_needs_change_checkbox()
+            self.kb_article_review_revision_page.add_text_to_needs_change_comment(
+                self.utilities.kb_revision_test_data['needs_change_message']
             )
 
         if ready_for_l10n:
-            super()._check_ready_for_localization_checkbox()
+            self.kb_article_review_revision_page.check_ready_for_localization_checkbox()
 
         if significance_type != '':
             if significance_type == 'minor':
-                super()._click_on_minor_significance_option()
+                self.kb_article_review_revision_page.click_on_minor_significance_option()
             if significance_type == 'normal':
-                super()._click_on_normal_significance_option()
+                self.kb_article_review_revision_page.click_on_normal_significance_option()
             if significance_type == 'major':
-                super()._click_on_major_significance_option()
+                self.kb_article_review_revision_page.click_on_major_significance_option()
 
-        super()._click_accept_revision_accept_button()
+        self.kb_article_review_revision_page.click_accept_revision_accept_button()
 
     def submit_new_kb_revision(self,
                                keywords=None,
@@ -243,62 +252,63 @@ class AddKbArticleFlow(Utilities, SubmitKBArticlePage, AddKbMediaFlow, KBArticle
                                approve_revision=False
                                ) -> dict[str, Any]:
 
-        super()._click_on_edit_article_option()
+        self.kb_article_page.click_on_edit_article_option()
 
         # Only admin accounts can update article keywords.
         if is_admin:
             # Keywords step.
             if keywords is None:
-                super()._fill_edit_article_keywords_field(
-                    self.kb_article_test_data['updated_keywords']
+                self.edit_kb_article_page.fill_edit_article_keywords_field(
+                    self.utilities.kb_article_test_data['updated_keywords']
                 )
             else:
-                super()._fill_edit_article_keywords_field(keywords)
+                self.edit_kb_article_page.fill_edit_article_keywords_field(keywords)
 
         # Search Result Summary step.
         if search_result_summary is None:
-            super()._fill_edit_article_search_result_summary_field(
-                self.kb_article_test_data['updated_search_result_summary']
+            self.edit_kb_article_page.fill_edit_article_search_result_summary_field(
+                self.utilities.kb_article_test_data['updated_search_result_summary']
             )
         else:
-            super()._fill_edit_article_search_result_summary_field(search_result_summary)
+            self.edit_kb_article_page.fill_edit_article_search_result_summary_field(
+                search_result_summary)
 
         # Content step.
         if content is None:
-            super()._fill_edit_article_content_field(
-                self.kb_article_test_data['updated_article_content']
+            self.edit_kb_article_page.fill_edit_article_content_field(
+                self.utilities.kb_article_test_data['updated_article_content']
             )
         else:
-            super()._fill_edit_article_content_field(content)
+            self.edit_kb_article_page.fill_edit_article_content_field(content)
 
         # Expiry date step.
         if expiry_date is None:
-            super()._fill_edit_article_expiry_date(
-                self.kb_article_test_data['updated_expiry_date']
+            self.edit_kb_article_page.fill_edit_article_expiry_date(
+                self.utilities.kb_article_test_data['updated_expiry_date']
             )
         else:
-            super()._fill_edit_article_expiry_date(expiry_date)
+            self.edit_kb_article_page.fill_edit_article_expiry_date(expiry_date)
 
         # Submitting for preview steps
-        super()._click_submit_for_review_button()
+        self.edit_kb_article_page.click_submit_for_review_button()
 
         if changes_description is None:
-            super()._fill_edit_article_changes_panel_comment(
-                self.kb_article_test_data['changes_description']
+            self.edit_kb_article_page.fill_edit_article_changes_panel_comment(
+                self.utilities.kb_article_test_data['changes_description']
             )
         else:
-            super()._fill_edit_article_changes_panel_comment(changes_description)
+            self.edit_kb_article_page.fill_edit_article_changes_panel_comment(changes_description)
 
-        super()._click_edit_article_changes_panel_submit_button()
+        self.edit_kb_article_page.click_edit_article_changes_panel_submit_button()
 
-        revision_id = super()._get_last_revision_id()
+        revision_id = self.kb_article_show_history_page.get_last_revision_id()
 
         if approve_revision:
             self.approve_kb_revision(revision_id)
 
-        revision_time = super()._get_revision_time(revision_id)
+        revision_time = self.kb_article_show_history_page.get_revision_time(revision_id)
 
         return {"revision_id": revision_id,
                 "revision_time": revision_time,
-                "changes_description": self.kb_article_test_data['changes_description']
+                "changes_description": self.utilities.kb_article_test_data['changes_description']
                 }

--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_media_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_media_flow.py
@@ -3,14 +3,14 @@ from playwright.sync_api import Page
 from playwright_tests.pages.contribute.contributor_tools_pages.media_gallery import MediaGallery
 
 
-class AddKbMediaFlow(MediaGallery):
+class AddKbMediaFlow:
     def __init__(self, page: Page):
-        super().__init__(page)
+        self.media_gallery_page = MediaGallery(page)
 
     def add_media_to_kb_article(self, file_type, file_name):
         if file_type == 'Videos':
-            super()._click_on_videos_filter()
+            self.media_gallery_page.click_on_videos_filter()
 
-        super()._fill_search_modal_gallery_searchbox_input_field(file_name)
-        super()._select_media_file_from_list(file_name, is_modal=True)
-        super()._click_on_insert_media_button()
+        self.media_gallery_page.fill_search_modal_gallery_searchbox_input_field(file_name)
+        self.media_gallery_page.select_media_file_from_list(file_name, is_modal=True)
+        self.media_gallery_page.click_on_insert_media_button()

--- a/playwright_tests/flows/explore_articles_flows/article_flows/delete_kb_article_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/delete_kb_article_flow.py
@@ -15,7 +15,7 @@ class DeleteKbArticleFlow(Utilities, KBArticleShowHistoryPage, KBArticlePage, To
     def delete_kb_article(self):
         # If the delete button is not displayed we presume that we are not on the show history page
         # Clicking on the 'Show History' page.
-        if not super()._is_delete_button_displayed():
-            super()._click_on_show_history_option()
-        super()._click_on_delete_this_document_button()
-        super()._click_on_confirmation_delete_button()
+        if not super().is_delete_button_displayed():
+            super().click_on_show_history_option()
+        super().click_on_delete_this_document_button()
+        super().click_on_confirmation_delete_button()

--- a/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
@@ -29,7 +29,7 @@ class EditArticleMetaFlow(Utilities, KBArticleEditMetadata, SubmitKBArticlePage,
                               single_group=""):
 
         if KBArticleRevision.KB_EDIT_METADATA not in self._get_current_page_url():
-            self._click_on_edit_article_metadata()
+            self.click_on_edit_article_metadata()
 
         if restricted_to_groups:
             for group in restricted_to_groups:
@@ -51,12 +51,12 @@ class EditArticleMetaFlow(Utilities, KBArticleEditMetadata, SubmitKBArticlePage,
 
         if topics:
             if isinstance(topics, list):
-                self._click_on_a_particular_child_topic_checkbox(
+                self.click_on_a_particular_child_topic_checkbox(
                     topics[0],
                     topics[1],
                 )
             else:
-                self._click_on_a_particular_parent_topic_checkbox(
+                self.click_on_a_particular_parent_topic_checkbox(
                     topics
                 )
 
@@ -92,7 +92,7 @@ class EditArticleMetaFlow(Utilities, KBArticleEditMetadata, SubmitKBArticlePage,
 
     def _remove_a_restricted_visibility_group(self, group_name=''):
         if KBArticleRevision.KB_EDIT_METADATA not in self._get_current_page_url():
-            self._click_on_edit_article_metadata()
+            self.click_on_edit_article_metadata()
 
         self._delete_a_restricted_visibility_group_metadata(group_name)
         self._click_on_save_changes_button()

--- a/playwright_tests/flows/explore_articles_flows/article_flows/kb_article_threads_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/kb_article_threads_flow.py
@@ -21,8 +21,8 @@ class KbThreads(Utilities, KBArticleDiscussionPage, KBArticlePage):
             super()._click_on_delete_this_thread_reply_confirmation_button()
 
     def add_new_kb_discussion_thread(self, title='') -> [dict[str, Any]]:
-        super()._click_on_editing_tools_discussion_option()
-        article_discussion_url = super()._get_url()
+        super().click_on_editing_tools_discussion_option()
+        article_discussion_url = super().get_url()
         super()._click_on_post_a_new_thread_option()
         if title == '':
             thread_title = (super().kb_new_thread_test_data['new_thread_title'] + super()
@@ -71,7 +71,7 @@ class KbThreads(Utilities, KBArticleDiscussionPage, KBArticlePage):
             super()._click_on_thread_post_reply_button()
 
         return {
-            "reply_id": super()._get_thread_reply_id(super()._get_url())
+            "reply_id": super()._get_thread_reply_id(super().get_url())
         }
 
     def delete_reply_to_thread(self, reply_id: str, submit_deletion=True):

--- a/playwright_tests/flows/explore_articles_flows/article_flows/kb_localization_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/kb_localization_flow.py
@@ -73,7 +73,7 @@ class KbArticleTranslationFlow(TranslateArticlePage, Utilities, SubmitKBArticleP
             )
             super()._click_on_description_submit_button()
 
-        first_revision_id = super()._get_last_revision_id()
+        first_revision_id = super().get_last_revision_id()
         if approve_translation_revision:
             self.approve_kb_translation(first_revision_id)
 
@@ -87,8 +87,8 @@ class KbArticleTranslationFlow(TranslateArticlePage, Utilities, SubmitKBArticleP
         }
 
     def approve_kb_translation(self, revision_id: str):
-        super()._click_on_review_revision(
+        super().click_on_review_revision(
             revision_id
         )
-        super()._click_on_approve_revision_button()
-        super()._click_accept_revision_accept_button()
+        super().click_on_approve_revision_button()
+        super().click_accept_revision_accept_button()

--- a/playwright_tests/pages/contribute/contributor_tools_pages/media_gallery.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/media_gallery.py
@@ -29,73 +29,73 @@ class MediaGallery(BasePage):
         super().__init__(page)
 
     # Media Gallery page actions.
-    def _click_on_upload_a_new_media_file_button(self):
-        super()._click(self.__upload_a_new_media_file_button)
+    def click_on_upload_a_new_media_file_button(self):
+        self._click(self.__upload_a_new_media_file_button)
 
     # Media Gallery image preview actions.
-    def _get_image_heading(self) -> str:
-        return super()._get_text_of_element(self.__image_heading)
+    def get_image_heading(self) -> str:
+        return self._get_text_of_element(self.__image_heading)
 
-    def _get_image_creator_text(self) -> str:
-        return super()._get_text_of_element(self.__image_creator)
+    def get_image_creator_text(self) -> str:
+        return self._get_text_of_element(self.__image_creator)
 
-    def _click_on_image_creator_link(self):
-        super()._click(self.__image_creator)
+    def click_on_image_creator_link(self):
+        self._click(self.__image_creator)
 
-    def _get_image_description(self) -> str:
-        return super()._get_text_of_element(self.__image_description)
+    def get_image_description(self) -> str:
+        return self._get_text_of_element(self.__image_description)
 
-    def _get_image_in_documents_text(self) -> str:
-        return super()._get_text_of_element(self.__image_in_documents_text)
+    def get_image_in_documents_text(self) -> str:
+        return self._get_text_of_element(self.__image_in_documents_text)
 
-    def _get_image_in_documents_list_items_text(self) -> list[str]:
-        return super()._get_text_of_elements(self.__image_in_documents_list)
+    def get_image_in_documents_list_items_text(self) -> list[str]:
+        return self._get_text_of_elements(self.__image_in_documents_list)
 
-    def _click_on_a_linked_in_document(self, document_name: str):
-        super()._click(f"//div[@class='documents']//li/a[text()='{document_name}']")
+    def click_on_a_linked_in_document(self, document_name: str):
+        self._click(f"//div[@class='documents']//li/a[text()='{document_name}']")
 
-    def _click_on_delete_this_image_button(self):
-        super()._click(self.__delete_this_image_button)
+    def click_on_delete_this_image_button(self):
+        self._click(self.__delete_this_image_button)
 
-    def _click_on_edit_this_image_button(self):
-        super()._click(self.__edit_this_image_button)
+    def click_on_edit_this_image_button(self):
+        self._click(self.__edit_this_image_button)
 
     # Media Gallery search
-    def _fill_search_media_gallery_searchbox_input_field(self, text: str):
-        super()._fill(self.__search_gallery_searchbox, text)
+    def fill_search_media_gallery_searchbox_input_field(self, text: str):
+        self._fill(self.__search_gallery_searchbox, text)
 
-    def _click_on_media_gallery_searchbox_search_button(self):
-        super()._click(self.__search_gallery_search_button)
+    def click_on_media_gallery_searchbox_search_button(self):
+        self._click(self.__search_gallery_search_button)
 
     # Modal search.
-    def _fill_search_modal_gallery_searchbox_input_field(self, text: str):
-        super()._fill(self.__search_gallery_searchbox_modal, text)
+    def fill_search_modal_gallery_searchbox_input_field(self, text: str):
+        self._fill(self.__search_gallery_searchbox_modal, text)
 
-    def _click_on_search_modal_gallery_search_button(self):
-        super()._click(self.__search_gallery_search_button_modal)
+    def click_on_search_modal_gallery_search_button(self):
+        self._click(self.__search_gallery_search_button_modal)
 
     # Insert Media... kb panel actions.
-    def _click_on_images_filter(self):
-        super()._click(self.__show_images_filter)
+    def click_on_images_filter(self):
+        self._click(self.__show_images_filter)
 
-    def _click_on_videos_filter(self):
-        super()._click(self.__show_videos_filter)
+    def click_on_videos_filter(self):
+        self._click(self.__show_videos_filter)
 
-    def _click_on_cancel_media_insert(self):
-        super()._click(self.__insert_media_button)
+    def click_on_cancel_media_insert(self):
+        self._click(self.__insert_media_button)
 
-    def _click_on_upload_media_button(self):
-        super()._click(self.__upload_media_button)
+    def click_on_upload_media_button(self):
+        self._click(self.__upload_media_button)
 
-    def _select_media_file_from_list(self, media_file_name: str, is_modal=False):
+    def select_media_file_from_list(self, media_file_name: str, is_modal=False):
         if is_modal:
-            self._click_on_search_modal_gallery_search_button()
+            self.click_on_search_modal_gallery_search_button()
         else:
-            self._click_on_media_gallery_searchbox_search_button()
+            self.click_on_media_gallery_searchbox_search_button()
         xpath = f"//ol[@id='media-list']/li/a[@title='{media_file_name}']"
         # We need to wait a bit so that the list finishes to update in case of search.
-        super()._wait_for_given_timeout(1000)
-        super()._click(xpath)
+        self._wait_for_given_timeout(1000)
+        self._click(xpath)
 
-    def _click_on_insert_media_button(self):
-        super()._click(self.__insert_media_button)
+    def click_on_insert_media_button(self):
+        self._click(self.__insert_media_button)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
@@ -25,82 +25,82 @@ class KBArticlePage(BasePage):
         super().__init__(page)
 
     # KB Article page content actions.
-    def _click_on_a_particular_breadcrumb(self, breadcrumb_name: str):
-        super()._click(f"//ol[@id='breadcrumbs']//a[text()='{breadcrumb_name}']")
+    def click_on_a_particular_breadcrumb(self, breadcrumb_name: str):
+        self._click(f"//ol[@id='breadcrumbs']//a[text()='{breadcrumb_name}']")
 
-    def _get_text_of_all_breadcrumbs(self) -> list[str]:
-        return super()._get_text_of_elements(self.__kb_article_breadcrumbs_list)
+    def get_text_of_all_article_breadcrumbs(self) -> list[str]:
+        return self._get_text_of_elements(self.__kb_article_breadcrumbs_list)
 
-    def _get_text_of_article_title(self) -> str:
-        return super()._get_text_of_element(self.__kb_article_heading)
+    def get_text_of_article_title(self) -> str:
+        return self._get_text_of_element(self.__kb_article_heading)
 
-    def _get_restricted_visibility_banner_text(self) -> str:
-        return super()._get_text_of_element(self.__kb_article_restricted_banner)
+    def get_restricted_visibility_banner_text(self) -> str:
+        return self._get_text_of_element(self.__kb_article_restricted_banner)
 
-    def _is_restricted_visibility_banner_text_displayed(self) -> bool:
-        return super()._is_element_visible(self.__kb_article_restricted_banner)
+    def is_restricted_visibility_banner_text_displayed(self) -> bool:
+        return self._is_element_visible(self.__kb_article_restricted_banner)
 
-    def _get_list_of_kb_article_contributors(self) -> list[str]:
-        return super()._get_text_of_elements(self.__kb_article_contributors)
+    def get_list_of_kb_article_contributors(self) -> list[str]:
+        return self._get_text_of_elements(self.__kb_article_contributors)
 
-    def _click_on_a_particular_article_contributor(self, username: str):
-        super()._click(f"//div[@class='document--contributors-list text-body-xs']/"
-                       f"a[text()='{username}']")
+    def click_on_a_particular_article_contributor(self, username: str):
+        self._click(f"//div[@class='document--contributors-list text-body-xs']/"
+                    f"a[text()='{username}']")
 
-    def _get_text_of_kb_article_content_approved(self) -> str:
-        return super()._get_text_of_element(self.__kb_article_content_approved_content)
+    def get_text_of_kb_article_content_approved(self) -> str:
+        return self._get_text_of_element(self.__kb_article_content_approved_content)
 
-    def _get_text_of_kb_article_content(self) -> str:
-        return super()._get_text_of_element(self.__kb_article_content)
+    def get_text_of_kb_article_content(self) -> str:
+        return self._get_text_of_element(self.__kb_article_content)
 
-    def _click_on_what_links_here_option(self):
-        super()._click(self.__editing_tools_what_links_here)
+    def click_on_what_links_here_option(self):
+        self._click(self.__editing_tools_what_links_here)
 
-    def _get_what_links_here_locator(self):
-        return super()._get_element_locator(self.__editing_tools_what_links_here)
+    def get_what_links_here_locator(self):
+        return self._get_element_locator(self.__editing_tools_what_links_here)
 
     # KB Article editing tools section actions.
-    def _click_on_show_history_option(self):
-        super()._click(self.__editing_tools_show_history_option)
+    def click_on_show_history_option(self):
+        self._click(self.__editing_tools_show_history_option)
 
-    def _get_show_history_option_locator(self):
-        return super()._get_element_locator(self.__editing_tools_show_history_option)
+    def get_show_history_option_locator(self):
+        return self._get_element_locator(self.__editing_tools_show_history_option)
 
-    def _click_on_edit_article_option(self):
-        super()._click(self.__editing_tools_edit_article_option)
+    def click_on_edit_article_option(self):
+        self._click(self.__editing_tools_edit_article_option)
 
-    def _get_edit_article_option_locator(self):
-        return super()._get_element_locator(self.__editing_tools_edit_article_option)
+    def get_edit_article_option_locator(self):
+        return self._get_element_locator(self.__editing_tools_edit_article_option)
 
-    def _click_on_edit_article_metadata(self):
-        super()._click(self.__editing_tools_edit_article_metadata_option)
+    def click_on_edit_article_metadata(self):
+        self._click(self.__editing_tools_edit_article_metadata_option)
 
-    def _get_edit_article_metadata_locator(self):
-        return super()._get_element_locator(self.__editing_tools_edit_article_metadata_option)
+    def get_edit_article_metadata_locator(self):
+        return self._get_element_locator(self.__editing_tools_edit_article_metadata_option)
 
-    def _click_on_translate_article_option(self):
-        super()._click(self.__editing_tools_translate_article)
+    def click_on_translate_article_option(self):
+        self._click(self.__editing_tools_translate_article)
 
-    def _get_translate_article_option_locator(self):
-        return super()._get_element_locator(self.__editing_tools_translate_article)
+    def get_translate_article_option_locator(self):
+        return self._get_element_locator(self.__editing_tools_translate_article)
 
-    def _get_show_translations_option_locator(self):
-        return super()._get_element_locator(self.__editing_tools_show_translations)
+    def get_show_translations_option_locator(self):
+        return self._get_element_locator(self.__editing_tools_show_translations)
 
-    def _click_on_article_option(self):
-        super()._click(self.__editing_tools_article_option)
+    def click_on_article_option(self):
+        self._click(self.__editing_tools_article_option)
 
-    def _get_article_option_locator(self) -> Locator:
-        return super()._get_element_locator(self.__editing_tools_article_option)
+    def get_article_option_locator(self) -> Locator:
+        return self._get_element_locator(self.__editing_tools_article_option)
 
-    def _editing_tools_discussion_locator(self) -> Locator:
-        return super()._get_element_locator(self.__editing_tools_discussion_option)
+    def editing_tools_discussion_locator(self) -> Locator:
+        return self._get_element_locator(self.__editing_tools_discussion_option)
 
-    def _click_on_editing_tools_discussion_option(self):
-        super()._click(self.__editing_tools_discussion_option)
+    def click_on_editing_tools_discussion_option(self):
+        self._click(self.__editing_tools_discussion_option)
 
-    def _click_on_volunteer_learn_more_option(self):
-        super()._click(self.__learn_more_kb_article_option)
+    def click_on_volunteer_learn_more_option(self):
+        self._click(self.__learn_more_kb_article_option)
 
-    def _get_url(self) -> str:
-        return super()._get_current_page_url()
+    def get_url(self) -> str:
+        return self._get_current_page_url()

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_review_revision_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_review_revision_page.py
@@ -51,89 +51,89 @@ class KBArticleReviewRevisionPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
-    def _get_revision_header(self) -> str:
-        return super()._get_text_of_element(self.__revision_header)
+    def get_revision_header(self) -> str:
+        return self._get_text_of_element(self.__revision_header)
 
-    def _get_reviewing_revision_text(self) -> str:
-        return super()._get_text_of_element(self.__reviewing_revision_text)
+    def get_reviewing_revision_text(self) -> str:
+        return self._get_text_of_element(self.__reviewing_revision_text)
 
-    def _click_on_back_to_history_option(self):
-        super()._click(self.__back_to_history_link)
+    def click_on_back_to_history_option(self):
+        self._click(self.__back_to_history_link)
 
     # For single revision on the same kb article
-    def _get_no_current_revision_header(self) -> str:
-        return super()._get_text_of_element(self.__no_current_rev_header)
+    def get_no_current_revision_header(self) -> str:
+        return self._get_text_of_element(self.__no_current_rev_header)
 
     # For multiple revisions on the same kb article
-    def _get_unreviewed_revision_text(self) -> str:
-        return super()._get_text_of_element(self.__unreviewed_revision_header)
+    def get_unreviewed_revision_text(self) -> str:
+        return self._get_text_of_element(self.__unreviewed_revision_header)
 
-    def _get_unreviewed_revision_section_text(self) -> str:
-        return super()._get_text_of_element(self.__unreviewed_revision_section)
+    def get_unreviewed_revision_section_text(self) -> str:
+        return self._get_text_of_element(self.__unreviewed_revision_section)
 
-    def _click_on_review_revision_option(self):
-        super()._click(self.__review_revision_link)
+    def click_on_review_revision_option(self):
+        self._click(self.__review_revision_link)
 
-    def _is_keywords_header_visible(self) -> bool:
-        return super()._is_element_visible(self.__keywords_header)
+    def is_keywords_header_visible(self) -> bool:
+        return self._is_element_visible(self.__keywords_header)
 
-    def _get_keywords_content(self) -> str:
-        return super()._get_text_of_element(self.__keywords_content)
+    def get_keywords_content(self) -> str:
+        return self._get_text_of_element(self.__keywords_content)
 
-    def _is_search_results_summary_visible(self) -> bool:
-        return super()._is_element_visible(self.__search_results_summary_header)
+    def is_search_results_summary_visible(self) -> bool:
+        return self._is_element_visible(self.__search_results_summary_header)
 
-    def _get_search_results_summary_content(self) -> str:
-        return super()._get_text_of_element(self.__search_results_summary_content)
+    def get_search_results_summary_content(self) -> str:
+        return self._get_text_of_element(self.__search_results_summary_content)
 
-    def _is_revision_source_visible(self) -> bool:
-        return super()._is_element_visible(self.__revision_source_header)
+    def is_revision_source_visible(self) -> bool:
+        return self._is_element_visible(self.__revision_source_header)
 
-    def _revision_source_content(self) -> str:
-        return super()._get_text_of_element(self.__revision_source_content)
+    def revision_source_content(self) -> str:
+        return self._get_text_of_element(self.__revision_source_content)
 
-    def _is_revision_rendered_html_header_visible(self) -> bool:
-        return super()._is_element_visible(self.__revision_rendered_html_header)
+    def is_revision_rendered_html_header_visible(self) -> bool:
+        return self._is_element_visible(self.__revision_rendered_html_header)
 
-    def _get_revision_rendered_html_content(self) -> str:
-        return super()._get_text_of_element(self.__revision_rendered_html_content)
+    def get_revision_rendered_html_content(self) -> str:
+        return self._get_text_of_element(self.__revision_rendered_html_content)
 
-    def _click_on_defer_revision_button(self):
-        super()._click(self.__defer_revision_button)
+    def click_on_defer_revision_button(self):
+        self._click(self.__defer_revision_button)
 
-    def _click_on_defer_confirm_button(self):
-        super()._click(self.__defer_button)
+    def click_on_defer_confirm_button(self):
+        self._click(self.__defer_button)
 
-    def _click_on_cancel_defer_button(self):
-        super()._click(self.__cancel_defer)
+    def click_on_cancel_defer_button(self):
+        self._click(self.__cancel_defer)
 
-    def _click_on_approve_revision_button(self):
-        super()._click(self.__approve_revision_button)
+    def click_on_approve_revision_button(self):
+        self._click(self.__approve_revision_button)
 
     # Modal actions
-    def _get_accept_revision_modal_header(self) -> str:
-        return super()._get_text_of_element(self.__accept_revision_modal_header)
+    def get_accept_revision_modal_header(self) -> str:
+        return self._get_text_of_element(self.__accept_revision_modal_header)
 
-    def _click_accept_revision_accept_button(self):
-        super()._click(self.__modal_accept_button)
+    def click_accept_revision_accept_button(self):
+        self._click(self.__modal_accept_button)
 
-    def _check_ready_for_localization_checkbox(self):
-        super()._click(self.__ready_for_localization_modal_checkbox)
+    def check_ready_for_localization_checkbox(self):
+        self._click(self.__ready_for_localization_modal_checkbox)
 
-    def _is_needs_change_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__needs_change_modal_checkbox)
+    def is_needs_change_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__needs_change_modal_checkbox)
 
-    def _click_on_needs_change_checkbox(self):
-        super()._click(self.__needs_change_modal_checkbox)
+    def click_on_needs_change_checkbox(self):
+        self._click(self.__needs_change_modal_checkbox)
 
-    def _add_text_to_needs_change_comment(self, text: str):
-        super()._fill(self.__needs_change_comment_textarea, text)
+    def add_text_to_needs_change_comment(self, text: str):
+        self._fill(self.__needs_change_comment_textarea, text)
 
-    def _click_on_minor_significance_option(self):
-        super()._click(self.__minor_significance)
+    def click_on_minor_significance_option(self):
+        self._click(self.__minor_significance)
 
-    def _click_on_normal_significance_option(self):
-        super()._click(self.__normal_significance)
+    def click_on_normal_significance_option(self):
+        self._click(self.__normal_significance)
 
-    def _click_on_major_significance_option(self):
-        super()._click(self.__major_significance)
+    def click_on_major_significance_option(self):
+        self._click(self.__major_significance)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
@@ -37,136 +37,136 @@ class KBArticleShowHistoryPage(BasePage):
         super().__init__(page)
 
     # Page actions.
-    def _get_l10n_modal_locator(self) -> Locator:
-        return super()._get_element_locator(self.__l10n_modal)
+    def get_l10n_modal_locator(self) -> Locator:
+        return self._get_element_locator(self.__l10n_modal)
 
-    def _get_show_history_page_banner(self) -> str:
-        return super()._get_text_of_element(self.__show_history_page_banner)
+    def get_show_history_page_banner(self) -> str:
+        return self._get_text_of_element(self.__show_history_page_banner)
 
-    def _get_show_history_page_title(self) -> str:
-        return super()._get_text_of_element(self.__show_history_page_header)
+    def get_show_history_page_title(self) -> str:
+        return self._get_text_of_element(self.__show_history_page_header)
 
-    def _get_show_history_category_text(self) -> str:
-        return super()._get_text_of_element(self.__show_history_category_link)
+    def get_show_history_category_text(self) -> str:
+        return self._get_text_of_element(self.__show_history_category_link)
 
-    def _click_on_show_history_category(self):
-        super()._click(self.__show_history_category_link)
+    def click_on_show_history_category(self):
+        self._click(self.__show_history_category_link)
 
-    def _get_show_history_revision_for_locale_text(self) -> str:
-        return super()._get_text_of_element(self.__show_history_revision_history_for)
+    def get_show_history_revision_for_locale_text(self) -> str:
+        return self._get_text_of_element(self.__show_history_revision_history_for)
 
-    def _click_on_a_particular_revision_editor(self, revision_id: str, username: str):
-        super()._click(f"//tr[@id='{revision_id}']//a[contains(text(),'{username}')]")
+    def click_on_a_particular_revision_editor(self, revision_id: str, username: str):
+        self._click(f"//tr[@id='{revision_id}']//a[contains(text(),'{username}')]")
 
-    def _click_on_ready_for_l10n_option(self, revision_id: str):
-        super()._click(f"//tr[@id='{revision_id}']/td[@class='l10n']/a")
+    def click_on_ready_for_l10n_option(self, revision_id: str):
+        self._click(f"//tr[@id='{revision_id}']/td[@class='l10n']/a")
 
-    def _get_ready_for_localization_status(self, revision_id: str) -> Locator:
-        return super()._get_element_locator(f"//tr[@id='{revision_id}']/td[@class='l10n']/"
-                                            f"a[@class='yes']")
+    def get_ready_for_localization_status(self, revision_id: str) -> Locator:
+        return self._get_element_locator(f"//tr[@id='{revision_id}']/td[@class='l10n']/"
+                                         f"a[@class='yes']")
 
-    def _click_on_submit_l10n_readiness_button(self):
-        super()._click(self.__ready_for_l10_modal_submit_button)
+    def click_on_submit_l10n_readiness_button(self):
+        self._click(self.__ready_for_l10_modal_submit_button)
 
     # Delete document actions.
-    def _click_on_delete_this_document_button(self):
-        super()._click(self.__delete_this_document_button)
+    def click_on_delete_this_document_button(self):
+        self._click(self.__delete_this_document_button)
 
-    def _get_delete_this_document_button_locator(self) -> Locator:
-        return super()._get_element_locator(self.__delete_this_document_button)
+    def get_delete_this_document_button_locator(self) -> Locator:
+        return self._get_element_locator(self.__delete_this_document_button)
 
-    def _is_delete_button_displayed(self) -> bool:
-        return super()._is_element_visible(self.__delete_this_document_button)
+    def is_delete_button_displayed(self) -> bool:
+        return self._is_element_visible(self.__delete_this_document_button)
 
-    def _click_on_confirmation_delete_button(self):
-        super()._click(self.__delete_this_document_confirmation_delete_button)
+    def click_on_confirmation_delete_button(self):
+        self._click(self.__delete_this_document_confirmation_delete_button)
 
-    def _click_on_confirmation_cancel_button(self):
-        super()._click(self.__delete_this_document_confirmation_cancel_button)
+    def click_on_confirmation_cancel_button(self):
+        self._click(self.__delete_this_document_confirmation_cancel_button)
 
-    def _is_article_deleted_confirmation_messages_displayed(self) -> Locator:
-        super()._wait_for_selector(self.__article_deleted_confirmation_message)
-        return super()._get_element_locator(self.__article_deleted_confirmation_message)
+    def is_article_deleted_confirmation_messages_displayed(self) -> Locator:
+        self._wait_for_selector(self.__article_deleted_confirmation_message)
+        return self._get_element_locator(self.__article_deleted_confirmation_message)
 
-    def _get_last_revision_id(self) -> str:
-        revisions = super()._get_elements_locators(self.__article_revision_list_items)
-        return super()._get_element_attribute_value(
+    def get_last_revision_id(self) -> str:
+        revisions = self._get_elements_locators(self.__article_revision_list_items)
+        return self._get_element_attribute_value(
             revisions[0], "id"
         )
 
     # For unreviewed revisions but user session doesn't permit review.
-    def _click_on_a_revision_date(self, revision_id):
-        super()._click(f"//tr[@id='{revision_id}']/td[@class='date']/a")
+    def click_on_a_revision_date(self, revision_id):
+        self._click(f"//tr[@id='{revision_id}']/td[@class='date']/a")
 
-    def _get_revision_time(self, revision_id) -> str:
-        return super()._get_text_of_element(f"//tr[@id='{revision_id}']/td[@class='date']/a/time")
+    def get_revision_time(self, revision_id) -> str:
+        return self._get_text_of_element(f"//tr[@id='{revision_id}']/td[@class='date']/a/time")
 
-    def _get_revision_status(self, revision_id) -> str:
-        return super()._get_text_of_element(f"//tr[@id='{revision_id}']/td[@class='status']/span")
+    def get_revision_status(self, revision_id) -> str:
+        return self._get_text_of_element(f"//tr[@id='{revision_id}']/td[@class='status']/span")
 
-    def _get_a_particular_revision_locator(self, revision_id) -> Locator:
-        return super()._get_element_locator(f"//tr[@id='{revision_id}']")
+    def get_a_particular_revision_locator(self, revision_id) -> Locator:
+        return self._get_element_locator(f"//tr[@id='{revision_id}']")
 
     # For unreviewed revisions but user session permits review.
-    def _get_status_of_reviewable_revision(self, revision_id):
-        return super()._get_text_of_element(f"//tr[@id='{revision_id}']/td[@class='status']/a")
+    def get_status_of_reviewable_revision(self, revision_id):
+        return self._get_text_of_element(f"//tr[@id='{revision_id}']/td[@class='status']/a")
 
-    def _click_on_review_revision(self, revision_id):
-        super()._click(f"//tr[@id='{revision_id}']/td[@class='status']/a")
+    def click_on_review_revision(self, revision_id):
+        self._click(f"//tr[@id='{revision_id}']/td[@class='status']/a")
 
-    def _get_delete_revision_button_locator(self, revision_id) -> Locator:
-        return super()._get_element_locator(f"//tr[@id='{revision_id}']/td[@class='delete']/a")
+    def get_delete_revision_button_locator(self, revision_id) -> Locator:
+        return self._get_element_locator(f"//tr[@id='{revision_id}']/td[@class='delete']/a")
 
-    def _click_on_delete_revision_button(self, revision_id):
-        return super()._click(f"//tr[@id='{revision_id}']/td[@class='delete']/a")
+    def click_on_delete_revision_button(self, revision_id):
+        return self._click(f"//tr[@id='{revision_id}']/td[@class='delete']/a")
 
-    def _get_unable_to_delete_revision_header(self) -> str:
-        return super()._get_text_of_element(self.__unable_to_delete_revision_page_header)
+    def get_unable_to_delete_revision_header(self) -> str:
+        return self._get_text_of_element(self.__unable_to_delete_revision_page_header)
 
-    def _get_unable_to_delete_revision_subheader(self) -> str:
-        return super()._get_text_of_element(self.__unable_to_delete_revision_page_subheader)
+    def get_unable_to_delete_revision_subheader(self) -> str:
+        return self._get_text_of_element(self.__unable_to_delete_revision_page_subheader)
 
-    def _click_go_back_to_document_history_option(self):
-        super()._click(self.__unable_to_delete_revision_page_go_back_to_document_history)
+    def click_go_back_to_document_history_option(self):
+        self._click(self.__unable_to_delete_revision_page_go_back_to_document_history)
 
     # Article contribution actions.
-    def _click_on_edit_contributors_option(self):
-        super()._click(self.__edit_contributors_option)
+    def click_on_edit_contributors_option(self):
+        self._click(self.__edit_contributors_option)
 
-    def _get_edit_contributors_option_locator(self) -> Locator:
-        return super()._get_element_locator(self.__edit_contributors_option)
+    def get_edit_contributors_option_locator(self) -> Locator:
+        return self._get_element_locator(self.__edit_contributors_option)
 
-    def _add_a_new_contributor_inside_the_contributor_field(self, text: str):
+    def add_a_new_contributor_inside_the_contributor_field(self, text: str):
         # Adding contributor username inside the contributor field.
-        super()._type(self.__add_contributor_input_field, text, 100)
+        self._type(self.__add_contributor_input_field, text, 100)
 
-    def _click_on_new_contributor_search_result(self, username: str):
-        super()._click(f"//div[@class='name_search']/b[contains(text(), '{username}')]")
+    def click_on_new_contributor_search_result(self, username: str):
+        self._click(f"//div[@class='name_search']/b[contains(text(), '{username}')]")
 
-    def _click_on_add_contributor_button(self):
-        super()._click(self.__add_contributor_button)
+    def click_on_add_contributor_button(self):
+        self._click(self.__add_contributor_button)
 
-    def _click_on_a_particular_contributor(self, username: str):
-        super()._click(f"//span[text()='{username}']/..")
+    def click_on_a_particular_contributor(self, username: str):
+        self._click(f"//span[text()='{username}']/..")
 
-    def _click_on_delete_button_for_a_particular_contributor(self, username: str):
-        super()._click(f"//span[text()='{username}']/../..//a[@class='remove-button']")
+    def click_on_delete_button_for_a_particular_contributor(self, username: str):
+        self._click(f"//span[text()='{username}']/../..//a[@class='remove-button']")
 
-    def _get_list_of_all_contributors(self) -> list[str]:
-        return super()._get_text_of_elements(self.__all_contributors_usernames)
+    def get_list_of_all_contributors(self) -> list[str]:
+        return self._get_text_of_elements(self.__all_contributors_usernames)
 
-    def _get_delete_contributor_confirmation_page_header(self) -> str:
-        return super()._get_text_of_element(self.__delete_contributor_confirmation_page_header)
+    def get_delete_contributor_confirmation_page_header(self) -> str:
+        return self._get_text_of_element(self.__delete_contributor_confirmation_page_header)
 
-    def _click_on_delete_contributor_confirmation_page_cancel_button(self):
-        super()._click(self.__delete_contributor_confirmation_page_cancel_button)
+    def click_on_delete_contributor_confirmation_page_cancel_button(self):
+        self._click(self.__delete_contributor_confirmation_page_cancel_button)
 
-    def _click_on_delete_contributor_confirmation_page_confirm_button(self):
-        super()._click(self.__delete_contributor_confirmation_page_submit_button)
+    def click_on_delete_contributor_confirmation_page_confirm_button(self):
+        self._click(self.__delete_contributor_confirmation_page_submit_button)
 
-    def _get_all_contributors_locator(self) -> Locator:
-        return super()._get_element_locator(self.__all_contributors_list_items)
+    def get_all_contributors_locator(self) -> Locator:
+        return self._get_element_locator(self.__all_contributors_list_items)
 
-    def _get_revision_significance(self, revision_id: str) -> str:
-        return super()._get_text_of_element(f"//tr[@id='{revision_id}']"
-                                            f"/td[@class='significance']").strip()
+    def get_revision_significance(self, revision_id: str) -> str:
+        return self._get_text_of_element(f"//tr[@id='{revision_id}']"
+                                         f"/td[@class='significance']").strip()

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_page.py
@@ -26,60 +26,60 @@ class EditKBArticlePage(BasePage):
         super().__init__(page)
 
     # Edit kb article page actions.
-    def _get_edit_article_page_header(self) -> str:
-        return super()._get_text_of_element(self.__edit_article_page_header)
+    def get_edit_article_page_header(self) -> str:
+        return self._get_text_of_element(self.__edit_article_page_header)
 
-    def _get_warning_banner_locator(self) -> Locator:
-        return super()._get_element_locator(self.__edit_by_another_user_warning_banner)
+    def get_warning_banner_locator(self) -> Locator:
+        return self._get_element_locator(self.__edit_by_another_user_warning_banner)
 
-    def _get_edit_article_warning_message(self) -> str:
-        paragraphs = super()._get_text_of_elements(self.__edit_by_another_user_warning_message)
+    def get_edit_article_warning_message(self) -> str:
+        paragraphs = self._get_text_of_elements(self.__edit_by_another_user_warning_message)
         return ' '.join(paragraphs)
 
-    def _click_on_edit_anyway_option(self):
-        super()._click(self.__edit_by_another_user_edit_anyway_option)
+    def click_on_edit_anyway_option(self):
+        self._click(self.__edit_by_another_user_edit_anyway_option)
 
     # Edit kb article page field actions.
-    def _get_edit_article_keywords_field_value(self) -> str:
-        return super()._get_element_input_value(self.__edit_article_keywords_field)
+    def get_edit_article_keywords_field_value(self) -> str:
+        return self._get_element_input_value(self.__edit_article_keywords_field)
 
-    def _fill_edit_article_keywords_field(self, text: str):
-        super()._clear_field(self.__edit_article_keywords_field)
-        super()._fill(self.__edit_article_keywords_field, text)
+    def fill_edit_article_keywords_field(self, text: str):
+        self._clear_field(self.__edit_article_keywords_field)
+        self._fill(self.__edit_article_keywords_field, text)
 
-    def _get_edit_keywords_field_locator(self) -> Locator:
-        return super()._get_element_locator(self.__edit_article_keywords_field)
+    def get_edit_keywords_field_locator(self) -> Locator:
+        return self._get_element_locator(self.__edit_article_keywords_field)
 
-    def _get_edit_article_search_result_summary_text(self) -> str:
-        return super()._get_text_of_element(self.__edit_article_search_result_summary_field)
+    def get_edit_article_search_result_summary_text(self) -> str:
+        return self._get_text_of_element(self.__edit_article_search_result_summary_field)
 
-    def _fill_edit_article_search_result_summary_field(self, text: str):
-        super()._clear_field(self.__edit_article_search_result_summary_field)
-        super()._fill(self.__edit_article_search_result_summary_field, text)
+    def fill_edit_article_search_result_summary_field(self, text: str):
+        self._clear_field(self.__edit_article_search_result_summary_field)
+        self._fill(self.__edit_article_search_result_summary_field, text)
 
-    def _get_edit_article_content_field_text(self) -> str:
-        return super()._get_text_of_element(self.__edit_article_content_textarea_field)
+    def get_edit_article_content_field_text(self) -> str:
+        return self._get_text_of_element(self.__edit_article_content_textarea_field)
 
-    def _fill_edit_article_content_field(self, text: str):
+    def fill_edit_article_content_field(self, text: str):
         # We need to toggle the content field from syntax highlighting to make interaction easier.
-        super()._click(self.__edit_article_toggle_syntax_highlight)
-        super()._clear_field(self.__edit_article_content_textarea_field)
-        super()._fill(self.__edit_article_content_textarea_field, text)
+        self._click(self.__edit_article_toggle_syntax_highlight)
+        self._clear_field(self.__edit_article_content_textarea_field)
+        self._fill(self.__edit_article_content_textarea_field, text)
 
-    def _get_edit_article_expiry_date_value(self) -> str:
-        return super()._get_element_attribute_value(self.__edit_article_expiry_date_field,
-                                                    "value")
+    def get_edit_article_expiry_date_value(self) -> str:
+        return self._get_element_attribute_value(self.__edit_article_expiry_date_field,
+                                                 "value")
 
-    def _fill_edit_article_expiry_date(self, text: str):
-        super()._type(self.__edit_article_expiry_date_field, text, 0)
+    def fill_edit_article_expiry_date(self, text: str):
+        self._type(self.__edit_article_expiry_date_field, text, 0)
 
     # Edit kb button actions.
-    def _click_submit_for_review_button(self):
-        super()._click_on_first_item(self.__edit_article_submit_for_review_button)
+    def click_submit_for_review_button(self):
+        self._click_on_first_item(self.__edit_article_submit_for_review_button)
 
     # Submit you changes panel actions.
-    def _fill_edit_article_changes_panel_comment(self, text: str):
-        super()._fill(self.__edit_article_submit_changes_panel_comment_field, text)
+    def fill_edit_article_changes_panel_comment(self, text: str):
+        self._fill(self.__edit_article_submit_changes_panel_comment_field, text)
 
-    def _click_edit_article_changes_panel_submit_button(self):
-        super()._click(self.__edit_article_submit_changes_panel_submit_button)
+    def click_edit_article_changes_panel_submit_button(self):
+        self._click(self.__edit_article_submit_changes_panel_submit_button)

--- a/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
@@ -43,128 +43,128 @@ class SubmitKBArticlePage(BasePage):
 
     # Page error actions.
     def get_all_kb_errors(self) -> list[str]:
-        return super()._get_text_of_elements(self.__all_kb_errors)
+        return self._get_text_of_elements(self.__all_kb_errors)
 
     def get_kb_title_error_locator(self) -> Locator:
-        return super()._get_element_locator(self.__kb_title_error)
+        return self._get_element_locator(self.__kb_title_error)
 
     def get_kb_title_error_text(self) -> str:
-        return super()._get_text_of_element(self.__kb_title_error)
+        return self._get_text_of_element(self.__kb_title_error)
 
     def get_kb_slug_error(self) -> Locator:
-        return super()._get_element_locator(self.__kb_slug_error)
+        return self._get_element_locator(self.__kb_slug_error)
 
     def get_kb_slug_error_text(self) -> str:
-        return super()._get_text_of_element(self.__kb_slug_error)
+        return self._get_text_of_element(self.__kb_slug_error)
 
     # For Contributors side navbar actions.
-    def _for_contributors_section(self) -> Locator:
-        return super()._get_element_locator(self.__kb_article_for_contributors_sidebar)
+    def for_contributors_section(self) -> Locator:
+        return self._get_element_locator(self.__kb_article_for_contributors_sidebar)
 
     # New KB form actions.
-    def _add_and_select_restrict_visibility_group(self, group_name: str):
-        super()._fill(self.__kb_article_restrict_visibility_field, group_name)
-        super()._click(f"//div[@class='option active']/span[text()='{group_name}']")
+    def add_and_select_restrict_visibility_group(self, group_name: str):
+        self._fill(self.__kb_article_restrict_visibility_field, group_name)
+        self._click(f"//div[@class='option active']/span[text()='{group_name}']")
 
-    def _delete_a_restricted_visibility_group(self, group_name: str):
-        super()._click(f"//div[@class='item' and text()='{group_name}']/a")
+    def delete_a_restricted_visibility_group(self, group_name: str):
+        self._click(f"//div[@class='item' and text()='{group_name}']/a")
 
-    def _delete_all_restricted_visibility_groups(self):
-        super()._click(self.__kb_article_restrict_visibility_delete_all_groups)
+    def delete_all_restricted_visibility_groups(self):
+        self._click(self.__kb_article_restrict_visibility_delete_all_groups)
 
-    def _add_text_to_article_form_title_field(self, text: str):
+    def add_text_to_article_form_title_field(self, text: str):
         # Clearing the field first from auto-population
-        super()._clear_field(self.__kb_article_form_title)
-        super()._fill(self.__kb_article_form_title, text)
+        self._clear_field(self.__kb_article_form_title)
+        self._fill(self.__kb_article_form_title, text)
 
-    def _add_text_to_article_slug_field(self, text: str):
+    def add_text_to_article_slug_field(self, text: str):
         # Clearing the field first from auto-population
-        super()._clear_field(self.__kb_article_form_slug)
-        super()._fill(self.__kb_article_form_slug, text)
+        self._clear_field(self.__kb_article_form_slug)
+        self._fill(self.__kb_article_form_slug, text)
 
-    def _add_text_to_related_documents_field(self, text: str):
-        super()._fill(self.__kb_article_search_for_related_documents, text)
+    def add_text_to_related_documents_field(self, text: str):
+        self._fill(self.__kb_article_search_for_related_documents, text)
 
-    def _add_text_to_keywords_field(self, text: str):
-        super()._fill(self.__kb_article_keyword_input, text)
+    def add_text_to_keywords_field(self, text: str):
+        self._fill(self.__kb_article_keyword_input, text)
 
-    def _add_text_to_search_result_summary_field(self, text: str):
-        super()._fill(self.__kb_article_search_result_summary_textarea, text)
+    def add_text_to_search_result_summary_field(self, text: str):
+        self._fill(self.__kb_article_search_result_summary_textarea, text)
 
-    def _add_text_to_expiry_date_field(self, text: str):
-        super()._type(self.__kb_article_expiry_date, text, 0)
+    def add_text_to_expiry_date_field(self, text: str):
+        self._type(self.__kb_article_expiry_date, text, 0)
 
-    def _add_text_to_changes_description_field(self, text: str):
-        super()._fill(self.__kb_submit_changes_input_field, text)
+    def add_text_to_changes_description_field(self, text: str):
+        self._fill(self.__kb_submit_changes_input_field, text)
 
-    def _add_text_to_content_textarea(self, text: str):
-        super()._fill(self.__kb_article_content_textarea, text)
+    def add_text_to_content_textarea(self, text: str):
+        self._fill(self.__kb_article_content_textarea, text)
 
-    def _is_content_textarea_displayed(self) -> bool:
-        super()._wait_for_selector(self.__kb_article_content_textarea)
-        return super()._is_element_visible(self.__kb_article_content_textarea)
+    def is_content_textarea_displayed(self) -> bool:
+        self._wait_for_selector(self.__kb_article_content_textarea)
+        return self._is_element_visible(self.__kb_article_content_textarea)
 
-    def _click_on_insert_media_button(self):
-        super()._click(self.__kb_article_insert_media)
+    def click_on_insert_media_button(self):
+        self._click(self.__kb_article_insert_media)
 
-    def _click_on_toggle_syntax_highlight_option(self):
-        super()._click(self.__kb_article_toggle_syntax_highlighting)
+    def click_on_toggle_syntax_highlight_option(self):
+        self._click(self.__kb_article_toggle_syntax_highlighting)
 
-    def _click_on_preview_content_button(self):
-        super()._click(self.__kb_article_preview_content_button)
+    def click_on_preview_content_button(self):
+        self._click(self.__kb_article_preview_content_button)
 
-    def _click_on_submit_for_review_button(self):
-        super()._click(self.__kb_article_submit_for_preview_button)
+    def click_on_submit_for_review_button(self):
+        self._click(self.__kb_article_submit_for_preview_button)
 
-    def _click_on_changes_submit_button(self):
-        super()._click(self.__kb_submit_changes_button)
+    def click_on_changes_submit_button(self):
+        self._click(self.__kb_submit_changes_button)
 
-    def _is_showfor_panel_displayed(self) -> Locator:
-        return super()._get_element_locator(self.__kb_article_showfor_panel)
+    def is_showfor_panel_displayed(self) -> Locator:
+        return self._get_element_locator(self.__kb_article_showfor_panel)
 
-    def _is_preview_content_section_displayed(self) -> Locator:
-        return super()._get_element_locator(self.__kb_article_preview_content)
+    def is_preview_content_section_displayed(self) -> Locator:
+        return self._get_element_locator(self.__kb_article_preview_content)
 
-    def _get_text_of_label_for_relevant_to_checkbox(self, option_to_click) -> str:
-        return super()._get_text_of_element(
+    def get_text_of_label_for_relevant_to_checkbox(self, option_to_click) -> str:
+        return self._get_text_of_element(
             f"//div[@id='id_products']//" f"input[@id='id_products_{option_to_click}']/.."
         )
 
-    def _click_on_a_particular_product(self, product_name: str):
-        super()._click(f"//section[@id='relevant-products']//label[normalize-space(text())"
-                       f"='{product_name}']")
+    def click_on_a_particular_product(self, product_name: str):
+        self._click(f"//section[@id='relevant-products']//label[normalize-space(text())"
+                    f"='{product_name}']")
 
-    def _click_on_a_particular_parent_topic_checkbox(self, parent_topic_name: str):
-        super()._click(f"//section[@id='relevant-topics']//label[normalize-space(text())"
-                       f"='{parent_topic_name}']")
+    def click_on_a_particular_parent_topic_checkbox(self, parent_topic_name: str):
+        self._click(f"//section[@id='relevant-topics']//label[normalize-space(text())"
+                    f"='{parent_topic_name}']")
 
-    def _click_on_a_particular_child_topic_checkbox(
+    def click_on_a_particular_child_topic_checkbox(
         self, parent_topic: str, child_topic_checkbox: str
     ):
-        super()._click(f"//section[@id='relevant-topics']//label[normalize-space(text())='"
-                       f"{parent_topic}']/../../..//label[normalize-space(text())='"
-                       f"{child_topic_checkbox}']")
+        self._click(f"//section[@id='relevant-topics']//label[normalize-space(text())='"
+                    f"{parent_topic}']/../../..//label[normalize-space(text())='"
+                    f"{child_topic_checkbox}']")
 
-    def _click_on_insert_media_textarea_option(self):
-        super()._click(self.__kb_article_insert_media)
+    def click_on_insert_media_textarea_option(self):
+        self._click(self.__kb_article_insert_media)
 
-    def _click_on_first_image_from_media_panel(self):
-        super()._click_on_first_item(self.__kb_article_insert_media_modal_images)
+    def click_on_first_image_from_media_panel(self):
+        self._click_on_first_item(self.__kb_article_insert_media_modal_images)
 
-    def _click_on_insert_media_modal_button(self):
-        super()._click(self.__kb_article_insert_media_modal_insert_button)
+    def click_on_insert_media_modal_button(self):
+        self._click(self.__kb_article_insert_media_modal_insert_button)
 
-    def _select_category_option_by_text(self, option: str):
-        super()._select_option_by_label(self.__kb_article_category_select, option)
+    def select_category_option_by_text(self, option: str):
+        self._select_option_by_label(self.__kb_article_category_select, option)
 
-    def _check_allow_discussion_on_article_checkbox(self):
-        super()._click(self.__kb_article_allow_discussions_on_article)
+    def check_allow_discussion_on_article_checkbox(self):
+        self._click(self.__kb_article_allow_discussions_on_article)
 
-    def _is_allow_discussion_on_article_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__kb_article_allow_discussions_on_article)
+    def is_allow_discussion_on_article_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__kb_article_allow_discussions_on_article)
 
-    def _check_allow_translations_checkbox(self):
-        super()._click(self.__kb_article_allow_translations)
+    def check_allow_translations_checkbox(self):
+        self._click(self.__kb_article_allow_translations)
 
-    def _get_article_page_url(self) -> str:
-        return super()._get_current_page_url()
+    def get_article_page_url(self) -> str:
+        return self._get_current_page_url()

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
@@ -21,7 +21,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page):
 
     with allure.step("Create a new simple article"):
         article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
         article_url = utilities.get_page_url()
 
     with allure.step("Navigating to the kb dashboards and clicking on the 'Complete "
@@ -155,10 +155,10 @@ def test_kb_dashboard_articles_status(page: Page):
 
     with allure.step("Navigating back to the article history and deleting the revision"):
         utilities.navigate_to_link(article_url)
-        sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(
+        sumo_pages.kb_article_show_history_page.click_on_delete_revision_button(
             second_revision['revision_id']
         )
-        sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
+        sumo_pages.kb_article_show_history_page.click_on_confirmation_delete_button()
 
     with check, allure.step("Navigating back to the kb dashboard and verifying that the live "
                             "status is displayed"):
@@ -203,11 +203,11 @@ def test_kb_dashboard_revision_deferred_status(page: Page):
 
     with allure.step("Navigating back to the article history page and deferring the revision"):
         utilities.navigate_to_link(article_url)
-        sumo_pages.kb_article_show_history_page._click_on_review_revision(
+        sumo_pages.kb_article_show_history_page.click_on_review_revision(
             second_revision['revision_id']
         )
-        sumo_pages.kb_article_review_revision_page._click_on_defer_revision_button()
-        sumo_pages.kb_article_review_revision_page._click_on_defer_confirm_button()
+        sumo_pages.kb_article_review_revision_page.click_on_defer_revision_button()
+        sumo_pages.kb_article_review_revision_page.click_on_defer_confirm_button()
 
     with check, allure.step("Navigating back to the kb overview page and verifying that the "
                             "correct status is displayed"):
@@ -332,7 +332,7 @@ def test_ready_for_l10n_kb_dashboard_revision_approval(page: Page):
 
     article_url = utilities.get_page_url()
 
-    revision_id = sumo_pages.kb_article_show_history_page._get_last_revision_id()
+    revision_id = sumo_pages.kb_article_show_history_page.get_last_revision_id()
 
     with allure.step("Approving the first revision and marking it as ready for l10n"):
         sumo_pages.submit_kb_article_flow.approve_kb_revision(
@@ -378,10 +378,10 @@ def test_ready_for_l10n_kb_dashboard_revision_l10n_status(page: Page):
     with allure.step("Navigating back to the article page and marking the revision as ready "
                      "for l10n"):
         utilities.navigate_to_link(article_url)
-        sumo_pages.kb_article_show_history_page._click_on_ready_for_l10n_option(
+        sumo_pages.kb_article_show_history_page.click_on_ready_for_l10n_option(
             article_details['first_revision_id']
         )
-        sumo_pages.kb_article_show_history_page._click_on_submit_l10n_readiness_button()
+        sumo_pages.kb_article_show_history_page.click_on_submit_l10n_readiness_button()
 
     with allure.step("Navigating to the kb dashboard overview page and verifying that the "
                      "correct l10n status is displayed"):

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
@@ -250,7 +250,7 @@ def test_recent_revisions_dashboard_links(page: Page):
             approve_first_revision=True
         )
 
-    sumo_pages.kb_article_page._click_on_article_option()
+    sumo_pages.kb_article_page.click_on_article_option()
     article_url = utilities.get_page_url()
 
     with allure.step("Navigating to the recent revisions dashboard and verifying that the "
@@ -353,7 +353,7 @@ def test_recent_revisions_dashboard_title_and_username_update(page: Page):
             approve_first_revision=True
         )
 
-    sumo_pages.kb_article_page._click_on_article_option()
+    sumo_pages.kb_article_page.click_on_article_option()
     article_url = utilities.get_page_url()
 
     with allure.step("Changing the article title via the 'Edit Article Metadata' page"):

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
@@ -35,7 +35,7 @@ def test_kb_article_removal(page: Page, create_delete_article):
     with allure.step("Verifying that the delete button is not available for the only kb "
                      "revision"):
         expect(
-            sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
+            sumo_pages.kb_article_show_history_page.get_delete_revision_button_locator(
                 article_details['first_revision_id']
             )
         ).to_be_hidden()
@@ -53,7 +53,7 @@ def test_kb_article_removal(page: Page, create_delete_article):
     with allure.step("Navigating back and verifying that the delete button for the article "
                      "is not displayed"):
         utilities.navigate_to_link(article_details["article_url"])
-        expect(sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator(
+        expect(sumo_pages.kb_article_show_history_page.get_delete_this_document_button_locator(
         )).to_be_hidden()
 
     with check, allure.step("Verifying that manually navigating to the delete endpoint "
@@ -91,11 +91,11 @@ def test_kb_article_removal(page: Page, create_delete_article):
     with allure.step("Navigating back and verifying that the delete button is not available "
                      "for the only revision"):
         utilities.navigate_to_link(article_details["article_url"])
-        expect(sumo_pages.kb_article_show_history_page._get_delete_revision_button_locator(
+        expect(sumo_pages.kb_article_show_history_page.get_delete_revision_button_locator(
             article_details['first_revision_id'])).to_be_hidden()
 
     with allure.step("Verifying that the delete button for the article is not displayed"):
-        expect(sumo_pages.kb_article_show_history_page._get_delete_this_document_button_locator(
+        expect(sumo_pages.kb_article_show_history_page.get_delete_this_document_button_locator(
         )).to_be_hidden()
 
     with allure.step("Signing in with an admin user account"):
@@ -106,20 +106,20 @@ def test_kb_article_removal(page: Page, create_delete_article):
     with check, allure.step("Clicking on the delete revision button for the only available "
                             "revision and verifying that the correct 'Unable to delete the "
                             "revision' page header"):
-        sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(
+        sumo_pages.kb_article_show_history_page.click_on_delete_revision_button(
             article_details['first_revision_id']
         )
-        assert (sumo_pages.kb_article_show_history_page._get_unable_to_delete_revision_header(
+        assert (sumo_pages.kb_article_show_history_page.get_unable_to_delete_revision_header(
         ) == KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER)
 
     with check, allure.step("Verifying that the correct 'Unable to delete the revision' page "
                             "sub-header is displayed"):
-        assert (sumo_pages.kb_article_show_history_page._get_unable_to_delete_revision_subheader(
+        assert (sumo_pages.kb_article_show_history_page.get_unable_to_delete_revision_subheader(
         ) == KBArticleRevision.KB_REVISION_CANNOT_DELETE_ONLY_REVISION_SUBHEADER)
 
     with allure.step("Clicking on the 'Go back to document history button' and verifying "
                      "that we are redirected to the document history page"):
-        sumo_pages.kb_article_show_history_page._click_go_back_to_document_history_option()
+        sumo_pages.kb_article_show_history_page.click_go_back_to_document_history_option()
         expect(page).to_have_url(
             KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
             ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
@@ -128,8 +128,8 @@ def test_kb_article_removal(page: Page, create_delete_article):
     with allure.step("Clicking on the 'Delete article' button, canceling the confirmation "
                      "modal and verifying that we are back on the show history page for the "
                      "article"):
-        sumo_pages.kb_article_show_history_page._click_on_delete_this_document_button()
-        sumo_pages.kb_article_show_history_page._click_on_confirmation_cancel_button()
+        sumo_pages.kb_article_show_history_page.click_on_delete_this_document_button()
+        sumo_pages.kb_article_show_history_page.click_on_confirmation_cancel_button()
         expect(page).to_have_url(
             KBArticlePageMessages.KB_ARTICLE_PAGE_URL + article_details
             ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT
@@ -141,14 +141,14 @@ def test_kb_article_removal(page: Page, create_delete_article):
 
     with check, allure.step("Deleting the revision and verifying that the revision is not "
                             "displayed"):
-        sumo_pages.kb_article_show_history_page._click_on_delete_revision_button(
+        sumo_pages.kb_article_show_history_page.click_on_delete_revision_button(
             article_details['first_revision_id']
         )
-        sumo_pages.kb_article_show_history_page._click_on_confirmation_delete_button()
-        expect(sumo_pages.kb_article_show_history_page._get_a_particular_revision_locator(
+        sumo_pages.kb_article_show_history_page.click_on_confirmation_delete_button()
+        expect(sumo_pages.kb_article_show_history_page.get_a_particular_revision_locator(
             article_details['first_revision_id'])).to_be_hidden()
 
-        expect(sumo_pages.kb_article_show_history_page._get_a_particular_revision_locator(
+        expect(sumo_pages.kb_article_show_history_page.get_a_particular_revision_locator(
             second_revision['revision_id'])).to_be_visible()
 
     with check, allure.step("Deleting the article, navigating to the article and verifying "
@@ -180,23 +180,23 @@ def test_kb_article_category_link_and_header(page: Page, create_delete_article):
                                                       "is_template": True})[0]
 
         with check, allure.step("Verifying that the correct page header is displayed"):
-            assert sumo_pages.kb_article_show_history_page._get_show_history_page_title(
+            assert sumo_pages.kb_article_show_history_page.get_show_history_page_title(
             ) == KBArticleShowHistoryPageMessages.PAGE_TITLE + article_info["article_title"]
 
         with check, allure.step("Verifying that the correct category is displayed inside the "
                                 "'Show History' page"):
-            assert sumo_pages.kb_article_show_history_page._get_show_history_category_text(
+            assert sumo_pages.kb_article_show_history_page.get_show_history_category_text(
             ) == category
 
         with check, allure.step("Verifying that the correct revision history for locale is "
                                 "displayed"):
             assert (
-                sumo_pages.kb_article_show_history_page._get_show_history_revision_for_locale_text(
+                sumo_pages.kb_article_show_history_page.get_show_history_revision_for_locale_text(
                 ) == KBArticleShowHistoryPageMessages.DEFAULT_REVISION_FOR_LOCALE)
 
         with allure.step("Clicking on the 'Category' link and verifying that the user is "
                          "redirected to the correct page"):
-            sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+            sumo_pages.kb_article_show_history_page.click_on_show_history_category()
             expect(
                 page
             ).to_have_url(utilities.different_endpoints['kb_categories_links'][category])
@@ -213,13 +213,13 @@ def test_kb_article_contributor_removal(page: Page, create_delete_article):
     kb_show_history_page_messages = KBArticleShowHistoryPageMessages()
     article_details, username_one = create_delete_article("TEST_ACCOUNT_MODERATOR")
     with allure.step("Verifying that no users are added inside the contributors list"):
-        expect(sumo_pages.kb_article_show_history_page._get_all_contributors_locator()
+        expect(sumo_pages.kb_article_show_history_page.get_all_contributors_locator()
                ).to_be_hidden()
 
     with check, allure.step("Clicking on the Article menu option and verifying that the user "
                             "is not displayed inside the article contributors section"):
-        sumo_pages.kb_article_page._click_on_article_option()
-        assert username_one not in sumo_pages.kb_article_page._get_list_of_kb_article_contributors(
+        sumo_pages.kb_article_page.click_on_article_option()
+        assert username_one not in sumo_pages.kb_article_page.get_list_of_kb_article_contributors(
         )
 
     with allure.step("Navigating back to the 'Show History page and approving the revision"):
@@ -228,10 +228,10 @@ def test_kb_article_contributor_removal(page: Page, create_delete_article):
     with check, allure.step("Verifying that the username which created the revision is added "
                             "inside the 'Contributors' list"):
         assert username_one in (sumo_pages.kb_article_show_history_page
-                                ._get_list_of_all_contributors())
+                                .get_list_of_all_contributors())
 
-    sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
-    sumo_pages.kb_article_show_history_page._click_on_delete_button_for_a_particular_contributor(
+    sumo_pages.kb_article_show_history_page.click_on_edit_contributors_option()
+    sumo_pages.kb_article_show_history_page.click_on_delete_button_for_a_particular_contributor(
         username_one)
     deletion_link = utilities.get_page_url()
 
@@ -239,13 +239,13 @@ def test_kb_article_contributor_removal(page: Page, create_delete_article):
                             "Article menu option and verifying that the user is displayed "
                             "inside the article contributors section"):
         (sumo_pages.kb_article_show_history_page
-         ._click_on_delete_contributor_confirmation_page_cancel_button())
-        sumo_pages.kb_article_page._click_on_article_option()
-        assert username_one in sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+         .click_on_delete_contributor_confirmation_page_cancel_button())
+        sumo_pages.kb_article_page.click_on_article_option()
+        assert username_one in sumo_pages.kb_article_page.get_list_of_kb_article_contributors()
 
     with allure.step("Navigating back to the 'Show History page' and signing in with a "
                      "non-admin account"):
-        sumo_pages.kb_article_page._click_on_show_history_option()
+        sumo_pages.kb_article_page.click_on_show_history_option()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
@@ -256,7 +256,7 @@ def test_kb_article_contributor_removal(page: Page, create_delete_article):
                      "Contributors' option is not displayed for users which don't have the "
                      "necessary permissions"):
         second_revision_info = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
-        expect(sumo_pages.kb_article_show_history_page._get_edit_contributors_option_locator()
+        expect(sumo_pages.kb_article_show_history_page.get_edit_contributors_option_locator()
                ).to_be_hidden()
 
     with check, allure.step("Manually navigating to the deletion link and verifying that 403 "
@@ -270,15 +270,15 @@ def test_kb_article_contributor_removal(page: Page, create_delete_article):
                             "that the user is not displayed inside the article contributors "
                             "section"):
         utilities.navigate_to_link(article_details['article_url'])
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
         assert (username_two not in sumo_pages.kb_article_page
-                ._get_list_of_kb_article_contributors())
+                .get_list_of_kb_article_contributors())
 
     with allure.step("Navigating back to the 'Show History page', deleting the user session "
                      "and verifying that the 'Edit Contributors' options is not displayed"):
-        sumo_pages.kb_article_page._click_on_show_history_option()
+        sumo_pages.kb_article_page.click_on_show_history_option()
         utilities.delete_cookies()
-        expect(sumo_pages.kb_article_show_history_page._get_edit_contributors_option_locator()
+        expect(sumo_pages.kb_article_show_history_page.get_edit_contributors_option_locator()
                ).to_be_hidden()
 
     with check, allure.step("Manually navigating to the deletion link and the user is "
@@ -294,67 +294,67 @@ def test_kb_article_contributor_removal(page: Page, create_delete_article):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
         assert (username_two not in sumo_pages.kb_article_show_history_page
-                ._get_list_of_all_contributors())
+                .get_list_of_all_contributors())
 
     with check, allure.step("Approving the revision and verifying that the second username "
                             "is displayed inside the Contributors list"):
         sumo_pages.submit_kb_article_flow.approve_kb_revision(second_revision_info['revision_id'])
         assert (username_two in sumo_pages.kb_article_show_history_page
-                ._get_list_of_all_contributors())
+                .get_list_of_all_contributors())
 
     with check, allure.step("Clicking on the Article menu and verifying that the user is "
                             "displayed inside the article contributors section"):
-        sumo_pages.kb_article_page._click_on_article_option()
-        assert username_one in sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        sumo_pages.kb_article_page.click_on_article_option()
+        assert username_one in sumo_pages.kb_article_page.get_list_of_kb_article_contributors()
 
     with allure.step("Clicking on the delete button for user two"):
-        sumo_pages.kb_article_page._click_on_show_history_option()
-        sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+        sumo_pages.kb_article_page.click_on_show_history_option()
+        sumo_pages.kb_article_show_history_page.click_on_edit_contributors_option()
         (sumo_pages.kb_article_show_history_page
-         ._click_on_delete_button_for_a_particular_contributor(username_two))
+         .click_on_delete_button_for_a_particular_contributor(username_two))
 
     with check, allure.step("Verifying that the correct delete contributor page header is "
                             "displayed"):
         assert (sumo_pages.kb_article_show_history_page
-                ._get_delete_contributor_confirmation_page_header(
+                .get_delete_contributor_confirmation_page_header(
                 ) == kb_show_history_page_messages.get_remove_contributor_page_header(
                     username_two))
 
     with check, allure.step("Clicking on the 'Cancel' button and verifying that the second "
                             "username is displayed inside the Contributors list"):
         (sumo_pages.kb_article_show_history_page
-         ._click_on_delete_contributor_confirmation_page_cancel_button())
+         .click_on_delete_contributor_confirmation_page_cancel_button())
         assert (username_two in sumo_pages.kb_article_show_history_page
-                ._get_list_of_all_contributors())
+                .get_list_of_all_contributors())
 
     with check, allure.step("Clicking on the Article menu option and verifying that the user "
                             "is displayed inside the article contributors section"):
-        sumo_pages.kb_article_page._click_on_article_option()
-        assert username_one in sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        sumo_pages.kb_article_page.click_on_article_option()
+        assert username_one in sumo_pages.kb_article_page.get_list_of_kb_article_contributors()
 
     with allure.step("Navigating back to the 'Show History' page and deleting the the second "
                      "contributor"):
-        sumo_pages.kb_article_page._click_on_show_history_option()
-        sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+        sumo_pages.kb_article_page.click_on_show_history_option()
+        sumo_pages.kb_article_show_history_page.click_on_edit_contributors_option()
         (sumo_pages.kb_article_show_history_page
-         ._click_on_delete_button_for_a_particular_contributor(username_two))
+         .click_on_delete_button_for_a_particular_contributor(username_two))
         (sumo_pages.kb_article_show_history_page.
-         _click_on_delete_contributor_confirmation_page_confirm_button())
+         click_on_delete_contributor_confirmation_page_confirm_button())
 
     with check, allure.step("Verifying that the correct banner is displayed"):
-        assert sumo_pages.kb_article_show_history_page._get_show_history_page_banner(
+        assert sumo_pages.kb_article_show_history_page.get_show_history_page_banner(
         ) == kb_show_history_page_messages.get_contributor_removed_message(username_two)
 
     with check, allure.step("Verifying that second username is not displayed inside the "
                             "'Contributors' list"):
         assert (username_two not in sumo_pages.kb_article_show_history_page
-                ._get_list_of_all_contributors())
+                .get_list_of_all_contributors())
 
     with check, allure.step("Clicking on the Article menu and verifying that the user is not "
                             "displayed inside the contributors section"):
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
         assert (username_two not in sumo_pages.kb_article_page
-                ._get_list_of_kb_article_contributors())
+                .get_list_of_kb_article_contributors())
 
     with allure.step("Signing in with the removed username and creating a new revision"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -372,12 +372,12 @@ def test_kb_article_contributor_removal(page: Page, create_delete_article):
     with check, allure.step("Verifying that second username is not inside the 'Contributors' "
                             "list"):
         assert (username_two in sumo_pages.kb_article_show_history_page
-                ._get_list_of_all_contributors())
+                .get_list_of_all_contributors())
 
     with check, allure.step("Clicking on the Article menu and verifying that the user is not "
                             "displayed inside the contributors section"):
-        sumo_pages.kb_article_page._click_on_article_option()
-        assert username_two in sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        sumo_pages.kb_article_page.click_on_article_option()
+        assert username_two in sumo_pages.kb_article_page.get_list_of_kb_article_contributors()
 
 
 # C2101638
@@ -389,30 +389,30 @@ def test_contributors_can_be_manually_added(page: Page, create_delete_article):
     with allure.step("Clicking on the 'Edit Contributors' option, adding and selecting the "
                      "username from the search field"):
         create_delete_article("TEST_ACCOUNT_MODERATOR")
-        sumo_pages.kb_article_show_history_page._click_on_edit_contributors_option()
+        sumo_pages.kb_article_show_history_page.click_on_edit_contributors_option()
         new_contributor = utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         )
         (sumo_pages.kb_article_show_history_page
-         ._add_a_new_contributor_inside_the_contributor_field(new_contributor))
-        (sumo_pages.kb_article_show_history_page._click_on_new_contributor_search_result(
+         .add_a_new_contributor_inside_the_contributor_field(new_contributor))
+        (sumo_pages.kb_article_show_history_page.click_on_new_contributor_search_result(
             new_contributor))
 
     with check, allure.step("Clicking on the 'Add Contributor' option and verifying that the "
                             "correct banner is displayed"):
-        sumo_pages.kb_article_show_history_page._click_on_add_contributor_button()
-        assert sumo_pages.kb_article_show_history_page._get_show_history_page_banner(
+        sumo_pages.kb_article_show_history_page.click_on_add_contributor_button()
+        assert sumo_pages.kb_article_show_history_page.get_show_history_page_banner(
         ) == kb_show_history_page_messages.get_contributor_added_message(new_contributor)
 
     with check, allure.step("Verifying that the user was successfully added inside the "
                             "contributors list"):
         assert (new_contributor in sumo_pages.kb_article_show_history_page
-                ._get_list_of_all_contributors())
+                .get_list_of_all_contributors())
 
     with check, allure.step("Clicking on the Article menu option and verifying that the user "
                             "is displayed inside the article contributors section"):
-        sumo_pages.kb_article_page._click_on_article_option()
-        assert new_contributor in sumo_pages.kb_article_page._get_list_of_kb_article_contributors()
+        sumo_pages.kb_article_page.click_on_article_option()
+        assert new_contributor in sumo_pages.kb_article_page.get_list_of_kb_article_contributors()
 
 
 # C2101634, C2489553, C2102186
@@ -422,7 +422,7 @@ def test_kb_article_contributor_profile_access(page: Page, create_delete_article
     sumo_pages = SumoPages(page)
     kb_article_show_history_page = KBArticleShowHistoryPage(page)
     create_delete_article("TEST_ACCOUNT_MODERATOR", {"approve_first_revision": True})
-    sumo_pages.kb_article_page._click_on_article_option()
+    sumo_pages.kb_article_page.click_on_article_option()
     article_url = utilities.get_page_url()
 
     with allure.step("Signing in with a non-Admin account and creating a new revision"):
@@ -445,13 +445,13 @@ def test_kb_article_contributor_profile_access(page: Page, create_delete_article
 
     with allure.step("Clicking on the second contributor and verifying that we are "
                      "redirected to it's profile page"):
-        kb_article_show_history_page._click_on_a_particular_contributor(username_two)
+        kb_article_show_history_page.click_on_a_particular_contributor(username_two)
         expect(page).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
     with allure.step("Navigating back, clicking on the revision editor and verifying that we "
                      "are redirected to the editor homepage"):
         utilities.navigate_back()
-        kb_article_show_history_page._click_on_a_particular_revision_editor(
+        kb_article_show_history_page.click_on_a_particular_revision_editor(
             second_revision_info['revision_id'], username_two
         )
         expect(page).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
@@ -461,7 +461,7 @@ def test_kb_article_contributor_profile_access(page: Page, create_delete_article
 
     with allure.step("Clicking on the contributor listed inside the article page and "
                      "verifying that we are redirected to the editor homepage"):
-        sumo_pages.kb_article_page._click_on_a_particular_article_contributor(username_two)
+        sumo_pages.kb_article_page.click_on_a_particular_article_contributor(username_two)
         expect(page).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
     with allure.step("Navigating back and signin in with an admin account"):
@@ -473,20 +473,20 @@ def test_kb_article_contributor_profile_access(page: Page, create_delete_article
     with allure.step("Clicking on the Article menu option, clicking on the contributor "
                      "listed inside the article page and verifying that we are redirected to "
                      "the editor homepage"):
-        sumo_pages.kb_article_page._click_on_article_option()
-        sumo_pages.kb_article_page._click_on_a_particular_article_contributor(username_two)
+        sumo_pages.kb_article_page.click_on_article_option()
+        sumo_pages.kb_article_page.click_on_a_particular_article_contributor(username_two)
         expect(page).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
     with allure.step("Navigating back to the article history, clicking on the second "
                      "contributor and verifying that we are redirected to it's profile page"):
         utilities.navigate_back()
-        sumo_pages.kb_article_page._click_on_show_history_option()
-        kb_article_show_history_page._click_on_a_particular_contributor(username_two)
+        sumo_pages.kb_article_page.click_on_show_history_option()
+        kb_article_show_history_page.click_on_a_particular_contributor(username_two)
         expect(page).to_have_url(MyProfileMessages.get_my_profile_stage_url(username_two))
 
     with allure.step("Navigating back and clicking on the revision editor"):
         utilities.navigate_back()
-        kb_article_show_history_page._click_on_a_particular_revision_editor(
+        kb_article_show_history_page.click_on_a_particular_revision_editor(
             second_revision_info['revision_id'], username_two
         )
 
@@ -506,7 +506,7 @@ def test_kb_article_revision_date_functionality(page: Page, create_delete_articl
                      "approving it's first revision"):
         article_details, main_user = create_delete_article("TEST_ACCOUNT_MODERATOR",
                                                            {"approve_first_revision": True})
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
         article_url = utilities.get_page_url()
 
     with allure.step("Signing in with a non-admin account"):
@@ -519,10 +519,10 @@ def test_kb_article_revision_date_functionality(page: Page, create_delete_articl
 
     with allure.step("Deleting the user session and clicking on the first revision"):
         utilities.delete_cookies()
-        revision_time = sumo_pages.kb_article_show_history_page._get_revision_time(
+        revision_time = sumo_pages.kb_article_show_history_page.get_revision_time(
             second_revision_info['revision_id']
         )
-        sumo_pages.kb_article_show_history_page._click_on_a_revision_date(
+        sumo_pages.kb_article_show_history_page.click_on_a_revision_date(
             article_details['first_revision_id']
         )
 
@@ -533,7 +533,7 @@ def test_kb_article_revision_date_functionality(page: Page, create_delete_articl
 
     with allure.step("Navigating back and clicking on the revision time"):
         utilities.navigate_back()
-        sumo_pages.kb_article_show_history_page._click_on_a_revision_date(
+        sumo_pages.kb_article_show_history_page.click_on_a_revision_date(
             second_revision_info['revision_id'])
 
     with allure.step("Verifying that the revision information content is expanded by default"):
@@ -650,7 +650,7 @@ def test_kb_article_revision_date_functionality(page: Page, create_delete_articl
     with check, allure.step("Deleting the user session, clicking on the revision time and "
                             "verifying that the correct reviewed status is displayed"):
         utilities.delete_cookies()
-        sumo_pages.kb_article_show_history_page._click_on_a_revision_date(
+        sumo_pages.kb_article_show_history_page.click_on_a_revision_date(
             second_revision_info['revision_id']
         )
         assert (sumo_pages.kb_article_preview_revision_page._get_preview_revision_reviewed_text(

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
@@ -21,7 +21,7 @@ def test_article_thread_field_validation(page: Page):
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
         utilities.navigate_to_link(article_url)
-        sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+        sumo_pages.kb_article_page.click_on_editing_tools_discussion_option()
 
     with allure.step("Clicking on the 'Post a new thread button' and clicking on the 'Post "
                      "Thread' button without adding any data in the form fields"):
@@ -907,7 +907,7 @@ def test_posting_a_new_kb_test_article(page: Page):
     ))
 
     sumo_pages.submit_kb_article_flow.submit_simple_kb_article(approve_first_revision=True)
-    sumo_pages.kb_article_page._click_on_article_option()
+    sumo_pages.kb_article_page.click_on_article_option()
     with open("test_data/test_article", 'w') as file:
         file.write(utilities.get_page_url())
 

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
@@ -33,7 +33,7 @@ def test_not_ready_for_localization_articles_dashboard_status(page: Page):
 
     with allure.step("Clicking on the Translate Article Editing Tools option and selecting "
                      "the ro locale"):
-        sumo_pages.kb_article_page._click_on_translate_article_option()
+        sumo_pages.kb_article_page.click_on_translate_article_option()
         sumo_pages.translate_article_page._click_on_romanian_locale_from_list()
         translation_url = utilities.get_page_url()
 
@@ -110,10 +110,10 @@ def test_not_ready_for_localization_articles_dashboard_status(page: Page):
 
     with allure.step("Navigating to the parent article and marking it as ready for l10n"):
         utilities.navigate_to_link(parent_article_url)
-        sumo_pages.kb_article_show_history_page._click_on_ready_for_l10n_option(
+        sumo_pages.kb_article_show_history_page.click_on_ready_for_l10n_option(
             article_details['first_revision_id']
         )
-        sumo_pages.kb_article_show_history_page._click_on_submit_l10n_readiness_button()
+        sumo_pages.kb_article_show_history_page.click_on_submit_l10n_readiness_button()
 
     with check, allure.step("Navigating to the localization dashboard and verifying that the "
                             "article is displayed with the correct status"):
@@ -245,14 +245,14 @@ def test_revisions_cannot_be_marked_as_ready_for_l10n_if_lacking_permissions(pag
 
     with allure.step("Clicking on the ready for l10n button and verifying that it has no "
                      "effect"):
-        sumo_pages.kb_article_show_history_page._click_on_ready_for_l10n_option(
+        sumo_pages.kb_article_show_history_page.click_on_ready_for_l10n_option(
             article_details['first_revision_id']
         )
         utilities.wait_for_given_timeout(2000)
-        expect(sumo_pages.kb_article_show_history_page._get_l10n_modal_locator()).to_be_hidden()
+        expect(sumo_pages.kb_article_show_history_page.get_l10n_modal_locator()).to_be_hidden()
 
         expect(
-            sumo_pages.kb_article_show_history_page._get_ready_for_localization_status(
+            sumo_pages.kb_article_show_history_page.get_ready_for_localization_status(
                 article_details['first_revision_id']
             )
         ).to_be_hidden()

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
@@ -27,69 +27,69 @@ def test_kb_editing_tools_visibility(page: Page, username):
         sumo_pages.submit_kb_article_flow.submit_simple_kb_article(approve_first_revision=True)
 
     with allure.step("Navigating to the Article page"):
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
 
     if username == 'TEST_ACCOUNT_13':
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
         with allure.step("Verifying that only some editing tools options are displayed"):
-            expect(sumo_pages.kb_article_page._get_article_option_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.get_article_option_locator()).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_edit_article_option_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.get_edit_article_option_locator()).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_edit_article_metadata_locator()).to_be_hidden()
+            expect(sumo_pages.kb_article_page.get_edit_article_metadata_locator()).to_be_hidden()
 
-            expect(sumo_pages.kb_article_page._get_translate_article_option_locator()
+            expect(sumo_pages.kb_article_page.get_translate_article_option_locator()
                    ).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_show_translations_option_locator()
+            expect(sumo_pages.kb_article_page.get_show_translations_option_locator()
                    ).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_what_links_here_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.get_what_links_here_locator()).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_show_history_option_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.get_show_history_option_locator()).to_be_visible()
     elif username == '':
         utilities.delete_cookies()
         with allure.step("Verifying that all the editing tools options are not displayed"):
-            expect(sumo_pages.kb_article_page._get_article_option_locator()).to_be_hidden()
+            expect(sumo_pages.kb_article_page.get_article_option_locator()).to_be_hidden()
 
-            expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_hidden()
+            expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_hidden()
 
-            expect(sumo_pages.kb_article_page._get_edit_article_option_locator()).to_be_hidden()
+            expect(sumo_pages.kb_article_page.get_edit_article_option_locator()).to_be_hidden()
 
-            expect(sumo_pages.kb_article_page._get_edit_article_metadata_locator()).to_be_hidden()
+            expect(sumo_pages.kb_article_page.get_edit_article_metadata_locator()).to_be_hidden()
 
-            expect(sumo_pages.kb_article_page._get_translate_article_option_locator()
+            expect(sumo_pages.kb_article_page.get_translate_article_option_locator()
                    ).to_be_hidden()
 
-            expect(sumo_pages.kb_article_page._get_show_translations_option_locator()
+            expect(sumo_pages.kb_article_page.get_show_translations_option_locator()
                    ).to_be_hidden()
 
-            expect(sumo_pages.kb_article_page._get_what_links_here_locator()).to_be_hidden()
+            expect(sumo_pages.kb_article_page.get_what_links_here_locator()).to_be_hidden()
 
-            expect(sumo_pages.kb_article_page._get_show_history_option_locator()).to_be_hidden()
+            expect(sumo_pages.kb_article_page.get_show_history_option_locator()).to_be_hidden()
     else:
         with (allure.step("Verifying that all the editing tools options are displayed")):
-            expect(sumo_pages.kb_article_page._get_article_option_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.get_article_option_locator()).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_edit_article_option_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.get_edit_article_option_locator()).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_edit_article_metadata_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.get_edit_article_metadata_locator()).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_translate_article_option_locator()
+            expect(sumo_pages.kb_article_page.get_translate_article_option_locator()
                    ).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_show_translations_option_locator()
+            expect(sumo_pages.kb_article_page.get_show_translations_option_locator()
                    ).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_what_links_here_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.get_what_links_here_locator()).to_be_visible()
 
-            expect(sumo_pages.kb_article_page._get_show_history_option_locator()).to_be_visible()
+            expect(sumo_pages.kb_article_page.get_show_history_option_locator()).to_be_visible()
 
     if username != 'TEST_ACCOUNT_MODERATOR':
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -122,15 +122,15 @@ def test_non_admin_users_kb_article_submission(page: Page):
             ['article_slug'] + KBArticlePageMessages.KB_ARTICLE_HISTORY_URL_ENDPOINT)
 
     with check, allure.step("Verifying that the revision contains the correct status"):
-        status = sumo_pages.kb_article_show_history_page._get_revision_status(
+        status = sumo_pages.kb_article_show_history_page.get_revision_status(
             article_details['first_revision_id']
         )
         assert KBArticlePageMessages.UNREVIEWED_REVISION_STATUS == status
 
     with check, allure.step("Clicking on the 'Article' navbar menu and verifying that the "
                             "doc content contains the correct string"):
-        sumo_pages.kb_article_page._click_on_article_option()
-        assert sumo_pages.kb_article_page._get_text_of_kb_article_content(
+        sumo_pages.kb_article_page.click_on_article_option()
+        assert sumo_pages.kb_article_page.get_text_of_kb_article_content(
         ) == KBArticlePageMessages.KB_ARTICLE_NOT_APPROVED_CONTENT
 
     with check, allure.step("Deleting user session and verifying that the 404 page is "
@@ -147,9 +147,9 @@ def test_non_admin_users_kb_article_submission(page: Page):
 
     with check, allure.step("Clicking on the 'Show History' option and verifying that the "
                             "revision contains the correct status"):
-        sumo_pages.kb_article_page._click_on_show_history_option()
+        sumo_pages.kb_article_page.click_on_show_history_option()
         status = (
-            sumo_pages.kb_article_show_history_page._get_status_of_reviewable_revision(
+            sumo_pages.kb_article_show_history_page.get_status_of_reviewable_revision(
                 article_details['first_revision_id']))
         assert KBArticlePageMessages.REVIEW_REVISION_STATUS == status
 
@@ -179,14 +179,14 @@ def test_articles_revision_page_and_revision_approval(page: Page):
 
     with check, allure.step("Clicking on the first review and verifying that the correct "
                             "revision header is displayed"):
-        sumo_pages.kb_article_show_history_page._click_on_review_revision(
+        sumo_pages.kb_article_show_history_page.click_on_review_revision(
             article_details['first_revision_id']
         )
-        assert sumo_pages.kb_article_review_revision_page._get_revision_header(
+        assert sumo_pages.kb_article_review_revision_page.get_revision_header(
         ) == KBArticleRevision.KB_ARTICLE_REVISION_HEADER + article_details['article_title']
 
     with check, allure.step("Verifying that the correct subtext is displayed"):
-        assert (sumo_pages.kb_article_review_revision_page._get_reviewing_revision_text()
+        assert (sumo_pages.kb_article_review_revision_page.get_reviewing_revision_text()
                 .replace("\n", "").strip() == kb_revision.get_kb_article_revision_details(
             revision_id=re.findall(r'\d+', article_details['first_revision_id'])[0],
             username=username,
@@ -195,7 +195,7 @@ def test_articles_revision_page_and_revision_approval(page: Page):
 
     with allure.step("Click on the 'Back to History' option and verifying that the user is "
                      "redirected to the article history page"):
-        sumo_pages.kb_article_review_revision_page._click_on_back_to_history_option()
+        sumo_pages.kb_article_review_revision_page.click_on_back_to_history_option()
         expect(
             page
         ).to_have_url(
@@ -206,55 +206,55 @@ def test_articles_revision_page_and_revision_approval(page: Page):
     with check, allure.step("Navigate back and verifying that the 'Keywords:' header is "
                             "displayed"):
         utilities.navigate_back()
-        assert sumo_pages.kb_article_review_revision_page._is_keywords_header_visible()
+        assert sumo_pages.kb_article_review_revision_page.is_keywords_header_visible()
 
     with check, allure.step("Verifying that the correct keyword is displayed"):
-        assert sumo_pages.kb_article_review_revision_page._get_keywords_content(
+        assert sumo_pages.kb_article_review_revision_page.get_keywords_content(
         ) == article_details['keyword']
 
     with check, allure.step("Verifying that the correct header is displayed"):
-        assert (sumo_pages.kb_article_review_revision_page._is_search_results_summary_visible())
+        assert (sumo_pages.kb_article_review_revision_page.is_search_results_summary_visible())
 
     with check, allure.step("Verifying that the correct search result summary is displayed"):
-        assert (sumo_pages.kb_article_review_revision_page._get_search_results_summary_content(
+        assert (sumo_pages.kb_article_review_revision_page.get_search_results_summary_content(
         ) == article_details['search_results_summary'])
 
     with check, allure.step("Verifying that the 'Revision source:' header is displayed"):
-        assert sumo_pages.kb_article_review_revision_page._is_revision_source_visible()
+        assert sumo_pages.kb_article_review_revision_page.is_revision_source_visible()
 
     with check, allure.step("Verifying that the correct revision source content is displayed"):
-        assert sumo_pages.kb_article_review_revision_page._revision_source_content(
+        assert sumo_pages.kb_article_review_revision_page.revision_source_content(
         ) == article_details['article_content']
 
     with check, allure.step("Verifying that the correct header is displayed"):
         assert (sumo_pages.kb_article_review_revision_page
-                ._is_revision_rendered_html_header_visible())
+                .is_revision_rendered_html_header_visible())
 
     with check, allure.step("Verifying that the correct 'Revision rendered html:' content is "
                             "displayed"):
-        assert (sumo_pages.kb_article_review_revision_page._get_revision_rendered_html_content(
+        assert (sumo_pages.kb_article_review_revision_page.get_revision_rendered_html_content(
         ) == article_details['article_content_html'])
 
     with allure.step("Approving the revision"):
-        sumo_pages.kb_article_review_revision_page._click_on_approve_revision_button()
-        sumo_pages.kb_article_review_revision_page._click_accept_revision_accept_button()
+        sumo_pages.kb_article_review_revision_page.click_on_approve_revision_button()
+        sumo_pages.kb_article_review_revision_page.click_accept_revision_accept_button()
 
     with check, allure.step("Verifying that the review status updates to 'Current'"):
-        assert sumo_pages.kb_article_show_history_page._get_revision_status(
+        assert sumo_pages.kb_article_show_history_page.get_revision_status(
             article_details['first_revision_id']
         ) == KBArticlePageMessages.CURRENT_REVISION_STATUS
 
     with allure.step("Clicking on the 'Article' editing tools option"):
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
 
     with check, allure.step("Verifying that the correct html article content is displayed"):
-        assert sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(
+        assert sumo_pages.kb_article_page.get_text_of_kb_article_content_approved(
         ) == article_details['article_content_html']
 
     with check, allure.step("Signing out and verifying that the correct article content is "
                             "displayed"):
         utilities.delete_cookies()
-        assert sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(
+        assert sumo_pages.kb_article_page.get_text_of_kb_article_content_approved(
         ) == article_details['article_content_html']
 
     with check, allure.step("Signing in with a non admin account and verifying if the "
@@ -262,7 +262,7 @@ def test_articles_revision_page_and_revision_approval(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
-        assert sumo_pages.kb_article_page._get_text_of_kb_article_content_approved(
+        assert sumo_pages.kb_article_page.get_text_of_kb_article_content_approved(
         ) == article_details['article_content_html']
 
     with allure.step("Signing in with an admin account and creating a new revision"):
@@ -273,7 +273,7 @@ def test_articles_revision_page_and_revision_approval(page: Page):
 
     with check, allure.step("Verifying that the first approved revision is marked as the "
                             "current"):
-        assert sumo_pages.kb_article_show_history_page._get_revision_status(
+        assert sumo_pages.kb_article_show_history_page.get_revision_status(
             article_details['first_revision_id']
         ) == KBArticlePageMessages.CURRENT_REVISION_STATUS
 
@@ -282,11 +282,11 @@ def test_articles_revision_page_and_revision_approval(page: Page):
 
     with check, allure.step("Verifying that the first revision status is 'Approved', and the"
                             "second is 'Current'"):
-        assert sumo_pages.kb_article_show_history_page._get_revision_status(
+        assert sumo_pages.kb_article_show_history_page.get_revision_status(
             article_details['first_revision_id']
         ) == KBArticlePageMessages.PREVIOUS_APPROVED_REVISION_STATUS
 
-        assert sumo_pages.kb_article_show_history_page._get_revision_status(
+        assert sumo_pages.kb_article_show_history_page.get_revision_status(
             second_revision['revision_id']
         ) == KBArticlePageMessages.CURRENT_REVISION_STATUS
 
@@ -308,9 +308,9 @@ def test_articles_discussions_allowed(page: Page):
         article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
 
     with allure.step("Clicking on the article option and posting a new article thread"):
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
         article_url = utilities.get_page_url()
-        sumo_pages.kb_article_page._click_on_editing_tools_discussion_option()
+        sumo_pages.kb_article_page.click_on_editing_tools_discussion_option()
         sumo_pages.kb_article_discussion_page._click_on_post_a_new_thread_option()
         thread_info = sumo_pages.kb_article_thread_flow.add_new_kb_discussion_thread()
 
@@ -345,7 +345,7 @@ def test_articles_discussions_allowed(page: Page):
     with allure.step("Deleting user session and verifying that the discussion editing tools "
                      "option is not available"):
         utilities.delete_cookies()
-        expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_hidden()
+        expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_hidden()
 
     with allure.step("Manually navigating to the discuss endpoint and verifying that the "
                      "posted thread is successfully displayed"):
@@ -412,10 +412,10 @@ def test_articles_discussions_not_allowed(page: Page):
 
     with allure.step("Clicking on the article option and verifying that the 'Discussion' "
                      "option is not displayed"):
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
         article_url = utilities.get_page_url()
         expect(
-            sumo_pages.kb_article_page._editing_tools_discussion_locator()
+            sumo_pages.kb_article_page.editing_tools_discussion_locator()
         ).to_be_hidden()
 
     with check, allure.step("Manually navigating to the 'Discuss' endpoint and verifying "
@@ -440,7 +440,7 @@ def test_articles_discussions_not_allowed(page: Page):
     with allure.step("Navigating back to the article page and verifying that the "
                      "'Discussion' option is not displayed"):
         utilities.navigate_to_link(article_url)
-        expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_hidden()
+        expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_hidden()
 
     with check, allure.step("Manually navigating to the 'Discuss' endpoint and verifying "
                             "that the 404 page is returned"):
@@ -457,7 +457,7 @@ def test_articles_discussions_not_allowed(page: Page):
         utilities.delete_cookies()
 
     with allure.step("Verifying that the 'Discussion' option is not displayed"):
-        expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_hidden()
+        expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_hidden()
 
     with check, allure.step("Manually navigating to the 'Discuss' endpoint and verifying "
                             "that the 404 page is displayed"):
@@ -543,11 +543,11 @@ def test_kb_article_title_and_slug_validations(page: Page):
 
     with check, allure.step("Submitting the form and verifying that both title and slug "
                             "errors are displayed"):
-        sumo_pages.kb_submit_kb_article_form_page._click_on_submit_for_review_button()
-        sumo_pages.kb_submit_kb_article_form_page._add_text_to_changes_description_field(
+        sumo_pages.kb_submit_kb_article_form_page.click_on_submit_for_review_button()
+        sumo_pages.kb_submit_kb_article_form_page.add_text_to_changes_description_field(
             utilities.kb_article_test_data["changes_description"]
         )
-        sumo_pages.kb_submit_kb_article_form_page._click_on_changes_submit_button()
+        sumo_pages.kb_submit_kb_article_form_page.click_on_changes_submit_button()
         for error in sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors():
             assert error in KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS
 
@@ -573,11 +573,11 @@ def test_kb_article_title_and_slug_validations(page: Page):
 
     with check, allure.step("Submitting the form and verifying that the correct error is "
                             "displayed"):
-        sumo_pages.kb_submit_kb_article_form_page._click_on_submit_for_review_button()
-        sumo_pages.kb_submit_kb_article_form_page._add_text_to_changes_description_field(
+        sumo_pages.kb_submit_kb_article_form_page.click_on_submit_for_review_button()
+        sumo_pages.kb_submit_kb_article_form_page.add_text_to_changes_description_field(
             utilities.kb_article_test_data["changes_description"]
         )
-        sumo_pages.kb_submit_kb_article_form_page._click_on_changes_submit_button()
+        sumo_pages.kb_submit_kb_article_form_page.click_on_changes_submit_button()
         assert sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors(
         )[0] == KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS[0]
 
@@ -602,11 +602,11 @@ def test_kb_article_title_and_slug_validations(page: Page):
 
     with check, allure.step("Submitting the form and verifying that the correct error "
                             "message is displayed"):
-        sumo_pages.kb_submit_kb_article_form_page._click_on_submit_for_review_button()
-        sumo_pages.kb_submit_kb_article_form_page._add_text_to_changes_description_field(
+        sumo_pages.kb_submit_kb_article_form_page.click_on_submit_for_review_button()
+        sumo_pages.kb_submit_kb_article_form_page.add_text_to_changes_description_field(
             utilities.kb_article_test_data["changes_description"]
         )
-        sumo_pages.kb_submit_kb_article_form_page._click_on_changes_submit_button()
+        sumo_pages.kb_submit_kb_article_form_page.click_on_changes_submit_button()
         assert sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors(
         )[0] == KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS[1]
 
@@ -742,7 +742,7 @@ def test_kb_article_keywords_and_summary(page: Page, username):
     with check, allure.step("Clicking on the article and verifying that the user is "
                             "redirected to the kb article"):
         sumo_pages.search_page._click_on_a_particular_article(article_details['article_title'])
-        assert sumo_pages.kb_article_page._get_text_of_article_title(
+        assert sumo_pages.kb_article_page.get_text_of_article_title(
         ) == article_details['article_title']
 
     with allure.step("Deleting the created article"):
@@ -771,12 +771,12 @@ def test_edit_non_approved_articles(page: Page):
 
     with allure.step("Verifying that both the first and second revisions are displayed"):
         expect(
-            sumo_pages.kb_article_show_history_page._get_a_particular_revision_locator(
+            sumo_pages.kb_article_show_history_page.get_a_particular_revision_locator(
                 article_details['first_revision_id']
             )
         ).to_be_visible()
         expect(
-            sumo_pages.kb_article_show_history_page._get_a_particular_revision_locator(
+            sumo_pages.kb_article_show_history_page.get_a_particular_revision_locator(
                 second_revision['revision_id']
             )
         ).to_be_visible()
@@ -811,11 +811,11 @@ def test_kb_article_keyword_and_summary_update(page: Page):
 
     with check, allure.step("Navigating to the 'Edit Article' form and verifying that the "
                             "edit keyword field is not displayed"):
-        sumo_pages.kb_article_page._click_on_edit_article_option()
-        expect(sumo_pages.kb_edit_article_page._get_edit_keywords_field_locator()).to_be_hidden()
+        sumo_pages.kb_article_page.click_on_edit_article_option()
+        expect(sumo_pages.kb_edit_article_page.get_edit_keywords_field_locator()).to_be_hidden()
 
     with allure.step("Navigating back to the article"):
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
 
     with allure.step("Signing in with an Admin account"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -825,16 +825,16 @@ def test_kb_article_keyword_and_summary_update(page: Page):
     with check, allure.step("Clicking on the 'Edit Article' option and verifying that the "
                             "correct notification banner is displayed stating that another "
                             "user is also working on an edit"):
-        sumo_pages.kb_article_page._click_on_edit_article_option()
+        sumo_pages.kb_article_page.click_on_edit_article_option()
         check.equal(
-            sumo_pages.kb_edit_article_page._get_edit_article_warning_message(),
+            sumo_pages.kb_edit_article_page.get_edit_article_warning_message(),
             kb_revision.get_article_warning_message(
                 utilities.username_extraction_from_email(
                     utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_1"]
                 )
             )
         )
-        sumo_pages.kb_edit_article_page._click_on_edit_anyway_option()
+        sumo_pages.kb_edit_article_page.click_on_edit_anyway_option()
 
     with allure.step("Creating a new revision for the kb article and approving it"):
         sumo_pages.submit_kb_article_flow.submit_new_kb_revision(
@@ -903,7 +903,7 @@ def test_kb_article_keyword_and_summary_update(page: Page):
                             "redirected to the kb article"):
         sumo_pages.search_page._click_on_a_particular_article(article_details['article_title'])
         check.equal(
-            sumo_pages.kb_article_page._get_text_of_article_title(),
+            sumo_pages.kb_article_page.get_text_of_article_title(),
             article_details['article_title']
         )
 
@@ -935,12 +935,12 @@ def test_edit_article_metadata_title(page: Page):
         ))
 
     with allure.step("Clicking on the Article option"):
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
         article_url = utilities.get_page_url()
 
     with check, allure.step("Verifying that the 'Edit Article Metadata option is not "
                             "displayed'"):
-        expect(sumo_pages.kb_article_page._get_edit_article_metadata_locator()).to_be_hidden()
+        expect(sumo_pages.kb_article_page.get_edit_article_metadata_locator()).to_be_hidden()
 
     with check, allure.step("Navigating to the /metadata endpoint and verifying that the "
                             "Access Denied page is returned"):
@@ -963,7 +963,7 @@ def test_edit_article_metadata_title(page: Page):
 
     with check, allure.step("Clicking on the 'Edit Article Metadata' option and verifying "
                             "that the updated title and original slug is displayed"):
-        sumo_pages.kb_article_page._click_on_edit_article_metadata()
+        sumo_pages.kb_article_page.click_on_edit_article_metadata()
         check.equal(
             (sumo_pages.kb_article_edit_article_metadata_page._get_text_of_title_input_field()),
             utilities.kb_article_test_data['updated_kb_article_title'] + article_details
@@ -1016,7 +1016,7 @@ def test_edit_article_metadata_slug(page: Page):
 
     with check, allure.step("Clicking on the 'Edit Article Metadata' option and verifying "
                             "that the slug was updated"):
-        sumo_pages.kb_article_page._click_on_edit_article_metadata()
+        sumo_pages.kb_article_page.click_on_edit_article_metadata()
 
         check.equal(
             sumo_pages.kb_article_edit_article_metadata_page._get_slug_input_field(),
@@ -1157,11 +1157,11 @@ def test_edit_article_metadata_product_and_topic(page: Page):
     with check, allure.step("Verifying that the correct breadcrumb is displayed"):
         check.is_in(
             "Pocket",
-            sumo_pages.kb_article_page._get_text_of_all_breadcrumbs()
+            sumo_pages.kb_article_page.get_text_of_all_article_breadcrumbs()
         )
         check.is_in(
             "Getting Started",
-            sumo_pages.kb_article_page._get_text_of_all_breadcrumbs()
+            sumo_pages.kb_article_page.get_text_of_all_article_breadcrumbs()
         )
 
     with allure.step("Deleting the article"):
@@ -1184,7 +1184,7 @@ def test_edit_metadata_article_discussions(page: Page):
         )
 
     with check, allure.step("Verifying that the 'Discussion' is visible for admin users"):
-        expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_visible()
+        expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_visible()
 
     with allure.step("Signing in with a non-admin user and verifying that the discussion "
                      "options is visible"):
@@ -1193,7 +1193,7 @@ def test_edit_metadata_article_discussions(page: Page):
         ))
 
     with check, allure.step("Verifying that the 'Discussion' is visible for non-admin users"):
-        expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_visible()
+        expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_visible()
 
     with allure.step("Signing in with an admin account and disabling article discussions via "
                      "edit article metadata form"):
@@ -1203,7 +1203,7 @@ def test_edit_metadata_article_discussions(page: Page):
         sumo_pages.edit_article_metadata_flow.edit_article_metadata(discussions=False)
 
     with check, allure.step("Verifying that 'Discussion' is not displayed for admin users"):
-        expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_hidden()
+        expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_hidden()
 
     with check, allure.step("Navigating to the /discuss endpoint and verifying that 404 is "
                             "returned"):
@@ -1220,7 +1220,7 @@ def test_edit_metadata_article_discussions(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_hidden()
+        expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_hidden()
 
     with check, allure.step("Navigating to the /discuss endpoint and verifying that 404 is "
                             "returned"):
@@ -1240,13 +1240,13 @@ def test_edit_metadata_article_discussions(page: Page):
         sumo_pages.edit_article_metadata_flow.edit_article_metadata(discussions=True)
 
     with check, allure.step("Verifying that the 'Discussion' is visible for admin users"):
-        expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_visible()
+        expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_visible()
 
     with check, allure.step("Verifying that the 'Discussion' is visible for non-admin users"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
         ))
-        expect(sumo_pages.kb_article_page._editing_tools_discussion_locator()).to_be_visible()
+        expect(sumo_pages.kb_article_page.editing_tools_discussion_locator()).to_be_visible()
 
     with allure.step("Deleting the article"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -1270,21 +1270,21 @@ def test_edit_metadata_article_multiple_users(page: Page):
         sumo_pages.submit_kb_article_flow.submit_simple_kb_article(approve_first_revision=True)
 
     with allure.step("Clicking on the 'Edit Article Metadata' option"):
-        sumo_pages.kb_article_page._click_on_edit_article_metadata()
+        sumo_pages.kb_article_page.click_on_edit_article_metadata()
 
     with allure.step("Navigating back to the article page and signing in with a non-admin "
                      "user account"):
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
 
     with allure.step("Clicking on the 'Edit Article Metadata' option"):
-        sumo_pages.kb_article_page._click_on_edit_article_metadata()
+        sumo_pages.kb_article_page.click_on_edit_article_metadata()
 
     with check, allure.step("Verifying that the correct error message is displayed"):
         check.equal(
-            sumo_pages.kb_edit_article_page._get_edit_article_warning_message(),
+            sumo_pages.kb_edit_article_page.get_edit_article_warning_message(),
             kb_revision.get_article_warning_message(
                 utilities.username_extraction_from_email(
                     utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
@@ -1294,11 +1294,11 @@ def test_edit_metadata_article_multiple_users(page: Page):
 
     with allure.step("Clicking on the 'Edit Anyway' option and verifying that the warning "
                      "banner is no longer displayed"):
-        sumo_pages.kb_edit_article_page._click_on_edit_anyway_option()
-        expect(sumo_pages.kb_edit_article_page._get_warning_banner_locator()).to_be_hidden()
+        sumo_pages.kb_edit_article_page.click_on_edit_anyway_option()
+        expect(sumo_pages.kb_edit_article_page.get_warning_banner_locator()).to_be_hidden()
 
     with allure.step("Deleting the article"):
-        sumo_pages.kb_article_page._click_on_article_option()
+        sumo_pages.kb_article_page.click_on_article_option()
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
@@ -1329,12 +1329,12 @@ def test_archived_kb_article_edit(page: Page):
         ))
 
     with allure.step("Verifying that the 'Edit Article' navbar option is not displayed"):
-        expect(sumo_pages.kb_article_page._get_edit_article_option_locator()).to_be_hidden()
+        expect(sumo_pages.kb_article_page.get_edit_article_option_locator()).to_be_hidden()
 
     with allure.step("Navigating to the 'Show History' page and clicking on the existing "
                      "revision"):
-        sumo_pages.kb_article_page._click_on_show_history_option()
-        sumo_pages.kb_article_show_history_page._click_on_a_revision_date(
+        sumo_pages.kb_article_page.click_on_show_history_option()
+        sumo_pages.kb_article_show_history_page.click_on_a_revision_date(
             article_details['first_revision_id']
         )
 
@@ -1343,20 +1343,20 @@ def test_archived_kb_article_edit(page: Page):
         (sumo_pages.kb_article_preview_revision_page
          ._click_on_edit_article_based_on_this_revision_link())
 
-        sumo_pages.kb_edit_article_page._fill_edit_article_content_field(
+        sumo_pages.kb_edit_article_page.fill_edit_article_content_field(
             utilities.kb_article_test_data['updated_article_content']
         )
         # Submitting for preview steps
-        sumo_pages.kb_edit_article_page._click_submit_for_review_button()
+        sumo_pages.kb_edit_article_page.click_submit_for_review_button()
 
-        (sumo_pages.kb_edit_article_page._fill_edit_article_changes_panel_comment(
+        (sumo_pages.kb_edit_article_page.fill_edit_article_changes_panel_comment(
             utilities.kb_article_test_data['changes_description']
         ))
 
-        sumo_pages.kb_edit_article_page._click_edit_article_changes_panel_submit_button()
+        sumo_pages.kb_edit_article_page.click_edit_article_changes_panel_submit_button()
 
     with allure.step("Verifying that the revision was successfully submitted"):
-        second_revision = sumo_pages.kb_article_show_history_page._get_last_revision_id()
+        second_revision = sumo_pages.kb_article_show_history_page.get_last_revision_id()
         assert (article_details['first_revision_id'] != second_revision)
 
     with allure.step("Deleting the article"):
@@ -1383,7 +1383,7 @@ def test_revision_significance(page: Page):
 
     with check, allure.step("Verifying that the significance is the correct one"):
         check.equal(
-            sumo_pages.kb_article_show_history_page._get_revision_significance(
+            sumo_pages.kb_article_show_history_page.get_revision_significance(
                 article_details['first_revision_id']
             ),
             KBArticlePageMessages.MAJOR_SIGNIFICANCE
@@ -1397,7 +1397,7 @@ def test_revision_significance(page: Page):
             significance_type='minor'
         )
         check.equal(
-            sumo_pages.kb_article_show_history_page._get_revision_significance(
+            sumo_pages.kb_article_show_history_page.get_revision_significance(
                 second_revision['revision_id']
             ),
             KBArticlePageMessages.MINOR_SIGNIFICANCE
@@ -1410,7 +1410,7 @@ def test_revision_significance(page: Page):
             approve_revision=True
         )
         check.equal(
-            sumo_pages.kb_article_show_history_page._get_revision_significance(
+            sumo_pages.kb_article_show_history_page.get_revision_significance(
                 third_revision['revision_id']
             ),
             KBArticlePageMessages.NORMAL_SIGNIFICANCE
@@ -1424,7 +1424,7 @@ def test_revision_significance(page: Page):
             significance_type='major'
         )
         check.equal(
-            sumo_pages.kb_article_show_history_page._get_revision_significance(
+            sumo_pages.kb_article_show_history_page.get_revision_significance(
                 forth_revision['revision_id']
             ),
             KBArticlePageMessages.MAJOR_SIGNIFICANCE

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
@@ -22,7 +22,7 @@ def test_kb_restrict_visibility(page: Page, create_delete_article, is_template):
         "is_template": is_template
     })[0]
 
-    sumo_pages.kb_article_page._click_on_article_option()
+    sumo_pages.kb_article_page.click_on_article_option()
     article_url = utilities.get_page_url()
     with check, allure.step("Navigating to the article and verifying that 404 is not returned"):
         with page.expect_navigation() as navigation_info:
@@ -32,7 +32,7 @@ def test_kb_restrict_visibility(page: Page, create_delete_article, is_template):
 
     with check, allure.step("Verifying that the correct restricted banner is displayed"):
         assert (KBArticlePageMessages.KB_ARTICLE_RESTRICTED_BANNER in sumo_pages.kb_article_page
-                ._get_restricted_visibility_banner_text())
+                .get_restricted_visibility_banner_text())
 
     with allure.step("Signing out from SUMO"):
         utilities.delete_cookies()
@@ -68,7 +68,7 @@ def test_kb_restrict_visibility(page: Page, create_delete_article, is_template):
 
     with allure.step("Verifying that the correct restricted banner is displayed"):
         assert (KBArticlePageMessages.KB_ARTICLE_RESTRICTED_BANNER in sumo_pages.kb_article_page
-                ._get_restricted_visibility_banner_text())
+                .get_restricted_visibility_banner_text())
 
     with allure.step("Signing in with an admin account and whitelisting a new group"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -90,7 +90,7 @@ def test_kb_restrict_visibility(page: Page, create_delete_article, is_template):
 
     with check, allure.step("Verifying that the correct restricted banner is displayed"):
         assert (KBArticlePageMessages.KB_ARTICLE_RESTRICTED_BANNER in sumo_pages.kb_article_page
-                ._get_restricted_visibility_banner_text())
+                .get_restricted_visibility_banner_text())
 
     with allure.step("Signing in with a user which is part of the whitelisted groups"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -105,7 +105,7 @@ def test_kb_restrict_visibility(page: Page, create_delete_article, is_template):
 
     with check, allure.step("Verifying that the correct restricted banner is displayed"):
         assert (KBArticlePageMessages.KB_ARTICLE_RESTRICTED_BANNER in sumo_pages.kb_article_page
-                ._get_restricted_visibility_banner_text())
+                .get_restricted_visibility_banner_text())
 
     with allure.step("Signing in with a user which is not part of the whitelisted groups"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -163,7 +163,7 @@ def test_kb_restrict_visibility(page: Page, create_delete_article, is_template):
         assert response.status != 404
 
     with allure.step("Verifying that the restricted banner is no longer displayed"):
-        assert not sumo_pages.kb_article_page._is_restricted_visibility_banner_text_displayed()
+        assert not sumo_pages.kb_article_page.is_restricted_visibility_banner_text_displayed()
 
 
 # C2466516
@@ -307,15 +307,15 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
 
     with check, allure.step("Searching for the added image and verifying that the article is "
                             "displayed for admin users inside the 'Articles' image list"):
-        sumo_pages.media_gallery._fill_search_media_gallery_searchbox_input_field(
+        sumo_pages.media_gallery.fill_search_media_gallery_searchbox_input_field(
             utilities.kb_article_test_data['article_image']
         )
-        sumo_pages.media_gallery._click_on_media_gallery_searchbox_search_button()
-        sumo_pages.media_gallery._select_media_file_from_list(
+        sumo_pages.media_gallery.click_on_media_gallery_searchbox_search_button()
+        sumo_pages.media_gallery.select_media_file_from_list(
             utilities.kb_article_test_data['article_image']
         )
         assert article_details['article_title'] in (sumo_pages.media_gallery
-                                                    ._get_image_in_documents_list_items_text())
+                                                    .get_image_in_documents_list_items_text())
 
     with allure.step("Signing out from SUMO"):
         utilities.delete_cookies()
@@ -323,7 +323,7 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
     with check, allure.step("Verifying that the article is not displayed for signed out "
                             "users inside the 'Articles image list'"):
         assert article_details['article_title'] not in (sumo_pages.media_gallery
-                                                        ._get_image_in_documents_list_items_text())
+                                                        .get_image_in_documents_list_items_text())
 
     with allure.step("Signing in with an account that is not part of a whitelisted group"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -333,7 +333,7 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
     with check, allure.step("Verifying that the article is not displayed for users belonging "
                             "to a non-whitelisted group inside the 'Articles image list'"):
         assert article_details['article_title'] not in (sumo_pages.media_gallery
-                                                        ._get_image_in_documents_list_items_text())
+                                                        .get_image_in_documents_list_items_text())
 
     with allure.step("Signing in with an account that is part of the whitelisted group"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -343,7 +343,7 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
     with allure.step("Verifying that the article is displayed for users belonging to a "
                      "whitelisted inside the 'Articles image list'"):
         assert article_details['article_title'] in (sumo_pages.media_gallery
-                                                    ._get_image_in_documents_list_items_text())
+                                                    .get_image_in_documents_list_items_text())
 
     with allure.step("Signing in with an admin account and whitelisting a new group"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -359,11 +359,11 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
 
     with check, allure.step("Searching for the added image and verifying that the article is "
                             "displayed for admin users inside the 'Articles' image list"):
-        sumo_pages.media_gallery._fill_search_media_gallery_searchbox_input_field(
+        sumo_pages.media_gallery.fill_search_media_gallery_searchbox_input_field(
             utilities.kb_article_test_data['article_image']
         )
-        sumo_pages.media_gallery._click_on_media_gallery_searchbox_search_button()
-        sumo_pages.media_gallery._select_media_file_from_list(
+        sumo_pages.media_gallery.click_on_media_gallery_searchbox_search_button()
+        sumo_pages.media_gallery.select_media_file_from_list(
             utilities.kb_article_test_data['article_image']
         )
 
@@ -373,7 +373,7 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
         ))
         assert article_details['article_title'] in (sumo_pages.media_gallery
-                                                    ._get_image_in_documents_list_items_text())
+                                                    .get_image_in_documents_list_items_text())
     with allure.step("Removing restrictions"):
         utilities.navigate_to_link(article_details['article_url'])
         remove_all_article_restrictions(page)
@@ -382,16 +382,16 @@ def test_kb_restricted_visibility_media_gallery(page: Page, is_template, create_
                      "article is displayed for signed out users"):
         sumo_pages.top_navbar.click_on_media_gallery_option()
         utilities.delete_cookies()
-        sumo_pages.media_gallery._fill_search_media_gallery_searchbox_input_field(
+        sumo_pages.media_gallery.fill_search_media_gallery_searchbox_input_field(
             utilities.kb_article_test_data['article_image']
         )
-        sumo_pages.media_gallery._click_on_media_gallery_searchbox_search_button()
-        sumo_pages.media_gallery._select_media_file_from_list(
+        sumo_pages.media_gallery.click_on_media_gallery_searchbox_search_button()
+        sumo_pages.media_gallery.select_media_file_from_list(
             utilities.kb_article_test_data['article_image']
         )
         utilities.delete_cookies()
         assert article_details['article_title'] in (sumo_pages.media_gallery
-                                                    ._get_image_in_documents_list_items_text())
+                                                    .get_image_in_documents_list_items_text())
 
 
 # C2466531
@@ -485,9 +485,9 @@ def test_kb_restricted_visibility_in_topics_page(page: Page, create_delete_artic
         ['restricted_visibility_groups'][0]
     })[0]
 
-    sumo_pages.kb_article_page._click_on_article_option()
+    sumo_pages.kb_article_page.click_on_article_option()
     with allure.step("Clicking on the article child topic"):
-        sumo_pages.kb_article_page._click_on_a_particular_breadcrumb(
+        sumo_pages.kb_article_page.click_on_a_particular_breadcrumb(
             article_details['article_topic'][0]
         )
 
@@ -526,9 +526,9 @@ def test_kb_restricted_visibility_in_topics_page(page: Page, create_delete_artic
             single_group=utilities.kb_article_test_data['restricted_visibility_groups'][1]
         )
 
-    sumo_pages.kb_article_page._click_on_article_option()
+    sumo_pages.kb_article_page.click_on_article_option()
     with allure.step("Clicking on the article child topic"):
-        sumo_pages.kb_article_page._click_on_a_particular_breadcrumb(
+        sumo_pages.kb_article_page.click_on_a_particular_breadcrumb(
             article_details['article_topic'][0]
         )
 
@@ -757,7 +757,7 @@ def test_kb_restricted_visibility_what_links_here_page(page: Page, is_template,
 
     with check, allure.step("Navigating to the 'What Links Here' page and verifying that the "
                             "restricted article is displayed for admin accounts"):
-        sumo_pages.kb_article_page._click_on_what_links_here_option()
+        sumo_pages.kb_article_page.click_on_what_links_here_option()
         expect(
             sumo_pages.kb_what_links_here_page._get_a_particular_what_links_here_article_locator(
                 article_details['article_title'])).to_be_visible()
@@ -804,7 +804,7 @@ def test_kb_restricted_visibility_what_links_here_page(page: Page, is_template,
 
     with allure.step("Navigating to the 'What Links Here' page and verifying that the linked "
                      "article is displayed to the newly added group members"):
-        sumo_pages.kb_article_page._click_on_what_links_here_option()
+        sumo_pages.kb_article_page.click_on_what_links_here_option()
         expect(sumo_pages.kb_what_links_here_page
                ._get_a_particular_what_links_here_article_locator(article_details['article_title'])
                ).to_be_visible()
@@ -818,7 +818,7 @@ def test_kb_restricted_visibility_what_links_here_page(page: Page, is_template,
 
     with allure.step("Navigating to the 'What Links Here' page and verifying that the "
                      "article is displayed for signed out users"):
-        sumo_pages.kb_article_page._click_on_what_links_here_option()
+        sumo_pages.kb_article_page.click_on_what_links_here_option()
         utilities.delete_cookies()
         expect(sumo_pages.kb_what_links_here_page
                ._get_a_particular_what_links_here_article_locator(article_details['article_title'])
@@ -842,8 +842,8 @@ def test_kb_restricted_visibility_category_page(page: Page, is_template, create_
     with check, allure.step("Navigating to the article category field and verifying that the "
                             "restricted kb article is displayed for admin accounts"):
         utilities.navigate_to_link(article_details['article_url'])
-        sumo_pages.kb_article_page._click_on_show_history_option()
-        sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+        sumo_pages.kb_article_page.click_on_show_history_option()
+        sumo_pages.kb_article_show_history_page.click_on_show_history_category()
 
         expect(sumo_pages.kb_category_page._get_a_particular_article_locator_from_list(
             article_details['article_title'])).to_be_visible()
@@ -885,8 +885,8 @@ def test_kb_restricted_visibility_category_page(page: Page, is_template, create_
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
         ))
         utilities.navigate_to_link(article_details['article_url'])
-        sumo_pages.kb_article_page._click_on_show_history_option()
-        sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+        sumo_pages.kb_article_page.click_on_show_history_option()
+        sumo_pages.kb_article_show_history_page.click_on_show_history_category()
         expect(sumo_pages.kb_category_page._get_a_particular_article_locator_from_list(
             article_details['article_title'])).to_be_visible()
 
@@ -895,8 +895,8 @@ def test_kb_restricted_visibility_category_page(page: Page, is_template, create_
         remove_all_article_restrictions(page)
 
     utilities.navigate_to_link(article_details['article_url'])
-    sumo_pages.kb_article_page._click_on_show_history_option()
-    sumo_pages.kb_article_show_history_page._click_on_show_history_category()
+    sumo_pages.kb_article_page.click_on_show_history_option()
+    sumo_pages.kb_article_show_history_page.click_on_show_history_category()
 
     with allure.step("Navigating to the article discussion page and verifying that the "
                      "article is displayed for signed out users"):

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
@@ -180,7 +180,7 @@ def test_product_support_page_featured_articles_redirect(page: Page):
                         with check, allure.step("Verifying the accessed article title is the "
                                                 "correct one"):
                             assert featured_article_names[count - 1] == (
-                                sumo_pages.kb_article_page._get_text_of_article_title())
+                                sumo_pages.kb_article_page.get_text_of_article_title())
                         count += 1
                         utilities.navigate_back()
                 else:

--- a/playwright_tests/tests/homepage_tests/test_homepage.py
+++ b/playwright_tests/tests/homepage_tests/test_homepage.py
@@ -59,10 +59,10 @@ def test_homepage_feature_articles_are_available_and_interactable(page: Page):
             articles_names = sumo_pages.homepage._get_featured_articles_titles()
             sumo_pages.homepage._click_on_a_featured_card(counter)
             assert (
-                sumo_pages.kb_article_page._get_text_of_article_title().strip()
+                sumo_pages.kb_article_page.get_text_of_article_title().strip()
                 == articles_names[counter].strip()
             ), (f"Incorrect featured article displayed. Expected: {featured_article} "
-                f"Received: {sumo_pages.kb_article_page._get_text_of_article_title()}")
+                f"Received: {sumo_pages.kb_article_page.get_text_of_article_title()}")
 
             with allure.step("Navigating back to the previous page"):
                 utilities.navigate_back()

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -487,12 +487,12 @@ def test_new_message_preview(page: Page):
                      "redirected to the correct article"):
         sumo_pages.new_message_page.click_on_preview_internal_link()
         assert (
-            sumo_pages.kb_article_page._get_text_of_article_title()
+            sumo_pages.kb_article_page.get_text_of_article_title()
             == NewMessagePageMessages.PREVIEW_MESSAGE_INTERNAL_LINK_TITLE
         ), (
             f"Incorrect article title displayed! "
             f"Expected: {NewMessagePageMessages.PREVIEW_MESSAGE_INTERNAL_LINK_TITLE} "
-            f"Received: {sumo_pages.kb_article_page._get_text_of_article_title()}"
+            f"Received: {sumo_pages.kb_article_page.get_text_of_article_title()}"
         )
 
     with allure.step("Verifying that the message was no sent by checking the "


### PR DESCRIPTION
- Mark the functions from the kb related classes as public and replace super() with self.
- Use composition instead of inheritance for the add_kb_article_flow.py and add_kb_media_flow.py class.
- Updating modified function calls in tests.