### PR TITLE
add function to get active taxonomy as YAML or JSON

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,14 +9,14 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         files: "^kitsune/"
         exclude: "^.*/migrations/.*$|kitsune/sumo/db_strings.py"
         language_version: python3.11
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.2.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -28,18 +28,19 @@ repos:
           - prettier-plugin-svelte@3.1.2
         files: "^svelte/"
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.12.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         # Add to the "additional_dependencies" list below any poetry
         # dependencies or their stub packages that provide type hints.
         additional_dependencies:
-          - boto3-stubs==1.34.17
+          - boto3-stubs==1.38.8
           - types-redis==4.6.0.20240106
-          - types-requests==2.31.0.20240106
-          - types-bleach==6.1.0.1
-          - types-python-dateutil==2.8.19.20240106
-          - types-simplejson==3.19.0.2
+          - types-requests==2.32.0.20250328
+          - types-bleach==6.2.0.20241123
+          - types-python-dateutil==2.9.0.20241206
+          - types-simplejson==3.20.0.20250326
+          - types-PyYAML==6.0.12.20250402
         files: "^kitsune/"
         exclude: "/migrations/"
 

--- a/kitsune/products/tests/test_utils.py
+++ b/kitsune/products/tests/test_utils.py
@@ -1,0 +1,410 @@
+from kitsune.products.tests import ProductFactory, TopicFactory
+from kitsune.products.utils import get_taxonomy
+from kitsune.sumo.tests import TestCase
+
+
+class GetTaxonomyTests(TestCase):
+
+    def setUp(self):
+        p1 = ProductFactory(title="product1", slug="p1")
+        p2 = ProductFactory(title="product2", slug="p2")
+        self.p3 = p3 = ProductFactory(title="product3", slug="mozilla-account", visible=False)
+        p4 = ProductFactory(title="product4", slug="p4", visible=False)
+        p5 = ProductFactory(title="product5", slug="p5", is_archived=True)
+
+        TopicFactory(
+            title="topic1",
+            description="Something brief about t1...",
+            metadata={
+                "description": "Details about t1...",
+                "example-questions-assigned-to-this-topic": [
+                    "Can you tell me about topic1?",
+                    "Is there a setting for topic1?",
+                ],
+            },
+            products=[p1, p2, p3, p4],
+        )
+        t2 = TopicFactory(
+            title="topic2",
+            description="Something brief about t2...",
+            metadata={
+                "description": "Details about t2...",
+                "example-questions-assigned-to-this-topic": [
+                    "Can you tell me about topic2?",
+                    "Is there a setting for topic2?",
+                ],
+            },
+            products=[p2, p3, p4],
+        )
+        t3 = TopicFactory(
+            title="topic3",
+            description="Something brief about t3...",
+            metadata={"description": "Details about t3..."},
+            products=[p2, p3, p4],
+        )
+        TopicFactory(
+            title="topic4",
+            description="Something brief about t4...",
+            metadata={
+                "description": "Details about t4...",
+                "example-questions-assigned-to-this-topic": [
+                    "Can you tell me about topic4?",
+                    "Is there a setting for topic4?",
+                ],
+            },
+            parent=t2,
+            products=[p2, p3, p4],
+        )
+        t5 = TopicFactory(
+            title="topic5",
+            description="Something brief about t5...",
+            metadata={},
+            parent=t3,
+            products=[p2, p3, p4],
+        )
+        t6 = TopicFactory(
+            title="topic6",
+            description="Something brief about t6...",
+            metadata={
+                "description": "Details about t6...",
+                "example-questions-assigned-to-this-topic": [
+                    "Can you tell me about topic6?",
+                    "Is there a setting for topic6?",
+                ],
+            },
+            parent=t3,
+            products=[p3, p4],
+        )
+        TopicFactory(
+            title="topic7",
+            description="Something brief about t7...",
+            metadata={"description": "Details about t7..."},
+            parent=t5,
+            products=[p2, p3, p4],
+        )
+        TopicFactory(
+            title="topic8",
+            description="Something brief about t8...",
+            metadata={},
+            parent=t6,
+            products=[p3, p4],
+        )
+        TopicFactory(
+            title="topic9",
+            description="Something brief about t9...",
+            metadata={
+                "description": "Details about t9...",
+                "example-questions-assigned-to-this-topic": [
+                    "Can you tell me about topic9?",
+                    "Is there a setting for topic9?",
+                ],
+            },
+            parent=t6,
+            products=[p3, p4],
+        )
+        TopicFactory(
+            title="topic10",
+            description="Something brief about t10...",
+            metadata={"description": "Details about t10..."},
+            products=[p4, p5],
+        )
+
+    def test_all_products_with_defaults(self):
+        self.assertEqual(
+            get_taxonomy(),
+            """topics:
+- title: topic1
+  description: Something brief about t1...
+  products:
+  - title: product1
+  - title: product2
+  - title: product3
+  subtopics: []
+- title: topic2
+  description: Something brief about t2...
+  products:
+  - title: product2
+  - title: product3
+  subtopics:
+  - title: topic4
+    description: Something brief about t4...
+    products:
+    - title: product2
+    - title: product3
+    subtopics: []
+- title: topic3
+  description: Something brief about t3...
+  products:
+  - title: product2
+  - title: product3
+  subtopics:
+  - title: topic5
+    description: Something brief about t5...
+    products:
+    - title: product2
+    - title: product3
+    subtopics:
+    - title: topic7
+      description: Something brief about t7...
+      products:
+      - title: product2
+      - title: product3
+      subtopics: []
+  - title: topic6
+    description: Something brief about t6...
+    products:
+    - title: product3
+    subtopics:
+    - title: topic8
+      description: Something brief about t8...
+      products:
+      - title: product3
+      subtopics: []
+    - title: topic9
+      description: Something brief about t9...
+      products:
+      - title: product3
+      subtopics: []
+""",
+        )
+
+    def test_all_products_as_json(self):
+        self.assertEqual(
+            get_taxonomy(output_format="json"),
+            """{
+  "topics": [
+    {
+      "title": "topic1",
+      "description": "Something brief about t1...",
+      "products": [
+        {
+          "title": "product1"
+        },
+        {
+          "title": "product2"
+        },
+        {
+          "title": "product3"
+        }
+      ],
+      "subtopics": []
+    },
+    {
+      "title": "topic2",
+      "description": "Something brief about t2...",
+      "products": [
+        {
+          "title": "product2"
+        },
+        {
+          "title": "product3"
+        }
+      ],
+      "subtopics": [
+        {
+          "title": "topic4",
+          "description": "Something brief about t4...",
+          "products": [
+            {
+              "title": "product2"
+            },
+            {
+              "title": "product3"
+            }
+          ],
+          "subtopics": []
+        }
+      ]
+    },
+    {
+      "title": "topic3",
+      "description": "Something brief about t3...",
+      "products": [
+        {
+          "title": "product2"
+        },
+        {
+          "title": "product3"
+        }
+      ],
+      "subtopics": [
+        {
+          "title": "topic5",
+          "description": "Something brief about t5...",
+          "products": [
+            {
+              "title": "product2"
+            },
+            {
+              "title": "product3"
+            }
+          ],
+          "subtopics": [
+            {
+              "title": "topic7",
+              "description": "Something brief about t7...",
+              "products": [
+                {
+                  "title": "product2"
+                },
+                {
+                  "title": "product3"
+                }
+              ],
+              "subtopics": []
+            }
+          ]
+        },
+        {
+          "title": "topic6",
+          "description": "Something brief about t6...",
+          "products": [
+            {
+              "title": "product3"
+            }
+          ],
+          "subtopics": [
+            {
+              "title": "topic8",
+              "description": "Something brief about t8...",
+              "products": [
+                {
+                  "title": "product3"
+                }
+              ],
+              "subtopics": []
+            },
+            {
+              "title": "topic9",
+              "description": "Something brief about t9...",
+              "products": [
+                {
+                  "title": "product3"
+                }
+              ],
+              "subtopics": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}""",
+        )
+
+    def test_all_products_with_metadata(self):
+        self.assertEqual(
+            get_taxonomy(
+                include_metadata=["description", "example-questions-assigned-to-this-topic"]
+            ),
+            """topics:
+- title: topic1
+  description: Details about t1...
+  example-questions-assigned-to-this-topic:
+  - Can you tell me about topic1?
+  - Is there a setting for topic1?
+  products:
+  - title: product1
+  - title: product2
+  - title: product3
+  subtopics: []
+- title: topic2
+  description: Details about t2...
+  example-questions-assigned-to-this-topic:
+  - Can you tell me about topic2?
+  - Is there a setting for topic2?
+  products:
+  - title: product2
+  - title: product3
+  subtopics:
+  - title: topic4
+    description: Details about t4...
+    example-questions-assigned-to-this-topic:
+    - Can you tell me about topic4?
+    - Is there a setting for topic4?
+    products:
+    - title: product2
+    - title: product3
+    subtopics: []
+- title: topic3
+  description: Details about t3...
+  products:
+  - title: product2
+  - title: product3
+  subtopics:
+  - title: topic6
+    description: Details about t6...
+    example-questions-assigned-to-this-topic:
+    - Can you tell me about topic6?
+    - Is there a setting for topic6?
+    products:
+    - title: product3
+    subtopics:
+    - title: topic9
+      description: Details about t9...
+      example-questions-assigned-to-this-topic:
+      - Can you tell me about topic9?
+      - Is there a setting for topic9?
+      products:
+      - title: product3
+      subtopics: []
+""",
+        )
+
+    def test_specific_product_with_metadata(self):
+        expected = """topics:
+- title: topic1
+  description: Details about t1...
+  example-questions-assigned-to-this-topic:
+  - Can you tell me about topic1?
+  - Is there a setting for topic1?
+  subtopics: []
+- title: topic2
+  description: Details about t2...
+  example-questions-assigned-to-this-topic:
+  - Can you tell me about topic2?
+  - Is there a setting for topic2?
+  subtopics:
+  - title: topic4
+    description: Details about t4...
+    example-questions-assigned-to-this-topic:
+    - Can you tell me about topic4?
+    - Is there a setting for topic4?
+    subtopics: []
+- title: topic3
+  description: Details about t3...
+  subtopics:
+  - title: topic6
+    description: Details about t6...
+    example-questions-assigned-to-this-topic:
+    - Can you tell me about topic6?
+    - Is there a setting for topic6?
+    subtopics:
+    - title: topic9
+      description: Details about t9...
+      example-questions-assigned-to-this-topic:
+      - Can you tell me about topic9?
+      - Is there a setting for topic9?
+      subtopics: []
+"""
+        self.assertEqual(
+            get_taxonomy(
+                self.p3,
+                include_metadata=["description", "example-questions-assigned-to-this-topic"],
+            ),
+            expected,
+        )
+        self.assertEqual(
+            get_taxonomy(
+                "mozilla-account",
+                include_metadata=["description", "example-questions-assigned-to-this-topic"],
+            ),
+            expected,
+        )
+        self.assertEqual(
+            get_taxonomy(
+                "product3",
+                include_metadata=["description", "example-questions-assigned-to-this-topic"],
+            ),
+            expected,
+        )

