### PR TITLE
Fix "Show More" and "Show Less" missing localization

### DIFF
--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -883,7 +883,7 @@
 {% endif %}
 {% if is_collapsible %}
   <a href="#" class="color-link show-more-btn hide-on-mobile" id="show-more-link">
-      Show More
+      {{ _('Show More') }}
   </a>
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
- Mark "Show More" and "Show Less" options from the "Contributor tools" side-navbar as ready for localization in Pontoon.