### PR TITLE
Playwright fix playwright.yml and update the Related Documents locator

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -82,10 +82,6 @@ jobs:
       - name: Download NLTK Data
         run: |
           poetry run python -m nltk.downloader wordnet omw-1.4
-      - name: Ensure Playwright browsers are installed
-        run: |
-            pip3 install playwright
-            python -m playwright install
       - name: Set up browsers env
         if: "github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'"
         run: |
@@ -99,6 +95,9 @@ jobs:
             elif [ "${{ github.event_name }}" == 'workflow_dispatch' ]; then
                 echo "BROWSER=${{inputs.Browsers}}" >> $GITHUB_ENV
             fi
+      - name: Ensure Playwright browsers are installed
+        run: |
+            poetry run playwright install ${{ env.BROWSER }}
       - name: Creating User Sessions for ${{ env.BROWSER }}
         id: create-sessions
         working-directory: playwright_tests

--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
@@ -129,8 +129,9 @@ class AddKbArticleFlow:
                 .is_allow_discussion_on_article_checkbox_checked() is True):
             self.submit_kb_article_page.check_allow_discussion_on_article_checkbox()
 
-        self.submit_kb_article_page.add_text_to_related_documents_field(
-            kb_article_test_data["related_documents"])
+        # Removing this step until https://github.com/mozilla/sumo/issues/2359 is fixed
+        # self.submit_kb_article_page.add_text_to_related_documents_field(
+        #     kb_article_test_data["related_documents"])
 
         keyword = None
         if article_keyword is None:

--- a/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
@@ -19,7 +19,7 @@ class SubmitKBArticlePage(BasePage):
         self.kb_article_allow_discussions_on_article = page.locator(
             "label[for='id_allow_discussion']")
         self.kb_article_allow_translations = page.locator("label[for='id_is_localizable']")
-        self.kb_article_search_for_related_documents = page.locator("input#search-related")
+        self.kb_article_search_for_related_documents = page.locator("search-related-ts-control")
         self.kb_article_keyword_input = page.locator("input#id_keywords")
         self.kb_article_search_result_summary_textarea = page.locator("textarea#id_summary")
 


### PR DESCRIPTION
This pull request includes updates to the Playwright workflows and test flows for submitting KB articles. The changes improve browser installation handling in workflows, temporarily remove a testing step due to a known issue, and update a locator in the KB article submission page.

### Workflow updates:

* [`.github/workflows/playwright.yml`](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3R98-R100): Moved the Playwright browser installation step to occur after the `BROWSER` environment variable is set, ensuring the correct browser is installed based on the workflow inputs.

### Test flow adjustments:

* [`playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py`](diffhunk://#diff-439ce9ce89f8f336c17b39c6e97e758b95f8049190121be4cf45dd6d45a4e808L132-R134): Commented out the step for adding text to the "related documents" field in the KB article submission flow due to an unresolved issue (`https://github.com/mozilla/sumo/issues/2359`).

### Locator update:

* [`playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py`](diffhunk://#diff-a58cdc52da81ab7127e00a76e38e5e75bd12c245656e776be429de9b1720c3c3L22-R22): Updated the locator for the "related documents" field to `search-related-ts-control` to reflect a change in the page structure.