### PR TITLE
Playwright enable productSupportPage tests, expand coverage over Contributors Support & some refactoring 

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,6 +28,7 @@ on:
                     - User Pages
                     - contactSupportPage
                     - productSolutionsPage
+                    - productSupportPage
                     - productTopicsPage
                     - AAQ
                     - KB Articles
@@ -102,7 +103,7 @@ jobs:
         if: success() || failure() && steps.create-sessions.outcome == 'success'
         run: |
             declare dispatch_test_suite="${{inputs.TestSuite}}"
-            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "messagingSystemCleanup" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics", "searchTests")
+            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "messagingSystemCleanup" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productSupportPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics", "searchTests")
             if [ "$dispatch_test_suite" == "All" ] || [ "${{ github.event_name}}" == "schedule" ] ; then
                 for test in "${all_test_suites[@]}"; do
                     if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then

--- a/playwright_tests/pages/explore_help_articles/articles/products_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/products_page.py
@@ -16,20 +16,20 @@ class ProductsPage(BasePage):
         super().__init__(page)
 
     # Page breadcrumbs actions.
-    def _click_on_first_breadcrumb(self):
-        super()._click(self.__first_breadcrumb)
+    def click_on_first_breadcrumb(self):
+        self._click(self.__first_breadcrumb)
 
     # Page content actions.
-    def _get_page_header(self) -> str:
-        return super()._get_text_of_element(self.__page_header)
+    def get_page_header(self) -> str:
+        return self._get_text_of_element(self.__page_header)
 
     # Product card actions.
-    def _get_subheading_of_card(self, card_title: str) -> str:
-        return super()._get_text_of_element(f"//a[normalize-space(text())='{card_title}']/../"
-                                            f"following-sibling::p[@class='card--desc']")
+    def get_subheading_of_card(self, card_title: str) -> str:
+        return self._get_text_of_element(f"//a[normalize-space(text())='{card_title}']/../"
+                                         f"following-sibling::p[@class='card--desc']")
 
-    def _click_on_a_particular_product_support_card(self, card_title):
-        super()._click(f"//div[@class='card--details']//a[normalize-space(text())='{card_title}']")
+    def click_on_a_particular_product_support_card(self, card_title):
+        self._click(f"//div[@class='card--details']//a[normalize-space(text())='{card_title}']")
 
-    def _get_all_product_support_titles(self) -> list[str]:
-        return super()._get_text_of_elements(self.__all_product_card_titles)
+    def get_all_product_support_titles(self) -> list[str]:
+        return self._get_text_of_elements(self.__all_product_card_titles)

--- a/playwright_tests/pages/explore_help_articles/product_support_page.py
+++ b/playwright_tests/pages/explore_help_articles/product_support_page.py
@@ -17,10 +17,11 @@ class ProductSupportPage(BasePage):
     __frequent_topics_section_title = "//h2[contains(text(),'Frequent Topics')]"
     __frequent_topics_section_subtitle = ("//h2[contains(text(),'Frequent "
                                           "Topics')]/following-sibling::p")
-    __frequent_topic_all_cards = ("//h2[contains(text(),'Frequent Topics')]/../../../..//a["
-                                  "@data-event-action='topic']")
+    __frequent_topic_all_cards = "//div[contains(@class,'card card--topic')]//a"
 
     # Still need help widget locators.
