### PR TITLE
Fix 500 error when viewing questions with solutions from deleted users

### DIFF
--- a/kitsune/questions/models.py
+++ b/kitsune/questions/models.py
@@ -259,7 +259,10 @@ class Question(AAQBase):
         """Get the user that solved the question."""
         solver_id = self.metadata.get("solver_id")
         if solver_id:
-            return User.objects.get(id=solver_id)
+            try:
+                return User.objects.get(id=solver_id)
+            except User.DoesNotExist:
+                return None
 
     @property
     def product_config(self):


### PR DESCRIPTION
When a user who marked an answer as a solution is later deleted, viewing the question was causing a 500 error. This occurred because the Question.solver property tried to retrieve the user from the solver_id metadata but failed since the user no longer exists in the database.

The fix adds error handling in the Question.solver property to gracefully return None when User.DoesNotExist is raised, which is properly handled by the template's existing conditional checks.

Steps to reproduce the fixed issue:
1. User A submits a question
2. User B leaves a reply
3. User A marks User B's reply as solution
4. Delete User A
5. Navigate back to the question (previously 500 error, now works properly)
