### PR TITLE
fix some strings for l10n extraction

### DIFF
--- a/kitsune/announcements/tasks.py
+++ b/kitsune/announcements/tasks.py
@@ -31,9 +31,11 @@ def send_group_email(announcement_id):
     @safe_translation
     def _make_mail(locale, user):
         if groups.count() == 1:
-            subject = _(f"New announcement for {groups[0].name}")
+            subject = _("New announcement for {name}").format(name=groups[0].name)
         else:
-            subject = _(f"New announcement for groups [{', '.join([g.name for g in groups])}]")
+            subject = _("New announcement for groups [{names}]").format(
+                names=", ".join(g.name for g in groups)
+            )
 
         mail = make_mail(
             subject=subject,

--- a/kitsune/sumo/form_fields.py
+++ b/kitsune/sumo/form_fields.py
@@ -107,7 +107,7 @@ class MultiUsernameOrGroupnameField(forms.Field):
         for key, value in key_value_pairs:
             # check if the value is a valid username in the database
             if key.lower() == "user" and not User.objects.filter(username=value).exists():
-                raise ValidationError(_(f"{value} is not a valid username."))
+                raise ValidationError(_("{name} is not a valid username.").format(name=value))
             to_objects.setdefault(f"{key.lower()}s", []).append(value)
 
         return to_objects


### PR DESCRIPTION
mozilla/sumo#2103

# Notes
This was a quick and easy one. We don't yet support Python `f-strings` when extracting for localization, so this PR adjusts the 3 `f-strings` used within `gettext` calls such that they're included in the extraction process. I ran `./manage.py extract` in the context of this PR and verified that each of these strings is now extracted. ✅ 