### PR TITLE
Locale switch from parent non-default locale document should 404

### DIFF
--- a/kitsune/wiki/tests/test_utils.py
+++ b/kitsune/wiki/tests/test_utils.py
@@ -821,6 +821,24 @@ class GetVisibleDocumentTests(TestCase):
                 self.user, locale="de", slug="doesnt-exist", look_for_translation_via_parent=True
             )
 
+    def test_parent_document_in_non_default_locale_no_english_version(self):
+        """Test that accessing English version of a non-default locale parent
+        document returns 404."""
+
+        ApprovedRevisionFactory(
+            document__locale="de",
+            document__slug="german-only-parent",
+            document__parent=None,
+        )
+
+        with self.assertRaises(Http404):
+            get_visible_document_or_404(
+                self.user,
+                locale="en-US",
+                slug="german-only-parent",
+                look_for_translation_via_parent=True,
+            )
+
     def test_unapproved_revision(self):
         """Test that users can't see documents without approved revisions."""
         unapproved_doc = RevisionFactory(

--- a/kitsune/wiki/utils.py
+++ b/kitsune/wiki/utils.py
@@ -203,17 +203,17 @@ def get_visible_document_or_404(
             translation = base_doc.translated_to(locale, visible_for_user=user)
             if translation:
                 return translation
-        else:
-            translation = base_doc.translated_to(locale, visible_for_user=user)
-            if translation:
-                return translation
 
     # Don't try final fallback if not looking for translations or in default language
     if not look_for_translation_via_parent or locale == settings.WIKI_DEFAULT_LANGUAGE:
         raise Http404
 
     kwargs["locale"] = settings.WIKI_DEFAULT_LANGUAGE
-    parent = get_object_or_404(Document.objects.visible(user, **kwargs))
+    try:
+        parent = Document.objects.get_visible(user, **kwargs)
+    except Document.DoesNotExist:
+        raise Http404
+
     translation = parent.translated_to(locale, visible_for_user=user)
     if translation:
         return translation


### PR DESCRIPTION
This covers a case where the user is on a document that is not in the default locale (in our case en-US) and is not a translation.
If the user tries to use the locale switcher to go to English, since there is no parent as we are not on a translation, the user should get a 404.