### PR TITLE
Playwright handle wait timeouts and add new AAQ topics for AAQ test coverage

### DIFF
--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
@@ -99,4 +99,4 @@ class KBArticleEditMetadata(BasePage):
 
     def click_on_save_changes_button(self):
         self._click(self.__save_changes_button)
-        self._wait_for_dom_load_to_finish()
+        self.wait_for_page_to_load()

--- a/playwright_tests/pages/messaging_system_pages/inbox_page.py
+++ b/playwright_tests/pages/messaging_system_pages/inbox_page.py
@@ -237,7 +237,7 @@ class InboxPage(BasePage):
             excerpt: The excerpt of the message.
             expected_url: The expected URL after deleting all the messages.
         """
-        self._wait_for_dom_load_to_finish()
+        self.wait_for_dom_to_load()
         if excerpt != '':
             inbox_messages_count = self._inbox_message_element_handles(excerpt)
         else:

--- a/playwright_tests/test_data/aaq_question.json
+++ b/playwright_tests/test_data/aaq_question.json
@@ -83,10 +83,12 @@
     },
     "Firefox for Enterprise": {
       "Accounts": "accounts",
+      "Browse": "browse",
       "Installation and updates": "installation-and-updates",
+      "Performance and connectivity": "performance-and-connectivity",
       "Privacy and security": "privacy-and-security",
       "Settings": "settings",
-      "default_slug": "none"
+      "default_slug": "firefox-enterprise"
     },
     "Thunderbird": {
       "Accessibility": "accessibility",
@@ -98,16 +100,22 @@
       "Privacy and security": "privacy-and-security",
       "Search, tag, and share": "search-tag-and-share",
       "Settings": "settings",
-      "default_slug": "none"
+      "default_slug": "thunderbird"
     },
     "Thunderbird for Android": {
+      "Accessibility": "accessibility",
+      "Accounts": "accounts",
       "Email and messaging": "email-and-messaging",
       "Installation and updates": "installation-and-updates",
+      "Passwords and sign in": "passwords-and-sign-in",
+      "Performance and connectivity": "performance-and-connectivity",
       "Privacy and security": "privacy-and-security",
+      "Search, tag, and share": "search-tag-and-share",
       "Settings": "settings",
       "default_slug": "thunderbird-android"
     },
     "Firefox Focus": {
+      "Browse": "browse",
       "Installation and updates": "installation-and-updates",
       "Performance and connectivity": "performance-and-connectivity",
       "Privacy and security": "privacy-and-security",

--- a/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
@@ -1,7 +1,6 @@
 import allure
 import pytest
 from pytest_check import check
-
 from playwright.sync_api import expect, TimeoutError, Page
 from playwright_tests.core.utilities import Utilities
 from playwright_tests.messages.ask_a_question_messages.AAQ_messages.aaq_widget import (
@@ -13,7 +12,9 @@ from playwright_tests.pages.sumo_pages import SumoPages
 
 #  C890370, C890374
 @pytest.mark.productSolutionsPage
-def test_featured_articles_redirect(page: Page):
+def test_featured_articles_redirect(page: Page, is_chromium):
+    if is_chromium:
+        pytest.skip("Skipping this test for chromium browser")
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Accessing the contact support page via the top navbar Get Help > "

--- a/playwright_tests/tests/conftest.py
+++ b/playwright_tests/tests/conftest.py
@@ -15,8 +15,8 @@ def navigate_to_homepage(page: Page):
     object.
     """
     utilities = Utilities(page)
-    # Set default navigation timeout to 2 minutes.
-    page.set_default_navigation_timeout(120000)
+    # Set default navigation timeout to 30 seconds.
+    page.set_default_navigation_timeout(30000)
 
     # Block pontoon requests in the current page context.
     page.route("**/pontoon.mozilla.org/**", utilities.block_request)
@@ -36,7 +36,7 @@ def navigate_to_homepage(page: Page):
     page.context.on("response", handle_502_error)
 
     # Navigate to the SUMO stage homepage.
