### PR TITLE
Playwright refactor delete kb article and edit article metadata flows

### DIFF
--- a/playwright_tests/flows/explore_articles_flows/article_flows/delete_kb_article_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/delete_kb_article_flow.py
@@ -1,21 +1,20 @@
-from playwright_tests.core.utilities import Utilities
 from playwright.sync_api import Page
 
 from playwright_tests.pages.explore_help_articles.articles.kb_article_page import KBArticlePage
 from playwright_tests.pages.explore_help_articles.articles.kb_article_show_history_page import \
     KBArticleShowHistoryPage
-from playwright_tests.pages.top_navbar import TopNavbar
 
 
-class DeleteKbArticleFlow(Utilities, KBArticleShowHistoryPage, KBArticlePage, TopNavbar):
+class DeleteKbArticleFlow:
 
     def __init__(self, page: Page):
-        super().__init__(page)
+        self.kb_article_show_history_page = KBArticleShowHistoryPage(page)
+        self.kb_article_page = KBArticlePage(page)
 
     def delete_kb_article(self):
         # If the delete button is not displayed we presume that we are not on the show history page
         # Clicking on the 'Show History' page.
-        if not super().is_delete_button_displayed():
-            super().click_on_show_history_option()
-        super().click_on_delete_this_document_button()
-        super().click_on_confirmation_delete_button()
+        if not self.kb_article_show_history_page.is_delete_button_displayed():
+            self.kb_article_page.click_on_show_history_option()
+        self.kb_article_show_history_page.click_on_delete_this_document_button()
+        self.kb_article_show_history_page.click_on_confirmation_delete_button()

--- a/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
@@ -10,11 +10,13 @@ from playwright_tests.pages.explore_help_articles.articles.submit_kb_article_pag
     SubmitKBArticlePage
 
 
-class EditArticleMetaFlow(Utilities, KBArticleEditMetadata, SubmitKBArticlePage,
-                          KBArticlePage):
+class EditArticleMetaFlow:
 
     def __init__(self, page: Page):