--- a/kitsune/products/utils.py
+++ b/kitsune/products/utils.py
@@ -1,0 +1,81 @@
+import json
+
+from django.db.models import Prefetch, Q
+import yaml
+
+from kitsune.products.models import Product, Topic
+
+
+def get_taxonomy(
+    product: Product | str | None = None,
+    include_metadata: list[str] | tuple[str, ...] | None = None,
+    output_format: str = "YAML",
+) -> str:
+    """
+    Returns the currently active taxonomy as a string in the output format requested
+    (either "YAML" or "JSON"). If a product is given, the taxonomy is limited to that
+    product, otherwise the entire taxonomy, spanning all products, is returned. Requires
+    only a single database query if a specific product is given, otherwise two queries.
+    """
+
+    result = {}
+
+    qs_topics = Topic.active.filter(visible=True).select_related("parent")
+
+    if product:
+        if isinstance(product, Product):
+            qs_topics = qs_topics.filter(products=product)
+        else:
+            qs_topics = qs_topics.filter(
+                products__in=Product.active.filter(Q(title=product) | Q(slug=product))
+            )
+    else:
+        qs_products = Product.active.filter(Q(visible=True) | Q(slug="mozilla-account"))
+        qs_topics = (
+            qs_topics.filter(products__in=qs_products)
+            .distinct()
+            .prefetch_related(
+                Prefetch("products", qs_products.only("id", "title").order_by("title"))
+            )
+        )
+
+    # Get all of the topics and organize them by parent.
+    topics_by_parent: dict[None | int, list[Topic]] = dict()
+    for topic in qs_topics.only(
+        "id", "title", "parent", "metadata" if include_metadata else "description"
+    ).order_by("title"):
+        topics_by_parent.setdefault(topic.parent.id if topic.parent else None, []).append(topic)
+
+    def get_topics(parent=None):
+        """
+        Recursive function that returns the topics with the given parent.
+        """
+        result = []
+
+        for topic in topics_by_parent.get(parent.id if parent else None, ()):
+            item = dict(title=topic.title)
+
+            if include_metadata:
+                if not topic.metadata:
+                    # Skip topics that don't have any metadata.
+                    continue
+                for name in include_metadata:
+                    if value := topic.metadata.get(name):
+                        item[name] = value
+            else:
+                item["description"] = topic.description
+
+            if not product:
+                item["products"] = [{"title": p.title} for p in topic.products.all()]
+            item["subtopics"] = get_topics(parent=topic)
+
+            result.append(item)
+
+        return result
+
+    result["topics"] = get_topics()
+
+    if output_format.lower() == "json":
+        return json.dumps(result, indent=2, sort_keys=False)
+
+    return yaml.dump(result, indent=2, sort_keys=False)

--- a/kitsune/wiki/tests/test_parser.py
+++ b/kitsune/wiki/tests/test_parser.py
@@ -941,10 +941,10 @@ class WhatLinksHereTests(TestCase):
     def test_unicode(self):
         """Unicode is hard. Test that."""
         # \u03C0 is pi and \u2764 is a heart symbol.
-        d1 = DocumentFactory(title="\u03C0", slug="pi")
-        ApprovedRevisionFactory(document=d1, content="I \u2764 \u03C0")
+        d1 = DocumentFactory(title="\u03c0", slug="pi")
+        ApprovedRevisionFactory(document=d1, content="I \u2764 \u03c0")
         d2 = DocumentFactory(title="\u2764", slug="heart")
-        ApprovedRevisionFactory(document=d2, content="What do you think about [[\u03C0]]?")
+        ApprovedRevisionFactory(document=d2, content="What do you think about [[\u03c0]]?")
 
         self.assertEqual(len(d1.links_to()), 1)
         self.assertEqual(len(d1.links_from()), 0)


### PR DESCRIPTION
mozilla/sumo#2314

As part of this work, I had to add `types-PyYAML` to `.pre-commit-config.yaml`, and decided to also update all of the `pre-commit` hooks.