### PR TITLE
add GCP token file to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,6 @@ __pycache__
 /dist
 .gnupg*
 styleguide
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
reference bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1959182