### PR TITLE
close email connections when done

### DIFF
--- a/kitsune/sumo/email_utils.py
+++ b/kitsune/sumo/email_utils.py
@@ -19,11 +19,9 @@ def send_messages(messages):
     if not messages:
         return
 
-    conn = mail.get_connection(fail_silently=True)
-    conn.open()
-
-    for msg in messages:
-        conn.send_messages([msg])
+    with mail.get_connection(fail_silently=True) as conn:
+        for msg in messages:
+            conn.send_messages([msg])
 
 
 def safe_translation(f):

--- a/kitsune/tidings/events.py
+++ b/kitsune/tidings/events.py
@@ -135,11 +135,9 @@ class Event(object):
           passed in, each of those users will not be notified, though anonymous
           notifications having the same email address may still be sent.
         """
-        connection = mail.get_connection(fail_silently=True)
-        # Warning: fail_silently swallows errors thrown by the generators, too.
-        connection.open()
-        for m in self._mails(self._users_watching(exclude=exclude)):
-            connection.send_messages([m])
+        with mail.get_connection(fail_silently=True) as connection:
+            for m in self._mails(self._users_watching(exclude=exclude)):
+                connection.send_messages([m])
 
     def serialize(self):
         """


### PR DESCRIPTION
mozilla/sumo#2179 (and part of mozilla/sumo#1993)

## Notes
- An instance of the `django.core.mail.backends.smtp.EmailBackend` class -- which is what `django.core.mail.get_connection` returns -- is a Python context manager, so it'll automatically take care of opening and closing the connection when used in a `with` statement.
- This PR ensures that **all** of SUMO's email connections are closed after they've been used. **Every** email in SUMO is sent from either the `kitsune.sumo.email_utils.send_messages` function or the `kitsune.tidings.events.Event.send_emails` method.
