### PR TITLE
Handle new topic cards in aaq

### DIFF
--- a/kitsune/products/jinja2/products/includes/topic_macros.html
+++ b/kitsune/products/jinja2/products/includes/topic_macros.html
@@ -27,7 +27,7 @@
         {% for document in topic_data.documents %}
         <li>
           <a href="{{ document.url }}">      
-            {{ document.document_title }}</a>
+            {{ document.title }}</a>
         </li>
         {% endfor %}
       </ul>

--- a/kitsune/questions/utils.py
+++ b/kitsune/questions/utils.py
@@ -66,7 +66,7 @@ def get_mobile_product_from_ua(user_agent):
         return "mobile"
 
 
-def get_featured_articles(product, locale):
+def get_featured_articles(product, locale, topic=None):
     """
     Returns 4 featured articles for the AAQ.
 
@@ -91,7 +91,9 @@ def get_featured_articles(product, locale):
         pinned_articles = []
 
     if len(pinned_articles) < 4:
-        return (pinned_articles + kb_get_featured_articles(product=product, locale=locale))[:4]
+        return (
+            pinned_articles + kb_get_featured_articles(product=product, locale=locale, topic=topic)
+        )[:4]
 
     return pinned_articles[-4:]
 

--- a/kitsune/questions/utils.py
+++ b/kitsune/questions/utils.py
@@ -66,7 +66,7 @@ def get_mobile_product_from_ua(user_agent):
         return "mobile"
 
 
-def get_featured_articles(product, locale, topic=None):
+def get_featured_articles(product, locale):
     """
     Returns 4 featured articles for the AAQ.
 
@@ -91,9 +91,7 @@ def get_featured_articles(product, locale, topic=None):
         pinned_articles = []
 
     if len(pinned_articles) < 4:
-        return (
-            pinned_articles + kb_get_featured_articles(product=product, locale=locale, topic=topic)
-        )[:4]
+        return (pinned_articles + kb_get_featured_articles(product=product, locale=locale))[:4]
 
     return pinned_articles[-4:]
 

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -70,6 +70,7 @@ from kitsune.tidings.models import Watch
 from kitsune.upload.models import ImageAttachment
 from kitsune.users.models import Setting
 from kitsune.wiki.facets import documents_for, topics_for
+from kitsune.wiki.utils import get_featured_articles as kb_get_featured_articles
 
 log = logging.getLogger("k.questions")
 
@@ -571,8 +572,8 @@ def aaq(request, product_slug=None, step=1, is_loginless=False):
         # Format topics data for the help_topics macro
         topics_data = []
         for topic in topics_for(request.user, product, parent=None):
-            # Get documents using get_featured_articles like product_landing does
-            docs = get_featured_articles(product, locale=request.LANGUAGE_CODE, topic=topic)
+            # Get documents using kb_get_featured_articles like product_landing does
+            docs = kb_get_featured_articles(product, locale=request.LANGUAGE_CODE, topic=topic)
 
             # Get total count of articles using documents_for like product_landing
             all_docs, _ = documents_for(
@@ -588,10 +589,7 @@ def aaq(request, product_slug=None, step=1, is_loginless=False):
                     "total_articles": total_articles,
                     "image_url": topic.image_url
                     or settings.STATIC_URL + "products/img/topic_placeholder.png",
-                    "documents": [
-                        {"url": doc.url, "document_title": doc.document_title}
-                        for doc in docs[:3]  # Limit to first 3 documents
-                    ],
+                    "documents": docs[:3],
                 }
             )
 


### PR DESCRIPTION
The new topic modules that display popular articles were not working on the aaq step 2. The reason is that the context wasn't being properly sent from the view. Further, the aaq uses it's own flavor of `get_featured_articles`, so prior changes to accept topics in the kb version weren't reflected in the aaq version.

This should fix and allow the topic module boxes to display properly in aaq.