### PR TITLE
fix `pageviews_by_document` to properly handle article locale

### DIFF
--- a/kitsune/dashboards/models.py
+++ b/kitsune/dashboards/models.py
@@ -41,10 +41,13 @@ class WikiDocumentVisits(ModelBase):
             if verbose:
                 log.info("Gathering pageviews per article from GA4 data API...")
 
-            instance_by_locale_and_slug = {}
-            for (locale, slug), visits in googleanalytics.pageviews_by_document(
+            # At this point, this is a dictionary of integer values (visits).
+            instance_by_locale_and_slug = googleanalytics.pageviews_by_document(
                 period, verbose=verbose
-            ):
+            )
+
+            # Replace the integer values (visits) with WikiDocumentVisits instances.
+            for (locale, slug), visits in instance_by_locale_and_slug.items():
                 instance_by_locale_and_slug[(locale, slug)] = cls(
                     document_id=Subquery(
                         Document.objects.filter(locale=locale, slug=slug).values("id")

--- a/kitsune/dashboards/tests/test_models.py
+++ b/kitsune/dashboards/tests/test_models.py
@@ -17,7 +17,7 @@ class DocumentVisitsTests(TestCase):
         d2 = ApprovedRevisionFactory(document__slug="doc2-slug").document
         d3 = ApprovedRevisionFactory(document__slug="doc3-slüg").document
 
-        pageviews_by_document.return_value = (
+        pageviews_by_document.return_value = dict(
             row
             for row in (
                 (("en-US", d1.slug), 1000),

--- a/kitsune/sumo/tests/test_googleanalytics.py
+++ b/kitsune/sumo/tests/test_googleanalytics.py
@@ -87,7 +87,14 @@ class GoogleAnalyticsTests(TestCase):
                     DimensionValue(value="/es/kb/doc2-slug"),
                     DimensionValue(value="en-US"),
                 ],
-                metric_values=[MetricValue(value="2000")],
+                metric_values=[MetricValue(value="1000")],
+            ),
+            Row(
+                dimension_values=[
+                    DimensionValue(value="/en-US/kb/doc2-slug"),
+                    DimensionValue(value="en-US"),
+                ],
+                metric_values=[MetricValue(value="1000")],
             ),
             Row(
                 dimension_values=[
@@ -105,13 +112,13 @@ class GoogleAnalyticsTests(TestCase):
             ),
         )
 
-        result = list(googleanalytics.pageviews_by_document(LAST_7_DAYS))
+        result = googleanalytics.pageviews_by_document(LAST_7_DAYS)
 
         self.assertEqual(4, len(result))
-        self.assertEqual(result[0], (("en-US", "doc1-slug"), 1000))
-        self.assertEqual(result[1], (("en-US", "doc2-slug"), 2000))
-        self.assertEqual(result[2], (("de", "doc3-slug"), 3000))
-        self.assertEqual(result[3], (("es", "doc4-slug"), 4000))
+        self.assertEqual(result[("en-US", "doc1-slug")], 1000)
+        self.assertEqual(result[("en-US", "doc2-slug")], 2000)
+        self.assertEqual(result[("de", "doc3-slug")], 3000)
+        self.assertEqual(result[("es", "doc4-slug")], 4000)
 
     @patch.object(googleanalytics, "run_report")
     def test_pageviews_by_question(self, run_report):


### PR DESCRIPTION
mozilla/sumo#1896

The root of the problem was my earlier change to use the actual locale of the KB article displayed to the user (AKA the `article_locale`) instead of the locale in the URL of the KB article requested (see https://github.com/mozilla/kitsune/blob/4cc50d80f28bc5b8cc7cdfee935e263f289bcd48/kitsune/sumo/googleanalytics.py#L312). This caused the `pageviews_by_document` function to return multiple rows for the same `(article_locale, slug)` pair, which the `WikiDocumentVisits.reload_period_from_analytics` method wasn't expecting. It only used the last row encountered, so the `visits` count for many of the `WikiDocumentVisits` entries was way off.

This PR resolves that by fixing it within the `pageviews_by_document` function itself, which now returns a dictionary rather than a generator.