### PR TITLE
Fix document slug translation handling in get_visible_document_or_404

### DIFF
--- a/kitsune/wiki/utils.py
+++ b/kitsune/wiki/utils.py
@@ -189,9 +189,11 @@ def get_visible_document_or_404(
 
     # First try to find the document in the default locale
     if locale != settings.WIKI_DEFAULT_LANGUAGE:
-        kwargs.update(locale=settings.WIKI_DEFAULT_LANGUAGE)
+        # Create a copy of kwargs to avoid modifying the original
+        default_locale_kwargs = kwargs.copy()
+        default_locale_kwargs["locale"] = settings.WIKI_DEFAULT_LANGUAGE
         try:
-            parent = Document.objects.get_visible(user, **kwargs)
+            parent = Document.objects.get_visible(user, **default_locale_kwargs)
             # If there's a visible translation of the parent for the requested locale, return it
             translation = parent.translations.filter(locale=locale).first()
             if translation and translation.is_visible_for(user):
@@ -252,9 +254,11 @@ def get_visible_document_or_404(
         # If we're in a non-default locale and couldn't find a translation,
         # try to return the parent document
         try:
-            return Document.objects.get_visible(
-                user, locale=settings.WIKI_DEFAULT_LANGUAGE, **kwargs
-            )
+            # Create a copy of kwargs to avoid modifying the original and
+            # set the locale to the default language
+            default_locale_kwargs = kwargs.copy()
+            default_locale_kwargs["locale"] = settings.WIKI_DEFAULT_LANGUAGE
+            return Document.objects.get_visible(user, **default_locale_kwargs)
         except Document.DoesNotExist:
             pass
 


### PR DESCRIPTION
When a user tries to access a document using a translated slug in the default locale (e.g. /en-US/kb/flash-113-german), the function now properly finds and redirects to the English document (/en-US/kb/flash-113) by:

1. Looking for any document with the given slug in non-default locales
2. Finding its parent document
3. Using the parent's slug to locate the English document

This completes the bidirectional translation handling, ensuring proper redirects in both directions:
- English -> Translated: /en-US/kb/flash-113 -> /de/kb/flash-113-german
- Translated -> English: /de/kb/flash-113-german -> /en-US/kb/flash-113
- English with translated slug -> English: /en-US/kb/flash-113-german -> /en-US/kb/flash-113