### PR TITLE
Playwright extend test coverage over the new topic cards

### DIFF
--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
@@ -338,18 +338,33 @@ class AddKbArticleFlow:
                 }
 
     def kb_article_creation_via_api(self, page: Page, approve_revision=False,
-                                    is_template=False) -> dict[str, Any]:
+                                    is_template=False, product=None, topic=None, category=None
+                                    ) -> dict[str, Any]:
+        """
+        Create a new KB article via API.
+        :param page: Page object.
+        :param approve_revision: Approve the first revision of the article.
+        :param is_template: Create a KB template.
+        :param product: Product ID.
+        :param topic: Topic ID.
+        :param category: Category ID.
+        """
         kb_article_test_data = self.utilities.kb_article_test_data
         self.utilities.navigate_to_link(KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL)
-        if is_template:
+        if is_template or category == "60":
             kb_title = (kb_article_test_data["kb_template_title"] + self.utilities.
                         generate_random_number(0, 5000))
             category = "60"
-        else:
+        elif category is None:
             kb_title = (kb_article_test_data["kb_article_title"] + self.utilities.
                         generate_random_number(0, 5000))
             category = "10"
+        else:
+            kb_title = (kb_article_test_data["kb_article_title"] + self.utilities.
+                        generate_random_number(0, 5000))
 
+        topic = topic if topic is not None else "383"
+        product = product if product is not None else "1"
         slug = slugify(kb_title)
 
         form_data = {
@@ -358,8 +373,8 @@ class AddKbArticleFlow:
             "slug": slug,
             "category": category,
             "is_localizable": "on",
-            "products": "1",
-            "topics": "383",
+            "products": product,
+            "topics": topic,
             "allow_discussion": "on",
             "keywords": kb_article_test_data["keywords"],
             "summary": kb_article_test_data["search_result_summary"],
@@ -372,6 +387,7 @@ class AddKbArticleFlow:
         response = self.utilities.post_api_request(
             page, KBArticlePageMessages.CREATE_NEW_KB_ARTICLE_STAGE_URL, data=form_data
         )
+
         print(response)
         self.utilities.navigate_to_link(response.url)
 

--- a/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
@@ -70,7 +70,11 @@ class EditArticleMetaFlow:
                 )
 
         if obsolete:
-            self.kb_article_edit_metadata_page.click_on_obsolete_checkbox()
+            if not self.kb_article_edit_metadata_page.is_obsolete_checkbox_checked():
+                self.kb_article_edit_metadata_page.click_on_obsolete_checkbox()
+        else:
+            if self.kb_article_edit_metadata_page.is_obsolete_checkbox_checked():
+                self.kb_article_edit_metadata_page.click_on_obsolete_checkbox()
 
         if discussions:
             if not self.kb_article_edit_metadata_page.is_allow_discussion_checkbox_checked():

--- a/playwright_tests/messages/explore_help_articles/products_support_page_messages.py
+++ b/playwright_tests/messages/explore_help_articles/products_support_page_messages.py
@@ -1,6 +1,6 @@
 class ProductSupportPageMessages:
     PRODUCT_SUPPORT_PAGE_TITLE = " Support"
-    PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_TITLE = "Frequent Topics"
+    PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_TITLE = "Topics"
     PRODUCT_SUPPORT_PAGE_FREQUENT_TOPICS_SUBTITLE = "Explore the knowledge base."
     PRODUCT_SUPPORT_PAGE_FREQUENT_ARTICLES_TITLE = "Featured Articles"
     STILL_NEED_HELP_WIDGET_TITLE = "Still need help?"

--- a/playwright_tests/pages/ask_a_question/product_topics_pages/product_topics_page.py
+++ b/playwright_tests/pages/ask_a_question/product_topics_pages/product_topics_page.py
@@ -4,53 +4,80 @@ from playwright_tests.core.basepage import BasePage
 
 class ProductTopicPage(BasePage):
     # Product topic page content locators.
-    __page_title = "//h1[@class='topic-title sumo-page-heading']"
-    __page_subheading = "//div[@class='sumo-article-header--text']/p"
+    GENERAL_PAGE_LOCATORS = {
+        "page_title": "//h1[@class='topic-title sumo-page-heading']",
+        "page_subheading": "//div[@class='sumo-article-header--text']/p",
+        "all_articles": "//section[@class='topic-list']/article//h2/a",
+        "article_link": lambda article_title: f"//h2[@class='sumo-card-heading']/a[normalize-space"
+                                              f"(text())='{article_title}']"
+    }
 
     # Product topic page navbar locators.
