### PR TITLE
provide moderation filtering by time period

### DIFF
--- a/kitsune/flagit/jinja2/flagit/content_moderation.html
+++ b/kitsune/flagit/jinja2/flagit/content_moderation.html
@@ -51,6 +51,15 @@
       options=products,
       selected_filter=selected_product
   ) }}
+  {{ filter_dropdown(
+      form_id='time-period-filter-form',
+      select_id='flagit-time-period-filter',
+      label='Filter by time periods:',
+      name='time-period',
+      default_option='All periods',
+      options=time_periods,
+      selected_filter=selected_time_period
+  ) }}
 {% endblock %}
 {# Hide the deactivation log on content moderation #}
 {% block deactivation_log %}

--- a/kitsune/sumo/static/sumo/js/flagit.js
+++ b/kitsune/sumo/static/sumo/js/flagit.js
@@ -131,6 +131,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const flaggedQueue = document.getElementById('flagged-queue');
     initializeFilterDropdown('flagit-reason-filter', 'reason');
     initializeFilterDropdown('flagit-product-filter', 'product');
+    initializeFilterDropdown('flagit-time-period-filter', 'time-period');
 
     function initializeFilterDropdown(filterId, queryParam) {
         const filterElement = document.getElementById(filterId);

--- a/kitsune/sumo/static/sumo/scss/components/_flaggit.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_flaggit.scss
@@ -64,3 +64,7 @@
         margin-top: p.$spacing-md;
     }
 }
+
+#time-period-filter-form {
+    margin-top: p.$spacing-md;
+}


### PR DESCRIPTION
mozilla/sumo#2124

This is a hack to provide moderation filtering by time periods, so each agent can take a separate time period.