-    page.goto(HomepageMessages.STAGE_HOMEPAGE_URL)
+    utilities.navigate_to_link(HomepageMessages.STAGE_HOMEPAGE_URL)
 
     return page
 

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
@@ -20,9 +20,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page):
         ))
 
     with allure.step("Create a new simple article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
-        sumo_pages.kb_article_page.click_on_article_option()
-        article_url = utilities.get_page_url()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(page)
 
     with allure.step("Navigating to the kb dashboards and clicking on the 'Complete "
                      "overview' option"):
@@ -75,7 +73,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page):
         sumo_pages.kb_dashboard_page._click_on_article_title(article_details['article_title'])
 
     with allure.step("Verifying that the user is redirected to the correct kb page"):
-        expect(page).to_have_url(article_url)
+        expect(page).to_have_url(article_details['article_url'])
 
     with allure.step("Approving the article revision"):
         sumo_pages.submit_kb_article_flow.approve_kb_revision(article_details['first_revision_id'])
@@ -134,13 +132,10 @@ def test_kb_dashboard_articles_status(page: Page):
         ))
 
     with allure.step("Creating a new simple article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True
-        )
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page,approve_revision=True)
 
-    article_url = utilities.get_page_url()
-
-    with allure.step("Creating a anew revision for the document"):
+    with allure.step("Creating a new revision for the document"):
         second_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
 
     with check, allure.step("Navigating to the kb overview dashboard and verifying that the "
@@ -154,7 +149,7 @@ def test_kb_dashboard_articles_status(page: Page):
         )
 
     with allure.step("Navigating back to the article history and deleting the revision"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.kb_article_show_history_page.click_on_delete_revision_button(
             second_revision['revision_id']
         )
@@ -184,11 +179,10 @@ def test_kb_dashboard_revision_deferred_status(page: Page):
         ))
 
     with allure.step("Creating a new simple article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True
-        )
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page,approve_revision=True)
 
-    article_url = utilities.get_page_url()
+    article_show_history_url = utilities.get_page_url()
 
     with allure.step("Creating a new revision for the document"):
         second_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
@@ -202,7 +196,7 @@ def test_kb_dashboard_revision_deferred_status(page: Page):
             second_revision['changes_description'])
 
     with allure.step("Navigating back to the article history page and deferring the revision"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_show_history_url)
         sumo_pages.kb_article_show_history_page.click_on_review_revision(
             second_revision['revision_id']
         )
@@ -217,7 +211,7 @@ def test_kb_dashboard_revision_deferred_status(page: Page):
         ) == kb_dashboard_page_messages.KB_LIVE_STATUS
 
     with allure.step("Deleting the article"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_show_history_url)
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
@@ -232,11 +226,8 @@ def test_kb_dashboard_needs_update_when_reviewing_a_revision(page: Page):
         ))
 
     with allure.step("Creating a new simple article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True
-        )
-
-    article_url = utilities.get_page_url()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page,approve_revision=True)
 
     with allure.step("Creating an new article revision for the document"):
         second_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
@@ -252,7 +243,7 @@ def test_kb_dashboard_needs_update_when_reviewing_a_revision(page: Page):
         ).strip() == utilities.kb_revision_test_data['needs_change_message']
 
     with allure.step("Deleting the article"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
@@ -268,11 +259,8 @@ def test_kb_dashboard_needs_update_edit_metadata(page: Page):
         ))
 
     with allure.step("Create a new simple article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True
-        )
-
-    article_url = utilities.get_page_url()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page, approve_revision=True)
 
     with allure.step("Clicking on the 'Edit Article Metadata' option and enabling the 'Needs "
                      "change with comment' option"):
