### PR TITLE
Improved topic cards now show three articles, with new design

### DIFF
--- a/kitsune/products/jinja2/products/includes/topic_macros.html
+++ b/kitsune/products/jinja2/products/includes/topic_macros.html
@@ -8,7 +8,6 @@
     - documents: three documents for the topic
 #}
 <div class="topics-section">
-  <h2>Topics</h2>
   <div class="topics-grid">
     {% for topic_data in topics %}
     <div class="card--topic">

--- a/kitsune/products/jinja2/products/includes/topic_macros.html
+++ b/kitsune/products/jinja2/products/includes/topic_macros.html
@@ -1,10 +1,11 @@
-{% macro help_topics(topics, documents, product_slug=None, new_tab=False) -%}
+{% macro help_topics(topics, product_slug=None, new_tab=False) -%}
 {# topics: List of topic_data dicts containing:
     - topic: Topic model instance
     - topic_url: URL to topic page
     - title: Topic title
     - total_articles: Number of articles
     - image_url: URL to topic icon
+    - documents: three documents for the topic
 #}
 <div class="topics-section">
   <h2>Topics</h2>
@@ -24,7 +25,7 @@
           </h3>
       </div>
       <ul class="article-list">
-        {% for document in documents[topic_data.topic] %}
+        {% for document in topic_data.documents %}
         <li>
           <a href="{{ document.url }}">      
             {{ document.document_title }}</a>

--- a/kitsune/products/jinja2/products/includes/topic_macros.html
+++ b/kitsune/products/jinja2/products/includes/topic_macros.html
@@ -1,31 +1,44 @@
-{% macro help_topics(topics, product_slug=None, new_tab=False) -%}
-  <div class="sumo-card-grid">
-    <div class="scroll-wrap">
-      {% for topic in topics %}
-      {% set topic_url = url('products.documents', product_slug=product_slug or product.slug, topic_slug=topic.slug) %}
-      <div class="card card--topic">
+{% macro help_topics(topics, documents, product_slug=None, new_tab=False) -%}
+{# topics: List of topic_data dicts containing:
+    - topic: Topic model instance
+    - topic_url: URL to topic page
+    - title: Topic title
+    - total_articles: Number of articles
+    - image_url: URL to topic icon
+#}
+<div class="topics-section">
+  <h2>Topics</h2>
+  <div class="topics-grid">
+    {% for topic_data in topics %}
+    <div class="card--topic">
+      <div class="topic-header">
         <img
           class="card--icon"
-          src="{{ topic.image_url }}"
-          alt="{{ pgettext('DB: products.Topic.title', topic.title) }} icon"
+          src="{{ topic_data.image_url }}"
+          alt="{{ pgettext('DB: products.Topic.title', topic_data.title) }} icon"
         />
-        <div class="card--details">
           <h3 class="card--title">
-            <a class="expand-this-link" href="{{ topic_url }}" data-on-hover="{{ _('See all') }}" {% if new_tab %} target="_blank" {% endif %}
-              data-event-name="link_click"
-              data-event-parameters='{
-                "link_name": "product-and-topic-home",
-                "link_detail": "{{ (product_slug or product.slug) + '/' + topic.slug }}"
-              }'>
-              {{ pgettext('DB: products.Topic.title', topic.title) }}
+            <a href="{{ topic_data.topic_url }}">
+              {{ pgettext('DB: products.Topic.title', topic_data.title) }}
             </a>
           </h3>
-        </div>
       </div>
-      {% endfor %}
+      <ul class="article-list">
+        {% for document in documents[topic_data.topic] %}
+        <li>
+          <a href="{{ document.url }}">      
+            {{ document.document_title }}</a>
+        </li>
+        {% endfor %}
+      </ul>
+      <a class="view-all-link" href="{{ topic_data.topic_url }}">View All {{ topic_data.total_articles }} Articles</a>
     </div>
+    {% endfor %}
   </div>
+</div>
 {%- endmacro %}
+
+
 
 {% macro topic_metadata(topics, product=None) %}
 {% if product and has_aaq_config and not settings.READ_ONLY %}

--- a/kitsune/products/jinja2/products/product.html
+++ b/kitsune/products/jinja2/products/product.html
@@ -147,7 +147,7 @@
       </div>
       {% endif %}
     </div>
-    {{ help_topics(topics) }}
+    {{ help_topics(topics, documents) }}
   </div>
 
   {{ topic_metadata(topics, product=product) }}

--- a/kitsune/products/jinja2/products/product.html
+++ b/kitsune/products/jinja2/products/product.html
@@ -147,7 +147,7 @@
       </div>
       {% endif %}
     </div>
-    {{ help_topics(topics, documents) }}
+    {{ help_topics(topics) }}
   </div>
 
   {{ topic_metadata(topics, product=product) }}

--- a/kitsune/products/jinja2/products/product.html
+++ b/kitsune/products/jinja2/products/product.html
@@ -123,7 +123,7 @@
     <div class="sumo-page-subheader">
       <div class="sumo-page-subheader--text">
         <div class="text-center-to-left-on-large">
-          <h2 class="sumo-page-subheading">{{ _('Frequent Topics') }}</h2>
+          <h2 class="sumo-page-subheading">{{ _('Topics') }}</h2>
           <p class="sumo-page-intro">{{ _('Explore the knowledge base.') }}</p>
         </div>
       </div>

--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -59,13 +59,15 @@ def product_landing(request, slug: str) -> HttpResponse:
             latest_version = 0
     topics = topics_for(request.user, product=product, parent=None)
     # Create a dictionary of topics and three documents
-    # TODO: get popular documents instead of just the first three
     topics_with_urls = []
     for topic in topics:
         docs, _ = documents_for(
             request.user, request.LANGUAGE_CODE, topics=[topic], products=[product]
         )
         total_articles = len(docs)
+        # Leverage get_featured_articles to get active articles
+        docs = get_featured_articles(product, locale=request.LANGUAGE_CODE, topic=topic)
+
         # Create a dict with topic data including the URL
         topic_data = {
             "topic": topic,

--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -60,7 +60,6 @@ def product_landing(request, slug: str) -> HttpResponse:
     topics = topics_for(request.user, product=product, parent=None)
     # Create a dictionary of topics and three documents
     # TODO: get popular documents instead of just the first three
-    documents = {}
     topics_with_urls = []
     for topic in topics:
         docs, _ = documents_for(
@@ -73,10 +72,10 @@ def product_landing(request, slug: str) -> HttpResponse:
             "topic_url": reverse("products.documents", args=[product.slug, topic.slug]),
             "title": topic.title,
             "total_articles": total_articles,
-            "image_url": getattr(topic, "image_url", ""),
+            "image_url": topic.image_url,
+            "documents": docs[:3],
         }
         topics_with_urls.append(topic_data)
-        documents[topic] = docs[:3]
 
     return render(
         request,
@@ -89,7 +88,6 @@ def product_landing(request, slug: str) -> HttpResponse:
             "latest_version": latest_version,
             "featured": get_featured_articles(product, locale=request.LANGUAGE_CODE),
             "has_aaq_config": has_aaq_config(product),
-            "documents": documents,
         },
     )
 

--- a/kitsune/sumo/static/sumo/scss/components/_card.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_card.scss
@@ -181,21 +181,74 @@
   }
 
   &--topic {
-    @include c.elevation-01;
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 16px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-sizing: border-box;
 
-    .card-title {
-      margin: 0;
+    .topic-header {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      margin-bottom: 16px;
     }
 
     .card--icon {
-      width: p.$spacing-lg;
-      height: p.$spacing-lg;
-      object-fit: contain;
-      font-size: 9px;
-      line-height: 1;
-      flex: 0 0 auto;
+      flex-shrink: 0;
+      width: 18px;
+      height: 18px;
+    }
+
+    .card--title {
+      font-family: Inter;
+      font-size: 16px;
+      font-weight: 700;
+      margin: 0;
+      line-height: 1.2;
+      flex-grow: 1;
+    }
+
+    .article-list {
+      flex-grow: 1;
+      margin: 0 0 16px;
+      padding: 0;
+      list-style: none;
+
+      li {
+        margin-bottom: 8px;
+        line-height: 1.5;
+
+        a {
+          color: black;
+          font-size: 14px;
+          text-decoration: underline;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+
+    .view-all-link {
+      border-top: 1px solid #ddd;
+      padding-top: 10px;
+      margin-top: 16px;
+      display: inline-block;
+      font-size: 14px;
+      color: #000000;
+      text-decoration: underline;
+      font-weight: normal;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 

--- a/kitsune/sumo/static/sumo/scss/layout/_products.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_products.scss
@@ -32,3 +32,21 @@
     margin: 0 p.$spacing-xs;
   }
 }
+
+
+// SCSS for Topics Section Layout
+
+.topics-section {
+  padding: 40px 20px;
+  h2 {
+    font-size: 24px;
+    margin-bottom: 30px;
+    color: #333;
+  }
+}
+
+.topics-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}

--- a/kitsune/sumo/static/sumo/scss/layout/_products.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_products.scss
@@ -40,7 +40,7 @@
   padding: 40px 20px;
   h2 {
     font-size: 24px;
-    margin-bottom: 30px;
+    margin-bottom: 0px;
     color: #333;
   }
 }

--- a/kitsune/wiki/utils.py
+++ b/kitsune/wiki/utils.py
@@ -103,10 +103,11 @@ def _active_contributors_id(from_date, to_date, locale, product):
     return set(list(editors) + list(reviewers))
 
 
-def get_featured_articles(product=None, locale=settings.WIKI_DEFAULT_LANGUAGE):
+def get_featured_articles(product=None, locale=settings.WIKI_DEFAULT_LANGUAGE, topic=None):
     """Returns 4 random articles from the most visited.
 
-    If a product is passed, it returns 4 random highly visited articles.
+    If a product is passed, it returns 4 random highly visited articles from that product.
+    If a topic is passed, it returns 4 random highly visited articles from that topic.
     """
     visits = (
         WikiDocumentVisits.objects.filter(period=LAST_7_DAYS)
@@ -123,6 +124,9 @@ def get_featured_articles(product=None, locale=settings.WIKI_DEFAULT_LANGUAGE):
 
     if product:
         visits = visits.filter(document__products__in=[product.id])
+
+    if topic:
+        visits = visits.filter(document__topics__in=[topic.id])
 
     visits = visits[:10]
     documents = []


### PR DESCRIPTION
* Alter the help_topics macro to support showing three articles
* Add show more section with sectional line above
* Add logic to the product_landing view to return docs and counts
* Styling

Note - right now this just shows three (the first three) documents in a topic. This should be updated to choose most popular or newest pending discussions with Content.