### PR TITLE
Playwright extend user profile tests 

### DIFF
--- a/playwright_tests/core/utilities.py
+++ b/playwright_tests/core/utilities.py
@@ -23,7 +23,7 @@ class Utilities:
         self.page = page
 
     # Fetching test data from json files.
-    with open("test_data/profile_edit.json", "r") as edit_test_data_file:
+    with open("test_data/profile_edit.json", "r", encoding="utf-8") as edit_test_data_file:
         profile_edit_test_data = json.load(edit_test_data_file)
     edit_test_data_file.close()
 

--- a/playwright_tests/flows/auth_flows/auth_flow.py
+++ b/playwright_tests/flows/auth_flows/auth_flow.py
@@ -71,5 +71,5 @@ class AuthFlowPage:
             """If the OTP code input field is displayed, provide the OTP code."""
             self.__provide_otp_code(self.utilities.get_fxa_verification_code(
                 fxa_username=username))
-
+        self.utilities.wait_for_dom_to_load()
         return username

--- a/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
+++ b/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
@@ -419,9 +419,9 @@ class QuestionPage(BasePage):
         self._click(self.__post_reply_button,
                     expected_locator=f"//span[@class='display-name' and contains(text(), "
                                      f"'{repliant_username}')]")
-        return self._get_element_attribute_value(f"//span[@class='display-name' and "
-                                                 f"contains(text(), '{repliant_username}')]/"
-                                                 f"ancestor::div[@class='answer ']",
+        return self._get_element_attribute_value("(//span[@class='display-name' and "
+                                                 f"contains(text(), '{repliant_username}')]"
+                                                 "/ancestor::div[@class='answer '])[last()]",
                                                  "id")
 
     # Question Tools actions.
@@ -577,3 +577,11 @@ class QuestionPage(BasePage):
 
     def click_on_common_responses_insert_response_button(self):
         self._click(self.__common_responses_insert_response_button)
+
+    def get_time_from_reply(self, reply_id: str) -> str:
+        """Returns the time displayed inside the question for when a reply was made.
+
+        Args:
+            reply_id (str): The reply id.
+        """
+        return self._get_text_of_element(f"//div[@id='{reply_id}']//time/time")

--- a/playwright_tests/pages/user_pages/my_profile_answers_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_answers_page.py
@@ -32,3 +32,12 @@ class MyProfileAnswersPage(BasePage):
         return self._get_text_of_element(f"//article[@id='profile']//"
                                          f"a[contains(@href, '{answer_id}')]/"
                                          f"following-sibling::blockquote")
+
+    def get_my_answer_question_title(self, answer_id: str) -> str:
+        """Get the title of the question that the answer belongs to.
+
+        Args:
+        answer_id: str: The id of the answer.
+        """
+        return self._get_text_of_element(f"//article[@id='profile']//a[contains(@href,"
+                                         f" '{answer_id}')]")

--- a/playwright_tests/pages/user_pages/my_profile_edit.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit.py
@@ -266,10 +266,10 @@ class MyProfileEdit(BasePage):
         """Click the cancel button"""
         self._click(self.EDIT_PROFILE_PAGE_LOCATORS["cancel_button"])
 
-    def click_update_my_profile_button(self, expected_url=None):
+    def click_update_my_profile_button(self, expected_url=None, expected_locator=None):
         """Click the update my profile button"""
         self._click(self.EDIT_PROFILE_PAGE_LOCATORS["update_my_profile_button"],
-                    expected_url=expected_url)
+                    expected_url=expected_url, expected_locator=expected_locator)
 
     def click_close_account_option(self):
         """Click the close account and delete all profile information link"""

--- a/playwright_tests/pages/user_pages/my_profile_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_page.py
@@ -78,6 +78,14 @@ class MyProfilePage(BasePage):
         """Get the display name header text."""
         return self._get_text_of_element(self.PROFILE_DETAILS_LOCATORS["display_name_header"])
 
+    def get_expected_header_locator(self, expected_username: str) -> str:
+        """Get the expected header locator.
+
+        Args:
+            expected_username (str): The expected username
+        """
+        return f"//h2[normalize-space(text())='{expected_username}']"
+
     def get_my_profile_display_name_username_text(self) -> str:
         """Get the display name username text."""
         return self._get_text_of_element(self.PROFILE_DETAILS_LOCATORS["username_info"])
@@ -110,9 +118,9 @@ class MyProfilePage(BasePage):
         """Get the contributed from text."""
         return self._get_text_of_element(self.PROFILE_DETAILS_LOCATORS["contributed_from_info"])
 
-    def get_my_profile_bio_text(self) -> str:
+    def get_my_profile_bio_text_paragraphs(self) -> list[str]:
         """Get the bio text."""
-        return self._get_text_of_element(self.PROFILE_DETAILS_LOCATORS["bio_info"])
+        return self._get_text_of_elements(self.PROFILE_DETAILS_LOCATORS["bio_info"])
 
     def get_my_profile_page_header(self) -> str:
         """Get the profile page header."""