-    __navbar_links = "//ul[@class='sidebar-nav--list']/li/a"
-    __selected_nav_link = "//a[contains(@class,'selected')]"
-
+    NAVBAR_LOCATORS = {
+        "navbar_links": "//ul[@class='sidebar-nav--list']/li/a",
+        "selected_nav_link": "//a[contains(@class,'selected')]",
+        "navbar_option": lambda option_name: f"//ul[@class='sidebar-nav--list']/li/a[contains("
+                                             f"text(),'{option_name}')]"
+    }
     # Product topic page learn more locators.
-    __learn_more_button = "//section[@id='get-involved-button']//a"
+    LEARN_MORE_LOCATORS = {
+        "learn_more_button": "//section[@id='get-involved-button']//a"
+    }
 
     # Product topic page still need help locators.
-    __still_need_help_subheading = "//div[contains(@class, 'aaq-widget')]/p"
-    __aaq_button = "//div[contains(@class,'aaq-widget')]/a"
+    AAQ_WIDGET_LOCATORS = {
+        "still_need_help_subheading": "//div[contains(@class, 'aaq-widget')]/p",
+        "aaq_button": "//div[contains(@class,'aaq-widget')]/a"
+    }
 
     def __init__(self, page: Page):
         super().__init__(page)
 
     # Page content actions.
+    def get_all_listed_article_titles(self) -> list[str]:
+        """Returns a list of all the article titles displayed on the page."""
+        return self._get_text_of_elements(self.GENERAL_PAGE_LOCATORS["all_articles"])
+
     def get_page_title(self) -> str:
-        return self._get_text_of_element(self.__page_title)
+        """Returns the title of the page."""
+        return self._get_text_of_element(self.GENERAL_PAGE_LOCATORS["page_title"])
 
     def get_a_particular_article_locator(self, article_title: str):
-        return self._get_element_locator(f"//h2[@class='sumo-card-heading']/a[normalize-space"
-                                         f"(text())='{article_title}']")
+        """Returns the locator of a particular article."""
+        return self._get_element_locator(self.GENERAL_PAGE_LOCATORS["article_link"](article_title))
+
+    def click_on_a_particular_article(self, article_title: str):
+        self._click(self.GENERAL_PAGE_LOCATORS["article_link"](article_title))
 
     # Navbar actions.
     def get_selected_navbar_option(self) -> str:
-        return self._get_text_of_element(self.__selected_nav_link)
+        """Returns the text of the selected navbar option."""
+        return self._get_text_of_element(self.NAVBAR_LOCATORS["selected_nav_link"])
 
     def click_on_a_navbar_option(self, option_name: str):
-        self._click(f"//ul[@class='sidebar-nav--list']/li/a[contains(text(),'{option_name}')]")
+        """Clicks on a particular navbar option."""
+        self._click(self.NAVBAR_LOCATORS["navbar_option"](option_name))
 
     def get_navbar_links_text(self) -> list[str]:
-        return self._get_text_of_elements(self.__navbar_links)
+        """Returns a list of all the navbar links displayed on the page."""
+        return self._get_text_of_elements(self.NAVBAR_LOCATORS["navbar_links"])
 
     def get_navbar_option_link(self, option_name: str) -> str:
-        return self._get_element_attribute_value(f"//ul[@class='sidebar-nav--list']/li/"
-                                                 f"a[contains(text(),'{option_name}')]",
+        """Returns the href value of a particular navbar option."""
+        return self._get_element_attribute_value(self.NAVBAR_LOCATORS["navbar_option"]
+                                                 (option_name),
                                                  "href")
 
     # AAQ section actions.
-    def _get_aaq_widget_subheading_text(self) -> str:
-        return self._get_text_of_element(self.__still_need_help_subheading)
+    def get_aaq_widget_subheading_text(self) -> str:
+        """Returns the text of the subheading displayed on the AAQ widget."""
+        return self._get_text_of_element(self.AAQ_WIDGET_LOCATORS["still_need_help_subheading"])
 
     def click_on_aaq_button(self):
-        self._click(self.__aaq_button)
+        """Clicks on the 'Ask a question' button."""
+        self._click(self.AAQ_WIDGET_LOCATORS["aaq_button"])
 
     # Learn more section actions.
     def click_on_learn_more_button(self):
-        self._click(self.__learn_more_button)
+        """Clicks on the 'Learn More' button."""
+        self._click(self.LEARN_MORE_LOCATORS["learn_more_button"])

--- a/playwright_tests/pages/common_elements/common_web_elements.py
+++ b/playwright_tests/pages/common_elements/common_web_elements.py
@@ -1,3 +1,5 @@
+import random
+from typing import Literal
 from playwright.sync_api import Page
 from playwright_tests.core.basepage import BasePage
 
@@ -9,6 +11,28 @@ class CommonWebElements(BasePage):
         "learn_more_button": "//div[@id='id_scam_alert']//a"
     }
 
