### PR TITLE
Playwright expand test coverage over the unread new message UI notification

### DIFF
--- a/playwright_tests/pages/messaging_system_pages/inbox_page.py
+++ b/playwright_tests/pages/messaging_system_pages/inbox_page.py
@@ -28,6 +28,9 @@ class InboxPage(BasePage):
     __inbox_messages_section = "//ol[@class='inbox-table']"
     __inbox_messages_delete_button = "//div[@class='email-cell delete']//a[@class='delete']"
     __inbox_delete_checkbox = "//div[@class='email-cell check']/input"
+    __all_unread_messages = "//li[@class='email-row unread']"
+    __all_read_messages_excerpt = ("//ol[@class='inbox-table']//li[not(contains(@class,'unread'))]"
+                                   "/div[@class='email-cell excerpt']/a")
 
     def __init__(self, page: Page):
         super().__init__(page)
@@ -125,6 +128,9 @@ class InboxPage(BasePage):
     def are_inbox_messages_displayed(self) -> bool:
         return self._is_element_visible(self.__inbox_messages_section)
 
+    def get_all_read_messages_excerpt(self) -> list[str]:
+        return self._get_text_of_elements(self.__all_read_messages_excerpt)
+
     def delete_all_inbox_messages(self):
         inbox_messages_count = self._get_element_handles(self.__inbox_messages)
         for i in range(len(inbox_messages_count)):
@@ -134,6 +140,10 @@ class InboxPage(BasePage):
 
             delete_button.click()
             self.click_on_delete_page_delete_button()
+
+    def check_a_particular_message(self, excerpt=''):
+        inbox_checkbox = self.inbox_message_select_checkbox_element(excerpt)
+        inbox_checkbox[0].click()
 
     def delete_all_inbox_messages_via_delete_selected_button(self, excerpt=''):
         if excerpt != '':
@@ -152,3 +162,6 @@ class InboxPage(BasePage):
 
         self.click_on_inbox_delete_selected_button()
         self.click_on_delete_page_delete_button()
+
+    def get_all_unread_messages(self) -> list[Locator]:
+        return self._get_elements_locators(self.__all_unread_messages)

--- a/playwright_tests/pages/top_navbar.py
+++ b/playwright_tests/pages/top_navbar.py
@@ -113,6 +113,9 @@ class TopNavbar(BasePage):
     __signed_in_settings_option = "//h4[contains(text(), 'Settings')]/parent::a"
     __signed_in_inbox_option = "//h4[contains(text(), 'Inbox')]/parent::a"
     __sign_out_button = "//a[contains(text(), 'Sign Out')]"
+    __unread_message_profile_notification = ("//div[@id='profile-navigation']//"
+                                             "div[@class='avatar-container-message-alert']")
+    __unread_message_count = "//span[@class='message-count-alert']"
 
     def __init__(self, page: Page):
         super().__init__(page)
@@ -257,6 +260,18 @@ class TopNavbar(BasePage):
 
     def get_text_of_logged_in_username(self) -> str:
         return self._get_text_of_element(self.__signed_in_username)
+
+    def is_unread_message_notification_displayed(self) -> bool:
+        return self._is_element_visible(self.__unread_message_profile_notification)
+
+    def get_unread_message_notification_counter_value(self) -> int:
+        return int(self._get_text_of_element(self.__unread_message_count))
+
+    def is_unread_message_notification_counter_visible(self) -> bool:
+        return self._is_element_visible(self.__unread_message_count)
+
+    def mouse_over_profile_avatar(self):
+        self._hover_over_element(self.__signed_in_username)
 
     """
         General actions against the top-navbar section.


### PR DESCRIPTION
- Add locators for unread, read messages and related functions inside inbox_page.py
- Expand playwright test coverage over the unread message avatar red dot notification & counter inside test_messaging_system.py
- Add locators for the red dot unread message notification, unread notification counter and functions against them inside top_navbar.py