### PR TITLE
Implement tom-select for related documents

### DIFF
--- a/kitsune/sumo/static/sumo/js/wiki_search.js
+++ b/kitsune/sumo/static/sumo/js/wiki_search.js
@@ -65,7 +65,7 @@ document.addEventListener("DOMContentLoaded", function() {
             };
           })
           .filter(item => item.id)
-          .filter(item => !currentDocId || item.id != currentDocId);
+          .filter(item => !currentDocId || String(item.id) !== String(currentDocId));
 
         callback(formattedResults);
       });

--- a/kitsune/sumo/static/sumo/scss/components/_wiki.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_wiki.scss
@@ -3,6 +3,12 @@
 
 @import 'tom-select/dist/scss/tom-select.default';
 
+// Hide the related documents list on edit metadata and new document pages
+body.edit_metadata #related-docs-list,
+body.new #related-docs-list {
+  display: none !important;
+}
+
 figure {
   &.linked-in-product {
     display: flex;

--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -416,23 +416,25 @@
       <div class="sumo-card-grid">
         <div class="scroll-wrap">
           {% for related in docs %}
-          <div class="card card--article">
-              <img class="card--icon-sm" src="{{ webpack_static('protocol/img/icons/reader-mode.svg') }}" alt="todo: title" />
-              <div class="card--details">
-                <h3 class="card--title">
-                  <a class="expand-this-link" href="{{ url('wiki.document', related.slug) }}"
-                    data-event-name="link_click"
-                    data-event-parameters='{"link_name": "related.kb-article"}'>
-                    {{ related.title }}
-                  </a>
-                </h3>
-                <div class="card--desc">
-                  <p>
-                  {{ related.html|striptags|truncate(length=150) }}
-                  </p>
-                </div>
+            {% if related.is_unrestricted_for(user) %}
+              <div class="card card--article">
+                  <img class="card--icon-sm" src="{{ webpack_static('protocol/img/icons/reader-mode.svg') }}" alt="todo: title" />
+                  <div class="card--details">
+                    <h3 class="card--title">
+                      <a class="expand-this-link" href="{{ url('wiki.document', related.slug) }}"
+                        data-event-name="link_click"
+                        data-event-parameters='{"link_name": "related.kb-article"}'>
+                        {{ related.title }}
+                      </a>
+                    </h3>
+                    <div class="card--desc">
+                      <p>
+                      {{ related.html|striptags|truncate(length=150) }}
+                      </p>
+                    </div>
+                  </div>
               </div>
-          </div>
+            {% endif %}
           {% endfor %}
         </div>
       </div>

--- a/kitsune/wiki/jinja2/wiki/includes/related_docs_widget.html
+++ b/kitsune/wiki/jinja2/wiki/includes/related_docs_widget.html
@@ -1,14 +1,12 @@
-<input type="search" autocomplete="off" id="search-related" placeholder="{{ _('Search for documents...') }}">
-<ul id="related-docs-list">
+<select id="search-related" class="tom-select-related-docs" placeholder="{{ _('Search for documents...') }}">
   {% if related_documents.count() %}
     {% for doc in related_documents.all() %}
-      <li data-pk="{{ doc.pk }}">
-        <input type="checkbox" name="{{ name }}" value="{{ doc.pk }}" checked/>
-        {{ doc.title }}
-        <span data-close-type="remove" class="close-button"></span>
-      </li>
+      <option value="{{ doc.pk }}" selected>{{ doc.title }}</option>
     {% endfor %}
-  {% else %}
-    <li class="empty-message">{{ _('No related documents.') }}</li>
   {% endif %}
-</ul>
+</select>
+<div id="related-docs-list">
+  {% if not related_documents.count() %}
+    <div class="empty-message">{{ _('No related documents.') }}</div>
+  {% endif %}
+</div>


### PR DESCRIPTION
- Don't allow addition of article to it's own related
- Don't show old checkbox list on edit or new document pages
- On document view pages, don't show restricted articles in the related documents section if the user lacks permissions

This should fix [2259](https://github.com/mozilla/sumo/issues/2259), [2260](https://github.com/mozilla/sumo/issues/2260), [2261](https://github.com/mozilla/sumo/issues/2261)
