### PR TITLE
Playwright fix test failures and improve the pytest_runtest_makereport hook 

### DIFF
--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -521,7 +521,11 @@ def test_loginless_mozilla_account_aaq(page: Page):
                      "blocked after 3 submissions"):
         i = 1
         while i <= 4:
-            sumo_pages.top_navbar.click_on_signin_signup_button()
+            # In case a 502 error occurs we might end up in the auth page after the automatic
+            # refresh/retry so we need to skip the signin_signup button click since the
+            # element is not available.
+            if sumo_pages.top_navbar.is_sign_in_up_button_displayed():
+                sumo_pages.top_navbar.click_on_signin_signup_button()
             sumo_pages.auth_page.click_on_cant_sign_in_to_my_mozilla_account_link()
             sumo_pages.aaq_flow.submit_an_aaq_question(
                 subject=utilities.aaq_question_test_data['premium_aaq_question']['subject'],

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py
@@ -1332,8 +1332,9 @@ def test_solves_this_problem(page: Page):
         sumo_pages.aaq_flow.deleting_question_flow()
 
 
-# Need to add test for preview as well.
 # T5696791, T5696772, T5696774, T5696776, T5696792
+# Skipped until we decide if we should revert https://github.com/mozilla/sumo/issues/2245 or not
+@pytest.mark.skip
 @pytest.mark.postedQuestions
 @pytest.mark.parametrize("quote_on", ['reply', 'question'])
 def test_quote_reply_functionality(page: Page, quote_on):

--- a/playwright_tests/tests/explore_help_articles_tests/explore_by_topic_tests/test_explore_by_topics.py
+++ b/playwright_tests/tests/explore_help_articles_tests/explore_by_topic_tests/test_explore_by_topics.py
@@ -35,9 +35,13 @@ def test_explore_by_topic_product_filter(page: Page):
             if product.strip() == "All Products":
                 continue
             else:
-                sumo_pages.explore_by_topic_page.select_a_filter_by_product_option(
-                    product.strip())
-                time.sleep(2)
+                with page.expect_navigation(timeout=3000) as navigation_info:
+                    sumo_pages.explore_by_topic_page.select_a_filter_by_product_option(
+                        product.strip())
+                response = navigation_info.value
+                if response is None:
+                    print("Navigation did not occur. Refreshing the page.")
+                    utilities.refresh_page()
                 if not sumo_pages.explore_by_topic_page.get_metadata_of_all_listed_articles():
                     pytest.fail(f"There is no sublist for {product}")
 

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -782,7 +782,7 @@ def test_group_messages_cannot_be_sent_by_non_staff_users(page: Page):
         )
 
     with allure.step("Verifying that no users are returned"):
-        expect(sumo_pages.new_message_page.get_no_user_to_locator()).to_be_visible(timeout=10000)
+        expect(sumo_pages.new_message_page.get_no_user_to_locator()).to_be_visible(timeout=15000)
 
     with allure.step("Navigating to the groups page"):
         utilities.navigate_to_link(utilities.general_test_data['groups'])
@@ -1053,7 +1053,7 @@ def test_unable_to_send_group_messages_to_profiless_groups(page: Page):
         sumo_pages.new_message_page.type_into_new_message_to_input_field("kb-contributors")
 
     with allure.step("Verifying that no users are returned"):
-        expect(sumo_pages.new_message_page.get_no_user_to_locator()).to_be_visible(timeout=10000)
+        expect(sumo_pages.new_message_page.get_no_user_to_locator()).to_be_visible(timeout=15000)
 
 
 # C2083482


### PR DESCRIPTION
This pull request includes several changes to improve error handling, and debugging capabilities. 

The most important changes include handling the 502 errors for the test_loginless_mozilla_account_aaq test (which was the main flakiness reason for that test), extending timeouts for two messaging system tests (Sometimes SuMo returns the expected search results with a >10 seconds delay so I've bumped the wait to 15) & skipped the AAQ quote test for now .

Error Handling Improvements:

* [`playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py`](diffhunk://#diff-eca7a9428ab539311780b56327d6c206ace722fa461c535cc97b620e19501b01R524-R527): Added a check to skip the sign-in button click if a 502 error occurs and the auth page is already displayed due to a forced page refresh.
* [`playwright_tests/tests/conftest.py`](diffhunk://#diff-251261da1d31d439f9a7c4a4aa6c5f75523426bd9d5b420015f79ac926d1540fR44-L68): Refactored the `pytest_runtest_makereport` hook to ensure video recordings are properly saved and attached to the Allure report when a test fails by taking into account not only the call.excinfo (exception is raised) but also the pytest-check failures.

Test Reliability Enhancements:

* [`playwright_tests/tests/ask_a_question_tests/aaq_tests/test_posted_questions.py`](diffhunk://#diff-c2a88765f99281fb5777c78bf1647bd07d685eeb54dfa4d1755f2dc0135f4b71L1335-R1337): Skipped the `test_quote_reply_functionality` test until a decision is made on whether to revert a related change.
* [`playwright_tests/tests/explore_help_articles_tests/explore_by_topic_tests/test_explore_by_topics.py`](diffhunk://#diff-174963bd5766c669f76749cf8fafc6a8d484ab16dabf089007d48337b199dc6bR38-R44): Added navigation expectation and refresh logic to handle cases where navigation does not occur => causes the test to fail.

Timeout Adjustments:

* [`playwright_tests/tests/messaging_system_tests/test_messaging_system.py`](diffhunk://#diff-cca6fc350d52c1f3b2d1c7176b326f883b7377f57c90146992b7f57190081f54L785-R785): Increased the timeout for verifying that no users are returned inside the messaging system search results in two separate tests. [[1]](diffhunk://#diff-cca6fc350d52c1f3b2d1c7176b326f883b7377f57c90146992b7f57190081f54L785-R785) [[2]](diffhunk://#diff-cca6fc350d52c1f3b2d1c7176b326f883b7377f57c90146992b7f57190081f54L1056-R1056)