### PR TITLE
Playwright refactor contact support, product solutions and product topics pages

### DIFF
--- a/playwright_tests/pages/ask_a_question/contact_support_pages/contact_support_page.py
+++ b/playwright_tests/pages/ask_a_question/contact_support_pages/contact_support_page.py
@@ -18,26 +18,26 @@ class ContactSupportPage(BasePage):
         super().__init__(page)
 
     # Breadcrumb related actions.
-    def _get_text_of_current_milestone(self) -> str:
-        return super()._get_text_of_element(self.__current_milestone)
+    def get_text_of_current_milestone(self) -> str:
+        return self._get_text_of_element(self.__current_milestone)
 
     # Page actions.
-    def _get_contact_support_main_heading(self) -> str:
-        return super()._get_text_of_element(self.__page_main_heading)
+    def get_contact_support_main_heading(self) -> str:
+        return self._get_text_of_element(self.__page_main_heading)
 
-    def _get_contact_support_subheading_text(self) -> str:
-        return super()._get_text_of_element(self.__page_subheading)
+    def get_contact_support_subheading_text(self) -> str:
+        return self._get_text_of_element(self.__page_subheading)
 
-    def _click_on_browse_all_product_forums_button(self):
-        super()._click(self.__browse_all_product_forums_button)
+    def click_on_browse_all_product_forums_button(self):
+        self._click(self.__browse_all_product_forums_button)
 
     # Product card actions.
-    def _get_all_product_card_titles(self) -> list[str]:
-        return super()._get_text_of_elements(self.__product_cards_titles)
+    def get_all_product_card_titles(self) -> list[str]:
+        return self._get_text_of_elements(self.__product_cards_titles)
 
-    def _get_product_card_subtitle(self, card_name: str) -> str:
-        return super()._get_text_of_element(f"//a[normalize-space(text()) = '{card_name}']/..//"
-                                            f"following-sibling::p[@class='card--desc']")
+    def get_product_card_subtitle(self, card_name: str) -> str:
+        return self._get_text_of_element(f"//a[normalize-space(text()) = '{card_name}']/..//"
+                                         f"following-sibling::p[@class='card--desc']")
 
-    def _click_on_a_particular_card(self, card_name: str):
-        super()._click(f"//h3[@class='card--title']/a[normalize-space(text())='{card_name}']")
+    def click_on_a_particular_card(self, card_name: str):
+        self._click(f"//h3[@class='card--title']/a[normalize-space(text())='{card_name}']")

--- a/playwright_tests/pages/ask_a_question/product_solutions_pages/product_solutions_page.py
+++ b/playwright_tests/pages/ask_a_question/product_solutions_pages/product_solutions_page.py
@@ -37,64 +37,64 @@ class ProductSolutionsPage(BasePage):
         super().__init__(page)
 
     # Still need help actions.
-    def _click_ask_now_button(self):
-        super()._click(self.__still_need_help_ask_now_button)
+    def click_ask_now_button(self):
+        self._click(self.__still_need_help_ask_now_button)
 
-    def _get_aaq_subheading_text(self) -> str:
-        return super()._get_text_of_element(self.__still_need_help_subheading)
+    def get_aaq_product_solutions_subheading_text(self) -> str:
+        return self._get_text_of_element(self.__still_need_help_subheading)
 
-    def _get_aaq_widget_button_name(self) -> str:
-        return super()._get_text_of_element(self.__still_need_help_ask_now_button)
+    def get_aaq_widget_button_name(self) -> str:
+        return self._get_text_of_element(self.__still_need_help_ask_now_button)
 
-    def _get_still_need_help_locator(self) -> Locator:
-        return super()._get_element_locator(self.__still_need_help_ask_now_button)
+    def get_still_need_help_locator(self) -> Locator:
+        return self._get_element_locator(self.__still_need_help_ask_now_button)
 
     # Breadcrumb actions.
-    def _click_on_the_completed_milestone(self):
-        super()._click(self.__complete_progress_item)
+    def click_on_the_completed_milestone(self):
+        self._click(self.__complete_progress_item)
 
