### PR TITLE
Topic cards revised to show three articles

### DIFF
--- a/kitsune/products/jinja2/products/includes/topic_macros.html
+++ b/kitsune/products/jinja2/products/includes/topic_macros.html
@@ -1,31 +1,44 @@
 {% macro help_topics(topics, product_slug=None, new_tab=False) -%}
-  <div class="sumo-card-grid">
-    <div class="scroll-wrap">
-      {% for topic in topics %}
-      {% set topic_url = url('products.documents', product_slug=product_slug or product.slug, topic_slug=topic.slug) %}
-      <div class="card card--topic">
+{# topics: List of topic_data dicts containing:
+    - topic: Topic model instance
+    - topic_url: URL to topic page
+    - title: Topic title
+    - total_articles: Number of articles
+    - image_url: URL to topic icon
+    - documents: three documents for the topic
+#}
+<div class="topics-section">
+  <div class="topics-grid">
+    {% for topic_data in topics %}
+    <div class="card--topic">
+      <div class="topic-header">
         <img
           class="card--icon"
-          src="{{ topic.image_url }}"
-          alt="{{ pgettext('DB: products.Topic.title', topic.title) }} icon"
+          src="{{ topic_data.image_url }}"
+          alt="{{ pgettext('DB: products.Topic.title', topic_data.title) }} icon"
         />
-        <div class="card--details">
           <h3 class="card--title">
-            <a class="expand-this-link" href="{{ topic_url }}" data-on-hover="{{ _('See all') }}" {% if new_tab %} target="_blank" {% endif %}
-              data-event-name="link_click"
-              data-event-parameters='{
-                "link_name": "product-and-topic-home",
-                "link_detail": "{{ (product_slug or product.slug) + '/' + topic.slug }}"
-              }'>
-              {{ pgettext('DB: products.Topic.title', topic.title) }}
+            <a href="{{ topic_data.topic_url }}">
+              {{ pgettext('DB: products.Topic.title', topic_data.title) }}
             </a>
           </h3>
-        </div>
       </div>
-      {% endfor %}
+      <ul class="article-list">
+        {% for document in topic_data.documents %}
+        <li>
+          <a href="{{ document.get_absolute_url() }}">      
+            {{ document.title }}</a>
+        </li>
+        {% endfor %}
+      </ul>
+      <a class="view-all-link" href="{{ topic_data.topic_url }}">View All {{ topic_data.total_articles }} Articles</a>
     </div>
+    {% endfor %}
   </div>
+</div>
 {%- endmacro %}
+
+
 
 {% macro topic_metadata(topics, product=None) %}
 {% if product and has_aaq_config and not settings.READ_ONLY %}

--- a/kitsune/products/jinja2/products/product.html
+++ b/kitsune/products/jinja2/products/product.html
@@ -123,7 +123,7 @@
     <div class="sumo-page-subheader">
       <div class="sumo-page-subheader--text">
         <div class="text-center-to-left-on-large">
-          <h2 class="sumo-page-subheading">{{ _('Frequent Topics') }}</h2>
+          <h2 class="sumo-page-subheading">{{ _('Topics') }}</h2>
           <p class="sumo-page-intro">{{ _('Explore the knowledge base.') }}</p>
         </div>
       </div>

--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -11,7 +11,7 @@ from kitsune.sumo.utils import has_aaq_config, set_aaq_context
 from kitsune.wiki.decorators import check_simple_wiki_locale
 from kitsune.wiki.facets import documents_for, topics_for
 from kitsune.wiki.models import Document, Revision
-from kitsune.wiki.utils import get_featured_articles
+from kitsune.wiki.utils import build_topics_data, get_featured_articles
 
 
 @check_simple_wiki_locale
@@ -23,8 +23,19 @@ def product_list(request):
 
 
 @check_simple_wiki_locale
-def product_landing(request, slug):
-    """The product landing page."""
+def product_landing(request, slug: str) -> HttpResponse:
+    """The product landing page.
+
+    Args:
+        request: The HTTP request
+        slug: Product slug identifier
+
+    Returns:
+        Rendered product landing page
+
+    Raises:
+        Http404: If product not found
+    """
     if slug == "firefox-accounts":
         return redirect(product_landing, slug="mozilla-account", permanent=True)
 
@@ -45,6 +56,7 @@ def product_landing(request, slug):
             latest_version = versions[0].min_version
         else:
             latest_version = 0
