### PR TITLE
Playwright expanding group coverage for group leaders testing

### DIFF
--- a/playwright_tests/flows/user_groups_flows/user_group_flow.py
+++ b/playwright_tests/flows/user_groups_flows/user_group_flow.py
@@ -8,13 +8,38 @@ class UserGroupFlow:
         self.utilities = Utilities(page)
         self.groups_page = GroupsPage(page)
 
-    def remove_a_user_from_group(self, user: str):
-        self.groups_page.click_on_edit_group_members()
-        self.groups_page.click_on_remove_a_user_from_group_button(user)
-        self.groups_page.click_on_remove_member_confirmation_button()
+    def remove_a_user_from_group(self, user: str, is_leader=False):
+        """
+        Remove a user from a group.
 
-    def add_a_user_to_group(self, user: str):
-        self.groups_page.click_on_edit_group_members()
-        self.groups_page.type_into_add_member_field(user)
+        Args:
+            user (str): The username to be removed from the group.
+            is_leader (bool, optional): If True, the user is a leader. Defaults
+        """
+        self.groups_page.click_on_edit_group_leaders_option(
+        ) if is_leader else self.groups_page.click_on_edit_group_members()
+
+        self.groups_page.click_on_remove_a_user_from_group_button(
+            user,True) if is_leader else (self.groups_page.
+                                          click_on_remove_a_user_from_group_button(user))
+
+        self.groups_page.click_on_remove_leader_button(
+        ) if is_leader else self.groups_page.click_on_remove_member_button()
+
+    def add_a_user_to_group(self, user: str, is_leader=False):
+        """
+        Add a user to a group.
+
+        Args:
+            user (str): The username of the user to add to the group.
+            is_leader (bool, optional): If True, the user will be added as a leader. Defaults to
+            False.
+        """
+
+        self.groups_page.click_on_edit_group_leaders_option(
+        ) if is_leader else self.groups_page.click_on_edit_group_members()
+        self.groups_page.type_into_add_leader_field(
+            user) if is_leader else self.groups_page.type_into_add_member_field(user)
         self.groups_page.group_click_on_a_searched_username(user)
-        self.groups_page.click_on_add_member_button()
+        self.groups_page.click_on_add_group_leader_button(
+        ) if is_leader else self.groups_page.click_on_add_member_button()

--- a/playwright_tests/messages/user_groups_messages.py
+++ b/playwright_tests/messages/user_groups_messages.py
@@ -4,21 +4,31 @@ class UserGroupMessages:
                                "replace the current one.")
     GROUP_INFORMATION_UPDATE_NOTIFICATION = "Group information updated successfully!"
 
-    def get_user_added_success_message(username: str) -> str:
+    def get_user_added_success_message(username: str, to_leaders=False) -> str:
         """Get the user added success message.
 
         Args:
             username (str): The username of the user added to the group
+            to_leaders (bool, optional): If True, the user was added to the leaders. Defaults to
+            False.
         """
-        return f"{username} added to the group successfully!"
+        if to_leaders:
+            return f"{username} added to the group leaders successfully!"
+        else:
+            return f"{username} added to the group successfully!"
 
-    def get_user_removed_success_message(username: str) -> str:
+    def get_user_removed_success_message(username: str, from_leaders=False) -> str:
         """Get the user removed success message.
 
         Args:
             username (str): The username of the user removed from the group
+            from_leaders (bool, optional): If True, the user was removed from the leaders. Defaults
+            to False.
         """
-        return f"{username} removed from the group successfully!"
+        if from_leaders:
+            return f"{username} removed from the group leaders successfully!"
+        else:
+            return f"{username} removed from the group successfully!"
 
     def get_change_avatar_page_header(user_group: str) -> str:
         """Get the change avatar page header.
@@ -44,14 +54,18 @@ class UserGroupMessages:
         """
         return f"Are you sure you want to delete the {user_group} group avatar?"
 
-    def get_delete_user_header(username: str, group: str) -> str:
+    def get_delete_user_header(username: str, group: str, delete_leader=False) -> str:
         """Get the delete user page header.
 
         Args:
             username (str): The username of the user to delete.
             group (str): The group name.
+            delete_leader (bool, optional): If True, the user is a leader. Defaults to False.
         """
