### PR TITLE
handle revision `reviewer` and `readied_for_localization_by` fields on user deletion

### DIFF
--- a/kitsune/wiki/handlers.py
+++ b/kitsune/wiki/handlers.py
@@ -30,6 +30,10 @@ class DocumentListener(UserDeletionListener):
 
         sumo_bot = Profile.get_sumo_bot()
         Revision.objects.filter(creator=user).update(creator=sumo_bot)
+        Revision.objects.filter(reviewer=user).update(reviewer=sumo_bot)
+        Revision.objects.filter(readied_for_localization_by=user).update(
+            readied_for_localization_by=sumo_bot
+        )
         # Anonymize any revision votes.
         HelpfulVote.objects.filter(creator=user).update(
             creator=None, anonymous_id=AnonymousIdentity().anonymous_id


### PR DESCRIPTION
mozilla/sumo#2248
mozilla/sumo#2249