### PR TITLE
standardize topic listing

### DIFF
--- a/kitsune/flagit/views.py
+++ b/kitsune/flagit/views.py
@@ -157,7 +157,9 @@ def get_hierarchical_topics(product, cache_timeout=3600):
         return cached_topics
 
     topics = list(
-        Topic.active.filter(products=product).order_by("title").values("id", "title", "parent_id")
+        Topic.active.filter(products=product, visible=True)
+        .order_by("title")
+        .values("id", "title", "parent_id")
     )
     topic_dict = {}
     for topic in topics:

--- a/kitsune/questions/jinja2/questions/question_details.html
+++ b/kitsune/questions/jinja2/questions/question_details.html
@@ -462,7 +462,7 @@
                   {% if user and user.has_perm('questions.change_question') %}
                     <select id="details-topic" name="topic">
                       {% for t in all_topics %}
-                        <option {% if topic and t.id == topic.id %}selected="selected"{% endif %} value="{{ t.id }}">{{ t.title }}</option>
+                        <option {% if topic and t.id == topic.id %}selected="selected"{% endif %} value="{{ t.id }}">{{ t.title|safe }}</option>
                       {% endfor %}
                     </select>
                   {% endif %}

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -37,6 +37,7 @@ from zenpy.lib.exception import APIException
 from kitsune.access.decorators import login_required, permission_required
 from kitsune.customercare.forms import ZendeskForm
 from kitsune.flagit.models import FlaggedObject
+from kitsune.flagit.views import get_hierarchical_topics
 from kitsune.products.models import Product, Topic, TopicSlugHistory
 from kitsune.questions import config
 from kitsune.questions.events import QuestionReplyEvent, QuestionSolvedEvent
@@ -450,7 +451,8 @@ def question_details(
     extra_kwargs.update(ans_)
 
     products = Product.active.with_question_forums(request)
-    topics = topics_for(request.user, product=question.product)
+    # Use get_hierarchical_topics instead of topics_for to match the moderate view
+    topics = get_hierarchical_topics(question.product) if question.product else []
 
     related_documents = question.related_documents
     related_questions = question.related_questions


### PR DESCRIPTION
Show the heirarchical topic listing on both the `/moderate` page as well as the question detail sidebar.