### PR TITLE
Revert "Properly display article titles"

### DIFF
--- a/kitsune/products/jinja2/products/includes/topic_macros.html
+++ b/kitsune/products/jinja2/products/includes/topic_macros.html
@@ -27,7 +27,7 @@
         {% for document in topic_data.documents %}
         <li>
           <a href="{{ document.url }}">      
-            {{ document.title }}</a>
+            {{ document.document_title }}</a>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
Reverts mozilla/kitsune#6455