--- a/playwright_tests/test_data/profile_edit.json
+++ b/playwright_tests/test_data/profile_edit.json
@@ -2,9 +2,7 @@
   "valid_user_edit": {
     "username": "modifiedUsernameAutoTestt",
     "display_name": "Modified display name",
-    "display_name_chrome": "Modified display name ch",
-    "display_name_firefox": "Modified displayed name fx",
-    "biography": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+    "biography": "Test\n<b>What the</b>\n\n<blockquote> Another test </blockquote>\n\n<code>host_ip = socket.gethostbyname(socket.gethostname()</code>\n\n<ul>\n<li> Test</li>\n<li>We</li>\n</ul>\n\n<ol>\n<li><i>www</i></li>\n</ol>\n\n<strong>Emil</strong>\n\nThe <abbr title=\"World Health Organization\">WHO</abbr> was founded in 1948.\n\n<a href='https://www.digi24.ro'>Digi link</a>",
     "website": "https://edition.cnn.com/",
     "twitter_username": "twitterTestUser",
     "community_portal_username": "169008142",
@@ -20,16 +18,15 @@
     "involved_from_year": "2017"
   },
   "valid_user_edit_with_symbols":{
-      "username_with_valid_symbols_firefox": "5Testing@and.with+and-and_",
-      "username_with_valid_symbols_chrome": "6Testing@and.with+and-and_"
+    "username_with_valid_symbols_firefox": "5Testing@and.with+and-and_",
+    "username_with_non_ascii_japanese_chars": "こんにちは"
   },
   "invalid_username_with_symbols": {
-    "username_with_invalid_symbols": "testMozilla12^"
+    "username_with_invalid_symbols": "testMozilla12^",
+    "username_with_non_ascii_arabic_chars": "أهلاًبك",
+    "emoji_for_username": "Test\uD83D\uDE3A\uD83D\uDE38"
   },
   "uppercase_lowercase_valid_username": {
     "uppercase_lowercase_username": "fICENCEp"
-  },
-  "biography_field_with_html_data": {
-    "biography_html_data": "Test\n<b>What the</b>\n\n<blockquote> Another test </blockquote>\n\n<code>\n\nhost_ip = socket.gethostbyname(socket.gethostname())\n\nif browser == \"chrome\":\nbrowser_options = ChromeOptions()\nbrowser_options.add_argument(\"-headless\")\nbrowser_options.add_argument('-window-size=1200x600')\nbrowser_options.add_argument(\"-disable-gpu\")\nbrowser_options.add_argument(\"--log-level=3\")\n\nelse:\nbrowser_options = FirefoxOptions()\nbrowser_options.add_argument(\"-headless\")\nbrowser_options.add_argument('-window-size=1200x600')\nbrowser_options.add_argument(\"-disable-gpu\")\nbrowser_options.log.level = 'warn'\n\ndriver = webdriver.Remote(\ncommand_executor=f'http://{host_ip}:4444',\noptions=browser_options\n)\n\n</code>\n\n<ul>\n<li> Test</li>\n<li>We</li>\n</ul>\n\n<ol>\n<li><i>www</i></li>\n</ol>\n\n<strong>Emil</strong>\n\n "
   }
 }

--- a/playwright_tests/tests/contribute_tests/test_groups.py
+++ b/playwright_tests/tests/contribute_tests/test_groups.py
@@ -208,9 +208,7 @@ def test_change_group_avatar(page: Page):
 def test_add_new_group_leader(page: Page):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    test_user = utilities.username_extraction_from_email(
-        utilities.user_secrets_accounts["TEST_ACCOUNT_12"]
-    )
+    test_user = "manualtest4"
 
     test_group = utilities.user_message_test_data['test_groups'][2]
 

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -133,7 +133,7 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page):
         expect(sumo_pages.product_support_page.product_product_title_element()).to_be_visible()
 
 
-# C890832,  C2094281, C891410
+# C890832,  C2094281, C891410, C2245210, C2245211, C2245212, C2245209
 @pytest.mark.userProfile
 def test_number_of_my_profile_answers_is_successfully_displayed(page: Page):
     utilities = Utilities(page)
@@ -192,16 +192,74 @@ def test_number_of_my_profile_answers_is_successfully_displayed(page: Page):
         assert reply_text == sumo_pages.my_answers_page.get_my_answer_text(
             answer_id=answer_id
         ), "My question reply is not displayed inside the my profile answers list"
+        assert question_info["aaq_subject"] == (sumo_pages.my_answers_page.
+                                                get_my_answer_question_title(answer_id))
 
