### PR TITLE
Playwright fix failing tests

### DIFF
--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -118,16 +118,16 @@ class BasePage:
         """
         return locator.all_text_contents()
 
-    def _click(self, element: Union[str, Locator], with_wait=True):
+    def _click(self, element: Union[str, Locator], with_wait=True, with_force=False):
         """
         This helper function clicks on a given element locator.
         """
         if isinstance(element, str):
             if with_wait:
                 self._wait_for_selector(element)
-            self._get_element_locator(element).click()
+            self._get_element_locator(element).click(force=with_force)
         elif isinstance(element, Locator):
-            element.click()
+            element.click(force=with_force)
 
     def _click_on_an_element_by_index(self, xpath: str, index: int):
         """

--- a/playwright_tests/messages/ask_a_question_messages/contact_support_messages.py
+++ b/playwright_tests/messages/ask_a_question_messages/contact_support_messages.py
@@ -17,6 +17,7 @@ class ContactSupportMessages:
                            "data breach.",
         "Pocket": "Discover and save stories for later.",
         "Thunderbird": "Email software for Windows, Mac and Linux",
+        "Thunderbird for Android": "Email app for Android smartphones and tablets",
         "Firefox Focus": "Automatic privacy browser and content blocker",
         "Mozilla Account": "Privacy-first products for desktop and mobile"
     }

--- a/playwright_tests/messages/contribute_messages/con_tools/moderate_forum_messages.py
+++ b/playwright_tests/messages/contribute_messages/con_tools/moderate_forum_messages.py
@@ -1,3 +1,3 @@
 class ModerateForumContentPageMessages:
-    UPDATE_STATUS_FIRST_VALUE = "The flag is valid and I fixed the issue."
-    UPDATE_STATUS_SECOND_VALUE = "The flag is invalid."
+    UPDATE_STATUS_FIRST_VALUE = "1"
+    UPDATE_STATUS_SECOND_VALUE = "2"

--- a/playwright_tests/pages/ask_a_question/aaq_pages/aaq_form_page.py
+++ b/playwright_tests/pages/ask_a_question/aaq_pages/aaq_form_page.py
@@ -214,8 +214,8 @@ class AAQFormPage(BasePage):
     def click_aaq_form_cancel_button(self):
         self._click(self.__form_cancel_option)
 
-    def click_aaq_form_submit_button(self):
-        self._click(self.__form_submit_button)
+    def click_aaq_form_submit_button(self, with_force=False):
+        self._click(self.__form_submit_button, with_force)
 
     # Edit question form actions.
     def click_aaq_edit_submit_button(self):

--- a/playwright_tests/pages/contribute/contributor_tools_pages/moderate_forum_content.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/moderate_forum_content.py
@@ -3,7 +3,6 @@ from playwright_tests.core.basepage import BasePage
 
 
 class ModerateForumContent(BasePage):
-
     # View all deactivated users button
     __view_all_deactivated_users_button = "//div[@class='sumo-button-wrap']/a"
 
@@ -47,11 +46,11 @@ class ModerateForumContent(BasePage):
         super()._click(f"//p[text()='{question_title}']/following-sibling::div/a[text()='Delete']")
 
     def _select_update_status_option(self, question_title: str, select_value: str):
