### PR TITLE
limit update of question to relevant fields

### DIFF
--- a/kitsune/questions/utils.py
+++ b/kitsune/questions/utils.py
@@ -209,7 +209,7 @@ def update_question_fields_from_classification(question, result, sumo_bot):
     if update_fields:
         for field, value in update_fields.items():
             setattr(question, field, value)
-        question.save()
+        question.save(update_fields=update_fields.keys())
         question.clear_cached_tags()
         question.tags.clear()
         question.auto_tag()


### PR DESCRIPTION
mozilla/sumo#2376

@emilghittasv asked me about the issue, and after looking at it, the fix was so simple, that I decided to go ahead and create a PR. I've tested this locally, and it works great, even if the question is deleted prior to the LLM classification completing.