+    # Frequent Topics locators applicable to product & product solutions pages.
+    FREQUENT_TOPICS_LOCATORS = {
+        "frequent_topics_section_title": "//h2[normalize-space(text())= 'Topics']",
+        "frequent_topics_section_subtitle": "//h2[normalize-space(text())='Topics']/following-"
+                                            "sibling::p",
+        "frequent_topic_card_headers": "//div[@class='card--topic']/div[@class='topic-header']/"
+                                       "h3[@class='card--title']/a",
+        "frequent_topic_card_header": lambda card_title:
+        f"//div[@class='card--topic']/div[@class='topic-header']/h3[@class='card--title']"
+        f"/a[normalize-space(text())='{card_title}']",
+        "frequent_topic_card_articles": lambda card_title:
+        f"//div[@class='card--topic']/div[@class='topic-header']/h3/a[normalize-space(text())="
+        f"'{card_title}']/../../following-sibling::ul/li/a",
+        "frequent_topic_card_article": lambda card_title, article_title:
+        f'//div[@class="card--topic"]/div[@class="topic-header"]/h3/a[normalize-space(text())='
+        f'"{card_title}"]/../..//following-sibling::ul/li/a[normalize-space(text())='
+        f'"{article_title}"]',
+        "frequent_topic_view_all_articles": lambda card_title:
+        f"//div[@class='card--topic']/div[@class='topic-header']/h3[@class='card--title']/"
+        f"a[normalize-space(text())='{card_title}']/../../following-sibling::a"
+    }
+
     def __init__(self, page: Page):
         super().__init__(page)
 
@@ -16,3 +40,78 @@ class CommonWebElements(BasePage):
     def get_scam_banner_text(self) -> str:
         """Returns the scam banner text."""
         return self._get_text_of_element(self.AVOID_SPAM_BANNER["scam_banner_text"])
