### PR TITLE
Fix n+1 query

### DIFF
--- a/kitsune/flagit/views.py
+++ b/kitsune/flagit/views.py
@@ -193,7 +193,7 @@ def moderate_content(request):
             product_slug=product_slug,
         )
         .select_related("content_type", "creator", "assignee")
-        .prefetch_related("content_object__product")
+        .prefetch_related("content_object__product", "content_object__tags")
     )
 
     if request.method == "POST":


### PR DESCRIPTION
In this part of the code:

`for obj in objects:
    question = obj.content_object
    obj.available_topics = get_hierarchical_topics(question.product)
    obj.available_tags = available_tags
    obj.saved_tags = question.tags.values_list("id", flat=True)`

We had `obj.saved_tags` executing a query for each questions tags. Now we `prefetch_related` in the initial query and hopefully avoid.