### PR TITLE
Playwright block Pontoon requests

### DIFF
--- a/playwright_tests/pages/user_pages/my_profile_edit.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit.py
@@ -196,7 +196,7 @@ class MyProfileEdit(BasePage):
         self._click(self.__cancel_button)
 
     def click_update_my_profile_button(self):
-        self._click(self.__update_my_profile_button)
+        self._click(self.__update_my_profile_button, with_force=True)
 
     def click_close_account_option(self):
         self._click(self.__close_account_and_delete_all_profile_information_link)

--- a/playwright_tests/tests/user_page_tests/test_my_questions.py
+++ b/playwright_tests/tests/user_page_tests/test_my_questions.py
@@ -185,8 +185,8 @@ def test_my_question_page_reflects_posted_questions_and_redirects_to_the_correct
     with allure.step("Navigating to my questions profile page and verifying that the first "
                      "element from the My Questions page is the recently posted question"):
         sumo_pages.top_navbar.click_on_my_questions_profile_option()
-        assert sumo_pages.my_questions_page._get_text_of_first_listed_question().replace(
-            " ", "") == question_info["aaq_subject"].replace(" ", "")
+        assert sumo_pages.my_questions_page._get_text_of_first_listed_question(
+        ).strip() == question_info["aaq_subject"].strip()
 
     with allure.step("Clicking on the first list item and verifying that the user is "
                      "redirected to the correct question"):


### PR DESCRIPTION
- Block all Pontoon requests in page context during Playwright test execution.
- Simplifying a userQuestions test.
- Forcing the click for the update_my_profile_button to try avoiding flakiness.