### PR TITLE
Playwright handle 502 errors and increase execution threads to 4

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -106,34 +106,34 @@ jobs:
             declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "messagingSystemCleanup" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productSupportPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics", "searchTests")
             if [ "$dispatch_test_suite" == "All" ] || [ "${{ github.event_name}}" == "schedule" ] ; then
                 for test in "${all_test_suites[@]}"; do
-                    if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
+                    if ! poetry run pytest -m ${test} --numprocesses 4 --browser ${{ env.BROWSER }} --reruns 1; then
                         any_failures=true
                     fi
                 done
             elif [ "$dispatch_test_suite" == "User Pages" ]; then
                 for test in "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions"; do
-                    if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
+                    if ! poetry run pytest -m ${test} --numprocesses 4 --browser ${{ env.BROWSER }} --reruns 1; then
                         any_failures=true
                     fi
                 done
             elif [ "$dispatch_test_suite" == "AAQ" ]; then
                 for test in "aaqPage" "postedQuestions"; do
-                    if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
+                    if ! poetry run pytest -m ${test} --numprocesses 4 --browser ${{ env.BROWSER }} --reruns 1; then
                         any_failures=true
                     fi
                 done
             elif [ "$dispatch_test_suite" == "KB Articles" ]; then
                 for test in "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory"; do
-                    if ! poetry run pytest -m ${test} --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
+                    if ! poetry run pytest -m ${test} --numprocesses 4 --browser ${{ env.BROWSER }} --reruns 1; then
                         any_failures=true
                     fi
                 done
             elif [ "$dispatch_test_suite" == "KB Article Translation" ]; then
-                if ! poetry run pytest -m kbArticleTranslation --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
+                if ! poetry run pytest -m kbArticleTranslation --numprocesses 4 --browser ${{ env.BROWSER }} --reruns 1; then
                     any_failures=true
                 fi
             else
-                if ! poetry run pytest -m $dispatch_test_suite --numprocesses 2 --browser ${{ env.BROWSER }} --reruns 1; then
+                if ! poetry run pytest -m $dispatch_test_suite --numprocesses 4 --browser ${{ env.BROWSER }} --reruns 1; then
                         any_failures=true
                 fi
             fi

--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -14,14 +14,14 @@ class BasePage:
         This helper function returns the element locator from a given xpath.
         """
         if with_wait:
-            self.__wait_for_dom_load_to_finish()
+            self._wait_for_dom_load_to_finish()
         return self.page.locator(xpath)
 
     def _get_elements_locators(self, xpath: str) -> list[Locator]:
         """
         This helper function returns a list of element locators from a given xpath.
         """
-        self.__wait_for_dom_load_to_finish()
+        self._wait_for_dom_load_to_finish()
         return self.page.locator(xpath).all()
 
     def _get_current_page_url(self) -> str:
@@ -80,7 +80,7 @@ class BasePage:
         if isinstance(element, str):
             return self._get_element_locator(element).get_attribute(attribute)
         elif isinstance(element, list):
-            self.__wait_for_dom_load_to_finish()
+            self._wait_for_dom_load_to_finish()
             values = []
             for element in element:
                 values.append(element.get_attribute(attribute))
@@ -240,7 +240,7 @@ class BasePage:
         """
         return self._get_element_locator(xpath).is_checked()
 
-    def __wait_for_dom_load_to_finish(self):
+    def _wait_for_dom_load_to_finish(self):
         """
         This helper function performs two waits:
         1. Waits for the dom load to finish.

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
@@ -98,3 +98,4 @@ class KBArticleEditMetadata(BasePage):
 
     def click_on_save_changes_button(self):
         self._click(self.__save_changes_button)
+        self._wait_for_dom_load_to_finish()

--- a/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
@@ -82,7 +82,8 @@ def test_popular_topics_redirect(page: Page):
 
                     popular_topic = (feature_article_page
                                      .locator("//h1[@class='topic-title sumo-page-heading']")
-                                     .inner_text())
+                                     .inner_text()
+                                     .strip())
                     assert popular_topic == topic
                     feature_article_page.close()
         else:

--- a/playwright_tests/tests/conftest.py
+++ b/playwright_tests/tests/conftest.py
@@ -19,6 +19,19 @@ def navigate_to_homepage(page: Page):
     # Block pontoon requests in the current page context.
     page.route("**/pontoon.mozilla.org/**", utilities.block_request)
 
+    def handle_502_error(response):
+        """
+        This function is used to handle 502 errors. It reloads the page after 5 seconds if a
+        502 error is encountered.
+        """
+        if response.status == 502:
+            page = response.request.frame.page
+            print("502 error encountered. Reloading the page after 5 seconds.")
+            page.wait_for_timeout(5000)
+            page.reload()
+
+    page.context.on("response", handle_502_error)
+
     # Navigate to the SUMO stage homepage.
     page.goto(HomepageMessages.STAGE_HOMEPAGE_URL)
 


### PR DESCRIPTION
- Handle 502 errors inside the page context by refreshing the current page after a 5 seconds delay.
- Increase number of threads from 2 to 4 for playwright tests.