### PR TITLE
2278 remove user title from sumobot

### DIFF
--- a/kitsune/forums/jinja2/forums/includes/post.html
+++ b/kitsune/forums/jinja2/forums/includes/post.html
@@ -14,8 +14,8 @@
           <span class="display-name">{{ display_name(post.author) }}</span>
           {% if not post.author.profile.is_system_account %}
             {# L10n: {0} is the number of posts. #}
-            <span
-              class="user-title">{{ ngettext('1 post', '{0} posts', post.author_post_count)|f(post.author_post_count) }}
+            <span class="user-title">
+              {{ ngettext('1 post', '{0} posts', post.author_post_count)|f(post.author_post_count) }}
             </span>
           {% endif %}
         </a>

--- a/kitsune/forums/jinja2/forums/includes/post.html
+++ b/kitsune/forums/jinja2/forums/includes/post.html
@@ -12,9 +12,12 @@
       <div class="asked-by">
         <a class="author-name" rel="nofollow" href="{{ profile_url(post.author) }}">
           <span class="display-name">{{ display_name(post.author) }}</span>
-          {# L10n: {0} is the number of posts. #}
-          <span
-            class="user-title">{{ ngettext('1 post', '{0} posts', post.author_post_count)|f(post.author_post_count) }}</span>
+          {% if not post.author.profile.is_system_account %}
+            {# L10n: {0} is the number of posts. #}
+            <span
+              class="user-title">{{ ngettext('1 post', '{0} posts', post.author_post_count)|f(post.author_post_count) }}
+            </span>
+          {% endif %}
         </a>
 
       </div>

--- a/kitsune/kbforums/jinja2/kbforums/includes/post.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/post.html
@@ -13,12 +13,13 @@
       <div class="asked-by">
         <a class="author-name" rel="nofollow" href="{{ profile_url(post.creator, request.user == post.creator) }}">
           <span class="display-name">{{ display_name(post.creator) }}</span>
-          {# L10n: {0} is the number of posts. #}
-          {% with count = post.creator.post_set.count() %}
-          <span class="user-title">{{ ngettext('1 post', '{0} posts', count)|f(count) }}</span>
-          {% endwith %}
+          {% if not post.creator.profile.is_system_account %}
+            {# L10n: {0} is the number of posts. #}
+            {% with count = post.creator.post_set.count() %}
+            <span class="user-title">{{ ngettext('1 post', '{0} posts', count)|f(count) }} HELLO</span>
+            {% endwith %}
+          {% endif %}
         </a>
-
       </div>
       <span class="asked-on">
         {{ datetimeformat(post.created, format='longdatetime') }}

--- a/kitsune/kbforums/jinja2/kbforums/includes/post.html
+++ b/kitsune/kbforums/jinja2/kbforums/includes/post.html
@@ -16,7 +16,9 @@
           {% if not post.creator.profile.is_system_account %}
             {# L10n: {0} is the number of posts. #}
             {% with count = post.creator.post_set.count() %}
-            <span class="user-title">{{ ngettext('1 post', '{0} posts', count)|f(count) }} HELLO</span>
+            <span class="user-title">
+              {{ ngettext('1 post', '{0} posts', count)|f(count) }}
+            </span>
             {% endwith %}
           {% endif %}
         </a>


### PR DESCRIPTION
In forums and kbforums, remove the `user-title` section that displays counts.