### PR TITLE
Playwright - Fix delete cookies check & update test_synonyms file

### DIFF
--- a/playwright_tests/core/utilities.py
+++ b/playwright_tests/core/utilities.py
@@ -11,6 +11,8 @@ from typing import Any, Union
 from datetime import datetime
 from nltk import SnowballStemmer, WordNetLemmatizer
 from playwright.sync_api import Page, Locator
+
+from playwright_tests.messages.auth_pages_messages.fxa_page_messages import FxAPageMessages
 from playwright_tests.messages.homepage_messages import HomepageMessages
 from requests.exceptions import HTTPError
 from playwright_tests.pages.top_navbar import TopNavbar
@@ -307,8 +309,11 @@ class Utilities:
             try:
                 self.page.context.clear_cookies()
                 self.refresh_page()
-                self.page.wait_for_selector(top_navbar.TOP_NAVBAR_SIGNIN_SIGNUP_LOCATORS
-                                            ["signin_signup_button"], timeout=3000)
+                if FxAPageMessages.AUTH_PAGE_URL in self.get_page_url():
+                    break
+                else:
+                    self.page.wait_for_selector(top_navbar.TOP_NAVBAR_SIGNIN_SIGNUP_LOCATORS
+                                                ["signin_signup_button"], timeout=3000)
                 break
             except PlaywrightTimeoutError:
                 print("Cookies were not successfully deleted. Retrying...")

--- a/playwright_tests/test_data/search_synonym.py
+++ b/playwright_tests/test_data/search_synonym.py
@@ -8,7 +8,7 @@ class SearchSynonyms:
         'cache': ['cash', 'cookies'],
         'popup': ['pop up'],
         'pop up': ['popup'],
-        'popups': ['pop-up', 'pop-ups', 'pop ups'],
+        'popups': ['pop-up', 'pop-ups', 'pop ups', 'pops up'],
 
         # Actions
         'clear': ['delete', 'remove', 'deleting'],


### PR DESCRIPTION
- There are some cases in which deleting the playwright user session redirects to the login page (depending on which page the session cookies deletion was performed). Since the login page doesn't contain the top navbar options,  we must treat the login page as a pass while checking that the user was indeed signed out after the session deletion. This fix should improve the execution time on those particular tests by breaking out from the attempts/retry loop.
- It seems that searching for "popups" will also return results containing "pops up". I'm adding that to the synonm list.