### PR TITLE
ensure htmx processes dynamically-loaded content

### DIFF
--- a/kitsune/sumo/static/sumo/js/flagit.js
+++ b/kitsune/sumo/static/sumo/js/flagit.js
@@ -159,6 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 flaggedQueue.innerHTML = doc.querySelector('#flagged-queue').innerHTML;
                 disableUpdateStatusButtons();
                 initializeDropdownsAndTags();
+                htmx.process(flaggedQueue);
             }
         });
     }


### PR DESCRIPTION
mozilla/sumo#2137
mozilla/sumo#2138

This was something I missed in https://github.com/mozilla/kitsune/pull/6460.

Any dynamically-loaded content that contains elements with `htmx` attributes and has been loaded by something other than `htmx` must have `htmx.process(...)` applied in order to ensure that the `htmx` event handlers are added.