### PR TITLE
Update robots view to disallow non-canonical

### DIFF
--- a/kitsune/sumo/views.py
+++ b/kitsune/sumo/views.py
@@ -105,7 +105,12 @@ def robots(request):
     if not settings.ENGAGE_ROBOTS:
         template = "User-Agent: *\nDisallow: /"
     else:
-        template = render(request, "sumo/robots.html")
+        if not request.build_absolute_uri("/").startswith("https://support.mozilla.org"):
+            # We will differentiate this for tests with a comment
+            template = "# Non-canoncial\nUser-Agent: *\nDisallow: /"
+        else:
+            template = render(request, "sumo/robots.html")
+
     return HttpResponse(template, content_type="text/plain")
 
 

--- a/kitsune/sumo/views.py
+++ b/kitsune/sumo/views.py
@@ -105,7 +105,7 @@ def robots(request):
     if not settings.ENGAGE_ROBOTS:
         template = "User-Agent: *\nDisallow: /"
     else:
-        if not request.build_absolute_uri("/").startswith("https://support.mozilla.org"):
+        if request.get_host() != "support.mozilla.org":
             # We will differentiate this for tests with a comment
             template = "# Non-canoncial\nUser-Agent: *\nDisallow: /"
         else:


### PR DESCRIPTION
This should disallow all crawls at any domain that isn't support.mozilla.org .

Our `robots.txt` file is dynamically generated, so this just adds another test to determine if we serve the detailed template or the 'disallow everything' code.