### PR TITLE
1968 - Document edit and metadata on mobile

### DIFF
--- a/kitsune/sumo/static/sumo/scss/base/forms/_button-wrap.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_button-wrap.scss
@@ -38,10 +38,10 @@
   margin-bottom: -#{p.$spacing-sm};
   padding: p.$spacing-sm 0;
   width: 100%;
-  max-width: 95%;  // Default for mobile
+  max-width: 95%; 
 
   @media #{p.$mq-md} {
-    max-width: 100%;  // Return to full width on desktop
+    max-width: 100%;
   }
 
   &.align-end {
@@ -158,8 +158,6 @@
   }
 }
 
-
-// stack buttons and fit to the biggest one.
 .sumo-button-stack {
   display: flex;
   flex-direction: column;

--- a/kitsune/sumo/static/sumo/scss/base/forms/_button-wrap.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_button-wrap.scss
@@ -38,6 +38,11 @@
   margin-bottom: -#{p.$spacing-sm};
   padding: p.$spacing-sm 0;
   width: 100%;
+  max-width: 95%;  // Default for mobile
+
+  @media #{p.$mq-md} {
+    max-width: 100%;  // Return to full width on desktop
+  }
 
   &.align-end {
     justify-content: flex-end;

--- a/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
@@ -70,7 +70,11 @@ label {
 .form-as-ul>li {
   position: relative;
   margin-bottom: p.$spacing-lg;
-  max-width: p.remify(480px);
+  max-width: 25rem;  // Default for mobile
+
+  @media #{p.$mq-md} {
+    max-width: p.remify(480px);  // Original desktop width
+  }
 
   .error-text {
     display: none;
@@ -81,7 +85,11 @@ label {
   }
 
   &.has-large-textarea {
-    max-width: 100%;
+    max-width: 95%;  // Default for mobile
+
+    @media #{p.$mq-md} {
+      max-width: 100%;  // Return to full width on desktop
+    }
 
     textarea {
       min-height: 340px;
@@ -406,11 +414,34 @@ textarea {
 }
 
 .checkbox-list {
-  display: grid;
-  grid-auto-flow: row;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: masonry;
-  gap: p.$spacing-sm p.$spacing-sm;
+  display: block;
+  margin: 0 0 p.$spacing-xl 0;
+  padding: 0;
+  list-style: none;
+
+  @media #{p.$mq-md} {
+    display: grid;
+    grid-auto-flow: row;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: masonry;
+    gap: p.$spacing-sm p.$spacing-sm;
+  }
+
+  &--sublist {
+    margin-left: 24px;
+    
+    @include p.bidi(((margin-left, 24px, 0),
+        (margin-right, 0, 24px),
+    ));
+
+    @media #{p.$mq-md} {
+      margin-left: 32px;
+      
+      @include p.bidi(((margin-left, 32px, 0),
+          (margin-right, 0, 32px),
+      ));
+    }
+  }
 }
 
 .products.mzp-c-details .is-summary button {

--- a/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
@@ -70,10 +70,10 @@ label {
 .form-as-ul>li {
   position: relative;
   margin-bottom: p.$spacing-lg;
-  max-width: 25rem;  // Default for mobile
+  max-width: 25rem;
 
   @media #{p.$mq-md} {
-    max-width: p.remify(480px);  // Original desktop width
+    max-width: p.remify(480px);
   }
 
   .error-text {
@@ -85,10 +85,10 @@ label {
   }
 
   &.has-large-textarea {
-    max-width: 95%;  // Default for mobile
+    max-width: 95%;
 
     @media #{p.$mq-md} {
-      max-width: 100%;  // Return to full width on desktop
+      max-width: 100%;
     }
 
     textarea {
@@ -428,17 +428,17 @@ textarea {
   }
 
   &--sublist {
-    margin-left: 24px;
+    margin-left: p.$spacing-lg;
     
-    @include p.bidi(((margin-left, 24px, 0),
-        (margin-right, 0, 24px),
+    @include p.bidi(((margin-left, p.$spacing-lg, 0),
+        (margin-right, 0, p.$spacing-lg),
     ));
 
     @media #{p.$mq-md} {
-      margin-left: 32px;
+      margin-left: p.$spacing-xl;
       
-      @include p.bidi(((margin-left, 32px, 0),
-          (margin-right, 0, 32px),
+      @include p.bidi(((margin-left, p.$spacing-xl, 0),
+          (margin-right, 0, p.$spacing-xl),
       ));
     }
   }


### PR DESCRIPTION
* Ensure topics are visible on mobile without overflow
* Ensure other fields don't exceed mobile width

With topics and subtopics being numerous, and our decision to show them all at once with indents, the only viable solution I could come up with for mobile was to have them fall into a tall vertical stack. I'm open to other solutions if anyone has strong feelings about my choice.