### PR TITLE
Playwright add test for doc_id search

### DIFF
--- a/playwright_tests/core/utilities.py
+++ b/playwright_tests/core/utilities.py
@@ -421,3 +421,6 @@ class Utilities:
         search_result = search_result.lower()
         print(f"Search result is: {search_result}")
         return search_term in search_result
+
+    def get_api_response(self, page: Page, api_url: str):
+        return page.request.get(api_url)

--- a/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
@@ -11,9 +11,8 @@ from playwright_tests.messages.ask_a_question_messages.product_solutions_message
 from playwright_tests.pages.sumo_pages import SumoPages
 
 
-# Currently fails due to https://github.com/mozilla/sumo/issues/1608
-#  C890370
-@pytest.mark.skip
+#  C890370, C890374
+@pytest.mark.productSolutionsPage
 def test_featured_articles_redirect(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)

--- a/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
+++ b/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
@@ -183,7 +183,7 @@ def test_browse_all_forum_threads_by_topic_redirect(page: Page):
                         == current_option)
 
 
-# T5696576, T5696591
+# T5696576, T5696591, C2663303
 @pytest.mark.topNavbarTests
 def test_ask_a_question_top_navbar_redirect(page: Page):
     sumo_pages = SumoPages(page)


### PR DESCRIPTION
- Adding test for doc_id field operator verification in test_main_searchbar.py
- Adding a function inside the utilities.py which returns the GET api response.
- Enabling test_featured_articles_redirect test inside test_product_solutions_page.py.
- Mapping some automated tests with their manual representative via the TestRail tc ID