### PR TITLE
close announcements per session

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -104,7 +104,7 @@
   {% call announcement_bar('geoip-suggestion', 'warning', close_memory="remember", close_type="remove") %}{% endcall %}
 
   {% for announ in get_announcements(request) %}
-      {% call announcement_bar(announ.id, 'warning') %}
+      {% call announcement_bar(announ.id, 'warning', close_memory="session") %}
           {{ announ.content | wiki_to_html }}
       {% endcall %}
   {% endfor %}

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -894,7 +894,8 @@
   {% endcall %}
 #}
 {% macro announcement_bar(id, level, close_memory="", close_type="") -%}
-<div id="announce-{{ id }}" class="mzp-c-notification-bar mzp-t-{{ level }}">
+<div id="announce-{{ id }}" class="mzp-c-notification-bar mzp-t-{{ level }}"
+  {% if close_memory %}data-close-initial="hidden"{% endif %}>
   <button class="mzp-c-notification-bar-button close-button" data-close-id="announce-{{ id }}" type="button"
     {% if close_memory %}data-close-memory="{{ close_memory }}" {% endif %}
     {% if close_type %}data-close-type="{{ close_type }}" {% endif %}>


### PR DESCRIPTION
mozilla/sumo#1196

# Notes
In order to fix this by using `announcement_bar(..., close_memory="session")`, I also had to fix the `announcement_bar` macro so it works when `close_memory` is used by adding `data-close-initial="hidden"`.