### PR TITLE
Playwright add second batch of search tests

### DIFF
--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
@@ -151,6 +151,8 @@ class AddKbArticleFlow:
         if article_content is None:
             self.submit_kb_article_page.add_text_to_content_textarea(
                 kb_article_test_data["article_content"])
+        else:
+            self.submit_kb_article_page.add_text_to_content_textarea(article_content)
 
         if article_content_image != '':
             self.submit_kb_article_page.click_on_insert_media_button()

--- a/playwright_tests/flows/explore_articles_flows/article_flows/kb_localization_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/kb_localization_flow.py
@@ -3,6 +3,7 @@ from typing import Any
 from playwright.sync_api import Page
 
 from playwright_tests.core.utilities import Utilities
+from playwright_tests.pages.explore_help_articles.articles.kb_article_page import KBArticlePage
 from playwright_tests.pages.explore_help_articles.articles.kb_article_review_revision_page import \
     KBArticleReviewRevisionPage
 from playwright_tests.pages.explore_help_articles.articles.kb_article_show_history_page import \
@@ -14,13 +15,18 @@ from playwright_tests.pages.explore_help_articles.articles.kb_translate_article_
 class KbArticleTranslationFlow:
     def __init__(self, page: Page):
         self.utilities = Utilities(page)
+        self.kb_article_page = KBArticlePage(page)
         self.translate_article_page = TranslateArticlePage(page)
         self.kb_article_show_history_page = KBArticleShowHistoryPage(page)
         self.kb_article_review_revision_page = KBArticleReviewRevisionPage(page)
 
     def _add_article_translation(self, approve_translation_revision: bool, title='', slug='',
                                  allow_discussions=True, keyword='', summary='', body='',
-                                 save_as_draft=False, submit=True) -> dict[str, Any]:
+                                 save_as_draft=False, submit=True, locale=None) -> dict[str, Any]:
+
+        if locale:
+            self.kb_article_page.click_on_translate_article_option()
+            self.translate_article_page.click_on_locale_from_list(locale)
 
         if title != '':
             translation_title = title

--- a/playwright_tests/pages/explore_help_articles/articles/kb_translate_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_translate_article_page.py
@@ -4,7 +4,6 @@ from playwright.sync_api import Page, Locator
 
 class TranslateArticlePage(BasePage):
     __translating_an_unready_article_banner = "//ul[@class='user-messages']/li"
-    __list_romanian_locale = "//li/a[normalize-space(text())='română (ro)']"
     __article_translation_page_title = "//h1[@class='sumo-page-heading']"
     __translation_title_field = "//input[@id='id_title']"
     __translation_slug_field = "//input[@id='id_slug']"
@@ -12,10 +11,10 @@ class TranslateArticlePage(BasePage):
     __translation_keyword_field = "//input[@id='id_keywords']"
     __translation_summary_field = "//textarea[@id='id_summary']"
     __translation_english_readonly_field = "//div[@id='content-or-diff']/textarea"
-    __translation_ro_text = "//textarea[@id='id_content']"
-    __change_body_view = "//a[text()='Comută evidențierea sintaxei']"
-    __send_translation_for_approval_button = "//button[text()='Trimite pentru aprobare']"
-    __save_translation_as_draft_button = "//button[text()='Salvează ca ciornă']"
+    __translation_text = "//textarea[@id='id_content']"
+    __change_body_view = "//div[@id='editor_wrapper']/following-sibling::a"
+    __send_translation_for_approval_button = "//button[contains(@class, 'btn-submit')][1]"
+    __save_translation_as_draft_button = "//button[contains(@class, 'btn-draft')][1]"
     __draft_saved_successfully_message = "//div[@id='draft-message']"
     __translation_changes_description_input_field = "//input[@id='id_comment']"
     __translation_changes_description_submit_button = "//button[@id='submit-document-form']"
@@ -23,8 +22,8 @@ class TranslateArticlePage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
-    def click_on_romanian_locale_from_list(self):
-        self._click(self.__list_romanian_locale)
+    def click_on_locale_from_list(self, locale: str):
+        self._click(f"//article[@id='select-locale']//a[contains(text(), '({locale})')]")
 
     def get_text_of_article_unready_for_translation_banner(self) -> str:
         return self._get_text_of_element(self.__translating_an_unready_article_banner)
@@ -55,8 +54,8 @@ class TranslateArticlePage(BasePage):
 
     def fill_body_translation_field(self, text: str):
         self._click(self.__change_body_view)
-        self._clear_field(self.__translation_ro_text)
-        self._fill(self.__translation_ro_text, text)
+        self._clear_field(self.__translation_text)
+        self._fill(self.__translation_text, text)
 
     def click_on_submit_translation_for_approval_button(self):
         self._get_element_locator(self.__send_translation_for_approval_button).first.click()

--- a/playwright_tests/pages/search/search_page.py
+++ b/playwright_tests/pages/search/search_page.py
@@ -103,6 +103,7 @@ class SearchPage(BasePage):
         return self._get_element_input_value(self.__searchbar)
 
     def fill_into_searchbar(self, text: str):
+        self.clear_the_searchbar()
         self._fill(self.__searchbar, text)
 
     def clear_the_searchbar(self):

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
@@ -34,7 +34,7 @@ def test_not_ready_for_localization_articles_dashboard_status(page: Page):
     with allure.step("Clicking on the Translate Article Editing Tools option and selecting "
                      "the ro locale"):
         sumo_pages.kb_article_page.click_on_translate_article_option()
-        sumo_pages.translate_article_page.click_on_romanian_locale_from_list()
+        sumo_pages.translate_article_page.click_on_locale_from_list("ro")
         translation_url = utilities.get_page_url()
 
     with check, allure.step("Verifying that the correct banner is displayed"):


### PR DESCRIPTION
- Added the possibility of submitting a test article with a custom content inside the add_kb_article_flow.py
- Expanded the functionality of playwright to translate articles in different locales (not only in the ro locale) inside the kb_localization_flow.py, and kb_translate_article_page.py
- Calling the clear_the_searchbar() each time playwright tries to add input inside the searchbar inside the fill_into_searchbar() function from the search_page.py page class.
- Added second batch of search tests inside test_main_searchbar.py