### PR TITLE
make the logging email backend a context manager

### DIFF
--- a/kitsune/lib/email.py
+++ b/kitsune/lib/email.py
@@ -3,7 +3,7 @@ import smtplib
 import time
 
 from django.conf import settings
-from django.core.mail.backends import smtp
+from django.core.mail.backends import base, smtp
 from django.utils.module_loading import import_string
 from sentry_sdk import capture_exception
 
@@ -11,7 +11,7 @@ from sentry_sdk import capture_exception
 log = logging.getLogger("k.lib.email")
 
 
-class LoggingEmailBackend(object):
+class LoggingEmailBackend(base.BaseEmailBackend):
     """
     Wraps a email backend defined in Django's settings and logs everything it does.
     """


### PR DESCRIPTION
mozilla/sumo#2179

## Notes
In #6496, I forgot to that our `LoggingEmailBackend` does not fully implement the standard interface of an email backend for Django -- which means it should implement the interface of `django.core.mail.backends.base.BaseEmailBackend` which includes acting as a context manager, and  `LoggingEmailBackend` lacks that -- so this PR does that.