+    topics = topics_for(request.user, product=product, parent=None)
 
     return render(
         request,
@@ -52,7 +64,7 @@ def product_landing(request, slug):
         {
             "product": product,
             "products": Product.active.filter(visible=True),
-            "topics": topics_for(request.user, product=product, parent=None),
+            "topics": build_topics_data(request, product, topics),
             "search_params": {"product": slug},
             "latest_version": latest_version,
             "featured": get_featured_articles(product, locale=request.LANGUAGE_CODE),

--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -2,7 +2,7 @@ import json
 
 from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from product_details import product_details
 
@@ -23,7 +23,7 @@ def product_list(request):
 
 
 @check_simple_wiki_locale
-def product_landing(request, slug: str) -> HttpResponse:
+def product_landing(request: HttpRequest, slug: str) -> HttpResponse:
     """The product landing page.
 
     Args:

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -70,6 +70,7 @@ from kitsune.tidings.models import Watch
 from kitsune.upload.models import ImageAttachment
 from kitsune.users.models import Setting
 from kitsune.wiki.facets import topics_for
+from kitsune.wiki.utils import build_topics_data
 
 log = logging.getLogger("k.questions")
 
@@ -568,8 +569,10 @@ def aaq(request, product_slug=None, step=1, is_loginless=False):
         context["ga_products"] = f"/{product_slug}/"
 
     if step == 2:
+        topics = topics_for(request.user, product, parent=None)
+
         context["featured"] = get_featured_articles(product, locale=request.LANGUAGE_CODE)
-        context["topics"] = topics_for(request.user, product, parent=None)
+        context["topics"] = build_topics_data(request, product, topics)
 
     elif step == 3:
         context["cancel_url"] = get_next_url(request) or (

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -571,9 +571,7 @@ def aaq(request, product_slug=None, step=1, is_loginless=False):
     if step == 2:
         topics = topics_for(request.user, product, parent=None)
 
-        context["featured"] = get_featured_articles(
-            product, topics=topics, locale=request.LANGUAGE_CODE
-        )
+        context["featured"] = get_featured_articles(product, locale=request.LANGUAGE_CODE)
         context["topics"] = build_topics_data(request, product, topics)
 
     elif step == 3:

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -571,7 +571,9 @@ def aaq(request, product_slug=None, step=1, is_loginless=False):
     if step == 2:
         topics = topics_for(request.user, product, parent=None)
 
-        context["featured"] = get_featured_articles(product, locale=request.LANGUAGE_CODE)
+        context["featured"] = get_featured_articles(
+            product, topics=topics, locale=request.LANGUAGE_CODE
+        )
         context["topics"] = build_topics_data(request, product, topics)
 
     elif step == 3:

--- a/kitsune/sumo/static/sumo/scss/components/_card.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_card.scss
@@ -185,18 +185,18 @@
     flex-direction: column;
     justify-content: space-between;
     height: 100%;
-    background-color: #fff;
+    background-color: p.$color-white;
     border: 1px solid #ddd;
-    border-radius: 8px;
-    padding: 16px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    border-radius: p.$border-radius-md;
+    padding: p.$spacing-md;
+    box-shadow: p.$box-shadow-sm;
     box-sizing: border-box;
 
     .topic-header {
       display: flex;
       align-items: flex-start;
       gap: 10px;
-      margin-bottom: 16px;
+      margin-bottom: p.$spacing-md;
     }
 
     .card--icon {
@@ -216,7 +216,7 @@
 
     .article-list {
       flex-grow: 1;
-      margin: 0 0 16px;
+      margin: 0 0 p.$spacing-md;
       padding: 0;
       list-style: none;
 
@@ -244,7 +244,7 @@
     .view-all-link {
       border-top: 1px solid #ddd;
       padding-top: 10px;
-      margin-top: 16px;
+      margin-top: p.$spacing-md;
       display: inline-block;
       font-size: 14px;
       color: #000000;

--- a/kitsune/sumo/static/sumo/scss/components/_card.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_card.scss
@@ -181,21 +181,79 @@
   }
 
   &--topic {
-    @include c.elevation-01;
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 16px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-sizing: border-box;
 
-    .card-title {
-      margin: 0;
+    .topic-header {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      margin-bottom: 16px;
     }
 
     .card--icon {
-      width: p.$spacing-lg;
-      height: p.$spacing-lg;
-      object-fit: contain;
-      font-size: 9px;
-      line-height: 1;
-      flex: 0 0 auto;
+      flex-shrink: 0;
+      width: 18px;
+      height: 18px;
+    }
+
+    .card--title {
+      font-family: Inter;
+      font-size: 16px;
+      font-weight: 700;
+      margin: 0;
+      line-height: 1.2;
+      flex-grow: 1;
+    }
+
+    .article-list {
+      flex-grow: 1;
+      margin: 0 0 16px;
+      padding: 0;
+      list-style: none;
+
+      li {
+        margin-bottom: 8px;
+        line-height: 1.5;
+        
+        a {
+          color: black;
+          font-size: 14px;
+          text-decoration: underline;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+
+    .view-all-link {
+      border-top: 1px solid #ddd;
+      padding-top: 10px;
+      margin-top: 16px;
+      display: inline-block;
+      font-size: 14px;
+      color: #000000;
+      text-decoration: underline;
+      font-weight: normal;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 

--- a/kitsune/sumo/static/sumo/scss/layout/_products.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_products.scss
@@ -1,7 +1,6 @@
 @use '../config' as c;
 @use 'protocol/css/includes/lib' as p;
 
-
 .sumo-page-subheader {
   display: flex;
   flex-direction: column-reverse;
@@ -33,9 +32,6 @@
   }
 }
 
-
-// SCSS for Topics Section Layout
-
 .topics-section {
   padding: 40px 20px;
   h2 {
@@ -45,7 +41,7 @@
   }
 
   @media #{p.$mq-sm} {
-    padding: 24px 16px;
+    padding: p.$spacing-lg p.$spacing-md;
   }
 }
 
@@ -56,35 +52,27 @@
     gap: 20px;
   }
 
-  // Mobile styles
   @media (max-width: #{p.$screen-lg}) {
     display: flex;
     overflow-x: auto;
-    gap: 16px;
-    padding: 16px 0;
+    gap: p.$spacing-md;
+    padding: p.$spacing-md 0;
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
     
-    // Hide scrollbar but keep functionality
-    scrollbar-width: none; // Firefox
     &::-webkit-scrollbar {
-      display: none; // Chrome, Safari, Edge
+      display: none;
     }
 
-    // Make sure child items are properly sized
     > .card--topic {
-      flex: 0 0 280px; // Fixed width for each item
-      height: 280px; // Fixed height
+      flex: 0 0 280px;
+      height: 280px;
       scroll-snap-align: start;
-      
-      // Force all content inside the card to respect the height
       display: flex;
       flex-direction: column;
-      
-      // Prevent content from overflowing
       overflow: hidden;
       
-      // Ensure all direct children within the card also respect the height
       > * {
         flex-shrink: 0;
       }

--- a/kitsune/sumo/static/sumo/scss/layout/_products.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_products.scss
@@ -32,3 +32,62 @@
     margin: 0 p.$spacing-xs;
   }
 }
+
+
+// SCSS for Topics Section Layout
+
+.topics-section {
+  padding: 40px 20px;
+  h2 {
+    font-size: 24px;
+    margin-bottom: 0px;
+    color: #333;
+  }
+
+  @media #{p.$mq-sm} {
+    padding: 24px 16px;
+  }
+}
+
+.topics-grid {
+  @media #{p.$mq-lg} {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+
+  // Mobile styles
+  @media (max-width: #{p.$screen-lg}) {
+    display: flex;
+    overflow-x: auto;
+    gap: 16px;
+    padding: 16px 0;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    
+    // Hide scrollbar but keep functionality
+    scrollbar-width: none; // Firefox
+    &::-webkit-scrollbar {
+      display: none; // Chrome, Safari, Edge
+    }
+
+    // Make sure child items are properly sized
+    > .card--topic {
+      flex: 0 0 280px; // Fixed width for each item
+      height: 280px; // Fixed height
+      scroll-snap-align: start;
+      
+      // Force all content inside the card to respect the height
+      display: flex;
+      flex-direction: column;
+      
+      // Prevent content from overflowing
+      overflow: hidden;
+      
+      // Ensure all direct children within the card also respect the height
+      > * {
+        flex-shrink: 0;
+      }
+    }
+  }
+}

--- a/kitsune/wiki/utils.py
+++ b/kitsune/wiki/utils.py
@@ -7,10 +7,16 @@ from django.db.models import Prefetch, Q
 from django.db.models.functions import Now
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.contrib.postgres.aggregates import StringAgg
+from django.db.models import TextField
+from django.db.models.functions import Cast
+from itertools import chain, islice
 
 from kitsune.dashboards import LAST_7_DAYS
 from kitsune.dashboards.models import WikiDocumentVisits
+from kitsune.sumo.urlresolvers import reverse
 from kitsune.wiki.models import Document, Revision
+from kitsune.wiki.facets import documents_for
 
 
 def active_contributors(from_date, to_date=None, locale=None, product=None):
@@ -103,10 +109,11 @@ def _active_contributors_id(from_date, to_date, locale, product):
     return set(list(editors) + list(reviewers))
 
 
-def get_featured_articles(product=None, locale=settings.WIKI_DEFAULT_LANGUAGE):
+def get_featured_articles(product=None, locale=settings.WIKI_DEFAULT_LANGUAGE, topic=None):
     """Returns 4 random articles from the most visited.
 
-    If a product is passed, it returns 4 random highly visited articles.
+    If a product is passed, it returns 4 random highly visited articles from that product.
+    If a topic is passed, it returns 4 random highly visited articles from that topic.
     """
     visits = (
         WikiDocumentVisits.objects.filter(period=LAST_7_DAYS)
@@ -119,10 +126,21 @@ def get_featured_articles(product=None, locale=settings.WIKI_DEFAULT_LANGUAGE):
         .exclude(document__is_template=True)
         .order_by("-visits")
         .select_related("document")
+        .annotate(
+            topic_ids=StringAgg(
+                Cast("document__topics__id", TextField()),
+                delimiter=",",
+                ordering="document__topics__id",
+                default="",
+            )
+        )
     )
 
     if product:
         visits = visits.filter(document__products__in=[product.id])
+
+    if topic:
+        visits = visits.filter(document__topics__in=[topic.id])
 
     visits = visits[:10]
     documents = []
@@ -194,3 +212,51 @@ def get_visible_document_or_404(
 
 def get_visible_revision_or_404(user, **kwargs):
     return get_object_or_404(Revision.objects.visible(user, **kwargs))
+
+
+def build_topics_data(request, product, topics):
+    """Build topics_data for use in topic cards"""
+    topics_data = []
+
+    # Get all documents for all topics up front
+    all_docs, _ = documents_for(
+        request.user, request.LANGUAGE_CODE, topics=list(topics), products=[product]
+    )
+
+    # Convert all docs to Document objects
+    doc_ids = [doc["id"] for doc in all_docs]
+    documents = (
+        Document.objects.filter(id__in=doc_ids)
+        .prefetch_related("topics")
+        .annotate(
+            topic_ids=StringAgg(
+                Cast("topics__id", TextField()), delimiter=",", ordering="topics__id", default=""
+            )
+        )
+    )
+
+    for topic in topics:
+        # Get featured articles first (returns up to 4 Document objects)
+        featured_articles = get_featured_articles(
+            product, locale=request.LANGUAGE_CODE, topic=topic
+        )
+
+        # Get docs for this topic from documents
+        topic_docs = [
+            doc for doc in documents if doc.topic_ids and str(topic.id) in doc.topic_ids.split(",")
+        ]
+
+        # Create a generator for remaining docs
+        remaining_docs = (doc for doc in topic_docs if doc not in featured_articles)
+
+        topic_data = {
+            "topic": topic,
+            "topic_url": reverse("products.documents", args=[product.slug, topic.slug]),
+            "title": topic.title,
+            "total_articles": len(topic_docs),
+            "image_url": topic.image_url,
+            "documents": list(islice(chain(featured_articles, remaining_docs), 3)),
+        }
+        topics_data.append(topic_data)
+
+    return topics_data

--- a/kitsune/wiki/utils.py
+++ b/kitsune/wiki/utils.py
@@ -1,5 +1,3 @@
-import random
-
 import requests
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -111,7 +109,7 @@ def _active_contributors_id(from_date, to_date, locale, product):
 
 
 def get_featured_articles(product=None, topics=None, locale=settings.WIKI_DEFAULT_LANGUAGE):
-    """Returns 4 random articles from the most visited.
+    """Returns up to 4 random articles per topic from the most visited.
 
     Args:
         product: Optional product to filter by
@@ -154,8 +152,8 @@ def get_featured_articles(product=None, topics=None, locale=settings.WIKI_DEFAUL
     if topics:
         visits = visits.filter(document__topics__in=topics).distinct()
 
-    # Order and limit after all filters are applied
-    visits = visits.order_by("-visits")[:10]
+    # Order by visits but don't limit - we need enough documents for all topics
+    visits = visits.order_by("-visits")
 
     # Convert to list to avoid additional queries
     visits = list(visits)
@@ -170,9 +168,8 @@ def get_featured_articles(product=None, topics=None, locale=settings.WIKI_DEFAUL
             if translation:
                 documents.append(translation)
 
-    if len(documents) <= 4:
-        return documents
-    return random.sample(documents, 4)
+    # Return all documents - the filtering per topic will happen in build_topics_data
+    return documents
 
 
 def get_visible_document_or_404(


### PR DESCRIPTION
* Improved topic card now show three top articles
* Alter the help_topics macro to support showing three articles
* Add show more section with sectional line above
* Add logic to the product_landing view to return docs and counts
* A utility function builds the topics_context for the cards
* Fix card scroll for topic cards on mobile
* Topics can only wrap once before being cut off with ellipses
* Use query annoation in `utils.py` to gather topics
* Use `chain` and `islice` to ensure proper doc order and count

This creates a new card for topics that contains three article titles. The articles are the three most frequently viewed for each topic and of that product, falling back three regular documents if we don't get enough documents from frequently viewed data.

The article titles are allowed to wrap once if they are lengthy, but then are cut off with an ellipse if they exceed two lines. 

The cards are in three columns, using a flex layout.

The cards scroll left to right on mobile, where they have fixed heights and widths to keep the experience optimal.