@@ -289,7 +277,7 @@ def test_kb_dashboard_needs_update_edit_metadata(page: Page):
 
     with allure.step("Navigating back to the article's 'Edit Article Metadata' page and "
                      "removing the comment from the needs change textarea"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.edit_article_metadata_flow.edit_article_metadata(needs_change=True)
 
     with allure.step("Navigating to the complete dashboard list and verifying that the "
@@ -301,7 +289,7 @@ def test_kb_dashboard_needs_update_edit_metadata(page: Page):
 
     with allure.step("Navigating back to the article's 'Edit Article Metadata' page and "
                      "removing the needs change updates"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.edit_article_metadata_flow.edit_article_metadata()
 
     with check, allure.step("Navigating to the kb overview page and verifying that the "
@@ -312,7 +300,7 @@ def test_kb_dashboard_needs_update_edit_metadata(page: Page):
         )
 
     with allure.step("Deleting the article"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
@@ -328,11 +316,9 @@ def test_ready_for_l10n_kb_dashboard_revision_approval(page: Page):
         ))
 
     with allure.step("Create a new simple article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(page=page)
 
-    article_url = utilities.get_page_url()
-
-    revision_id = sumo_pages.kb_article_show_history_page.get_last_revision_id()
+    revision_id = article_details['first_revision_id']
 
     with allure.step("Approving the first revision and marking it as ready for l10n"):
         sumo_pages.submit_kb_article_flow.approve_kb_revision(
@@ -346,7 +332,7 @@ def test_ready_for_l10n_kb_dashboard_revision_approval(page: Page):
         ) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
 
     with allure.step("Deleting the article"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
@@ -362,11 +348,8 @@ def test_ready_for_l10n_kb_dashboard_revision_l10n_status(page: Page):
         ))
 
     with allure.step("Creating a new kb article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True
-        )
-
-    article_url = utilities.get_page_url()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page, approve_revision=True)
 
     with check, allure.step("Navigating to the kb dashboard overview page and verifying that "
                             "the correct l10n status is displayed"):
@@ -377,7 +360,7 @@ def test_ready_for_l10n_kb_dashboard_revision_l10n_status(page: Page):
 
     with allure.step("Navigating back to the article page and marking the revision as ready "
                      "for l10n"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.kb_article_show_history_page.click_on_ready_for_l10n_option(
             article_details['first_revision_id']
         )
@@ -391,7 +374,7 @@ def test_ready_for_l10n_kb_dashboard_revision_l10n_status(page: Page):
         ) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
 
     with allure.step("Navigating to the article and deleting it"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
@@ -490,11 +473,8 @@ def test_article_title_update(page: Page):
         ))
 
     with allure.step("Creating a new kb article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True
-        )
-
-    article_url = utilities.get_page_url()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page, approve_revision=True)
 
     with allure.step("Navigating to the kb dashboard overview page and verifying that the "
                      "correct title is displayed"):
@@ -507,7 +487,7 @@ def test_article_title_update(page: Page):
 
     with allure.step("Navigating to the article's 'Edit Metadata page' page and changing the "
                      "title"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         new_article_title = "Updated " + article_details['article_title']
         sumo_pages.edit_article_metadata_flow.edit_article_metadata(title=new_article_title)
 
@@ -519,5 +499,5 @@ def test_article_title_update(page: Page):
         ).to_be_visible()
 
     with allure.step("Deleting the kb article"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.kb_article_deletion_flow.delete_kb_article()

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_recent_revisions_dashboard.py
@@ -23,9 +23,7 @@ def test_recent_revisions_revision_availability(page: Page):
     username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Creating a new kb article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
-
-    article_url = utilities.get_page_url()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(page=page)
 
     with allure.step("Navigating to the recent revisions dashboard and verifying that the "
                      "posted article is displayed for admin accounts"):
@@ -89,7 +87,7 @@ def test_recent_revisions_revision_availability(page: Page):
         ))
 
     with allure.step("Navigating to the article page and deleting it"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     with allure.step("Navigating back to the recent revisions page and verifying that the "
@@ -115,11 +113,8 @@ def test_second_revisions_availability(page: Page):
         ))
 
     with allure.step("Creating a new kb article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True
-        )
-
-    article_url = utilities.get_page_url()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page, approve_revision=True)
 
     with allure.step("Signing in with a non-admin account"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -175,7 +170,7 @@ def test_second_revisions_availability(page: Page):
         ).to_be_visible()
 
     with allure.step("Navigating to the article and approving the revision"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.submit_kb_article_flow.approve_kb_revision(second_revision['revision_id'])
         utilities.wait_for_given_timeout(1000)
 
@@ -205,7 +200,7 @@ def test_second_revisions_availability(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
     with allure.step("Navigating back to the recent revision dashboard, signing out and "
@@ -246,12 +241,8 @@ def test_recent_revisions_dashboard_links(page: Page):
     first_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Creating a new kb article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True
-        )
-
-    sumo_pages.kb_article_page.click_on_article_option()
-    article_url = utilities.get_page_url()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page, approve_revision=True)
 
     with allure.step("Navigating to the recent revisions dashboard and verifying that the "
                      "'Show Diff' option is not available for first revisions"):
@@ -265,7 +256,7 @@ def test_recent_revisions_dashboard_links(page: Page):
 
     with allure.step("Navigating to the article page, signing in with a non-admin user and "
                      "creating a new revision for the article"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details['article_url'])
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
         ))
