### PR TITLE
Exclude AAQ macro on the get-community-support page

### DIFF
--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -56,7 +56,9 @@
     {{ search_box(settings, id='support-search-sidebar', params=search_params) }}
   </div>
 
-  {{ aaq_widget(request) }}
+  {% if default_slug != 'get-community-support' %}
+    {{ aaq_widget(request) }}
+  {% endif %}
 
   {% if fallback_reason == 'no_translation' %}
     {# If there is no translation, there is no document and the (future) parent is document. #}

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -56,7 +56,7 @@
     {{ search_box(settings, id='support-search-sidebar', params=search_params) }}
   </div>
 
-  {% if default_slug != 'get-community-support' %}
+  {% if show_aaq_widget %}
     {{ aaq_widget(request) }}
   {% endif %}
 

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -304,6 +304,8 @@ def document(request, document_slug, document=None):
 
     is_first_revision = doc.revisions.filter(is_approved=True).count() == 1
 
+    show_aaq_widget = doc.slug != "get-community-support"
+
     data = {
         "document": doc,
         "is_first_revision": is_first_revision,
@@ -318,6 +320,7 @@ def document(request, document_slug, document=None):
         "ga_products": ga_products,
         "ga_article_locale": ga_article_locale,
         "related_products": doc.related_products.exclude(pk=product.pk),
+        "show_aaq_widget": show_aaq_widget,
         "breadcrumb_items": breadcrumbs,
         "document_css_class": document_css_class,
         "any_localizable_revision": any_localizable_revision,

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -304,7 +304,10 @@ def document(request, document_slug, document=None):
 
     is_first_revision = doc.revisions.filter(is_approved=True).count() == 1
 
-    show_aaq_widget = doc.slug != "get-community-support"
+    show_aaq_widget = (
+        not (doc.parent and doc.parent.slug == "get-community-support")
+        and doc.slug != "get-community-support"
+    )
 
     data = {
         "document": doc,


### PR DESCRIPTION
If the `default_slug` is set to `get-community-support` we won't show the aaq sidebar button. `default_slug` is already being set in the template, it represents the parent slug if there is a parent, or the current doc slug if there isn't.