### PR TITLE
restore GA4 logging which is used for testing on stage

### DIFF
--- a/kitsune/sumo/static/sumo/js/analytics.js
+++ b/kitsune/sumo/static/sumo/js/analytics.js
@@ -1,5 +1,11 @@
 export default function trackEvent(name, parameters) {
   if (window.gtag) {
+    if (window.gaConsoleLogging) {
+      console.log("------------------------------");
+      console.log(`event: ${name}:`);
+      console.log(`parameters: ${JSON.stringify(parameters, null, 2)}`);
+      console.log("------------------------------");
+    }
     window.gtag('event', name, parameters);
   }
 }

--- a/kitsune/sumo/static/sumo/js/gtm-snippet.js
+++ b/kitsune/sumo/static/sumo/js/gtm-snippet.js
@@ -10,6 +10,8 @@ import dntEnabled from "./libs/dnt-helper";
   let html = document.getElementsByTagName('html')[0];
   let GTM_CONTAINER_ID = html.getAttribute('data-gtm-container-id');
 
+  w.gaConsoleLogging = false;
+
   w.dataLayer = w.dataLayer || [];
 
   w.gtag = function () {
@@ -47,6 +49,15 @@ import dntEnabled from "./libs/dnt-helper";
     }
     if (html.dataset.gaDebugMode) {
       configParameters.debug_mode = true;
+    }
+    // Always ensure this block of console-logging code follows all
+    // of the code that modifies the "configParameters" object.
+    if (html.dataset.gaConsoleLogging) {
+      w.gaConsoleLogging = true;
+      console.log("------------------------------");
+      console.log(`config for ${GTM_CONTAINER_ID}:`);
+      console.log(`parameters: ${JSON.stringify(configParameters, null, 2)}`);
+      console.log("------------------------------");
     }
 
     w.gtag('config', GTM_CONTAINER_ID, configParameters);


### PR DESCRIPTION
https://github.com/mozilla/kitsune/pull/6418 removed the GA4 logging infrastructure, but it's our only way to test GA4 events within the `stage` environment (it's disabled in all other environments), so this PR restores it.