### PR TITLE
Use locale_picker_url in footer

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -314,7 +314,7 @@
 
         <section class="mzp-c-footer-col lang-col">
           <form class="mzp-c-language-switcher" method="get" action="#">
-            <a class="mzp-c-language-switcher-link" href="https://www.mozilla.org/locales/">{{ _('Language') }}</a>
+            <a class="mzp-c-language-switcher-link" href="{{ locale_picker_url }}">{{ _('Language') }}</a>
             <label for="mzp-c-language-switcher-select">{{ _('Language') }}</label>
             <select id="mzp-c-language-switcher-select" class="mzp-js-language-switcher-select"
              name="lang">


### PR DESCRIPTION
Link to `sumo.locales` instead of hardcoded _bedrock_ locale page.

Resolves https://github.com/mozilla/sumo/issues/2100