### PR TITLE
Playwright fix test failure due to tags dropdown tom-select transition

### DIFF
--- a/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
+++ b/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
@@ -67,9 +67,9 @@ class QuestionPage(BasePage):
     __mark_as_spam_option = "//ul[@id='related-content']//form[@class='spam-form cf']/a"
 
     # Tags section locators.
-    __question_tags_options = "//li[@class='tag']/a"
-    __add_a_tag_input_field = "//input[@id='id_tag_input']"
-    __add_a_tab_button = "//form[@class='tag-adder']/input[@type='submit']"
+    __question_tags_options_for_non_moderators = "//li[@class='tag']/a"
+    __question_tags_options_for_moderators = "//div[@class='ts-control']/div"
+    __add_a_tag_input_field = "//input[contains(@id, 'tag-select')]"
 
     # Post a reply section locators.
     __post_a_reply_section_heading = "//h3[@class='sumo-card-heading']"
@@ -269,36 +269,35 @@ class QuestionPage(BasePage):
                                          f"span[@class='user-title']")
 
     # Question tag actions.
-    def get_question_tag_options(self) -> list[str]:
-        return self._get_text_of_elements(self.__question_tags_options)
+    def get_question_tag_options(self, is_moderator: bool) -> list[str]:
+        return [tag.replace("\n×", "") for tag in self._get_text_of_elements(
+            self.__question_tags_options_for_moderators if is_moderator else self
+            .__question_tags_options_for_non_moderators
+        )]
 
     def get_remove_tag_button_locator(self, tag_name: str) -> Locator:
-        return self._get_element_locator(f"//ul[@class='tag-list cf']//a[text()='{tag_name}']/"
-                                         f"following-sibling::button[@class='remover']")
+        return self._get_element_locator(f"//div[@class='ts-control']/div[normalize-space("
+                                         f"text())='{tag_name}']/a[@class='remove']")
 
     def add_text_to_add_a_tag_input_field(self, text: str):
         self._fill(self.__add_a_tag_input_field, text)
-        self.page.click(f"//li[@class='ui-menu-item']/div[text()='{text}']")
+        self._wait_for_given_timeout(2000)
+        self._press_a_key(self.__add_a_tag_input_field, "Enter")
 
     def get_add_a_tag_input_field(self) -> Locator:
         return self._get_element_locator(self.__add_a_tag_input_field)
-
-    def get_add_a_tag_button(self) -> Locator:
-        return self._get_element_locator(self.__add_a_tab_button)
-
-    def click_on_add_a_tag_button(self):
-        self._click(self.__add_a_tab_button)
 
     def click_on_a_certain_tag(self, tag_name: str):
         self._click(f"//li[@class='tag']//a[text()='{tag_name}']",
                     expected_locator=ProductSupportForum.PAGE_LOCATORS["ask_the_community_button"])
 
     def get_a_certain_tag(self, tag_name: str) -> Locator:
-        return self._get_element_locator(f"//li[@class='tag']//a[text()='{tag_name}']")
+        return self._get_element_locator(f"//div[@class='ts-control']/div[@class='item' and "
+                                         f"normalize-space(text())='{tag_name}']")
 
     def click_on_tag_remove_button(self, tag_name: str):
-        self._click(f"//li[@class='tag']//a[text()='{tag_name}']/"
-                    f"following-sibling::button[@class='remover']")
+        self._click(f"//div[@class='item' and normalize-space(text())='{tag_name}']/"
+                    f"a[@class='remove']")
 
     # Attached image actions.
     def get_attached_image(self) -> Locator:

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -289,7 +289,9 @@ def test_post_aaq_questions_for_all_freemium_products_topics(page: Page):
                         )
                     assert (
                         all(map(
-                            lambda x: x in sumo_pages.question_page.get_question_tag_options(),
+                            lambda x: x in sumo_pages.question_page.get_question_tag_options(
+                                is_moderator=True
+                            ),
                             slugs))
                     )
 

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -734,11 +734,8 @@ def test_question_topics(page: Page, username):
                      "question"):
         posted_question = post_firefox_product_question_flow(page, 'TEST_ACCOUNT_12')
 
-    with allure.step("Verifying that the 'Add a tag' input field is not displayed for OP"):
+    with allure.step("Verifying that Tags cannot be added by OP user"):
         expect(sumo_pages.question_page.get_add_a_tag_input_field()).to_be_hidden()
-
-    with allure.step("Verifying that the 'Add' topic section button is not displayed for OP"):
-        expect(sumo_pages.question_page.get_add_a_tag_button()).to_be_hidden()
 
     with allure.step("Deleting user session"):
         utilities.delete_cookies()
@@ -749,14 +746,12 @@ def test_question_topics(page: Page, username):
                 utilities.user_secrets_accounts["TEST_ACCOUNT_13"]
             ))
 
-    with allure.step("Verifying that the 'Add a tag' input field is not displayed"):
+    with allure.step("Verifying that the 'Add a tag' input field is not displayed for "
+                     "permissionless accounts"):
         expect(sumo_pages.question_page.get_add_a_tag_input_field()).to_be_hidden()
 
-    with allure.step("Verifying that the 'Add' topic section button is not displayed"):
-        expect(sumo_pages.question_page.get_add_a_tag_button()).to_be_hidden()
-
     with allure.step("Verifying that the remove tag button is not displayed"):
-        for tag in sumo_pages.question_page.get_question_tag_options():
+        for tag in sumo_pages.question_page.get_question_tag_options(is_moderator=False):
             expect(sumo_pages.question_page.get_remove_tag_button_locator(tag)).to_be_hidden()
 
     with allure.step("Signing in with a admin user account, adding data inside the 'Add a "
@@ -767,7 +762,6 @@ def test_question_topics(page: Page, username):
         sumo_pages.question_page.add_text_to_add_a_tag_input_field(
             utilities.aaq_question_test_data['valid_firefox_question']['custom_tag']
         )
-        sumo_pages.question_page.click_on_add_a_tag_button()
 
     with allure.step("Deleting user session"):
         utilities.delete_cookies()
@@ -779,12 +773,14 @@ def test_question_topics(page: Page, username):
             ))
 
     with check, allure.step("Verifying that the tag is available for all users"):
-        page.reload()
-        assert (utilities.aaq_question_test_data['valid_firefox_question']
-                ['custom_tag'] in sumo_pages.question_page.get_question_tag_options())
+        utilities.refresh_page()
+        assert (
+            utilities.aaq_question_test_data['valid_firefox_question']['custom_tag'] in sumo_pages.
+            question_page.get_question_tag_options(is_moderator=False)
+        )
 
     with allure.step("Verifying that the question tags are acting as filters"):
-        for question in sumo_pages.question_page.get_question_tag_options():
+        for question in sumo_pages.question_page.get_question_tag_options(is_moderator=False):
             with check, allure.step(f"Clicking on the {question} tag and verifying tha the "
                                     f"filter is applied to the clicked tag"):
                 time.sleep(1)


### PR DESCRIPTION
- Fixing failures caused in test_question_topics test due to the transition of the tags dropdown to tom-select.