### PR TITLE
Playwright improve allure report generation

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -142,9 +142,9 @@ jobs:
         working-directory: playwright_tests
         if: success() || failure()
         run: |
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
-            brew install allure
+            curl -o allure-2.32.0.tgz -L https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.32.0/allure-commandline-2.32.0.tgz
+            tar -zxvf allure-2.32.0.tgz
+            export PATH=$PATH:$PWD/allure-2.32.0/bin
             allure generate --single-file reports/allure_reports
       - name: Upload the combined test report as artifact
         if: success() || failure()


### PR DESCRIPTION
Instead of using Homebrew to install Allure in order to generate the test report in a single .html file we are going to use the Allure commandline tool and use it directly to generate the test report in a single .html file.

This should reduce the step execution time from ~2 minutes to < 10 seconds