-        super().__init__(page)
+        self.utilities = Utilities(page)
+        self.kb_article_edit_metadata_page = KBArticleEditMetadata(page)
+        self.submit_kb_article_page = SubmitKBArticlePage(page)
+        self.kb_article_page = KBArticlePage(page)
 
     def edit_article_metadata(self, title=None,
                               slug=None,
@@ -28,71 +30,74 @@ class EditArticleMetaFlow(Utilities, KBArticleEditMetadata, SubmitKBArticlePage,
                               restricted_to_groups: list[str] = None,
                               single_group=""):
 
-        if KBArticleRevision.KB_EDIT_METADATA not in self._get_current_page_url():
-            self.click_on_edit_article_metadata()
+        if KBArticleRevision.KB_EDIT_METADATA not in self.utilities.get_page_url():
+            self.kb_article_page.click_on_edit_article_metadata()
 
         if restricted_to_groups:
             for group in restricted_to_groups:
-                self._add_and_select_restrict_visibility_group_metadata(group)
+                (self.kb_article_edit_metadata_page
+                 .add_and_select_restrict_visibility_group_metadata(group))
         if single_group != "":
-            self._add_and_select_restrict_visibility_group_metadata(single_group)
+            self.kb_article_edit_metadata_page.add_and_select_restrict_visibility_group_metadata(
+                single_group)
 
         if title:
-            self._add_text_to_title_field(title)
+            self.kb_article_edit_metadata_page.add_text_to_title_field(title)
 
         if slug:
-            self._add_text_to_slug_field(slug)
+            self.kb_article_edit_metadata_page.add_text_to_slug_field(slug)
 
         if category:
-            self._select_category(category)
+            self.kb_article_edit_metadata_page.select_category(category)
 
         if product:
-            self._check_product_checkbox(product)
+            self.kb_article_edit_metadata_page.check_product_checkbox(product)
 
         if topics:
             if isinstance(topics, list):
-                self.click_on_a_particular_child_topic_checkbox(
+                self.submit_kb_article_page.click_on_a_particular_child_topic_checkbox(
                     topics[0],
                     topics[1],
                 )
             else:
-                self.click_on_a_particular_parent_topic_checkbox(
+                self.submit_kb_article_page.click_on_a_particular_parent_topic_checkbox(
                     topics
                 )
 
         if obsolete:
-            self._click_on_obsolete_checkbox()
+            self.kb_article_edit_metadata_page.click_on_obsolete_checkbox()
 
         if discussions:
-            if not self._is_allow_discussion_checkbox_checked():
-                self._click_on_allow_discussion_on_article_checkbox()
+            if not self.kb_article_edit_metadata_page.is_allow_discussion_checkbox_checked():
+                self.kb_article_edit_metadata_page.click_on_allow_discussion_on_article_checkbox()
         else:
-            if self._is_allow_discussion_checkbox_checked():
-                self._click_on_allow_discussion_on_article_checkbox()
+            if self.kb_article_edit_metadata_page.is_allow_discussion_checkbox_checked():
+                self.kb_article_edit_metadata_page.click_on_allow_discussion_on_article_checkbox()
 
         # If it needs change we are going to ensure that the needs change checkbox is checked.
         if needs_change:
-            if not self._is_needs_change_checkbox():
-                self._click_needs_change_checkbox()
+            if not self.kb_article_edit_metadata_page.is_needs_change_checkbox():
+                self.kb_article_edit_metadata_page.click_needs_change_checkbox()
                 # If it needs change with comment we are also adding the comment.
             if needs_change_comment:
-                self._fill_needs_change_textarea(
-                    self.kb_revision_test_data['needs_change_message']
+                self.kb_article_edit_metadata_page.fill_needs_change_textarea(
+                    self.utilities.kb_revision_test_data['needs_change_message']
                 )
             # If it doesn't need comment we are ensuring that the textarea field is empty.
             else:
-                self._fill_needs_change_textarea('')
+                self.kb_article_edit_metadata_page.fill_needs_change_textarea('')
 
         # If it doesn't need change we are ensuring that the checkbox is not checked.
         else:
-            if self._is_needs_change_checkbox():
-                self._click_needs_change_checkbox()
+            if self.kb_article_edit_metadata_page.is_needs_change_checkbox():
+                self.kb_article_edit_metadata_page.click_needs_change_checkbox()
 
-        self._click_on_save_changes_button()
+        self.kb_article_edit_metadata_page.click_on_save_changes_button()
 
     def _remove_a_restricted_visibility_group(self, group_name=''):
-        if KBArticleRevision.KB_EDIT_METADATA not in self._get_current_page_url():
-            self.click_on_edit_article_metadata()
+        if KBArticleRevision.KB_EDIT_METADATA not in self.utilities.get_page_url():
+            self.kb_article_page.click_on_edit_article_metadata()
 
-        self._delete_a_restricted_visibility_group_metadata(group_name)
-        self._click_on_save_changes_button()
+        self.kb_article_edit_metadata_page.delete_a_restricted_visibility_group_metadata(
+            group_name)
+        self.kb_article_edit_metadata_page.click_on_save_changes_button()

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
@@ -26,75 +26,75 @@ class KBArticleEditMetadata(BasePage):
         super().__init__(page)
 
     # Edit article metadata page actions.
-    def _get_error_message(self) -> str:
-        return super()._get_text_of_element(self.__edit_article_metadata_error)
+    def get_error_message(self) -> str:
+        return self._get_text_of_element(self.__edit_article_metadata_error)
 
-    def _get_edit_article_metadata_page_header(self) -> str:
-        return super()._get_element_text_content(self.__edit_article_metadata_page_header)
+    def get_edit_article_metadata_page_header(self) -> str:
+        return self._get_element_text_content(self.__edit_article_metadata_page_header)
 
-    def _delete_a_chosen_restricted_visibility_group(self, chosen_group: str):
-        super()._click(
+    def delete_a_chosen_restricted_visibility_group(self, chosen_group: str):
+        self._click(
             f"//input[@id='id_restrict_to_groups-selectized']/../"
             f"div[text()='{chosen_group}']/a"
         )
 
-    def _clear_all_restricted_visibility_group_selections(self):
-        super()._click(self.__clear_all_selected_groups_button)
+    def clear_all_restricted_visibility_group_selections(self):
+        self._click(self.__clear_all_selected_groups_button)
 
-    def _is_clear_all_restricted_visibility_group_selection_visible(self) -> bool:
-        return super()._is_element_visible(self.__clear_all_selected_groups_button)
+    def is_clear_all_restricted_visibility_group_selection_visible(self) -> bool:
+        return self._is_element_visible(self.__clear_all_selected_groups_button)
 
-    def _add_and_select_restrict_visibility_group_metadata(self, group_name: str):
-        super()._fill(self.__kb_article_restrict_visibility_field, group_name)
-        super()._click(f"//div[@class='option active']/span[text()='{group_name}']")
+    def add_and_select_restrict_visibility_group_metadata(self, group_name: str):
+        self._fill(self.__kb_article_restrict_visibility_field, group_name)
+        self._click(f"//div[@class='option active']/span[text()='{group_name}']")
 
-    def _delete_a_restricted_visibility_group_metadata(self, group_name=""):
+    def delete_a_restricted_visibility_group_metadata(self, group_name=""):
         if group_name != "":
-            super()._click(f"//div[@class='item' and text()='{group_name}']/a")
+            self._click(f"//div[@class='item' and text()='{group_name}']/a")
         else:
-            super()._click(self.__kb_article_restrict_visibility_delete_all_groups)
+            self._click(self.__kb_article_restrict_visibility_delete_all_groups)
 
-    def _get_text_of_title_input_field(self) -> str:
-        return super()._get_element_input_value(self.__title_input_field)
+    def get_text_of_title_input_field(self) -> str:
+        return self._get_element_input_value(self.__title_input_field)
 
-    def _add_text_to_title_field(self, text: str):
-        super()._clear_field(self.__title_input_field)
-        super()._fill(self.__title_input_field, text)
+    def add_text_to_title_field(self, text: str):
+        self._clear_field(self.__title_input_field)
+        self._fill(self.__title_input_field, text)
 
-    def _get_slug_input_field(self) -> str:
-        return super()._get_element_input_value(self.__slug_input_field)
+    def get_slug_input_field(self) -> str:
+        return self._get_element_input_value(self.__slug_input_field)
 
-    def _add_text_to_slug_field(self, text: str):
-        super()._clear_field(self.__slug_input_field)
-        super()._fill(self.__slug_input_field, text)
+    def add_text_to_slug_field(self, text: str):
+        self._clear_field(self.__slug_input_field)
+        self._fill(self.__slug_input_field, text)
 
-    def _select_category(self, option: str):
-        super()._select_option_by_label(self.__category_select_field, option)
+    def select_category(self, option: str):
+        self._select_option_by_label(self.__category_select_field, option)
 
-    def _check_product_checkbox(self, product_name: str):
-        super()._click(f"//section[@id='relevant-products']//label[normalize-space(text())"
-                       f"='{product_name}']")
+    def check_product_checkbox(self, product_name: str):
+        self._click(f"//section[@id='relevant-products']//label[normalize-space(text())"
+                    f"='{product_name}']")
 
-    def _is_obsolete_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__obsolete_checkbox)
+    def is_obsolete_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__obsolete_checkbox)
 
-    def _click_on_obsolete_checkbox(self):
-        super()._click(self.__obsolete_checkbox)
+    def click_on_obsolete_checkbox(self):
+        self._click(self.__obsolete_checkbox)
 
-    def _is_allow_discussion_checkbox_checked(self) -> bool:
-        return super()._is_checkbox_checked(self.__allow_discussion_checkbox)
+    def is_allow_discussion_checkbox_checked(self) -> bool:
+        return self._is_checkbox_checked(self.__allow_discussion_checkbox)
 
-    def _click_on_allow_discussion_on_article_checkbox(self):
-        super()._click(self.__allow_discussion_checkbox)
+    def click_on_allow_discussion_on_article_checkbox(self):
+        self._click(self.__allow_discussion_checkbox)
 
-    def _is_needs_change_checkbox(self) -> bool:
-        return super()._is_checkbox_checked(self.__needs_change_checkbox)
+    def is_needs_change_checkbox(self) -> bool:
+        return self._is_checkbox_checked(self.__needs_change_checkbox)
 
-    def _click_needs_change_checkbox(self):
-        super()._click(self.__needs_change_checkbox)
+    def click_needs_change_checkbox(self):
+        self._click(self.__needs_change_checkbox)
 
-    def _fill_needs_change_textarea(self, text: str):
-        super()._fill(self.__needs_change_textarea, text)
+    def fill_needs_change_textarea(self, text: str):
+        self._fill(self.__needs_change_textarea, text)
 
-    def _click_on_save_changes_button(self):
-        super()._click(self.__save_changes_button)
+    def click_on_save_changes_button(self):
+        self._click(self.__save_changes_button)

--- a/playwright_tests/test_data/add_kb_article.json
+++ b/playwright_tests/test_data/add_kb_article.json
@@ -12,7 +12,7 @@
   "keywords": "auto test keywordv1",
   "updated_keywords": "auto updated keyword",
   "search_result_summary": "This is a search result summary testv1",
-  "updated_search_result_summary": "Updated This is a search result summary testv2",
+  "updated_search_result_summary": "Updated This is a search result summary testv4",
   "article_content": "'''Lorem ipsum''' dolor ''sit amet'', consectetur [https://www.mediafax.ro adipiscing] elit, [[Stage test owl|sed]] do eiusmod [[DoNotDelete]] tempor incididunt # ut labore * et dolore magna aliqua. Tincidunt id aliquet risus feugiat in ante. Etiam non quam lacus suspendisse faucibus interdum posuere. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Velit egestas dui id ornare arcu odio ut sem nulla. Risus nec feugiat in fermentum posuere urna nec tincidunt. Sed egestas egestas fringilla phasellus faucibus. Amet consectetur adipiscing elit duis tristique. Lorem mollis aliquam ut porttitor. Purus sit amet volutpat consequat mauris. Lobortis mattis aliquam faucibus purus in. Enim praesent elementum facilisis leo vel. Volutpat lacus laoreet non curabitur gravida arcu. Tempus iaculis urna id volutpat.",
   "article_image": "Automation test image",
   "updated_article_content": "Updated Content",

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
@@ -965,13 +965,13 @@ def test_edit_article_metadata_title(page: Page):
                             "that the updated title and original slug is displayed"):
         sumo_pages.kb_article_page.click_on_edit_article_metadata()
         check.equal(
-            (sumo_pages.kb_article_edit_article_metadata_page._get_text_of_title_input_field()),
+            (sumo_pages.kb_article_edit_article_metadata_page.get_text_of_title_input_field()),
             utilities.kb_article_test_data['updated_kb_article_title'] + article_details
             ['article_title']
         )
 
         check.equal(
-            sumo_pages.kb_article_edit_article_metadata_page._get_slug_input_field(),
+            sumo_pages.kb_article_edit_article_metadata_page.get_slug_input_field(),
             article_details['article_slug']
         )
 
@@ -999,7 +999,7 @@ def test_edit_article_metadata_slug(page: Page):
 
     with check, allure.step("Verifying that the correct error message is displayed"):
         check.equal(
-            sumo_pages.kb_article_edit_article_metadata_page._get_error_message(),
+            sumo_pages.kb_article_edit_article_metadata_page.get_error_message(),
             KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS[1]
         )
 
@@ -1019,7 +1019,7 @@ def test_edit_article_metadata_slug(page: Page):
         sumo_pages.kb_article_page.click_on_edit_article_metadata()
 
         check.equal(
-            sumo_pages.kb_article_edit_article_metadata_page._get_slug_input_field(),
+            sumo_pages.kb_article_edit_article_metadata_page.get_slug_input_field(),
             article_details['article_slug'] + "1"
         )
 
@@ -1050,7 +1050,7 @@ def test_edit_article_metadata_category(page: Page):
 
     with check, allure.step("Verifying that the correct error message is displayed"):
         check.equal(
-            sumo_pages.kb_article_edit_article_metadata_page._get_error_message(),
+            sumo_pages.kb_article_edit_article_metadata_page.get_error_message(),
             kb_article_messages.get_template_error(article_details['article_title'])
         )
 
@@ -1134,7 +1134,7 @@ def test_edit_article_metadata_product_and_topic(page: Page):
             product=article_details['article_product']
         )
         check.equal(
-            sumo_pages.kb_article_edit_article_metadata_page._get_error_message(),
+            sumo_pages.kb_article_edit_article_metadata_page.get_error_message(),
             KBArticlePageMessages.KB_ARTICLE_PRODUCT_ERROR
         )
 
@@ -1145,7 +1145,7 @@ def test_edit_article_metadata_product_and_topic(page: Page):
             product="Firefox for Android", topics=article_details['article_topic'][0]
         )
         check.equal(
-            sumo_pages.kb_article_edit_article_metadata_page._get_error_message(),
+            sumo_pages.kb_article_edit_article_metadata_page.get_error_message(),
             KBArticlePageMessages.KB_ARTICLE_TOPIC_ERROR
         )
 


### PR DESCRIPTION
- Mark the functions from the kb article metadata class as public and replace super() with self.
- Use composition instead of inheritance for the delete_kb_article_flow.py and edit_article_meta_flow.py class.
- Updating modified function calls in tests.
- Update the search summary used in tests to avoid failing with https://github.com/mozilla/sumo/issues/1985