### PR TITLE
Fix erroneous validation error

### DIFF
--- a/kitsune/groups/views.py
+++ b/kitsune/groups/views.py
@@ -82,7 +82,10 @@ def edit_avatar(request, group_slug):
     if not _user_can_edit(request.user, prof):
         raise PermissionDenied
 
-    form = GroupAvatarForm(request.POST or None, request.FILES, instance=prof, request=request)
+    if request.method == "POST":
+        form = GroupAvatarForm(request.POST, request.FILES, instance=prof, request=request)
+    else:
+        form = GroupAvatarForm(instance=prof, request=request)
 
     old_avatar_path = None
 

--- a/kitsune/upload/forms.py
+++ b/kitsune/upload/forms.py
@@ -13,6 +13,7 @@ MSG_IMAGE_LONG = _lazy(
 class LimitedImageField(forms.ImageField):
     ALLOWED_IMAGE_EXTENSIONS = ("jpg", "jpeg", "png", "gif")
     default_validators = [FileExtensionValidator(allowed_extensions=ALLOWED_IMAGE_EXTENSIONS)]
+    error_messages = {"required": MSG_IMAGE_REQUIRED}
 
 
 class ImageAttachmentUploadForm(forms.Form):


### PR DESCRIPTION
### Description of Fix for PR

**Issue**: When initially visiting the `edit_avatar` view, a field validation error about the avatar field being required is shown, even though the form has not been submitted.

**Fix**: The issue was caused by the form being instantiated with `request.FILES` even on a `GET` request, which triggered the validation logic prematurely. The fix involves modifying the `edit_avatar` view to ensure that the form is only instantiated with `request.POST` and `request.FILES` when the request method is `POST`.

**Changes Made**:
1. Updated the `edit_avatar` view to check the request method. If the request method is `POST`, the form is instantiated with `request.POST` and `request.FILES`. If the request method is `GET`, the form is instantiated without `request.POST` and `request.FILES`.
2. Ensured that the form validation logic is only triggered when the form is actually submitted (`POST` request).
