### PR TITLE
Return the pk/id for docs in search

### DIFF
--- a/kitsune/search/search.py
+++ b/kitsune/search/search.py
@@ -227,6 +227,7 @@ class WikiSearch(SumoSearch):
             "score": hit.meta.score,
             "title": hit.title[self.locale],
             "search_summary": summary,
+            "id": hit.meta.id,
         }
 
 


### PR DESCRIPTION
This [was reverted](https://github.com/mozilla/kitsune/pull/6544) a while back when we decided to remove the first attempt (pre tom-select) at setting up related documents.

This is required for the tom-select version to work, so needs to be added back now that we are moving ahead.

