### PR TITLE
fix the URL parsing used within `redis_client`

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -962,7 +962,6 @@ GA_DEBUG_MODE = config("GA_DEBUG_MODE", default=False, cast=bool)
 GA_CONSOLE_LOGGING = config("GA_CONSOLE_LOGGING", default=False, cast=bool)
 
 REDIS_BACKENDS = {
-    # TODO: Make sure that db number is respected
     "default": config("REDIS_DEFAULT_URL"),
     "helpfulvotes": config("REDIS_HELPFULVOTES_URL"),
 }

--- a/kitsune/sumo/redis_utils.py
+++ b/kitsune/sumo/redis_utils.py
@@ -1,10 +1,8 @@
 from functools import cached_property
-from urllib.parse import parse_qsl
 import random
 import time
 
 from django.conf import settings
-from django.core.cache.backends.base import InvalidCacheBackendError
 from redis import ConnectionError, Redis
 from sentry_sdk import capture_exception
 
@@ -13,84 +11,27 @@ class RedisError(Exception):
     """An error with the redis configuration or connnection."""
 
 
-def redis_client(name):
-    """Get a Redis client.
-
-    Uses the name argument to lookup the connection string in the
-    settings.REDIS_BACKEND dict.
+def redis_client(name: str) -> Redis:
     """
-    if name not in settings.REDIS_BACKENDS:
-        raise RedisError("{k} is not defined in settings.REDIS_BACKENDS".format(k=name))
+    Creates a Redis client from the connection URL specified by name, which
+    must be provided within settings.REDIS_BACKENDS.
+    """
+    url = settings.REDIS_BACKENDS.get(name)
 
-    uri = settings.REDIS_BACKENDS[name]
-    _, server, params = parse_backend_uri(uri)
-    db = params.pop("db", 1)
+    if not url:
+        raise RedisError(f"{name} is not defined in settings.REDIS_BACKENDS")
 
+    # The "decode_responses" keyword argument is a default, used only
+    # if not provided in the URL.
+    redis = Redis.from_url(url, decode_responses=True)
+
+    # Verify that we can connect.
     try:
-        db = int(db)
-    except (ValueError, TypeError):
-        db = 1
-    try:
-        socket_timeout = float(params.pop("socket_timeout"))
-    except (KeyError, ValueError):
-        socket_timeout = None
-    password = params.pop("password", None)
-    if ":" in server:
-        host, port = server.split(":")
-        try:
-            port = int(port)
-        except (ValueError, TypeError):
-            port = 6379
-    else:
-        host = server
-        port = 6379
-    redis = Redis(
-        host=host,
-        port=port,
-        db=db,
-        password=password,
-        socket_timeout=socket_timeout,
-        decode_responses=True,
-    )
-    try:
-        # Make a cheap call to verify we can connect.
         redis.exists("dummy-key")
     except ConnectionError:
-        raise RedisError("Unable to connect to redis backend: {k}".format(k=name))
+        raise RedisError(f"Unable to connect to redis backend: {name}")
+
     return redis
-
-
-# Copy/pasted from django 1.6:
-# https://github.com/django/django/blob/9d915ac1be1e7b8cfea3c92f707a4aeff4e62583/django/core/cache/__init__.py
-def parse_backend_uri(backend_uri):
-    """
-    Converts the "backend_uri" into a cache scheme ('db', 'memcached', etc), a
-    host and any extra params that are required for the backend. Returns a
-    (scheme, host, params) tuple.
-    """
-    if backend_uri.find(":") == -1:
-        raise InvalidCacheBackendError(
-            "Backend URI must start with scheme://. URI: {}".format(backend_uri)
-        )
-
-    scheme, rest = backend_uri.split(":", 1)
-
-    if not rest.startswith("//"):
-        raise InvalidCacheBackendError(
-            "Backend URI must start with scheme://. Split URI: {}".format(backend_uri)
-        )
-
-    host = rest[2:]
-    qpos = rest.find("?")
-    if qpos != -1:
-        params = dict(parse_qsl(rest[qpos + 1 :]))
-        host = rest[2:qpos]
-    else:
-        params = {}
-    if host.endswith("/"):
-        host = host[:-1]
-
-    return scheme, host, params
 
 
 class RateLimit:


### PR DESCRIPTION
mozilla/sumo#2253

I didn't think it made sense to add tests for this, since we'd only be testing the `Redis.from_url` class method that the `redis` package already tests, but just to be sure, I manually tested it with all of the Redis URLs that we use, and it worked just fine.

Once this is merged, the `"default"` and `"helpfulvotes"` Redis URLs will start using the Redis DB actually specified in their URLs (`0` and `3` respectively) instead of always using `1`. That means the `"default"` and `"helpfulvotes"` caches will start cold, which, in turn, means any existing KB article locks will be lost, as well as some slightly slower initial queries related to helpful votes.