+
+    def is_frequent_topics_section_displayed(self) -> bool:
+        """Check if the frequent topics section is displayed on the page."""
+        return self._is_element_visible(self.FREQUENT_TOPICS_LOCATORS
+                                        ["frequent_topics_section_title"])
+
+    def get_frequent_topic_card_titles(self) -> list[str]:
+        """Get the text of all the frequent topic cards."""
+        return self._get_text_of_elements(self.FREQUENT_TOPICS_LOCATORS
+                                          ['frequent_topic_card_headers'])
+
+    def is_frequent_topic_card_displayed(self, card_title: str) -> bool:
+        """Check if a particular frequent topic card is displayed."""
+        return self._is_element_visible(self.FREQUENT_TOPICS_LOCATORS
+                                        ['frequent_topic_card_header'](card_title))
+
+    def click_on_frequent_topic_card_title(self, topic_card_title: str):
+        """Click on a particular frequent topic card."""
+        self._click(self.FREQUENT_TOPICS_LOCATORS['frequent_topic_card_header'](topic_card_title))
+
+    def get_frequent_topic_card_articles(self, card_title: str) -> list[str]:
+        """Get the text of all the articles in a frequent topic card."""
+        return self._get_text_of_elements(self.FREQUENT_TOPICS_LOCATORS
+                                          ['frequent_topic_card_articles'](card_title))
+
+    def click_on_a_frequent_topic_card_article(self, card_title: str, article_title: str):
+        """Click on a particular article in a frequent topic card."""
+        self._click(self.FREQUENT_TOPICS_LOCATORS['frequent_topic_card_article'](
+            card_title, article_title))
+
+    def get_frequent_topic_card_view_all_articles_link_text(self, card_title: str):
+        """Get the text of the view all articles link in a frequent topic card."""
+        return self._get_text_of_element(self.FREQUENT_TOPICS_LOCATORS
+                                         ['frequent_topic_view_all_articles'](card_title))
+
+    def click_frequent_topic_card_view_all_articles_link(self, card_title: str):
+        """Click on the view all articles link in a frequent topic card."""
+        self._click(self.FREQUENT_TOPICS_LOCATORS['frequent_topic_view_all_articles'](card_title))
+
+    def get_frequent_topics_title_text(self) -> str:
+        """Get the frequent topics section title text."""
+        return self._get_text_of_element(self.FREQUENT_TOPICS_LOCATORS
+                                         ["frequent_topics_section_title"])
+
+    def get_frequent_topics_subtitle_text(self) -> str:
+        """Get the frequent topics section subtitle text."""
+        return self._get_text_of_element(self.FREQUENT_TOPICS_LOCATORS
+                                         ["frequent_topics_section_subtitle"])
+
+    def verify_topic_card_redirect(self, utilities, sumo_pages, card: str,
+                                   verification_type: Literal["heading", "article", "counter"]
+                                   ) -> bool:
+        if verification_type == "heading":
+            self.click_on_frequent_topic_card_title(card)
+            if sumo_pages.product_topics_page.get_page_title() != card:
+                return False
+        elif verification_type == "article":
+            listed_articles = sumo_pages.common_web_elements.get_frequent_topic_card_articles(
+                card)
+            random_article = random.choice(listed_articles)
+            sumo_pages.common_web_elements.click_on_a_frequent_topic_card_article(
+                card,random_article)
+            if sumo_pages.kb_article_page.get_text_of_article_title() != random_article:
+                return False
+        elif verification_type == "counter":
+            counter = utilities.number_extraction_from_string(
+                sumo_pages.common_web_elements.get_frequent_topic_card_view_all_articles_link_text(
+                    card))
+            sumo_pages.common_web_elements.click_frequent_topic_card_view_all_articles_link(card)
+            listed_articles = sumo_pages.product_topics_page.get_all_listed_article_titles()
+            if sumo_pages.product_topics_page.get_page_title() != card and len(listed_articles
+                                                                               ) != counter:
+                return False
+        utilities.navigate_back()
+        return True

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
@@ -89,6 +89,7 @@ class KBArticleShowHistoryPage(BasePage):
         return self._get_element_locator(self.__article_deleted_confirmation_message)
 
     def get_last_revision_id(self) -> str:
+        self._wait_for_selector(self.__article_revision_list_items)
         revisions = self._get_elements_locators(self.__article_revision_list_items)
         return self._get_element_attribute_value(
             revisions[0], "id"

--- a/playwright_tests/pages/explore_help_articles/product_support_page.py
+++ b/playwright_tests/pages/explore_help_articles/product_support_page.py
@@ -19,14 +19,6 @@ class ProductSupportPage(BasePage):
         "featured_articles_cards": "//h2[contains(text(),'Featured Articles')]/..//a"
     }
 
-    # Frequent Topics locators.
-    FREQUENT_TOPICS_LOCATORS = {
-        "frequent_topics_section_title": "//h2[contains(text(),'Frequent Topics')]",
-        "frequent_topics_section_subtitle": "//h2[contains(text(),'Frequent Topics')]/following-"
-                                            "sibling::p",
-        "frequent_topic_all_cards": "//div[contains(@class,'card card--topic')]//a"
-    }
-
     # Still need help widget locators.
     STILL_NEED_HELP_WIDGET_LOCATORS = {
         "still_need_help_widget": "//section[@class='support-callouts mzp-l-content sumo-page-"
@@ -62,35 +54,6 @@ class ProductSupportPage(BasePage):
     def product_product_title_element(self) -> Locator:
         """Get the product title element locator on the product support page."""
         return self._get_element_locator(self.PAGE_CONTENT_LOCATORS["product_title"])
-
-    def is_frequent_topics_section_displayed(self) -> bool:
-        """Check if the frequent topics section is displayed on the page."""
-        return self._is_element_visible(self.FREQUENT_TOPICS_LOCATORS
-                                        ["frequent_topics_section_title"])
-
-    def get_frequent_topics_title_text(self) -> str:
-        """Get the frequent topics section title text."""
-        return self._get_text_of_element(self.FREQUENT_TOPICS_LOCATORS
-                                         ["frequent_topics_section_title"])
-
-    def get_all_frequent_topics_cards(self) -> list[str]:
-        """Get the text of all the frequent topics cards."""
-        return self._get_text_of_elements(self.FREQUENT_TOPICS_LOCATORS
-                                          ["frequent_topic_all_cards"])
-
-    def get_frequent_topics_subtitle_text(self) -> str:
-        """Get the frequent topics section subtitle text."""
-        return self._get_text_of_element(self.FREQUENT_TOPICS_LOCATORS
-                                         ["frequent_topics_section_subtitle"])
-
-    def click_on_a_particular_frequent_topic_card(self, card_title: str):
-        """Click on a particular frequent topic card.
-
-        Args:
-            card_title (str): The title of the card to click on.
-        """
-        self._click(f"//h2[contains(text(),'Frequent Topics')]/../../../..//a[normalize-space("
-                    f"text())='{card_title}']")
 
     def get_featured_articles_header_text(self) -> str:
         """Get the featured articles section title text."""

--- a/playwright_tests/test_data/general_data.json
+++ b/playwright_tests/test_data/general_data.json
@@ -39,6 +39,28 @@
     "Firefox Focus": "https://support.allizom.org/en-US/products/focus-firefox/Focus-ios",
     "Mozilla Account": "https://support.allizom.org/en-US/products/mozilla-account/passwords-recovery"
   },
