### PR TITLE
fix Storage of sensitive information in build artifact

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -108,7 +108,9 @@ module.exports = {
       filename: "[name].css",
     }),
     new webpack.DefinePlugin({
-      "process.env": JSON.stringify(process.env),
+      "process.env": JSON.stringify({
+        DEBUG: process.env.DEBUG, // Add other variables as needed
+      }),
     }),
   ],
   cache: {


### PR DESCRIPTION
https://github.com/mozilla/kitsune/blob/d7ba74f9a35f1ac838b710e8b90f184c7c8aed70/webpack.common.js#L110-L112

fix the issue should avoid including all environment variables in the build artifact. Instead, we should explicitly whitelist only the environment variables that are safe and necessary for the application to function. This can be achieved by creating a new object that contains only the required variables and passing it to `webpack.DefinePlugin`.

In this case, we will replace the current `webpack.DefinePlugin` configuration to include only a specific set of environment variables, such as `DEBUG` or any other explicitly defined variables.

Sensitive information included in a build artifact can allow an attacker to access the sensitive information if the artifact is published. The following creates a `webpack` configuration that inserts all environment variables from the host into the build artifact:
```js
const webpack = require("webpack");

module.exports = [{
    plugins: [
        new webpack.DefinePlugin({
            "process.env": JSON.stringify(process.env)
        })
    ]
}];
```
The environment variables might include API keys or other sensitive information, and the build-system should instead insert only the environment variables that are supposed to be public. for fixed below, where only the `DEBUG` environment variable is inserted into the artifact.
```js
const webpack = require("webpack");

module.exports = [{
    plugins: [
        new webpack.DefinePlugin({
            'process.env': JSON.stringify({ DEBUG: process.env.DEBUG })
        })
    ]
}];
```
## References
[DefinePlugin API](https://webpack.js.org/plugins/define-plugin/)
[CWE-312](https://cwe.mitre.org/data/definitions/312.html)
[CWE-315](https://cwe.mitre.org/data/definitions/315.html)
[CWE-359](https://cwe.mitre.org/data/definitions/359.html)



