### PR TITLE
Skip write op in read only

### DIFF
--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -671,14 +671,15 @@ class Document(NotificationsMixin, ModelBase, DocumentPermissionMixin):
         if not self.current_revision:
             return ""
 
-        # Remove "what links here" reverse links, because they might be
-        # stale and re-rendering will re-add them. This cannot be done
-        # reliably in the parser's parse() function, because that is
-        # often called multiple times per document.
-        self.links_from().delete()
+        if not settings.READ_ONLY:
+            # Remove "what links here" reverse links, because they might be
+            # stale and re-rendering will re-add them. This cannot be done
+            # reliably in the parser's parse() function, because that is
+            # often called multiple times per document.
+            self.links_from().delete()
 
-        # Also delete the DocumentImage instances for this document.
-        DocumentImage.objects.filter(document=self).delete()
+            # Also delete the DocumentImage instances for this document.
+            DocumentImage.objects.filter(document=self).delete()
 
         from kitsune.wiki.parser import WhatLinksHereParser, wiki_to_html
 

--- a/kitsune/wiki/tasks.py
+++ b/kitsune/wiki/tasks.py
@@ -214,6 +214,7 @@ def rebuild_kb():
 
 
 @shared_task(rate_limit="5/m")
+@skip_if_read_only_mode
 def _rebuild_kb_chunk(data):
     """Re-render a chunk of documents.
 

--- a/kitsune/wiki/tasks.py
+++ b/kitsune/wiki/tasks.py
@@ -214,7 +214,6 @@ def rebuild_kb():
 
 
 @shared_task(rate_limit="5/m")
-@skip_if_read_only_mode
 def _rebuild_kb_chunk(data):
     """Re-render a chunk of documents.
 


### PR DESCRIPTION
Add `@skip_if_read_only_mode` to `_rebuild_kb_chunk` task

Prevents task from executing during read-only operations like document deletion,
avoiding transaction errors.