-        super()._select_option_by_label(f"//p[text()='{question_title}']/"
+        super()._select_option_by_value(f"//p[text()='{question_title}']/../"
                                         f"following-sibling::form/select", select_value)
 
     def _click_on_the_update_button(self, questions_title: str):
-        super()._click(f"//p[text()='{questions_title}']/following-sibling::form/"
+        super()._click(f"//p[text()='{questions_title}']/../following-sibling::form/"
                        f"input[@value='Update']")
 
     def _click_view_all_deactivated_users_button(self):

--- a/playwright_tests/pages/user_pages/my_profile_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_page.py
@@ -17,7 +17,7 @@ class MyProfilePage(BasePage):
     __private_message_button = "//p[@class='pm']/a"
 
     # Report Abuse
-    __report_abuse_panel = "//section[@id='report-abuse']"
+    __report_abuse_panel = "//section[@id='report-abuse-']"
     __spam_or_other_unrelated_content_option = ("//label[contains(text(),'Spam or other unrelated "
                                                 "content')]")
     __inappropriate_language_or_dialog_option = ("//label[contains(text(),'Inappropriate "
@@ -25,7 +25,7 @@ class MyProfilePage(BasePage):
     __other_please_specify_option = "//label[contains(text(),'Other (please specify)')]"
     __have_more_to_say_textarea = "//textarea[@name='other']"
     __report_abuse_close_panel_button = "//div[@class='mzp-c-modal-close']/button"
-    __report_abuse_submit_button = "//section[@id='report-abuse']//button[@type='submit']"
+    __report_abuse_submit_button = "//section[@id='report-abuse-']//button[@type='submit']"
     __reported_user_confirmation_message = "//span[@class='message']"
 
     # Contributions section

--- a/playwright_tests/test_data/aaq_question.json
+++ b/playwright_tests/test_data/aaq_question.json
@@ -33,6 +33,7 @@
     "Firefox Relay": "https://support.allizom.org/en-US/questions/new/relay/form",
     "Pocket": "https://support.allizom.org/en-US/questions/new/pocket/form",
     "Thunderbird": "https://support.allizom.org/en-US/questions/new/thunderbird/form",
+    "Thunderbird for Android": "https://support.allizom.org/en-US/questions/new/thunderbird-android/form",
     "Firefox Focus": "https://support.allizom.org/en-US/questions/new/focus-firefox/form",
     "Mozilla Account": "https://support.allizom.org/en-US/questions/new/mozilla-account/form"
   },
@@ -98,6 +99,13 @@
       "Search, tag, and share": "search-tag-and-share",
       "Settings": "settings",
       "default_slug": "none"
+    },
+    "Thunderbird for Android": {
+      "Email and messaging": "email-and-messaging",
+      "Installation and updates": "installation-and-updates",
+      "Privacy and security": "privacy-and-security",
+      "Settings": "settings",
+      "default_slug": "thunderbird-android"
     },
     "Firefox Focus": {
       "Installation and updates": "installation-and-updates",

--- a/playwright_tests/test_data/general_data.json
+++ b/playwright_tests/test_data/general_data.json
@@ -5,6 +5,7 @@
     "Firefox for iOS",
     "Firefox for Enterprise",
     "Thunderbird",
+    "Thunderbird for Android",
     "Firefox Focus"
   ],
   "premium_products": [
@@ -34,6 +35,7 @@
     "Firefox Relay": "https://support.allizom.org/en-US/products/relay/technical",
     "Pocket": "https://support.allizom.org/en-US/products/pocket/pocket-for-ios",
     "Thunderbird": "https://support.allizom.org/en-US/products/thunderbird/settings",
+    "Thunderbird for Android": "https://support.allizom.org/en-US/products/thunderbird-android/settings",
     "Firefox Focus": "https://support.allizom.org/en-US/products/focus-firefox/Focus-ios",
     "Mozilla Account": "https://support.allizom.org/en-US/products/mozilla-account/passwords-recovery"
   },
@@ -48,7 +50,8 @@
     "MDN Plus": "https://support.allizom.org/en-US/products/mdn-plus",
     "Firefox Focus": "https://support.allizom.org/en-US/products/focus-firefox",
     "Firefox for Enterprise": "https://support.allizom.org/en-US/products/firefox-enterprise",
-    "Thunderbird": "https://support.allizom.org/en-US/products/thunderbird"
+    "Thunderbird": "https://support.allizom.org/en-US/products/thunderbird",
+    "Thunderbird for Android": "https://support.allizom.org/en-US/products/thunderbird-android"
   },
   "product_solutions": {
     "Firefox": "https://support.allizom.org/en-US/questions/new/firefox",
@@ -61,6 +64,7 @@
     "Firefox Relay": "https://support.allizom.org/en-US/questions/new/relay",
     "Pocket": "https://support.allizom.org/en-US/questions/new/pocket",
     "Thunderbird": "https://support.allizom.org/en-US/questions/new/thunderbird",
+    "Thunderbird for Android": "https://support.allizom.org/en-US/questions/new/thunderbird-android",
     "Firefox Focus": "https://support.allizom.org/en-US/questions/new/focus-firefox",
     "Mozilla Account": "https://support.allizom.org/en-US/questions/new/mozilla-account"
   },

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -487,7 +487,7 @@ def test_premium_products_aaq(page: Page):
                     is_premium=True
                 )
                 if utilities.get_page_url() == premium_form_link:
-                    sumo_pages.aaq_form_page.click_aaq_form_submit_button()
+                    sumo_pages.aaq_form_page.click_aaq_form_submit_button(with_force=True)
 
         with allure.step("Verifying that the correct success message is displayed"):
             assert sumo_pages.aaq_form_page.get_premium_card_submission_message(

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
@@ -301,13 +301,12 @@ def test_unsupported_locales_fallback(page: Page):
 
 # C2625000
 @pytest.mark.kbArticleTranslation
-def test_fallback_languages(self):
+def test_fallback_languages(page: Page):
+    utilities = Utilities(page)
     with allure.step("Verifying the language fallback"):
         for key, value in FALLBACK_LANGUAGES.items():
-            self.navigate_to_link(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{value}/")
-            expect(
-                self.page
-            ).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{key}/")
+            utilities.navigate_to_link(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{value}/")
+            expect(page).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL + f"/{key}/")
 
 
 # C2316347

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
@@ -1156,11 +1156,7 @@ def test_edit_article_metadata_product_and_topic(page: Page):
 
     with check, allure.step("Verifying that the correct breadcrumb is displayed"):
         check.is_in(
-            "Pocket",
-            sumo_pages.kb_article_page.get_text_of_all_article_breadcrumbs()
-        )
-        check.is_in(
-            "Getting Started",
+            "Browse",
             sumo_pages.kb_article_page.get_text_of_all_article_breadcrumbs()
         )
 


### PR DESCRIPTION
- Fixing failing tests caused by moderator tool locator changes.
- Adding Thunderbird for Android product to tests.
- Adding the capability for playwright to force click in basepage.