+  "test_topics": {
+      "Thunderbird for Android": {
+            "topic_name": "Thunderbird for Android test topic",
+            "link": "https://support.allizom.org/en-US/products/thunderbird-android/test-topic-tha"
+      },
+      "Thunderbird": {
+            "topic_name": "Thunderbird test topic",
+            "link": "https://support.allizom.org/en-US/products/thunderbird/test-topic-th"
+      },
+      "Firefox": {
+            "topic_name": "Firefox test topic",
+            "link": "https://support.allizom.org/en-US/products/firefox/test-topic-firefox"
+        },
+      "Pocket": {
+            "topic_name": "Pocket test topic",
+            "link": "https://support.allizom.org/en-US/products/pocket/test-topic-pocket"
+      },
+      "MDN Plus": {
+            "topic_name": "MDN test topic",
+            "link": "https://support.allizom.org/en-US/products/mdn-plus/test-topic-mdn"
+      }
+      },
   "product_support": {
     "Firefox": "https://support.allizom.org/en-US/products/firefox",
     "Firefox for Android": "https://support.allizom.org/en-US/products/mobile",

--- a/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
@@ -76,10 +76,10 @@ def test_aaq_redirect(page: Page):
             with check, allure.step(f"Verifying that the correct subheading page for "
                                     f"{product_topic} is displayed"):
                 if product_topic in utilities.general_test_data["premium_products"]:
-                    assert sumo_pages.product_topics_page._get_aaq_widget_subheading_text(
+                    assert sumo_pages.product_topics_page.get_aaq_widget_subheading_text(
                     ) == AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
                 else:
-                    assert sumo_pages.product_topics_page._get_aaq_widget_subheading_text(
+                    assert sumo_pages.product_topics_page.get_aaq_widget_subheading_text(
                     ) == AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
 
             with allure.step("Clicking on the AAQ button"):

--- a/playwright_tests/tests/conftest.py
+++ b/playwright_tests/tests/conftest.py
@@ -77,6 +77,7 @@ def pytest_runtest_makereport(item, call) -> None:
 def browser_context_args(browser_context_args, tmpdir_factory: pytest.TempdirFactory):
     """
     Modifying the default browser context to include the location of the browser session screencast
+    and the custom user agent.
     """
     return {
         "user_agent": Utilities.user_agent,


### PR DESCRIPTION
- Extending the functionality of the kb_article_creation_via_api for it to be able to create kb articles under a certain product, topic and category.
- Expanding the common_web_elements.py page object to contain topic card locators & functionalities.
- Adding reference to the test topics in general_data.json
- Expanding the topic locators & functionalities inside the product_topics_page.py page object.

Expanding playwright coverage over the new topic cards:
1. Verifying that the article is displayed inside the topic card only after the first revision is approved.
2. Verifying that the "Verify all {x} Articles" counter successfully increments and decrements.
3. Verifying that updating an article title is also reflected inside the topic card.
4. Verifying that obsolete marked articles are not displayed inside the topic cards.
5. Verifying that category 40, 50, 60 and 70 articles are not listed inside the topic cards.
6. Verifying that all items from the topic cards for both the product solutions and product support page are redirecting the user to the correct pages.