### PR TITLE
consider locale when getting products with forums

### DIFF
--- a/kitsune/llm/questions/classifiers.py
+++ b/kitsune/llm/questions/classifiers.py
@@ -62,7 +62,9 @@ def classify_question(question: "Question") -> dict[str, Any]:
         if not ((action == ModerationAction.SPAM) and spam_result.get("maybe_misclassified")):
             return {"action": action, "product_result": {}}
 
-        payload["products"] = get_products(only_with_forums=True, output_format="JSON")
+        payload["products"] = get_products(
+            only_with_forums_for_locale=question.locale, output_format="JSON"
+        )
         product_result = product_classification_chain.invoke(payload)
         new_product = product_result.get("product")
 

--- a/kitsune/products/utils.py
+++ b/kitsune/products/utils.py
@@ -81,7 +81,9 @@ def get_taxonomy(
     return yaml.dump(result, indent=2, sort_keys=False)
 
 
-def get_products(only_with_forums: bool = False, output_format: str = "YAML") -> str:
+def get_products(
+    only_with_forums_for_locale: str | None = None, output_format: str = "YAML"
+) -> str:
     """
     Returns the currently active products, each with their title and description,
     as a string in the output format requested (either "YAML" or "JSON").
@@ -90,8 +92,8 @@ def get_products(only_with_forums: bool = False, output_format: str = "YAML") ->
     result = dict(products=products)
     products_qs = Product.active
 
-    if only_with_forums:
-        products_qs = products_qs.with_question_forums()
+    if only_with_forums_for_locale:
+        products_qs = products_qs.with_question_forums(language_code=only_with_forums_for_locale)
     products_qs = products_qs.filter(Q(visible=True) | Q(slug="mozilla-account"))
 
     for product in products_qs:


### PR DESCRIPTION
mozilla/sumo#2374

I tested this locally by creating a question exactly like https://support.allizom.org/it/questions/1480814 -- the question that @emilghittasv uses in mozilla/sumo#2374 -- with the `Thunderbird for Android Configuration` enabled for `it` and then disabled for `it`. When enabled, the question was re-classified to `Thunderbird for Android`, and when disabled, the LLM set the `maybe_misclassified` to `True` but since the `Thunderbird for Android` AAQ configuration wasn't enabled for `it`, the `product` returned was `None` -- so the question was marked as spam.