### PR TITLE
Return the pk/id for docs in search

### DIFF
--- a/kitsune/search/search.py
+++ b/kitsune/search/search.py
@@ -227,6 +227,7 @@ class WikiSearch(SumoSearch):
             "score": hit.meta.score,
             "title": hit.title[self.locale],
             "search_summary": summary,
+            "id": hit.meta.id,
         }
 
 


### PR DESCRIPTION
This resolves the issue where related documents could not be added when editing document metadata.

The search was not returning a pk/id, thus the JS could not assign the pk to a returned result, rendering the JS helpless to receive click event data. 

We should consider converting this to TomSelect or otherwise improving the UI/UX.