-    with allure.step("Deleting the posted question and verifying that the user is redirected "
-                     "to the product support forum page"):
+    with allure.step("Updating the question title and question reply"):
+        sumo_pages.my_answers_page.click_on_specific_answer(answer_id)
+        sumo_pages.question_page.click_on_edit_this_question_question_tools_option()
+        updated_title_text = ("Updated Question Title " + utilities.
+                              generate_random_number(1,1000))
+        updated_reply_text = "Updated reply"
+        sumo_pages.aaq_flow.editing_question_flow(
+            subject=updated_title_text,
+            submit_edit=True
+        )
+        sumo_pages.question_page.click_on_reply_more_options_button(answer_id)
+        sumo_pages.question_page.click_on_edit_this_post_for_a_certain_reply(answer_id)
+        sumo_pages.aaq_flow.editing_reply_flow(updated_reply_text, submit_reply=True)
+
+    with allure.step("Navigating back to the answers page from the profile section and verifying "
+                     "that the updates are reflected"):
+        sumo_pages.question_page.click_on_the_reply_author(answer_id)
+        assert (
+            utilities.number_extraction_from_string(
+                sumo_pages.my_profile_page.get_my_profile_answers_text()
+            ) == original_number_of_answers + 1
+        )
+
+        sumo_pages.my_profile_page.click_my_profile_answers_link()
+        assert updated_reply_text == sumo_pages.my_answers_page.get_my_answer_text(
+            answer_id=answer_id
+        ), "My question reply is not displayed inside the my profile answers list"
+
+        assert updated_title_text == sumo_pages.my_answers_page.get_my_answer_question_title(
+            answer_id)
+
+    with allure.step("Navigating back to the posted question and posting a reply to it"):
+        sumo_pages.my_answers_page.click_on_specific_answer(answer_id)
+        reply_text = "A new reply"
+        sumo_pages.question_page.add_text_to_post_a_reply_textarea(reply_text)
+        second_answer_id = sumo_pages.question_page.click_on_post_reply_button(
+            repliant_username=repliant_user
+        )
+
+    with allure.step("Navigating back to the answers page from the profile section and verifying "
+                     "that the updates are reflected"):
+        sumo_pages.question_page.click_on_the_reply_author(second_answer_id)
+        assert (
+            utilities.number_extraction_from_string(
+                sumo_pages.my_profile_page.get_my_profile_answers_text()
+            ) == original_number_of_answers + 2
+        )
+
+        sumo_pages.my_profile_page.click_my_profile_answers_link()
+        assert reply_text == sumo_pages.my_answers_page.get_my_answer_text(
+            answer_id=second_answer_id
+        ), "My question reply is not displayed inside the my profile answers list"
+
+        assert updated_title_text == sumo_pages.my_answers_page.get_my_answer_question_title(
+            second_answer_id)
+
+    with allure.step("Deleting the posted question and verifying that the user is redirected to "
+                     "the product support forum page"):
         utilities.navigate_to_link(question_info["question_page_url"])
         sumo_pages.question_page.click_delete_this_question_question_tools_option()
         sumo_pages.question_page.click_delete_this_question_button()
         expect(sumo_pages.product_support_page.product_product_title_element()).to_be_visible()
 
 
-#  C2094285, C2094284, C891309, C891410
+#  C2094285, C2094284, C891309, C891410, C2245213
 @pytest.mark.userProfile
 def test_number_of_posted_articles_is_successfully_displayed(page: Page):
     utilities = Utilities(page)
@@ -237,9 +295,29 @@ def test_number_of_posted_articles_is_successfully_displayed(page: Page):
             my_documents_page.get_text_of_document_links()
         )
 
+    with allure.step("Navigating to the article and changing the title"):
+        new_article_title = "Updated title test v1"
+        sumo_pages.my_documents_page.click_on_a_particular_document(
+            article_details['article_title'])
+        sumo_pages.edit_article_metadata_flow.edit_article_metadata(title=new_article_title)
+
+    with allure.step("Accessing the profile page and verifying that the number of posted "
+                     "documents is the same"):
+        sumo_pages.top_navbar.click_on_view_profile_option()
+        assert (
+            utilities.number_extraction_from_string(
+                sumo_pages.my_profile_page.get_my_profile_documents_text()
+            ) == original_number_of_documents + 1
+        )
+
+    with allure.step("Clicking on my posted documents link and verifying that the new document "
+                     "title is listed"):
+        sumo_pages.my_profile_page.click_on_my_profile_document_link()
+        assert (new_article_title in sumo_pages.my_documents_page.get_text_of_document_links())
+
     with allure.step("Deleting the article"):
         sumo_pages.my_documents_page.click_on_a_particular_document(
-            article_details['article_title']
+            new_article_title
         )
         sumo_pages.kb_article_deletion_flow.delete_kb_article()
 


### PR DESCRIPTION
- Extend Playwright coverage to test that usernames with non-ascii japanese characters are supported.
- Extend Playwright coverage to test that usernames with non-ascii arabic characters and usernames which contain emoji are not supported.
- Updated the mapping between Playwright and TestRail tests for some test cases.
- Extended Playwright coverage to user profile biography validation.
- Extended Playwright coverage to testing that the preferred timezone updates content accordingly.