+    __still_need_help_widget = ("//section[@class='support-callouts mzp-l-content sumo-page-"
+                                "section--inner']")
     __still_need_help_widget_title = ("//section[@class='support-callouts mzp-l-content "
                                       "sumo-page-section--inner']//h3[@class='card--title']")
     __still_need_help_widget_details = ("//section[@class='support-callouts mzp-l-content "
@@ -38,67 +39,71 @@ class ProductSupportPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
-    def _click_on_product_support_home_breadcrumb(self):
-        super()._click(self.__home_breadcrumb)
+    def click_on_product_support_home_breadcrumb(self):
+        self._click(self.__home_breadcrumb)
 
-    def _get_product_support_title_text(self) -> str:
-        return super()._get_text_of_element(self.__product_title)
+    def get_product_support_title_text(self) -> str:
+        return self._get_text_of_element(self.__product_title)
 
-    def _product_product_title_element(self) -> Locator:
-        return super()._get_element_locator(self.__product_title)
+    def product_product_title_element(self) -> Locator:
+        return self._get_element_locator(self.__product_title)
 
-    def _is_frequent_topics_section_displayed(self) -> bool:
-        return super()._is_element_visible(self.__frequent_topics_section_title)
+    def is_frequent_topics_section_displayed(self) -> bool:
+        return self._is_element_visible(self.__frequent_topics_section_title)
 
-    def _get_frequent_topics_title_text(self) -> str:
-        return super()._get_text_of_element(self.__frequent_topics_section_title)
+    def get_frequent_topics_title_text(self) -> str:
+        return self._get_text_of_element(self.__frequent_topics_section_title)
 
-    def _get_all_frequent_topics_cards(self) -> list[str]:
-        return super()._get_text_of_elements(self.__frequent_topic_all_cards)
+    def get_all_frequent_topics_cards(self) -> list[str]:
+        return self._get_text_of_elements(self.__frequent_topic_all_cards)
 
-    def _get_frequent_topics_subtitle_text(self) -> str:
-        return super()._get_text_of_element(self.__frequent_topics_section_subtitle)
+    def get_frequent_topics_subtitle_text(self) -> str:
+        return self._get_text_of_element(self.__frequent_topics_section_subtitle)
 
-    def _click_on_a_particular_frequent_topic_card(self, card_title: str):
-        super()._click(f"//h2[contains(text(),'Frequent Topics')]/../../../..//"
-                       f"a[normalize-space(text())='{card_title}']")
+    def click_on_a_particular_frequent_topic_card(self, card_title: str):
+        self._click(f"//h2[contains(text(),'Frequent Topics')]/../../../..//a[normalize-space("
+                    f"text())='{card_title}']")
 
-    def _get_featured_articles_header_text(self) -> str:
-        return super()._get_text_of_element(self.__featured_article_section_title)
+    def get_featured_articles_header_text(self) -> str:
+        return self._get_text_of_element(self.__featured_article_section_title)
 
-    def _is_featured_articles_section_displayed(self) -> bool:
-        return super()._is_element_visible(self.__featured_article_section_title)
+    def is_featured_articles_section_displayed(self) -> bool:
+        return self._is_element_visible(self.__featured_article_section_title)
 
-    def _get_list_of_featured_articles_headers(self) -> list[str]:
-        return super()._get_text_of_elements(self.__featured_articles_cards)
+    def get_list_of_featured_articles_headers(self) -> list[str]:
+        return self._get_text_of_elements(self.__featured_articles_cards)
 
-    def _get_feature_articles_count(self) -> int:
-        return len(super()._get_text_of_elements(self.__featured_articles_cards))
+    def get_feature_articles_count(self) -> int:
+        return len(self._get_text_of_elements(self.__featured_articles_cards))
 
-    def _click_on_a_particular_feature_article_card(self, card_title):
-        super()._click(f'//h2[contains(text(),"Featured Articles")]/..//a[text()="{card_title}"]')
+    def click_on_a_particular_feature_article_card(self, card_title):
+        self._click(f'//h2[contains(text(),"Featured Articles")]/..//a[normalize-space(text())'
+                    f'="{card_title}"]')
 
-    def _get_still_need_help_widget_title(self) -> str:
-        return super()._get_text_of_element(self.__still_need_help_widget_title)
+    def is_still_need_help_widget_displayed(self) -> bool:
+        return self._is_element_visible(self.__still_need_help_widget)
 
-    def _get_still_need_help_widget_content(self) -> str:
-        return super()._get_text_of_element(self.__still_need_help_widget_details)
+    def get_still_need_help_widget_title(self) -> str:
+        return self._get_text_of_element(self.__still_need_help_widget_title)
 
-    def _get_still_need_help_widget_button_text(self) -> str:
-        return super()._get_text_of_element(self.__ask_the_community_still_need_help_widget)
+    def get_still_need_help_widget_content(self) -> str:
+        return self._get_text_of_element(self.__still_need_help_widget_details)
 
-    def _click_still_need_help_widget_button(self):
-        super()._click(self.__ask_the_community_still_need_help_widget)
+    def get_still_need_help_widget_button_text(self) -> str:
+        return self._get_text_of_element(self.__ask_the_community_still_need_help_widget)
 
-    def _get_join_our_community_header_text(self) -> str:
-        return super()._get_text_of_element(self.__join_our_community_section_header)
+    def click_still_need_help_widget_button(self):
+        self._click(self.__ask_the_community_still_need_help_widget)
 
-    def _get_join_our_community_content_text(self) -> str:
-        return super()._get_text_of_elements(
+    def get_join_our_community_header_text(self) -> str:
+        return self._get_text_of_element(self.__join_our_community_section_header)
+
+    def get_join_our_community_content_text(self) -> str:
+        return self._get_text_of_elements(
             self.__join_our_community_section_paragraph_and_learn_more_option
         )[0]
 
-    def _click_join_our_community_learn_more_link(self):
-        return (super()._click_on_an_element_by_index
+    def click_join_our_community_learn_more_link(self):
+        return (self._click_on_an_element_by_index
                 (self.__join_our_community_section_paragraph_and_learn_more_option, 1)
                 )

--- a/playwright_tests/pages/top_navbar.py
+++ b/playwright_tests/pages/top_navbar.py
@@ -100,6 +100,9 @@ class TopNavbar(BasePage):
         "normalize-space(text())='Media gallery']"
     )
 
+    __guides_option = ("//ul[@class='mzp-c-menu-item-list sumo-nav--sublist']//a[normalize-space("
+                       "text())='Guides']")
+
     """
         Locators belonging to the username section of the top-navbar.
     """
@@ -218,6 +221,10 @@ class TopNavbar(BasePage):
     def click_on_media_gallery_option(self):
         self.hover_over_contribute_top_navbar()
         self._click(self.__media_gallery_option)
+
+    def click_on_guides_option(self):
+        self.hover_over_contribute_top_navbar()
+        self._click(self.__guides_option)
 
     """
         Actions against the sign-in/sign-up top-navbar section.

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_explore_articles_products_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_explore_articles_products_page.py
@@ -19,21 +19,21 @@ def test_products_page_content(page: Page):
         sumo_pages = SumoPages(page)
         utilities = Utilities(page)
         sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
-        assert sumo_pages.products_page._get_page_header(
+        assert sumo_pages.products_page.get_page_header(
         ) == ProductsPageMessages.PRODUCTS_PAGE_HEADER
 
     with allure.step("Clicking on the first 'Home' breadcrumb and verifying the redirect"):
-        sumo_pages.products_page._click_on_first_breadcrumb()
+        sumo_pages.products_page.click_on_first_breadcrumb()
         expect(page).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
 
     with allure.step("Navigating back to the 'Products' page"):
         utilities.navigate_back()
 
-    for card in sumo_pages.products_page._get_all_product_support_titles():
+    for card in sumo_pages.products_page.get_all_product_support_titles():
         with check, allure.step(f"Verifying that the {card} card contains the correct "
                                 f"subheading"):
             if card in ProductsPageMessages.PRODUCT_CARDS_SUBHEADING:
-                assert sumo_pages.products_page._get_subheading_of_card(
+                assert sumo_pages.products_page.get_subheading_of_card(
                     card) == ProductsPageMessages.PRODUCT_CARDS_SUBHEADING[card]
 
 
@@ -45,11 +45,11 @@ def test_products_page_card_redirect(page: Page):
     with allure.step("Navigating to products page via top-navbar"):
         sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
-    for card in sumo_pages.products_page._get_all_product_support_titles():
+    for card in sumo_pages.products_page.get_all_product_support_titles():
         if card in utilities.general_test_data['product_support']:
             with allure.step(f"Clicking on {card} card and verifying that we are redirected "
                              f"to the correct product url"):
-                sumo_pages.products_page._click_on_a_particular_product_support_card(card)
+                sumo_pages.products_page.click_on_a_particular_product_support_card(card)
                 expect(page).to_have_url(utilities.general_test_data['product_support'][card])
 
             with allure.step("Navigating back to the products page"):

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
@@ -1,7 +1,8 @@
 import allure
-from pytest_check import check
 import pytest
-from playwright.sync_api import expect, Page
+from pytest_check import check
+from typing import Union
+from playwright.sync_api import expect, Page, Locator
 from playwright_tests.core.utilities import Utilities
 from playwright_tests.messages.contribute_messages.con_pages.con_page_messages import (
     ContributePageMessages)
@@ -13,91 +14,43 @@ from playwright_tests.messages.ask_a_question_messages.product_solutions_message
 from playwright_tests.pages.sumo_pages import SumoPages
 
 
-# Causing some weird failures in GH runners. Need to investigate before re-enabling.
 # C890926, C890931, C2091563
-@pytest.mark.skip
-def test_product_support_page(page: Page):
+@pytest.mark.productSupportPage
+def test_product_support_page_join_community_section(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Navigating to products page via top-navbar"):
         sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
     with allure.step("Clicking on all product cards"):
-        for card in sumo_pages.products_page._get_all_product_support_titles():
-            if card in utilities.general_test_data['product_support']:
-                sumo_pages.products_page._click_on_a_particular_product_support_card(card)
-
-                with check, allure.step("Verifying that the correct page header is displayed"):
-                    assert (sumo_pages.product_support_page._get_product_support_title_text()
-                            ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
-
-                with check, allure.step("Verifying the correct topics header is displayed"):
-                    assert (sumo_pages.product_support_page._get_frequent_topics_title_text()
-                            ) == (ProductSupportPageMessages
-                                  .PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_TITLE)
-
-                with check, allure.step("Verifying that the correct topics subheader is "
-                                        "displayed"):
-                    assert (sumo_pages.product_support_page._get_frequent_topics_subtitle_text()
-                            ) == (ProductSupportPageMessages
-                                  .PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_SUBTITLE)
-
-                with check, allure.step("Verifying that the correct still need help title is "
-                                        "displayed"):
-                    assert (sumo_pages.product_support_page._get_still_need_help_widget_title()
-                            ) == ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_TITLE
-
-                if card in utilities.general_test_data['premium_products']:
-                    with check, allure.step("Verifying that the correct still need help "
-                                            "content is displayed"):
-                        assert (sumo_pages.product_support_page
-                                ._get_still_need_help_widget_content()
-                                ) == (ProductSupportPageMessages
-                                      .STILL_NEED_HELP_WIDGET_CONTENT_PREMIUM)
-
-                    with check, allure.step("Verifying that the correct still need help "
-                                            "button text is displayed"):
-                        assert (sumo_pages.product_support_page
-                                ._get_still_need_help_widget_button_text()
-                                ) == (ProductSupportPageMessages
-                                      .STILL_NEED_HELP_WIDGET_BUTTON_TEXT_PREMIUM)
+        cards = sumo_pages.products_page.get_all_product_support_titles()
+        cards.append("Guides")
+        for card in cards:
+            if card in utilities.general_test_data['product_support'] or card == "Guides":
+                if card != "Guides":
+                    sumo_pages.products_page.click_on_a_particular_product_support_card(card)
                 else:
-                    with check, allure.step("Verifying that the correct still need help "
-                                            "content is displayed"):
-                        assert (sumo_pages.product_support_page
-                                ._get_still_need_help_widget_content()
-                                ) == (ProductSupportPageMessages
-                                      .STILL_NEED_HELP_WIDGET_CONTENT_FREEMIUM)
+                    with allure.step("Signing in with an contributor account"):
+                        utilities.start_existing_session(utilities.username_extraction_from_email(
+                            utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
+                        ))
 
-                    with check, allure.step("Verifying that the correct still need help "
-                                            "button text is displayed"):
-                        assert (sumo_pages.product_support_page
-                                ._get_still_need_help_widget_button_text()
-                                ) == (ProductSupportPageMessages
-                                      .STILL_NEED_HELP_WIDGET_BUTTON_TEXT_FREEMIUM)
-
-                # Firefox Focus and Thunderbird don't have frequent articles section
-                if card != "Firefox Focus" and card != "Thunderbird":
-                    with check, allure.step("Verifying the correct featured articles header "
-                                            "is displayed"):
-                        assert (sumo_pages.product_support_page
-                                ._get_featured_articles_header_text()
-                                ) == (ProductSupportPageMessages
-                                      .PRODUCT_SUPPORT_PAGE_FREQUENT_ARTICLES_TITLE)
+                    with allure.step("Navigating to the 'Contributors Support' product page"):
+                        sumo_pages.top_navbar.click_on_guides_option()
 
                 with check, allure.step("Verifying that the correct 'Join Our Community' "
                                         "section header is displayed"):
-                    assert (sumo_pages.product_support_page._get_join_our_community_header_text()
+                    assert (sumo_pages.product_support_page.get_join_our_community_header_text()
                             ) == ProductSupportPageMessages.JOIN_OUR_COMMUNITY_SECTION_HEADER
 
                 with check, allure.step("Verifying that the correct 'Join Our Community "
                                         "section content is displayed'"):
-                    assert (sumo_pages.product_support_page._get_join_our_community_content_text()
+                    assert (sumo_pages.product_support_page.get_join_our_community_content_text()
                             ) == ProductSupportPageMessages.JOIN_OUR_COMMUNITY_SECTION_CONTENT
 
                 with allure.step("Clicking on the 'Learn more' option from the 'Join Our "
                                  "Community' section"):
-                    sumo_pages.product_support_page._click_join_our_community_learn_more_link()
+                    sumo_pages.product_support_page.click_join_our_community_learn_more_link()
 
                 with allure.step("Verify that we are redirected to the contribute messages page"):
                     expect(page).to_have_url(ContributePageMessages.STAGE_CONTRIBUTE_PAGE_URL)
@@ -105,48 +58,71 @@ def test_product_support_page(page: Page):
                 with allure.step("Navigate back, clicking on the 'Home' breadcrumb and "
                                  "verifying that we are redirected to the homepage"):
                     utilities.navigate_back()
-                    sumo_pages.product_support_page._click_on_product_support_home_breadcrumb()
+                    sumo_pages.product_support_page.click_on_product_support_home_breadcrumb()
                     expect(page).to_have_url(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
 
                 with allure.step("Navigating to products page via top-navbar"):
                     sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
 
-# C890929
-@pytest.mark.skip
+# C890929, C891335, C891336
+@pytest.mark.productSupportPage
 def test_product_support_page_frequent_topics_redirect(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
+
     with allure.step("Navigating to products page via top-navbar"):
         sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
     with allure.step("Clicking on all product cards"):
+        cards = sumo_pages.products_page.get_all_product_support_titles()
+        cards.append("Guides")
+        for card in cards:
+            if card in utilities.general_test_data['product_support'] or card == "Guides":
+                if card != "Guides":
+                    sumo_pages.products_page.click_on_a_particular_product_support_card(card)
+                else:
+                    with allure.step("Signing in with an contributor account"):
+                        utilities.start_existing_session(utilities.username_extraction_from_email(
+                            utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
+                        ))
 
-        for card in sumo_pages.products_page._get_all_product_support_titles():
-            if card in utilities.general_test_data['product_support']:
-                sumo_pages.products_page._click_on_a_particular_product_support_card(card)
+                    with allure.step("Navigating to the 'Contributors Support' product page"):
+                        sumo_pages.top_navbar.click_on_guides_option()
 
                 with check, allure.step("Verifying that the correct page header is displayed"):
-                    assert (sumo_pages.product_support_page._get_product_support_title_text()
-                            ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
+                    if card == "Guides":
+                        assert (sumo_pages.product_support_page.get_product_support_title_text()
+                                ) == "Contributors" + (ProductSupportPageMessages.
+                                                       PRODUCT_SUPPORT_PAGE_TITLE)
+                    else:
+                        assert (sumo_pages.product_support_page.get_product_support_title_text()
+                                ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
 
-                if sumo_pages.product_support_page._is_frequent_topics_section_displayed:
-                    for topic in sumo_pages.product_support_page._get_all_frequent_topics_cards():
-                        (sumo_pages.product_support_page
-                         ._click_on_a_particular_frequent_topic_card(topic))
-                        with check, allure.step("Clicking on a particular frequent topic "
-                                                "card and verifying that the correct topic "
-                                                "page title is displayed"):
-                            assert sumo_pages.product_topics_page.get_page_title() == topic
-                        utilities.navigate_back()
+                if sumo_pages.product_support_page.is_frequent_topics_section_displayed():
+                    with check, allure.step("Verifying the correct topics header is displayed"):
+                        assert (sumo_pages.product_support_page.get_frequent_topics_title_text()
+                                ) == (ProductSupportPageMessages
+                                      .PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_TITLE)
+
+                    with check, allure.step("Verifying that the correct topics subheader is "
+                                            "displayed"):
+                        assert sumo_pages.product_support_page.get_frequent_topics_subtitle_text(
+                        ) == (ProductSupportPageMessages.
+                              PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_SUBTITLE)
+
+                    assert _verify_card_redirect(
+                        page, sumo_pages.product_support_page.get_all_frequent_topics_cards(),
+                        is_topic=True
+                    )
                 else:
                     print(f"{card} has no frequent topics displayed!!!")
-                with allure.step("Navigating back"):
-                    utilities.navigate_back()
+            with allure.step("Navigating back"):
+                utilities.navigate_back()
 
 
-#  T5696580
-@pytest.mark.skip
+#  T5696580, C891335, C891336
+@pytest.mark.productSupportPage
 def test_product_support_page_featured_articles_redirect(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
@@ -154,44 +130,49 @@ def test_product_support_page_featured_articles_redirect(page: Page):
         sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
     with allure.step("Clicking on all product cards"):
-        for card in sumo_pages.products_page._get_all_product_support_titles():
-            if card in utilities.general_test_data['product_support']:
-                sumo_pages.products_page._click_on_a_particular_product_support_card(card)
+        cards = sumo_pages.products_page.get_all_product_support_titles()
+        cards.append("Guides")
+        for card in cards:
+            if card in utilities.general_test_data['product_support'] or card == "Guides":
+                if card != "Guides":
+                    sumo_pages.products_page.click_on_a_particular_product_support_card(card)
+                else:
+                    with allure.step("Signing in with an contributor account"):
+                        utilities.start_existing_session(utilities.username_extraction_from_email(
+                            utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
+                        ))
+
+                    with allure.step("Navigating to the 'Contributors Support' product page"):
+                        sumo_pages.top_navbar.click_on_guides_option()
 
                 with check, allure.step("Verifying that the correct page header is displayed"):
-                    assert (sumo_pages.product_support_page._get_product_support_title_text()
-                            ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
+                    if card != "Guides":
+                        assert (sumo_pages.product_support_page.get_product_support_title_text()
+                                ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
+                    else:
+                        assert (sumo_pages.product_support_page.get_product_support_title_text()
+                                ) == "Contributors" + (ProductSupportPageMessages.
+                                                       PRODUCT_SUPPORT_PAGE_TITLE)
 
-                if sumo_pages.product_support_page._is_featured_articles_section_displayed:
-                    featured_article_cards_count = (sumo_pages.product_support_page
-                                                    ._get_feature_articles_count())
-                    count = 1
-                    while count <= featured_article_cards_count:
-                        featured_article_names = (sumo_pages.product_support_page.
-                                                  _get_list_of_featured_articles_headers())
-                        # Skipping check for now because the Firefox Monitor article redirects
-                        # to a different one
-                        if featured_article_names[count - 1] == "Firefox Monitor":
-                            continue
-                        (sumo_pages.product_support_page.
-                            _click_on_a_particular_feature_article_card(
-                                featured_article_names[count - 1]))
-
-                        with check, allure.step("Verifying the accessed article title is the "
-                                                "correct one"):
-                            assert featured_article_names[count - 1] == (
-                                sumo_pages.kb_article_page.get_text_of_article_title())
-                        count += 1
-                        utilities.navigate_back()
+                if sumo_pages.product_support_page.is_featured_articles_section_displayed():
+                    with check, allure.step("Verifying the correct featured articles header "
+                                            "is displayed"):
+                        assert (sumo_pages.product_support_page
+                                .get_featured_articles_header_text()
+                                ) == (ProductSupportPageMessages
+                                      .PRODUCT_SUPPORT_PAGE_FREQUENT_ARTICLES_TITLE)
+                    assert _verify_card_redirect(
+                        page, (sumo_pages.product_support_page.get_feature_articles_count()),
+                        is_article=True)
                 else:
                     print(f"{card} has no featured articles displayed!!!")
 
-                with allure.step("Navigating back"):
-                    utilities.navigate_back()
+            with allure.step("Navigating back"):
+                utilities.navigate_back()
 
 
 # C890932
-@pytest.mark.skip
+@pytest.mark.productSupportPage
 def test_still_need_help_button_redirect(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
@@ -199,14 +180,69 @@ def test_still_need_help_button_redirect(page: Page):
         sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
 
     with allure.step("Clicking on all product cards"):
-        for card in sumo_pages.products_page._get_all_product_support_titles():
-            if card in utilities.general_test_data['product_support']:
-                sumo_pages.products_page._click_on_a_particular_product_support_card(card)
+        cards = sumo_pages.products_page.get_all_product_support_titles()
+        cards.append("Guides")
+        for card in cards:
+            if card in utilities.general_test_data['product_support'] or card == "Guides":
+                if card != "Guides":
+                    sumo_pages.products_page.click_on_a_particular_product_support_card(card)
+                else:
+                    continue  # to be removed once https://github.com/mozilla/sumo/issues/2006
+                    # is fixed
+                    # with allure.step("Signing in with an contributor account"):
+                    #     utilities.start_existing_session(utilities.username_extraction_from_email
+                    #     (
+                    #         utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
+                    #     ))
+                    #
+                    # with allure.step("Navigating to the 'Contributors Support' product page"):
+                    #     sumo_pages.top_navbar.click_on_guides_option()
+                    #
+                    # with allure.step("Verifying that the still need help CTA is no displayed"):
+                    #     assert not (sumo_pages.product_support_page
+                    #                 .is_still_need_help_widget_displayed())
 
                 with check, allure.step("Verifying that the correct page header is displayed"):
-                    assert (sumo_pages.product_support_page._get_product_support_title_text()
+                    assert (sumo_pages.product_support_page.get_product_support_title_text()
                             ) == card + ProductSupportPageMessages.PRODUCT_SUPPORT_PAGE_TITLE
-                sumo_pages.product_support_page._click_still_need_help_widget_button()
+
+                with check, allure.step("Verifying that the correct still need help title is "
+                                        "displayed"):
+                    assert (sumo_pages.product_support_page.get_still_need_help_widget_title()
+                            ) == ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_TITLE
+                if card in utilities.general_test_data['premium_products']:
+                    with check, allure.step("Verifying that the correct still need help "
+                                            "content is displayed"):
+                        assert (sumo_pages.product_support_page
+                                .get_still_need_help_widget_content()
+                                ) == (ProductSupportPageMessages
+                                      .STILL_NEED_HELP_WIDGET_CONTENT_PREMIUM)
+
+                    with check, allure.step("Verifying that the correct still need help "
+                                            "button text is displayed"):
+                        assert (sumo_pages.product_support_page
+                                .get_still_need_help_widget_button_text()
+                                ) == (ProductSupportPageMessages
+                                      .STILL_NEED_HELP_WIDGET_BUTTON_TEXT_PREMIUM)
+                    with allure.step("Clicking on the still need help widget button"):
+                        sumo_pages.product_support_page.click_still_need_help_widget_button()
+                else:
+                    with check, allure.step("Verifying that the correct still need help "
+                                            "content is displayed"):
+                        assert (sumo_pages.product_support_page
+                                .get_still_need_help_widget_content()
+                                ) == (ProductSupportPageMessages
+                                      .STILL_NEED_HELP_WIDGET_CONTENT_FREEMIUM)
+
+                    with check, allure.step("Verifying that the correct still need help "
+                                            "button text is displayed"):
+                        assert (sumo_pages.product_support_page
+                                .get_still_need_help_widget_button_text()
+                                ) == (ProductSupportPageMessages
+                                      .STILL_NEED_HELP_WIDGET_BUTTON_TEXT_FREEMIUM)
+
+                    with allure.step("Clicking on the still need help widget button"):
+                        sumo_pages.product_support_page.click_still_need_help_widget_button()
 
                 with allure.step("Verifying that we are redirected to the correct product "
                                  "solutions page"):
@@ -220,3 +256,29 @@ def test_still_need_help_button_redirect(page: Page):
 
                 with allure.step("Navigating to products page via top-navbar"):
                     sumo_pages.top_navbar.click_on_explore_our_help_articles_view_all_option()
+
+
+def _verify_card_redirect(page: Page, cards: Union[int, list[Locator]], is_topic=False,
+                          is_article=False) -> bool:
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+
+    if is_topic:
+        for card in cards:
+            sumo_pages.product_support_page.click_on_a_particular_frequent_topic_card(card)
+            if sumo_pages.product_topics_page.get_page_title() != card:
+                return False
+            utilities.navigate_back()
+    if is_article:
+        count = 1
+        while count <= cards:
+            featured_article_names = (sumo_pages.product_support_page.
+                                      get_list_of_featured_articles_headers())
+            sumo_pages.product_support_page.click_on_a_particular_feature_article_card(
+                featured_article_names[count - 1])
+            if featured_article_names[count - 1] != (sumo_pages.
+                                                     kb_article_page.get_text_of_article_title()):
+                return False
+            count += 1
+            utilities.navigate_back()
+    return True

--- a/playwright_tests/tests/homepage_tests/test_homepage.py
+++ b/playwright_tests/tests/homepage_tests/test_homepage.py
@@ -82,11 +82,11 @@ def test_product_cards_are_functional_and_redirect_to_the_proper_support_page(pa
             sumo_pages.homepage.click_on_product_card(counter)
             assert (
                 expected_product_title
-                == sumo_pages.product_support_page._get_product_support_title_text()
+                == sumo_pages.product_support_page.get_product_support_title_text()
             ), (f"Incorrect support page displayed. "
                 f"Expected: {expected_product_title} "
                 f"Received: "
-                f"{sumo_pages.product_support_page._get_product_support_title_text()}")
+                f"{sumo_pages.product_support_page.get_product_support_title_text()}")
 
             with allure.step("Navigating back to the previous page"):
                 utilities.navigate_back()

--- a/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
+++ b/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
@@ -82,10 +82,10 @@ def test_explore_by_product_redirects(page: Page):
                 current_option = utilities.remove_character_from_string(current_option, 'desktop')
 
             if current_option != "View all products":
-                support_page = sumo_pages.product_support_page._get_product_support_title_text()
+                support_page = sumo_pages.product_support_page.get_product_support_title_text()
                 assert current_option in support_page
             else:
-                assert (sumo_pages.products_page._get_page_header() == ProductsPageMessages.
+                assert (sumo_pages.products_page.get_page_header() == ProductsPageMessages.
                         PRODUCTS_PAGE_HEADER)
 
 
@@ -148,7 +148,7 @@ def test_browse_by_product_community_forum_redirect(page: Page):
 
             if current_option != "View all forums":
                 assert (f"{current_option} Community Forum" == sumo_pages.product_support_page
-                        ._get_product_support_title_text())
+                        .get_product_support_title_text())
             else:
                 assert utilities.get_page_url() == SupportForumsPageMessages.PAGE_URL
 
@@ -175,7 +175,7 @@ def test_browse_all_forum_threads_by_topic_redirect(page: Page):
                 sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option()
                 sumo_pages.top_navbar._click(option)
 
-            assert (sumo_pages.product_support_page._get_product_support_title_text()
+            assert (sumo_pages.product_support_page.get_product_support_title_text()
                     == "All Products Community Forum")
 
             with allure.step("Verifying that the correct default topic filter is selected"):

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -121,7 +121,7 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page):
         utilities.navigate_to_link(question_info["question_page_url"])
         sumo_pages.question_page.click_delete_this_question_question_tools_option()
         sumo_pages.question_page.click_delete_this_question_button()
-        expect(sumo_pages.product_support_page._product_product_title_element()).to_be_visible()
+        expect(sumo_pages.product_support_page.product_product_title_element()).to_be_visible()
 
 
 # C890832,  C2094281
@@ -188,7 +188,7 @@ def test_number_of_my_profile_answers_is_successfully_displayed(page: Page):
         utilities.navigate_to_link(question_info["question_page_url"])
         sumo_pages.question_page.click_delete_this_question_question_tools_option()
         sumo_pages.question_page.click_delete_this_question_button()
-        expect(sumo_pages.product_support_page._product_product_title_element()).to_be_visible()
+        expect(sumo_pages.product_support_page.product_product_title_element()).to_be_visible()
 
 
 #  C2094285, C2094284, C891309

--- a/playwright_tests/tests/user_page_tests/test_my_questions.py
+++ b/playwright_tests/tests/user_page_tests/test_my_questions.py
@@ -53,7 +53,7 @@ def test_number_of_questions_is_incremented_when_posting_a_question(page: Page):
         sumo_pages.question_page.click_delete_this_question_button()
 
     with allure.step("Verifying that we are on the product support forum page after deletion"):
-        expect(sumo_pages.product_support_page._product_product_title_element()).to_be_visible()
+        expect(sumo_pages.product_support_page.product_product_title_element()).to_be_visible()
 
     # write tests to check my questions section as well
 


### PR DESCRIPTION
- Added the possibility for playwright to navigate to the Contributors Support product page via the top-navbar section (Guides).
- Refactored & enabled the productSupportPage tests.
- Expanded playwright coverage for the "Contributors Support" product page inside the productSupportPage tests.
- Refactored the products_page.py by making the functions public & replace super() with self.
- Refactored the product_support_page.py by making the functions public & replace super() with self.
- Enabled the productSupportPage tests in playwright.yml