### PR TITLE
remove extra GA4 events when submitting survey

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -21,8 +21,8 @@
     </span>
     {% if created_date %}
       <span class="last-updated">
-       <img class="pencil" src="{{ webpack_static('sumo/img/pencil.svg') }}" /> 
-       <strong>{% if is_first_revision %}{{ _("Created") }}{% else %}{{ _("Last updated") }}{% endif %}:</strong> 
+       <img class="pencil" src="{{ webpack_static('sumo/img/pencil.svg') }}" />
+       <strong>{% if is_first_revision %}{{ _("Created") }}{% else %}{{ _("Last updated") }}{% endif %}:</strong>
         <span class="time">
           {{ datetimeformat(created_date, format="shortdate", use_naturaltime=True) }}
         </span>
@@ -353,10 +353,11 @@
   {% endif %}
   {% if document.allows_vote(request) and not document.current_revision.has_voted(request) %}
     <div class="document-vote elevation-02 text-center">
-      <form class="document-vote--form helpful" 
+      <form class="document-vote--form helpful"
             hx-post="{{ url('wiki.document_vote', document_slug=document.slug) }}"
             hx-indicator=".wait"
-            hx-target="this">
+            hx-target="this"
+            hx-swap="outerHTML">
           {% csrf_token %}
           <h4 class="document-vote--heading">{{ header }}</h4>
           <div class="document-vote--buttons">

--- a/kitsune/wiki/jinja2/wiki/includes/survey_form.html
+++ b/kitsune/wiki/jinja2/wiki/includes/survey_form.html
@@ -7,7 +7,7 @@
   </template>
 
   <template x-if="formVisible">
-    <form hx-post="{{ action_url }}" hx-target=".survey-container" hx-trigger="submit">
+    <form hx-post="{{ action_url }}" hx-target=".survey-container" hx-swap="outerHTML" hx-trigger="submit">
       {% csrf_token %}
       <input type="hidden" name="vote_id" value="{{ vote_id }}" />
       <input type="hidden" name="revision_id" value="{{ revision_id }}" />


### PR DESCRIPTION
mozilla/sumo#2131

## Notes
By default, the swapping method used by htmx for `hx-target` is `innerHTML`, so the target itself is not swapped, just its contents. In both cases, where we're using `hx-target` we really wanted to include the target in the swap, so I've added `hx-swap="outerHTML"` to both cases. This fixes the GA4 event problem because we were picking-up the `data-survey-type` of the old `.survey-container` not the new one that was just swapped in with the `response_message`, but now the old one is swapped out with the new one, and we pick-up the correct value for `data-survey-type`.