### PR TITLE
Remove pontoon.js interactive test

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -381,10 +381,5 @@
   {% endif %}
 {% endif %}
 
-{# Temporary Pontoon testing - bug 812176 #}
-{% if settings.STAGE %}
-  <script src="https://pontoon.mozilla.org/pontoon.js"></script>
-{% endif %}
-
 </body>
 </html>


### PR DESCRIPTION
The feature has been removed https://bugzil.la/1615928 and no future plans are currently in place. This fixes 404 errors on allizom staging.

Resolves #6412 

Similar to https://github.com/mozilla/bedrock/pull/13274