### PR TITLE
fix update of GA4 pageview data for questions

### DIFF
--- a/kitsune/questions/tests/test_models.py
+++ b/kitsune/questions/tests/test_models.py
@@ -572,7 +572,7 @@ class QuestionVisitsTests(TestCase):
         q2 = QuestionFactory()
         q3 = QuestionFactory()
 
-        pageviews_by_question.return_value = (
+        pageviews_by_question.return_value = dict(
             row
             for row in (
                 (q1.id, 42),
@@ -589,7 +589,7 @@ class QuestionVisitsTests(TestCase):
         self.assertEqual(1337, QuestionVisits.objects.get(question_id=q3.id).visits)
 
         # Change the data and run again to cover the update case.
-        pageviews_by_question.return_value = (
+        pageviews_by_question.return_value = dict(
             row
             for row in (
                 (q1.id, 100),

--- a/kitsune/sumo/googleanalytics.py
+++ b/kitsune/sumo/googleanalytics.py
@@ -332,6 +332,8 @@ def pageviews_by_question(period=LAST_YEAR, verbose=False):
     """
     date_range = DateRange(start_date=PERIOD_TO_DAYS_AGO[period], end_date="today")
 
+    pageviews_by_id = {}
+
     for row in run_report(date_range, create_question_report_request, verbose=verbose):
         path = row.dimension_values[0].value
         # The path should be a question path without any query parameters, but in reality
@@ -345,7 +347,13 @@ def pageviews_by_question(period=LAST_YEAR, verbose=False):
             question_id = int(question_id)
         except ValueError:
             continue
-        yield (question_id, num_page_views)
+
+        # The "run_report" will return one row for each unique question path. Since the
+        # path includes the locale, there can be multiple rows for each question, so we
+        # need to accumulate the sum of all of those rows.
+        pageviews_by_id[question_id] = pageviews_by_id.get(question_id, 0) + num_page_views
+
+    return pageviews_by_id
 
 
 def search_clicks_and_impressions(start_date, end_date, verbose=False):

--- a/kitsune/sumo/tests/test_googleanalytics.py
+++ b/kitsune/sumo/tests/test_googleanalytics.py
@@ -134,20 +134,28 @@ class GoogleAnalyticsTests(TestCase):
             ),
             Row(
                 dimension_values=[DimensionValue(value="/es/questions/782348")],
-                metric_values=[MetricValue(value="2000")],
+                metric_values=[MetricValue(value="187")],
             ),
             Row(
                 dimension_values=[DimensionValue(value="/de/questions/987235")],
                 metric_values=[MetricValue(value="3000")],
             ),
+            Row(
+                dimension_values=[DimensionValue(value="/it/questions/123456")],
+                metric_values=[MetricValue(value="17")],
+            ),
+            Row(
+                dimension_values=[DimensionValue(value="/en-US/questions/782348")],
+                metric_values=[MetricValue(value="2000")],
+            ),
         )
 
-        result = list(googleanalytics.pageviews_by_question(LAST_7_DAYS))
+        result = googleanalytics.pageviews_by_question(LAST_7_DAYS)
 
         self.assertEqual(3, len(result))
-        self.assertEqual(result[0], (123456, 1000))
-        self.assertEqual(result[1], (782348, 2000))
-        self.assertEqual(result[2], (987235, 3000))
+        self.assertEqual(result[123456], 1017)
+        self.assertEqual(result[782348], 2187)
+        self.assertEqual(result[987235], 3000)
 
     @patch.object(googleanalytics, "run_report")
     def test_search_clicks_and_impressions(self, run_report):


### PR DESCRIPTION
mozilla/sumo#1913

# Notes
- The `Reload Question Traffic Stats` weekly cron has been broken for over 5 months. This PR fixes it.
- There are two problems with the currently released code:
    - The `kitsune.sumo.googleanalytics.pageviews_by_question()` function returns multiple rows for each question ID -- one for each locale that a question was viewed in during the past 365 days -- and that means that more than 700K rows can be returned in `prod`. In this PR, it returns a `dict` with one entry for each question ID where the value of that entry is the total pageviews of the question across all locales, which means over 300K entries in `prod`.
    - The `QuestionVisits.reload_from_analytics()` method was causing an OOM error because it was building the `instance_by_question_id` `dict` for all questions at once. In this PR, that's now done in batches of 30K.
- A very minor variation of the code in this PR has already been successfully tested within the `prod` environment.