### PR TITLE
Fix browser back navigation on revision list pages

### DIFF
--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -657,7 +657,7 @@ import collapsibleAccordionInit from "sumo/js/protocol-details-init";
       updateRevisionList();
     }
 
-    function updateRevisionList(query) {
+    function updateRevisionList(query, pushState = true) {
       if (query === undefined) {
         query = $form.serialize();
       }
@@ -680,11 +680,23 @@ import collapsibleAccordionInit from "sumo/js/protocol-details-init";
         $('.loading').hide();
         $('#revisions-fragment').html(data).css('opacity', 1);
 
-        // Update URL without triggering page reload
-        const newUrl = window.location.pathname + query;
-        window.history.pushState({}, '', newUrl);
+        // Only update URL if pushState is true
+        if (pushState) {
+          const newUrl = window.location.pathname + query;
+          window.history.pushState({query: query}, '', newUrl);
+        }
       });
     }
+
+    // Handle browser back/forward buttons
+    window.addEventListener('popstate', function(event) {
+      if (event.state && event.state.query) {
+        updateRevisionList(event.state.query, false);
+      } else {
+        // Handle the initial state
+        updateRevisionList(window.location.search, false);
+      }
+    });
 
     // Handle filter changes
     var timeout;
@@ -720,7 +732,6 @@ import collapsibleAccordionInit from "sumo/js/protocol-details-init";
       }
     });
   }
-
 
   init();
 


### PR DESCRIPTION
When using browser back/forward buttons on paginated revision lists, the page would not properly update to show the previous state. This adds proper history state management by:

- Storing query parameters in history state
- Adding popstate event handler to restore previous views
- Preventing duplicate history entries during navigation

Fixes the issue where users couldn't navigate back through their revision list viewing history using browser navigation controls.