-    def _get_current_milestone_text(self) -> str:
-        return super()._get_text_of_element(self.__current_progress_item_label)
+    def get_current_milestone_text(self) -> str:
+        return self._get_text_of_element(self.__current_progress_item_label)
 
     # Featured article actions.
-    def _click_on_a_featured_article_card(self, card_name: str):
-        super()._click(f'//h2[contains(text(),"Featured Articles")]/../..//'
-                       f'a[normalize-space(text())="{card_name}"]')
+    def click_on_a_featured_article_card(self, card_name: str):
+        self._click(f'//h2[contains(text(),"Featured Articles")]/../..//'
+                    f'a[normalize-space(text())="{card_name}"]')
 
-    def _get_all_featured_articles_titles(self) -> list[str]:
-        return super()._get_text_of_elements(self.__featured_articles_cards)
+    def get_all_featured_articles_titles(self) -> list[str]:
+        return self._get_text_of_elements(self.__featured_articles_cards)
 
-    def _is_featured_article_section_displayed(self) -> bool:
-        return super()._is_element_visible(self.__featured_article_section_title)
+    def is_featured_article_section_displayed(self) -> bool:
+        return self._is_element_visible(self.__featured_article_section_title)
 
     # Popular topic actions.
-    def _click_on_a_popular_topic_card(self, card_name: str):
-        super()._click(f"//h2[contains(text(),'Popular Topics')]/../..//"
-                       f"a[normalize-space(text()) = '{card_name}']")
+    def click_on_a_popular_topic_card(self, card_name: str):
+        self._click(f"//h2[contains(text(),'Popular Topics')]/../..//"
+                    f"a[normalize-space(text()) = '{card_name}']")
 
-    def _get_popular_topics(self) -> list[str]:
-        return super()._get_text_of_elements(self.__popular_topics_cards)
+    def get_popular_topics(self) -> list[str]:
+        return self._get_text_of_elements(self.__popular_topics_cards)
 
-    def _is_popular_topics_section_displayed(self) -> bool:
-        return super()._is_element_visible(self.__popular_topics_section_title)
+    def is_popular_topics_section_displayed(self) -> bool:
+        return self._is_element_visible(self.__popular_topics_section_title)
 
     # Product solutions actions.
-    def _get_product_solutions_heading(self) -> str:
-        return super()._get_text_of_element(self.__product_title_heading)
+    def get_product_solutions_heading(self) -> str:
+        return self._get_text_of_element(self.__product_title_heading)
 
-    def _is_product_solutions_page_header_displayed(self) -> ElementHandle:
-        return super()._get_element_handle(self.__product_title_heading)
+    def is_product_solutions_page_header_displayed(self) -> ElementHandle:
+        return self._get_element_handle(self.__product_title_heading)
 
     # Support scam banner actions
 
     # Instead of clicking on the 'Learn More' button we are going to perform the assertion
     # by checking that the element has the correct href value. Navigating to prod can yield
     # a 429 error which we want to avoid.