@@ -282,7 +273,7 @@ def test_recent_revisions_dashboard_links(page: Page):
             article_title=article_details['article_title'], username=username
         )
         expect(page).to_have_url(
-            article_url + KBArticleRevision.
+            article_details['article_url'] + KBArticleRevision.
             KB_REVISION_PREVIEW + str(utilities.number_extraction_from_string(
                 second_revision['revision_id']
             ))
@@ -298,7 +289,7 @@ def test_recent_revisions_dashboard_links(page: Page):
         sumo_pages.recent_revisions_page._click_on_article_title(
             article_title=article_details['article_title'], creator=username
         )
-        expect(page).to_have_url(article_url)
+        expect(page).to_have_url(article_details['article_url'])
 
     with check, allure.step("Navigating back and verifying that the correct comment is "
                             "displayed"):
@@ -333,7 +324,7 @@ def test_recent_revisions_dashboard_links(page: Page):
         utilities.start_existing_session(utilities.username_extraction_from_email(
             utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
         ))
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details['article_url'])
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
@@ -349,12 +340,8 @@ def test_recent_revisions_dashboard_title_and_username_update(page: Page):
     first_username = sumo_pages.top_navbar.get_text_of_logged_in_username()
 
     with allure.step("Creating a new kb article"):
-        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True
-        )
-
-    sumo_pages.kb_article_page.click_on_article_option()
-    article_url = utilities.get_page_url()
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page, approve_revision=True)
 
     with allure.step("Changing the article title via the 'Edit Article Metadata' page"):
         sumo_pages.edit_article_metadata_flow.edit_article_metadata(
@@ -390,7 +377,7 @@ def test_recent_revisions_dashboard_title_and_username_update(page: Page):
         )
 
     with allure.step("Deleting the article"):
-        utilities.navigate_to_link(article_url)
+        utilities.navigate_to_link(article_details['article_url'])
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 

--- a/playwright_tests/tests/contribute_tests/test_groups.py
+++ b/playwright_tests/tests/contribute_tests/test_groups.py
@@ -271,7 +271,7 @@ def test_add_new_group_leader(page: Page):
         sumo_pages.user_group_flow.remove_a_user_from_group(test_user)
 
 
-# C2083499, C2715807
+# C2083499, C2715807, C891410
 @pytest.mark.userGroupsTests
 @pytest.mark.parametrize("user", ['TEST_ACCOUNT_MESSAGE_2', 'TEST_ACCOUNT_MODERATOR'])
 def test_add_group_members(page: Page, user):

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_threads.py
@@ -906,7 +906,7 @@ def test_posting_a_new_kb_test_article(page: Page):
         utilities.user_secrets_accounts["TEST_ACCOUNT_MODERATOR"]
     ))
 
-    sumo_pages.submit_kb_article_flow.submit_simple_kb_article(approve_first_revision=True)
+    sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(page=page, approve_revision=True)
     sumo_pages.kb_article_page.click_on_article_option()
     with open("test_data/test_article", 'w') as file:
         file.write(utilities.get_page_url())

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
@@ -123,7 +123,9 @@ def test_product_support_page_frequent_topics_redirect(page: Page):
 
 #  T5696580, C891335, C891336
 @pytest.mark.productSupportPage
-def test_product_support_page_featured_articles_redirect(page: Page):
+def test_product_support_page_featured_articles_redirect(page: Page, is_chromium):
+    if is_chromium:
+        pytest.skip("Skipping this test for chromium browser")
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     with allure.step("Navigating to products page via top-navbar"):

