### PR TITLE
avoid `tom-select` issues with assign more

### DIFF
--- a/kitsune/flagit/jinja2/flagit/content_moderation.html
+++ b/kitsune/flagit/jinja2/flagit/content_moderation.html
@@ -78,7 +78,7 @@
   <div id="my-queue-tools" data-current-username="{{ current_username }}"
        {% if not (selected_assignee and (selected_assignee == current_username)) %} hidden{% endif %}>
     <label>{{ _('Manage my queue') }}:</label>
-    <form hx-post="" hx-target="#flagged-queue" hx-select="#flagged-queue">
+    <form method="post" action="">
       {% csrf_token %}
       <input type="hidden" name="action" value="assign">
       <input class="sumo-button primary-button button-lg btn" type="submit" value="{{ _('Assign more') }}" />

--- a/kitsune/sumo/static/sumo/js/flagit.js
+++ b/kitsune/sumo/static/sumo/js/flagit.js
@@ -147,13 +147,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    document.body.addEventListener('htmx:afterSwap', function(evt) {
-        if (evt.detail.target === flaggedQueue) {
-            disableUpdateStatusButtons();
-            initializeDropdownsAndTags();
-        }
-    });
-
     function initializeFilterDropdown(filterId, queryParam, postChangeFunction) {
         const filterElement = document.getElementById(filterId);
         if (!filterElement) return;


### PR DESCRIPTION
mozilla/sumo#2145

## Notes
- We no longer need the event listener for `htmx:afterSwap` because the only thing that uses `htmx` to reload the flagged items is the `Unassign all` button, which always guarantees an empty queue of flagged items so there's no need to do anything.
- I'm still using `htmx` for the `Unassign all` button only because I can use the `htmx:beforeRequest` event to remove the `page` parameter if present.