### PR TITLE
Playwright: Extend coverage to kb helpfulness widget feedback canceled state & helpfulness metadata percentage information

### DIFF
--- a/playwright_tests/pages/ask_a_question/product_topics_pages/product_topics_page.py
+++ b/playwright_tests/pages/ask_a_question/product_topics_pages/product_topics_page.py
@@ -20,6 +20,11 @@ class ProductTopicPage(BasePage):
         self.navbar_option = lambda option_name: page.locator(
             "ul[class='sidebar-nav--list'] li").get_by_role("link").filter(has_text=option_name)
 
+        # Product topic page article metadata locators.
+        self.article_helpfulness_count = lambda article_name: page.locator(
+            f"//a[normalize-space(text())='{article_name}']/../../div[@id='document_metadata']//"
+            f"span[@class='helpful-count']")
+
     # Page content actions.
     def get_all_listed_article_titles(self) -> list[str]:
         """Returns a list of all the article titles displayed on the page."""
@@ -52,3 +57,7 @@ class ProductTopicPage(BasePage):
     def get_navbar_option_link(self, option_name: str) -> str:
         """Returns the href value of a particular navbar option."""
         return self._get_element_attribute_value(self.navbar_option(option_name),"href")
+
+    def is_article_helpfulness_metadata_displayed(self, article_title: str) -> bool:
+        """Checks if the article helpfulness metadata is displayed."""
+        return self._is_element_visible(self.article_helpfulness_count(article_title))

--- a/playwright_tests/pages/auth_page.py
+++ b/playwright_tests/pages/auth_page.py
@@ -18,7 +18,8 @@ class AuthPage(BasePage):
         self.user_logged_in_sign_in_button = page.get_by_role(
             "button", name="Sign in", exact=True)
         self.enter_your_email_input_field = page.locator("input[name='email']")
-        self.enter_your_email_submit_button = page.locator("button#submit-btn")
+        self.enter_your_email_submit_button = page.get_by_role(
+            "button", name='Sign up or sign in', exact=True)
         self.enter_your_password_input_field = page.locator("input[type='password']")
         self.enter_your_password_submit_button = page.get_by_role(
             "button", name="Sign in", exact=True)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
@@ -20,6 +20,10 @@ class KBArticlePage(BasePage):
             "div[class='document--contributors-list text-body-xs']").get_by_role(
             "link", name=f'{username}', exact=True)
 
+        # Article metadata locators.
+        self.kb_article_helpfulness_count = page.locator(
+            "div#document_metadata span[class='helpful-count']")
+
         # Editing Tools options locators.
         self.editing_tools_article_option = page.get_by_role("link", name="Article",
                                                              exact=True)
@@ -56,6 +60,9 @@ class KBArticlePage(BasePage):
 
     def get_text_of_all_article_breadcrumbs(self) -> list[str]:
         return self._get_text_of_elements(self.kb_article_breadcrumbs_list)
+
+    def get_text_of_kb_article_helpfulness_count_metadata(self) -> str:
+        return self._get_text_of_element(self.kb_article_helpfulness_count)
 
     def get_text_of_article_title(self) -> str:
         return self._get_text_of_element(self.kb_article_heading)

--- a/playwright_tests/test_data/ga4_data.json
+++ b/playwright_tests/test_data/ga4_data.json
@@ -11,10 +11,16 @@
             "survey_type": "unhelpful"
         }
     },
-    "cancel_survey": {
+    "cancel_survey_helpful": {
         "event": "article_survey_closed",
         "parameters": {
             "survey_type": "helpful"
+        }
+    },
+    "cancel_survey_unhelpful": {
+        "event": "article_survey_closed",
+        "parameters": {
+            "survey_type": "unhelpful"
         }
     },
     "article_helpfulness": {


### PR DESCRIPTION
Extended the playwright coverage to:
- Verifying that the Helpfulness widget transitions to the correct state and the correct GA4 data is sent if the "Cancel" button from the Helpfulness widget is clicked during both the positive & negative flows.
- Verifying that the correct kb article helpfulness metadata is displayed on positive & negative voting.
- Verifying that the helpfulness metadata information is not displayed inside the topic listing page.
- Added coverage for the https://github.com/mozilla/sumo/issues/2136 case.