-    def _get_scam_alert_banner_link(self) -> str:
-        return super()._get_element_attribute_value(
+    def get_scam_alert_banner_link(self) -> str:
+        return self._get_element_attribute_value(
             self.__support_scam_banner_learn_more_button,
             "href"
         )
 
-    def _get_scam_banner_locator(self) -> Locator:
-        return super()._get_element_locator(self.__support_scams_banner)
+    def get_scam_banner_locator(self) -> Locator:
+        return self._get_element_locator(self.__support_scams_banner)

--- a/playwright_tests/pages/ask_a_question/product_topics_pages/product_topics_page.py
+++ b/playwright_tests/pages/ask_a_question/product_topics_pages/product_topics_page.py
@@ -22,35 +22,35 @@ class ProductTopicPage(BasePage):
         super().__init__(page)
 
     # Page content actions.
-    def _get_page_title(self) -> str:
-        return super()._get_text_of_element(self.__page_title)
+    def get_page_title(self) -> str:
+        return self._get_text_of_element(self.__page_title)
 
-    def _get_a_particular_article_locator(self, article_title: str):
-        return super()._get_element_locator(f"//h2[@class='sumo-card-heading']/a[normalize-space"
-                                            f"(text())='{article_title}']")
+    def get_a_particular_article_locator(self, article_title: str):
+        return self._get_element_locator(f"//h2[@class='sumo-card-heading']/a[normalize-space"
+                                         f"(text())='{article_title}']")
 
     # Navbar actions.
-    def _get_selected_navbar_option(self) -> str:
-        return super()._get_text_of_element(self.__selected_nav_link)
+    def get_selected_navbar_option(self) -> str:
+        return self._get_text_of_element(self.__selected_nav_link)
 
-    def _click_on_a_navbar_option(self, option_name: str):
-        super()._click(f"//ul[@class='sidebar-nav--list']/li/a[contains(text(),'{option_name}')]")
+    def click_on_a_navbar_option(self, option_name: str):
+        self._click(f"//ul[@class='sidebar-nav--list']/li/a[contains(text(),'{option_name}')]")
 
-    def _get_navbar_links_text(self) -> list[str]:
-        return super()._get_text_of_elements(self.__navbar_links)
+    def get_navbar_links_text(self) -> list[str]:
+        return self._get_text_of_elements(self.__navbar_links)
 
-    def _get_navbar_option_link(self, option_name: str) -> str:
-        return super()._get_element_attribute_value(f"//ul[@class='sidebar-nav--list']/li/"
-                                                    f"a[contains(text(),'{option_name}')]",
-                                                    "href")
+    def get_navbar_option_link(self, option_name: str) -> str:
+        return self._get_element_attribute_value(f"//ul[@class='sidebar-nav--list']/li/"
+                                                 f"a[contains(text(),'{option_name}')]",
+                                                 "href")
 
     # AAQ section actions.
-    def _get_aaq_subheading_text(self) -> str:
-        return super()._get_text_of_element(self.__still_need_help_subheading)
+    def _get_aaq_widget_subheading_text(self) -> str:
+        return self._get_text_of_element(self.__still_need_help_subheading)
 
-    def _click_on_aaq_button(self):
-        super()._click(self.__aaq_button)
+    def click_on_aaq_button(self):
+        self._click(self.__aaq_button)
 
     # Learn more section actions.
-    def _click_on_learn_more_button(self):
-        super()._click(self.__learn_more_button)
+    def click_on_learn_more_button(self):
+        self._click(self.__learn_more_button)

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -86,16 +86,16 @@ def test_scam_banner_premium_products_not_displayed(page: Page, username):
 
             with allure.step(f"Verifying that the sam banner is not displayed for "
                              f"{premium_product} card"):
-                expect(sumo_pages.product_solutions_page._get_scam_banner_locator()).to_be_hidden()
+                expect(sumo_pages.product_solutions_page.get_scam_banner_locator()).to_be_hidden()
 
             if username != '':
                 with allure.step("Clicking on the Ask Now button and verifying that the scam "
                                  "banner is not displayed"):
-                    sumo_pages.product_solutions_page._click_ask_now_button()
+                    sumo_pages.product_solutions_page.click_ask_now_button()
                     utilities.wait_for_url_to_be(
                         utilities.aaq_question_test_data["products_aaq_url"][premium_product]
                     )
-                    expect(sumo_pages.product_solutions_page._get_scam_banner_locator()
+                    expect(sumo_pages.product_solutions_page.get_scam_banner_locator()
                            ).to_be_hidden()
 
 
@@ -119,17 +119,17 @@ def test_scam_banner_for_freemium_products_is_displayed(page: Page, username):
 
             with check, allure.step("Verifying that the 'Learn More' button contains the "
                                     "correct link"):
-                assert sumo_pages.product_solutions_page._get_scam_alert_banner_link(
+                assert sumo_pages.product_solutions_page.get_scam_alert_banner_link(
                 ) == QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
 
             if username != '':
                 with check, allure.step("Clicking on the Ask Now button and verifying that "
                                         "the 'Learn More' button contains the correct link"):
-                    sumo_pages.product_solutions_page._click_ask_now_button()
+                    sumo_pages.product_solutions_page.click_ask_now_button()
                     utilities.wait_for_url_to_be(
                         utilities.aaq_question_test_data["products_aaq_url"][freemium_product]
                     )
-                    assert sumo_pages.product_solutions_page._get_scam_alert_banner_link(
+                    assert sumo_pages.product_solutions_page.get_scam_alert_banner_link(
                     ) == QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
 
 
@@ -420,7 +420,7 @@ def test_system_details_information(page: Page):
     with allure.step("Navigating to each product aaq form and and adding data without "
                      "submitting the form"):
         for product in utilities.general_test_data["freemium_products"]:
-            if product == "Thunderbird":
+            if product == "Thunderbird" or product == "Thunderbird for Android":
                 continue
             else:
                 utilities.navigate_to_link(

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -39,13 +39,13 @@ def test_posted_question_details(page: Page, username):
         page.reload()
 
     with allure.step("Verifying that the scam banner is displayed"):
-        expect(sumo_pages.product_solutions_page._get_scam_banner_locator()).to_be_visible()
+        expect(sumo_pages.product_solutions_page.get_scam_banner_locator()).to_be_visible()
 
     with allure.step("Verifying that the still need help banner is displayed"):
-        expect(sumo_pages.product_solutions_page._get_still_need_help_locator()).to_be_visible()
+        expect(sumo_pages.product_solutions_page.get_still_need_help_locator()).to_be_visible()
 
     with check, allure.step("Verifying that the Learn More button contains the correct link"):
-        assert sumo_pages.product_solutions_page._get_scam_alert_banner_link(
+        assert sumo_pages.product_solutions_page.get_scam_alert_banner_link(
         ) == QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
 
     with allure.step("Signing in with an admin account and verifying that the scam banner is "
@@ -53,11 +53,11 @@ def test_posted_question_details(page: Page, username):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-        expect(sumo_pages.product_solutions_page._get_scam_banner_locator()).to_be_visible()
-        expect(sumo_pages.product_solutions_page._get_still_need_help_locator()).to_be_visible()
+        expect(sumo_pages.product_solutions_page.get_scam_banner_locator()).to_be_visible()
+        expect(sumo_pages.product_solutions_page.get_still_need_help_locator()).to_be_visible()
 
     with check, allure.step("Verifying that the Learn More button contains the correct link"):
-        assert sumo_pages.product_solutions_page._get_scam_alert_banner_link(
+        assert sumo_pages.product_solutions_page.get_scam_alert_banner_link(
         ) == QuestionPageMessages.AVOID_SCAM_SUPPORT_LEARN_MORE_LINK
 
     with allure.step("Deleting the posted question"):

--- a/playwright_tests/tests/ask_a_question_tests/contact_support_page_tests/test_contact_support_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/contact_support_page_tests/test_contact_support_page.py
@@ -21,22 +21,22 @@ def test_contact_support_page_content(page: Page):
         sumo_pages.top_navbar.click_on_browse_all_products_option()
 
     with check, allure.step("Verifying that the current milestone is the correct one"):
-        assert sumo_pages.contact_support_page._get_text_of_current_milestone(
+        assert sumo_pages.contact_support_page.get_text_of_current_milestone(
         ) == ContactSupportMessages.CURRENT_MILESTONE
 
     with check, allure.step("Verifying that the correct page header is displayed"):
-        assert sumo_pages.contact_support_page._get_contact_support_main_heading(
+        assert sumo_pages.contact_support_page.get_contact_support_main_heading(
         ) == ContactSupportMessages.MAIN_HEADER
 
     with check, allure.step("Verifying that the correct page subheading is displayed"):
-        assert sumo_pages.contact_support_page._get_contact_support_subheading_text(
+        assert sumo_pages.contact_support_page.get_contact_support_subheading_text(
         ) == ContactSupportMessages.SUBHEADING
 
     with allure.step("Verifying that each product card has the correct subheading"):
-        for card in sumo_pages.contact_support_page._get_all_product_card_titles():
+        for card in sumo_pages.contact_support_page.get_all_product_card_titles():
             with check, allure.step(f"Verifying {card} card has the correct subheading"):
                 assert (ContactSupportMessages.PRODUCT_CARDS_SUBHEADING[card] == sumo_pages.
-                        contact_support_page._get_product_card_subtitle(card))
+                        contact_support_page.get_product_card_subtitle(card))
 
 
 # C890368, C890387, C890388
@@ -48,20 +48,20 @@ def test_contact_support_page_cards_redirect(page: Page):
                      "View All"):
         sumo_pages.top_navbar.click_on_browse_all_products_option()
 
-    for card in sumo_pages.contact_support_page._get_all_product_card_titles():
+    for card in sumo_pages.contact_support_page.get_all_product_card_titles():
         with allure.step(f"Clicking on {card}"):
-            sumo_pages.contact_support_page._click_on_a_particular_card(card)
+            sumo_pages.contact_support_page.click_on_a_particular_card(card)
 
         with check, allure.step("Verifying that we are on the correct product solutions page"):
-            assert sumo_pages.product_solutions_page._get_product_solutions_heading(
+            assert sumo_pages.product_solutions_page.get_product_solutions_heading(
             ) == card + ProductSolutionsMessages.PAGE_HEADER
 
         with check, allure.step("Verifying that we are on the correct milestone"):
-            assert sumo_pages.product_solutions_page._get_current_milestone_text(
+            assert sumo_pages.product_solutions_page.get_current_milestone_text(
             ) == ProductSolutionsMessages.CURRENT_MILESTONE_TEXT
 
         with allure.step("Click on the 'Change Product' milestone"):
-            sumo_pages.product_solutions_page._click_on_the_completed_milestone()
+            sumo_pages.product_solutions_page.click_on_the_completed_milestone()
 
 
 # T5696795
@@ -74,5 +74,5 @@ def test_browse_all_product_forums_button_redirect(page: Page):
 
     with allure.step("Clicking on browse all product forums button and verifying that we are "
                      "redirected to the correct page"):
-        sumo_pages.contact_support_page._click_on_browse_all_product_forums_button()
+        sumo_pages.contact_support_page.click_on_browse_all_product_forums_button()
         expect(page).to_have_url(SupportForumsPageMessages.PAGE_URL)

--- a/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
@@ -24,22 +24,22 @@ def test_popular_topics_navbar(page: Page):
             utilities.navigate_to_link(topic_url)
             utilities.wait_for_url_to_be(topic_url)
 
-            for option in sumo_pages.product_topics_page._get_navbar_links_text():
+            for option in sumo_pages.product_topics_page.get_navbar_links_text():
                 with allure.step(f"Clicking on {option} navbar option"):
                     option_url = (HomepageMessages.STAGE_HOMEPAGE_URL + sumo_pages.
-                                  product_topics_page._get_navbar_option_link(option))
-                    sumo_pages.product_topics_page._click_on_a_navbar_option(option)
+                                  product_topics_page.get_navbar_option_link(option))
+                    sumo_pages.product_topics_page.click_on_a_navbar_option(option)
                     try:
                         utilities.wait_for_url_to_be(option_url)
                     except (TimeoutError, Error):
-                        sumo_pages.product_topics_page._click_on_a_navbar_option(option)
+                        sumo_pages.product_topics_page.click_on_a_navbar_option(option)
                         utilities.wait_for_url_to_be(option_url)
 
                 with check, allure.step("Verifying that the correct option is displayed"):
-                    assert sumo_pages.product_topics_page._get_page_title() == option
+                    assert sumo_pages.product_topics_page.get_page_title() == option
 
                 with check, allure.step("Verifying that the correct nav option is selected"):
-                    assert sumo_pages.product_topics_page._get_selected_navbar_option() == option
+                    assert sumo_pages.product_topics_page.get_selected_navbar_option() == option
 
 
 #  T5696796
@@ -54,7 +54,7 @@ def test_learn_more_redirect(page: Page):
             utilities.wait_for_url_to_be(topic_url)
 
             with allure.step("Clicking on the 'Learn More' button"):
-                sumo_pages.product_topics_page._click_on_learn_more_button()
+                sumo_pages.product_topics_page.click_on_learn_more_button()
 
             with allure.step("Verifying that the user is redirected to the contribute messages "
                              "page"):
@@ -76,14 +76,14 @@ def test_aaq_redirect(page: Page):
             with check, allure.step(f"Verifying that the correct subheading page for "
                                     f"{product_topic} is displayed"):
                 if product_topic in utilities.general_test_data["premium_products"]:
-                    assert sumo_pages.product_topics_page._get_aaq_subheading_text(
+                    assert sumo_pages.product_topics_page._get_aaq_widget_subheading_text(
                     ) == AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
                 else:
-                    assert sumo_pages.product_topics_page._get_aaq_subheading_text(
+                    assert sumo_pages.product_topics_page._get_aaq_widget_subheading_text(
                     ) == AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
 
             with allure.step("Clicking on the AAQ button"):
-                sumo_pages.product_topics_page._click_on_aaq_button()
+                sumo_pages.product_topics_page.click_on_aaq_button()
 
             with allure.step("Signing in to SUMO and verifying that we are on the correct AAQ "
                              "form page"):

--- a/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
@@ -22,17 +22,17 @@ def test_featured_articles_redirect(page: Page):
         sumo_pages.top_navbar.click_on_browse_all_products_option()
 
     with allure.step("Clicking on all product cards"):
-        for card in sumo_pages.contact_support_page._get_all_product_card_titles():
+        for card in sumo_pages.contact_support_page.get_all_product_card_titles():
             with check, allure.step(f"Clicking on the {card} and verifying that the correct "
                                     f"product solutions page header is displayed"):
-                sumo_pages.contact_support_page._click_on_a_particular_card(card)
-                assert sumo_pages.product_solutions_page._get_product_solutions_heading(
+                sumo_pages.contact_support_page.click_on_a_particular_card(card)
+                assert sumo_pages.product_solutions_page.get_product_solutions_heading(
                 ) == card + ProductSolutionsMessages.PAGE_HEADER
 
-            if sumo_pages.product_solutions_page._is_featured_article_section_displayed():
+            if sumo_pages.product_solutions_page.is_featured_article_section_displayed():
                 for featured_article_card in (sumo_pages.product_solutions_page
-                                              ._get_all_featured_articles_titles()):
-                    sumo_pages.product_solutions_page._click_on_a_featured_article_card(
+                                              .get_all_featured_articles_titles()):
+                    sumo_pages.product_solutions_page.click_on_a_featured_article_card(
                         featured_article_card)
                     with check, allure.step(f"Clicking on the {featured_article_card} and "
                                             f"verifying that the correct article page title "
@@ -57,16 +57,16 @@ def test_popular_topics_redirect(page: Page):
                      "Browse All products"):
         sumo_pages.top_navbar.click_on_browse_all_products_option()
 
-    for card in sumo_pages.contact_support_page._get_all_product_card_titles():
-        sumo_pages.contact_support_page._click_on_a_particular_card(card)
+    for card in sumo_pages.contact_support_page.get_all_product_card_titles():
+        sumo_pages.contact_support_page.click_on_a_particular_card(card)
         with check, allure.step(f"Clicking on the {card} card and verifying that the correct "
                                 f"product solutions page is displayed"):
-            assert sumo_pages.product_solutions_page._get_product_solutions_heading(
+            assert sumo_pages.product_solutions_page.get_product_solutions_heading(
             ) == card + ProductSolutionsMessages.PAGE_HEADER
 
-        if sumo_pages.product_solutions_page._is_popular_topics_section_displayed:
-            for topic in sumo_pages.product_solutions_page._get_popular_topics():
-                sumo_pages.product_solutions_page._click_on_a_popular_topic_card(topic)
+        if sumo_pages.product_solutions_page.is_popular_topics_section_displayed:
+            for topic in sumo_pages.product_solutions_page.get_popular_topics():
+                sumo_pages.product_solutions_page.click_on_a_popular_topic_card(topic)
                 with check, allure.step(f"Clicking on the {topic} topic and verifying if "
                                         f"correct topic page title is displayed"):
                     try:
@@ -75,7 +75,7 @@ def test_popular_topics_redirect(page: Page):
                             print(f"Tab open for topic: {topic}")
                     except TimeoutError:
                         print("Trying to click on the popular topic again")
-                        sumo_pages.product_solutions_page._click_on_a_popular_topic_card(
+                        sumo_pages.product_solutions_page.click_on_a_popular_topic_card(
                             topic)
                         with page.context.expect_page() as tab:
                             feature_article_page = tab.value
@@ -103,19 +103,19 @@ def test_ask_now_widget_redirect(page: Page):
     count = 0
     for freemium_product in utilities.general_test_data["freemium_products"]:
         with allure.step(f"Clicking on the {freemium_product} card "):
-            sumo_pages.contact_support_page._click_on_a_particular_card(freemium_product)
+            sumo_pages.contact_support_page.click_on_a_particular_card(freemium_product)
         with check, allure.step("verifying that the correct 'Still need help' subtext is "
                                 "displayed"):
-            assert sumo_pages.product_solutions_page._get_aaq_subheading_text(
+            assert sumo_pages.product_solutions_page.get_aaq_product_solutions_subheading_text(
             ) == AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
 
         with check, allure.step("Verifying that the correct AAQ button text is displayed"):
-            assert sumo_pages.product_solutions_page._get_aaq_widget_button_name(
+            assert sumo_pages.product_solutions_page.get_aaq_widget_button_name(
             ) == AAQWidgetMessages.FREEMIUM_AND_PREMIUM_PRODUCTS_AAQ_WIDGET_BUTTON_TEXT
 
         with allure.step("Clicking on the AAQ button and verifying that the auth page is "
                          "displayed"):
-            sumo_pages.product_solutions_page._click_ask_now_button()
+            sumo_pages.product_solutions_page.click_ask_now_button()
             if count == 0:
                 sumo_pages.auth_flow_page.sign_in_flow(
                     username=utilities.user_special_chars,
@@ -147,20 +147,20 @@ def test_contact_support_widget_redirect(page: Page):
     count = 0
     for premium_product in utilities.general_test_data["premium_products"]:
         with allure.step(f"Clicking on the {premium_product} card"):
-            sumo_pages.contact_support_page._click_on_a_particular_card(premium_product)
+            sumo_pages.contact_support_page.click_on_a_particular_card(premium_product)
 
         with check, allure.step("Verifying that the correct 'Still need help' subtext is "
                                 "displayed"):
-            assert sumo_pages.product_solutions_page._get_aaq_subheading_text(
+            assert sumo_pages.product_solutions_page.get_aaq_product_solutions_subheading_text(
             ) == AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
 
         with check, allure.step("Verifying that the correct AAQ button text is displayed"):
-            assert sumo_pages.product_solutions_page._get_aaq_widget_button_name(
+            assert sumo_pages.product_solutions_page.get_aaq_widget_button_name(
             ) == AAQWidgetMessages.FREEMIUM_AND_PREMIUM_PRODUCTS_AAQ_WIDGET_BUTTON_TEXT
 
         with allure.step("Clicking on the AAQ button, verifying that the auth page is "
                          "displayed and signing in to SUMO"):
-            sumo_pages.product_solutions_page._click_ask_now_button()
+            sumo_pages.product_solutions_page.click_ask_now_button()
 
             if count == 0:
                 sumo_pages.auth_flow_page.sign_in_flow(

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
@@ -493,12 +493,12 @@ def test_kb_restricted_visibility_in_topics_page(page: Page, create_delete_artic
 
     with check, allure.step("Verifying that the article is listed inside the article topic "
                             "page for admin users"):
-        expect(sumo_pages.product_topics_page._get_a_particular_article_locator(
+        expect(sumo_pages.product_topics_page.get_a_particular_article_locator(
             article_details['article_title'])).to_be_visible()
 
     with check, allure.step("Verifying that the article is not listed for signed out users"):
         utilities.delete_cookies()
-        expect(sumo_pages.product_topics_page._get_a_particular_article_locator(
+        expect(sumo_pages.product_topics_page.get_a_particular_article_locator(
             article_details['article_title'])).to_be_hidden()
 
     with check, allure.step("Verifying that the article is listed for users belonging to a "
@@ -506,7 +506,7 @@ def test_kb_restricted_visibility_in_topics_page(page: Page, create_delete_artic
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_4"]
         ))
-        expect(sumo_pages.product_topics_page._get_a_particular_article_locator(
+        expect(sumo_pages.product_topics_page.get_a_particular_article_locator(
             article_details['article_title'])).to_be_visible()
 
     with allure.step("Verifying that the article is not listed for users belonging to a "
@@ -514,7 +514,7 @@ def test_kb_restricted_visibility_in_topics_page(page: Page, create_delete_artic
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
         ))
-        expect(sumo_pages.product_topics_page._get_a_particular_article_locator(
+        expect(sumo_pages.product_topics_page.get_a_particular_article_locator(
             article_details['article_title'])).to_be_hidden()
 
     with allure.step("Signing in with an admin account and whitelisting a new group"):
@@ -537,7 +537,7 @@ def test_kb_restricted_visibility_in_topics_page(page: Page, create_delete_artic
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MESSAGE_5"]
         ))
-        expect(sumo_pages.product_topics_page._get_a_particular_article_locator(
+        expect(sumo_pages.product_topics_page.get_a_particular_article_locator(
             article_details['article_title'])).to_be_visible()
 
 

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
@@ -137,7 +137,7 @@ def test_product_support_page_frequent_topics_redirect(page: Page):
                         with check, allure.step("Clicking on a particular frequent topic "
                                                 "card and verifying that the correct topic "
                                                 "page title is displayed"):
-                            assert sumo_pages.product_topics_page._get_page_title() == topic
+                            assert sumo_pages.product_topics_page.get_page_title() == topic
                         utilities.navigate_back()
                 else:
                     print(f"{card} has no frequent topics displayed!!!")
@@ -215,7 +215,7 @@ def test_still_need_help_button_redirect(page: Page):
                     )
 
                 with check, allure.step("Verifying that we are on the correct milestone"):
-                    assert sumo_pages.product_solutions_page._get_current_milestone_text(
+                    assert sumo_pages.product_solutions_page.get_current_milestone_text(
                     ) == ProductSolutionsMessages.CURRENT_MILESTONE_TEXT
 
                 with allure.step("Navigating to products page via top-navbar"):

--- a/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
+++ b/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
@@ -209,7 +209,7 @@ def test_ask_a_question_top_navbar_redirect(page: Page):
 
             if current_option != "View all":
                 assert (f"{current_option} Solutions" == sumo_pages.product_solutions_page
-                        ._get_product_solutions_heading())
+                        .get_product_solutions_heading())
             else:
                 assert utilities.get_page_url() == ContactSupportMessages.PAGE_URL
 


### PR DESCRIPTION
- Try fixing situations in which the playwright click event is not successfully registered by attempting to re-click twice with a delay of 2 seconds between retries.
- Modified the contact_support_page.py, product_solutions_page.py and product_topics_page.py to use self. instead of super() and made the page functions public.
- Modified the function calls in tests.
- Excluded Thunderbird for Android from the test_system_details_information test.