--- a/playwright_tests/tests/explore_help_articles_tests/explore_by_topic_tests/test_explore_by_topics.py
+++ b/playwright_tests/tests/explore_help_articles_tests/explore_by_topic_tests/test_explore_by_topics.py
@@ -26,6 +26,7 @@ def test_explore_by_topic_product_filter(page: Page):
         topic = topic.strip()
         if topic != "Browse":
             sumo_pages.explore_by_topic_page.click_on_a_topic_filter(topic)
+            utilities.wait_for_dom_to_load()
         with allure.step("Verifying that the correct page header is displayed"):
             assert topic == (sumo_pages.explore_by_topic_page
                              .get_explore_by_topic_page_header().strip())

--- a/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
@@ -687,10 +687,6 @@ def _validate_profile_info(page: Page, target: str, profile_info: str, username:
         "involved_from_month": sumo_pages.my_profile_page.get_my_contributed_from_text,
         "involved_from_year": sumo_pages.my_profile_page.get_my_contributed_from_text,
     }
-    link_click_methods = {
-        "community_portal": sumo_pages.my_profile_page.click_on_community_portal_link,
-        "people_directory": sumo_pages.my_profile_page.click_on_people_directory_link,
-    }
 
     with allure.step("Signing in with a different non-admin user"):
         utilities.start_existing_session(utilities.username_extraction_from_email(
@@ -704,27 +700,11 @@ def _validate_profile_info(page: Page, target: str, profile_info: str, username:
         if profile_info not in profile_info_getters.get(target, lambda: None)():
             return False
 
-    if target in link_click_methods:
-        with allure.step("Clicking on the link and verifying redirection"):
-            link_click_methods[target]()
-            utilities.wait_for_networkidle()
-            print(utilities.get_page_url())
-            if profile_info not in utilities.get_page_url():
-                return False
-        utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username))
-
     with allure.step("Signing out and verifying the information again"):
         utilities.delete_cookies()
         utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username))
         if profile_info not in profile_info_getters.get(target, lambda: None)():
             return False
-
-        if target in link_click_methods:
-            with allure.step("Clicking on the link and verifying redirection"):
-                link_click_methods[target]()
-                utilities.wait_for_networkidle()
-                if profile_info not in utilities.get_page_url():
-                    return False
 
     utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username))
     return True

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -38,7 +38,7 @@ def test_my_profile_page_can_be_accessed_via_top_navbar(page: Page):
         ) == UserProfileNavbarMessages.NAVBAR_OPTIONS[0]
 
 
-#  C891411
+#  C891411, C891410
 @pytest.mark.userProfile
 def test_my_profile_sign_out_button_functionality(page: Page):
     utilities = Utilities(page)
@@ -63,7 +63,7 @@ def test_my_profile_sign_out_button_functionality(page: Page):
         expect(sumo_pages.top_navbar.sign_in_up_button_displayed_element()).to_be_visible()
 
 
-# C2108828
+# C2108828, C891410
 @pytest.mark.userProfile
 def test_provided_solutions_number_is_successfully_displayed(page: Page):
     utilities = Utilities(page)
@@ -133,7 +133,7 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page):
         expect(sumo_pages.product_support_page.product_product_title_element()).to_be_visible()
 
 
-# C890832,  C2094281
+# C890832,  C2094281, C891410
 @pytest.mark.userProfile
 def test_number_of_my_profile_answers_is_successfully_displayed(page: Page):
     utilities = Utilities(page)
@@ -201,7 +201,7 @@ def test_number_of_my_profile_answers_is_successfully_displayed(page: Page):
         expect(sumo_pages.product_support_page.product_product_title_element()).to_be_visible()
 
 
-#  C2094285, C2094284, C891309
+#  C2094285, C2094284, C891309, C891410
 @pytest.mark.userProfile
 def test_number_of_posted_articles_is_successfully_displayed(page: Page):
     utilities = Utilities(page)


### PR DESCRIPTION
- Adding the newly AAQ topics for AAQ test coverage.
- Adding the functionality of creating a new KB article via kb/new API inside the add_kb_article_flow.py
- Catching potential failures yielded by load_state events not being fired in conftest.py
- Reducing the default navigation timeout from 2 minutes to 30 seconds and using the internal navigate_to_link() function in conftest.py
- Creating kb articles via kb/new API calls in several tests.
- Removing external link validations in test_edit_my_profile.py
- Skipping some flaky tests from Chromium.