### PR TITLE
Deleting a user modal won't close and page won't redirect

### DIFF
--- a/kitsune/sumo/static/sumo/js/users.js
+++ b/kitsune/sumo/static/sumo/js/users.js
@@ -25,8 +25,33 @@
     });
   }
 
+  function handleAccountDeletion() {
+    // Handle the delete account button click 
+    $('#delete-profile-button').on('click', function(e) {
+      e.preventDefault();
+      
+      var $form = $(this).closest('form');
+      
+      // Close modals - keep both systems for compatibility
+      if (typeof Mzp !== 'undefined' && Mzp.Modal) {
+        Mzp.Modal.closeModal();
+      }
+      
+      if ($.kbox) {
+        $.kbox.close();
+      }
+      
+      // Directly submit the form after a small delay
+      // This ensures the modal closing completes before submission
+      setTimeout(function() {
+        $form[0].submit();
+      }, 50);
+    });
+  }
+
   $(function() {
     makeEmailsClickable();
     confirmUserDeactivation();
+    handleAccountDeletion();
   });
 })(jQuery);


### PR DESCRIPTION
When users attempted to delete their account, the form would submit but the modal would only shrink and empty instead of properly redirecting to the /users/close_account URL. This was caused by an interaction between the modal system(s) and the form submission process.

This fix:
- Handles the delete button click event directly
- Ensures both modal systems (Mzp.Modal and $.kbox) are properly closed
- Adds a small delay before programmatically submitting the form to allow modal closing to complete
- Prevents the default button submission behavior to take control of the submission flow