### PR TITLE
Extend debounce and improve query

### DIFF
--- a/kitsune/sumo/form_fields.py
+++ b/kitsune/sumo/form_fields.py
@@ -68,17 +68,13 @@ class MultiUsernameField(forms.Field):
             else:
                 return []
 
-        users = []
-        usernames = [name.strip() for name in value.split(",") if name]
+        usernames = [name.strip() for name in value.split(",") if name.strip()]
         if usernames:
             all_users = User.objects.filter(
-                Q(username__in=usernames) | Q(profile__name__in=usernames)
-            )
-            for user in all_users:
-                if user and user.is_active:
-                    users.append(user)
+                Q(profile__name__in=usernames) | Q(username__in=usernames), is_active=True
+            ).distinct()
 
-        return users
+        return list(all_users)
 
 
 class MultiUsernameOrGroupnameField(forms.Field):

--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -679,7 +679,7 @@ import collapsibleAccordionInit from "sumo/js/protocol-details-init";
         clearTimeout(timeout);
         timeout = setTimeout(function () {
             updateRevisionList();
-        }, 200);
+        }, 500);
 
         // Collect form data and save it as JSON in sessionStorage
         const currentData = $form.serializeArray().reduce((obj, item) => {


### PR DESCRIPTION
Trying to resolve inconsistencies on staging that are likely caused by DB calls and timing issues, and/or broken user look-ups.

This code:
* Makes the JS call to fetch the revision data wait a little longer between polls; move debounce from 200 to 500
* Further optimizes query and code