### PR TITLE
Change SumoBot to deleted_user

### DIFF
--- a/kitsune/messages/jinja2/messages/inbox.html
+++ b/kitsune/messages/jinja2/messages/inbox.html
@@ -1,5 +1,5 @@
 {% extends "messages/base.html" %}
-{% from "messages/includes/macros.html" import avatar_link, name_link %}
+{% from "messages/includes/macros.html" import avatar_link, display_user %}
 {% set title = _('Inbox') %}
 {% set crumbs = [(url('messages.inbox'), _('Messages')),
                  (None, title)] %}
@@ -37,7 +37,7 @@
                     {{ avatar_link(message.sender, default_avatar) }}
                 </div>
                 <div class="email-cell from">
-                    {{ name_link(message.sender) }}
+                    {{ display_user(message.sender) }}
                 </div>
                 <div class="email-cell date">
                     {{ datetimeformat(message.created) }}

--- a/kitsune/messages/jinja2/messages/includes/macros.html
+++ b/kitsune/messages/jinja2/messages/includes/macros.html
@@ -1,5 +1,13 @@
 {% from "includes/common_macros.html" import content_editor with context %}
 
+{% macro display_user(user) -%}
+  {% if user.profile.is_system_account %}
+    {{ _('deleted user') }}
+  {% else %}
+    {{ name_link(user) }}
+  {% endif %}
+{%- endmacro %}
+
 {% macro avatar_link(user=None, default_avatar=None) -%}
   {% if user %}
     <a rel="nofollow" href="{{ profile_url(user) }}">
@@ -12,11 +20,7 @@
 
 {% macro name_link(user=None, name=None) -%}
   {% if user -%}
-    {% if user.profile.is_system_account %}
-      {{ _('deleted user') }}
-    {% else %}
-      <a rel="nofollow" href="{{ profile_url(user) }}">{% if name %}{{ name }}{% else %}{{ display_name(user) }}{% endif %}</a>
-    {% endif %}
+    <a rel="nofollow" href="{{ profile_url(user) }}">{% if name %}{{ name }}{% else %}{{ display_name(user) }}{% endif %}</a>
   {%- else -%}
     {{ name if name else _('None') }}
   {%- endif %}
@@ -46,11 +50,7 @@
       {{ avatar_link(message.sender, default_avatar) }}
     </div>
     <div class="user from">
-    {% if message.sender.profile.is_system_account %}
-      {{ _('deleted user') }}
-    {% else %}
-      {{ name_link(message.sender) }} {{ datetimeformat(message.created) }}
-    {% endif %}
+      {{ display_user(message.sender) }} {{ datetimeformat(message.created) }}
     </div>
   </div>
 </section>
@@ -65,13 +65,9 @@
     {% set comma = joiner(', ') %}
     {% for user in message.to_users -%}
         {{ comma() }}
-      {% if user.profile.is_system_account %}
-        {{ _('deleted user') }}
-      {% else %}
-        {{ name_link(user) }}
-      {% endif %}
+        {{ display_user(user) }}
     {% else %}
-      {{ name_link(message.recipient) }}
+      {{ display_user(message.recipient) }}
     {% endfor %}
     </p>
   {% endif %}

--- a/kitsune/messages/jinja2/messages/includes/macros.html
+++ b/kitsune/messages/jinja2/messages/includes/macros.html
@@ -12,7 +12,11 @@
 
 {% macro name_link(user=None, name=None) -%}
   {% if user -%}
-    <a rel="nofollow" href="{{ profile_url(user) }}">{% if name %}{{ name }}{% else %}{{ display_name(user) }}{% endif %}</a>
+    {% if user.profile.is_system_account %}
+      {{ _('deleted user') }}
+    {% else %}
+      <a rel="nofollow" href="{{ profile_url(user) }}">{% if name %}{{ name }}{% else %}{{ display_name(user) }}{% endif %}</a>
+    {% endif %}
   {%- else -%}
     {{ name if name else _('None') }}
   {%- endif %}
@@ -42,7 +46,11 @@
       {{ avatar_link(message.sender, default_avatar) }}
     </div>
     <div class="user from">
+    {% if message.sender.profile.is_system_account %}
+      {{ _('deleted user') }}
+    {% else %}
       {{ name_link(message.sender) }} {{ datetimeformat(message.created) }}
+    {% endif %}
     </div>
   </div>
 </section>
@@ -55,9 +63,13 @@
   {% if message.recipients_count > 0 %}
     <p><strong>{{ _('To') }}:</strong>
     {% set comma = joiner(', ') %}
-    {% for user in message.to.all() -%}
+    {% for user in message.to_users -%}
         {{ comma() }}
+      {% if user.profile.is_system_account %}
+        {{ _('deleted user') }}
+      {% else %}
         {{ name_link(user) }}
+      {% endif %}
     {% else %}
       {{ name_link(message.recipient) }}
     {% endfor %}

--- a/kitsune/messages/jinja2/messages/outbox.html
+++ b/kitsune/messages/jinja2/messages/outbox.html
@@ -1,5 +1,5 @@
 {% extends "messages/base.html" %}
-{% from "messages/includes/macros.html" import avatar_link, name_link %}
+{% from "messages/includes/macros.html" import avatar_link, display_user %}
 {% set title = _('Sent Messages') %}
 {% set crumbs = [(url('messages.inbox'), _('Messages')),
                  (None, title)] %}
@@ -38,13 +38,7 @@
                 <div class="email-cell sent">{{ datetimeformat(message.created) }}</div>
                 <div class="email-cell to">
                 {% for user in message.to.all()[:1] -%}
-                    {% if user.profile.is_system_account %}
-                      {{ _('deleted user') }}
-                    {% else %}
-                      <a rel="nofollow" href="{{ profile_url(user) }}">
-                        {{ user.profile.display_name }}
-                      </a>
-                    {% endif %}
+                    {{ display_user(user) }}
                     {%- if message.recipients_count > 1 -%}, ...{% endif %}
                 {%- endfor %}
                 </div>

--- a/kitsune/messages/jinja2/messages/outbox.html
+++ b/kitsune/messages/jinja2/messages/outbox.html
@@ -38,9 +38,13 @@
                 <div class="email-cell sent">{{ datetimeformat(message.created) }}</div>
                 <div class="email-cell to">
                 {% for user in message.to.all()[:1] -%}
-                    <a rel="nofollow" href="{{ profile_url(user) }}">
+                    {% if user.profile.is_system_account %}
+                      {{ _('deleted user') }}
+                    {% else %}
+                      <a rel="nofollow" href="{{ profile_url(user) }}">
                         {{ user.profile.display_name }}
-                    </a>
+                      </a>
+                    {% endif %}
                     {%- if message.recipients_count > 1 -%}, ...{% endif %}
                 {%- endfor %}
                 </div>


### PR DESCRIPTION
SumoBot isn't a meaningful name in the messaging system for a user who is deleted, and could cause confusion.

- Messages from or to a deleted user will now be from or to `deleted user`.

https://github.com/mozilla/sumo/issues/2225