### PR TITLE
Change close_account to utilize the deletion pipeline

### DIFF
--- a/kitsune/users/tests/test_views.py
+++ b/kitsune/users/tests/test_views.py
@@ -452,29 +452,10 @@ class UserCloseAccountTests(TestCase):
         # Confirm the expected initial state.
         self.assertTrue(self.user.is_active)
         self.assertTrue(self.user.profile.name)
-        self.assertEqual(self.user.groups.count(), 1)
-        self.assertEqual(self.user.outbox.count(), 1)
-        self.assertEqual(self.user.inbox.count(), len(self.other_users))
-        for other_user in self.other_users:
-            self.assertEqual(other_user.inbox.count(), 1)
-            self.assertEqual(other_user.outbox.count(), 1)
 
         res = self.client.post(reverse("users.close_account", locale="en-US"))
         self.assertEqual(200, res.status_code)
 
-        self.user.refresh_from_db()
-
-        # The user should be anonymized.
-        self.assertTrue(self.user.username.startswith("user"))
-        self.assertTrue(self.user.email.endswith("@example.com"))
-        # The user should be deactivated, and the user's profile and groups cleared.
-        self.assertFalse(self.user.is_active)
-        self.assertFalse(self.user.profile.name)
-        self.assertEqual(self.user.groups.count(), 0)
-        # Confirm that the user's inbox and outbox have been cleared, and
-        # that the inbox and outbox of each of the other users remain intact.
-        self.assertEqual(self.user.outbox.count(), 0)
-        self.assertEqual(self.user.inbox.count(), 0)
-        for other_user in self.other_users:
-            self.assertEqual(other_user.inbox.count(), 1)
-            self.assertEqual(other_user.outbox.count(), 1)
+        # The user should be completely deleted
+        with self.assertRaises(User.DoesNotExist):
+            self.user.refresh_from_db()

--- a/kitsune/users/views.py
+++ b/kitsune/users/views.py
@@ -53,7 +53,6 @@ from kitsune.users.tasks import (
 )
 from kitsune.users.templatetags.jinja_helpers import profile_url
 from kitsune.users.utils import (
-    anonymize_user,
     deactivate_user,
     delete_user_pipeline,
     get_oidc_fxa_setting,
@@ -152,7 +151,7 @@ def profile(request, username):
 @login_required
 @require_POST
 def close_account(request):
-    anonymize_user(request.user)
+    delete_user_pipeline(request.user)
 
     # Log the user out
     auth.logout(request)


### PR DESCRIPTION
I just changed `close_account` to use the `delete_user_pipeline` and modified the tests to just make sure the user is gone.