### PR TITLE
Spam question redirect issue

### DIFF
--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -643,7 +643,10 @@ def aaq(request, product_slug=None, step=1, is_loginless=False):
             question_vote(request, question.id)
 
             if form.cleaned_data.get("is_spam"):
+                question.mark_as_spam(request.user)
                 _add_to_moderation_queue(request, question)
+                url = reverse("questions.list", args=[product.slug])
+                return HttpResponseRedirect(url)
 
             my_questions_url = reverse("users.questions", args=[request.user.username])
             messages.add_message(


### PR DESCRIPTION
Previously:
If a user submitted a question, and the question was immediately flagged as spam, then the user was redirected to a 404 after submission, with no other information. Even though their post was sent to the moderation queue, if they don't have perms to be able to moderate, they can't see the post, thus 404.
Also, if your post was auto-flagged, it was not done via `mark_as_spam` so the tag that was displayed (if you could see it) was that it was flagged as spam by None, at None. 

Now:
Upon submission, if the user's question is marked as spam, they are redirected to the general question listing, with a message that tells them about their post.
The post is marked as spam in their name, and gets a timestamp.