-        return f"Are you sure you want to remove {username} from {group}?"
+        if delete_leader:
+            return f"Are you sure you want to remove {username} from {group} leaders?"
+        else:
+            return f"Are you sure you want to remove {username} from {group}?"
 
     def get_edit_profile_information_page_header(group_name: str) -> str:
         """Get the edit profile information page header.

--- a/playwright_tests/pages/contribute/groups_page.py
+++ b/playwright_tests/pages/contribute/groups_page.py
@@ -21,12 +21,14 @@ class GroupsPage(BasePage):
         "edit_group_profile_textarea": "//textarea[@id='id_information']",
         "save_group_profile_edit_button": "//article[@id='group-profile']//input[@value='Save']",
         "edit_group_leaders_button": "//div[@id='group-leaders']/a[text()='Edit group leaders']",
+        "add_group_leader_field": "//div[@id='group-leaders']//input[@id='token-input-id_users']",
+        "add_group_leader_button": "//input[@value='Add Leader']",
         "private_message_group_members_button": "//section[@id='main-area']/p[@class='pm']/a",
         "user_notification": "//ul[@class='user-messages']//p",
         "edit_group_members_option": "//div[@id='group-members']/a",
         "add_group_member_field": "//div[@id='group-members']//input[@id='token-input-id_users']",
         "add_member_button": "//div[@id='group-members']//input[@value='Add Member']",
-        "remove_user_from_group_confirmation_button": "//input[@value='Remove member']",
+        "group_leader_list": "//div[@id='group-leaders']//div[@class='info']/a",
         "group_members_list": "//div[@id='group-members']//div[@class='info']/a"
     }
 
@@ -47,7 +49,9 @@ class GroupsPage(BasePage):
     }
 
     REMOVE_USER_PAGE_LOCATORS = {
+        "remove_leader_page_header": "//article[@id='remove-leader']/h1",
         "remove_user_page_header": "//article[@id='remove-member']/h1",
+        "remove_leader_button": "//input[@value='Remove leader']",
         "remove_member_button": "//input[@value='Remove member']",
         "remove_member_cancel_button": "//div[@class='form-actions']/a[text()='Cancel']"
     }
@@ -70,6 +74,10 @@ class GroupsPage(BasePage):
         self._click(f"//a[text()='{group_name}']")
 
     # Actions against the group page.
+    def get_all_leaders_name(self) -> list[str]:
+        """Get the names of all the leaders in the group"""
+        return self._get_text_of_elements(self.GROUP_PAGE_LOCATORS["group_leader_list"])
+
     def get_all_members_name(self) -> list[str]:
         """Get the names of all the members in the group"""
         return self._get_text_of_elements(self.GROUP_PAGE_LOCATORS["group_members_list"])
@@ -128,6 +136,20 @@ class GroupsPage(BasePage):
     def is_edit_group_members_option_visible(self) -> bool:
         """Check if the edit group members option is visible"""
         return self._is_element_visible(self.GROUP_PAGE_LOCATORS["edit_group_members_option"])
+
+    def click_on_edit_group_leaders_option(self):
+        self._click(self.GROUP_PAGE_LOCATORS["edit_group_leaders_button"])
+
+    def type_into_add_leader_field(self, text: str):
+        """Type into the add leader field
+
+        Args:
+            text (str): The text to type into the add leader field
+        """
+        self._type(self.GROUP_PAGE_LOCATORS["add_group_leader_field"], text, delay=0)
+
+    def click_on_add_group_leader_button(self):
+        self._click(self.GROUP_PAGE_LOCATORS["add_group_leader_button"])
 
     def click_on_pm_group_members_button(self):
         """Click on the PM group members button"""
@@ -220,18 +242,19 @@ class GroupsPage(BasePage):
         self._click(self.DELETE_AVATAR_PAGE_LOCATORS["delete_uploaded_avatar_button"])
 
     # Actions against the removal or user addition
-    def click_on_remove_a_user_from_group_button(self, username: str):
+    def click_on_remove_a_user_from_group_button(self, username: str, from_leaders=False):
         """Click on the remove a user from group button
 
         Args:
             username (str): The username of the user to remove from the group
+            from_leaders (bool, optional): If True, the user will be removed from the leaders.
         """
-        self._click(f"//div[@class='info']/a[text()='{username}']/../..//a[@title="
-                    f"'Remove user from group']")
-
-    def click_on_remove_member_confirmation_button(self):
-        """Click on the remove member confirmation button"""
-        self._click(self.GROUP_PAGE_LOCATORS["remove_user_from_group_confirmation_button"])
+        if from_leaders:
+            self._click(f"//div[@class='info']/a[text()='{username}']/../..//a[@title='Remove "
+                        f"user from leaders']")
+        else:
+            self._click(f"//div[@class='info']/a[text()='{username}']/../..//a[@title="
+                        f"'Remove user from group']")
 
     def type_into_add_member_field(self, text: str):
         """Type into the add member field
@@ -261,9 +284,24 @@ class GroupsPage(BasePage):
         """
         self._click(f"//div[@class='info']/a[text()='{username}']")
 
+    def click_on_a_listed_group_leader(self, username: str):
+        """Click on a listed group leader.
+
+        Args:
+            username (str): The username of the leader to click on
+        """
+        self._click(f"//div[@id='group-leaders']//a[normalize-space(text())='{username}']")
+
+    def get_remove_leader_page_header(self) -> str:
+        return self._get_text_of_element(self.REMOVE_USER_PAGE_LOCATORS
+                                         ["remove_leader_page_header"])
+
     def get_remove_user_page_header(self) -> str:
         """Get the text of the remove user page header"""
         return self._get_text_of_element(self.REMOVE_USER_PAGE_LOCATORS["remove_user_page_header"])
+
+    def click_on_remove_leader_button(self):
+        self._click(self.REMOVE_USER_PAGE_LOCATORS["remove_leader_button"])
 
     def click_on_remove_member_button(self):
         """Click on the remove member button"""

--- a/playwright_tests/test_data/user_message.json
+++ b/playwright_tests/test_data/user_message.json
@@ -7,5 +7,5 @@
     "one_character_message" : "a",
     "9_characters_message": "i3zOlXL9v"
   },
-  "test_groups": ["TestGroup1", "TestGroup2"]
+  "test_groups": ["TestGroup1", "TestGroup2", "TestGroup3"]
 }


### PR DESCRIPTION
- Adding TestGroup3 to playwright.
- Expanding the user_groups_messages.py to include locale leader removal or addition page messages.
- Modifying the flows in user_group_flow.py to handle actions against group leaders.
- Adding locators and functions for group leaders in groups_page.py page object. Adding a new test in test_groups.py which verifies:
- That admin users can add and remove locale leaders from groups.
- That the correct banner is displayed when adding or removing a group leader.
- That adding a group leader to a group successfully adds the leader in both the leaders & members group lists.