### PR TITLE
2046 - Mulitproduct AAQ CTA URL

### DIFF
--- a/kitsune/questions/jinja2/questions/includes/aaq_macros.html
+++ b/kitsune/questions/jinja2/questions/includes/aaq_macros.html
@@ -98,6 +98,7 @@
     {% set link_detail = aaq_context.product_slug if aaq_context else topic %}
     {% set has_support = aaq_context.has_ticketing_support if aaq_context else False %}
     {% set has_forum = aaq_context.has_public_forum if aaq_context else False %}
+    {% set multiple_products = aaq_context.multiple_products if aaq_context else False %}
 
     {% if aaq_context %}
       {% if request.user.is_authenticated %}
@@ -117,9 +118,15 @@
       <p>{{ _('Still need help? Continue to ask your question and get help.') }}</p>
     {% endif %}
 
-    {% set link_name = "aaq-widget.community-support.kb-article" if not (has_support or has_forum) else "aaq-widget.aaq-step-3" %}
-    {% set next_step = url('wiki.document', 'get-community-support')|urlparams(exit_aaq=1) if not (has_support or has_forum or topic) else url('questions.aaq_step3', product_slug=aaq_context.product_slug) if aaq_context else url('questions.aaq_step1') %}
+    {% set link_name = "aaq-widget.community-support.kb-article" if not (has_support or has_forum)
+                      else "aaq-widget.aaq-step-3" %}
 
+    {% set next_step = url('wiki.document', 'get-community-support')|urlparams(exit_aaq=1) 
+                       if not (has_support or has_forum or topic)
+                       else url('questions.aaq_step3', product_slug=aaq_context.product_slug) 
+                       if aaq_context and not multiple_products
+                       else url('questions.aaq_step1') %}
+  
     <a class="sumo-button primary-button feature-box"
       href="{{ next_step }}"
       data-event-name="link_click"

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -396,7 +396,7 @@ def has_aaq_config(product=None):
         return False
 
 
-def set_aaq_context(request, product):
+def set_aaq_context(request, product, multiple_products=False):
     """Set the AAQ context for a product."""
     if not has_aaq_config(product):
         request.session["aaq_context"] = {}
@@ -406,4 +406,5 @@ def set_aaq_context(request, product):
         "has_ticketing_support": product.has_ticketing_support,
         "product_slug": product.slug,
         "has_public_forum": product.questions_enabled(locale=request.LANGUAGE_CODE),
+        "multiple_products": multiple_products,
     }

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -238,7 +238,7 @@ def document(request, document_slug, document=None):
         product = products.first()
 
     # Set the AAQ context for the widget
-    set_aaq_context(request, product, multiple_products=True if len(products) > 1 else False)
+    set_aaq_context(request, product, multiple_products=len(products) > 1)
 
     product_topics = Topic.active.filter(products=product, visible=True)
 

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -238,7 +238,7 @@ def document(request, document_slug, document=None):
         product = products.first()
 
     # Set the AAQ context for the widget
-    set_aaq_context(request, product)
+    set_aaq_context(request, product, multiple_products=True if len(products) > 1 else False)
 
     product_topics = Topic.active.filter(products=product, visible=True)
 


### PR DESCRIPTION
Addresses https://github.com/mozilla/sumo/issues/2046

The AAQ CTA in the sidebar would send the user to the new question page for the first product on documents where there were multiple products. 

Now we set `multiple_products` in the `aaq_context` and if there are multiple products we will send the user to `/questions/new` so they can select a product.