### PR TITLE
Playwright: Extend coverage to related documents functionality

### DIFF
--- a/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
@@ -6,6 +6,8 @@ from playwright_tests.messages.explore_help_articles.kb_article_revision_page_me
 from playwright_tests.pages.explore_help_articles.articles.kb_article_page import KBArticlePage
 from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_meta import (
     KBArticleEditMetadata)
+from playwright_tests.pages.explore_help_articles.articles.kb_edit_article_page import \
+    EditKBArticlePage
 from playwright_tests.pages.explore_help_articles.articles.submit_kb_article_page import \
     SubmitKBArticlePage
 
@@ -17,6 +19,7 @@ class EditArticleMetaFlow:
         self.kb_article_edit_metadata_page = KBArticleEditMetadata(page)
         self.submit_kb_article_page = SubmitKBArticlePage(page)
         self.kb_article_page = KBArticlePage(page)
+        self.edit_kb_article_page = EditKBArticlePage(page)
 
     def edit_article_metadata(self, **kwargs):
         return self.utilities.re_call_function_on_error(
@@ -33,10 +36,14 @@ class EditArticleMetaFlow:
                                needs_change=False,
                                needs_change_comment=False,
                                restricted_to_groups: list[str] = None,
+                               related_documents: list[str] = None,
                                single_group=""):
 
         if KBArticleRevision.KB_EDIT_METADATA not in self.utilities.get_page_url():
             self.kb_article_page.click_on_edit_article_metadata()
+
+        if self.edit_kb_article_page.is_edit_anyway_option_visible():
+            self.edit_kb_article_page.click_on_edit_anyway_option()
 
         if restricted_to_groups:
             for group in restricted_to_groups:
@@ -101,6 +108,10 @@ class EditArticleMetaFlow:
             if self.kb_article_edit_metadata_page.is_needs_change_checkbox():
                 self.kb_article_edit_metadata_page.click_needs_change_checkbox()
 
+        if related_documents:
+            for document in related_documents:
+                self.kb_article_edit_metadata_page.add_related_documents(document)
+
         self.kb_article_edit_metadata_page.click_on_save_changes_button()
 
     def remove_a_restricted_visibility_group(self, **kwargs):
@@ -108,10 +119,12 @@ class EditArticleMetaFlow:
             lambda: self._remove_a_restricted_visibility_group(**kwargs)
         )
 
-    def _remove_a_restricted_visibility_group(self, group_name=''):
+    def _remove_a_restricted_visibility_group(self, group_name=""):
         if KBArticleRevision.KB_EDIT_METADATA not in self.utilities.get_page_url():
             self.kb_article_page.click_on_edit_article_metadata()
 
+        if self.edit_kb_article_page.is_edit_anyway_option_visible():
+            self.edit_kb_article_page.click_on_edit_anyway_option()
         self.kb_article_edit_metadata_page.delete_a_restricted_visibility_group_metadata(
             group_name)
         self.kb_article_edit_metadata_page.click_on_save_changes_button()

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
@@ -42,7 +42,7 @@ class KBArticlePage(BasePage):
         self.editing_tools_show_history_option = page.get_by_role("link", name="Show History",
                                                                   exact=True)
 
-        # Helpfulness widget
+        # Helpfulness widget section locators.
         self.helpfulness_widget = page.locator("form[class='document-vote--form helpful']")
         self.helpful_button = page.locator("button[class='btn helpful-button']")
         self.unhelpful_button = page.locator("button[class='btn not-helpful-button']")
@@ -53,6 +53,14 @@ class KBArticlePage(BasePage):
         self.helpfulness_widget_submit_button = page.locator(
             "//div[@class='sumo-button-wrap align-full']/button[normalize-space(text())='Submit']")
         self.survey_message = page.locator("div[class='survey-message']")
+
+        # Related Articles section locators.
+        self.related_articles_section = page.locator("section#related-documents")
+        self.related_article_cards = page.locator("section#related-documents h3.card--title a")
+        self.related_article = lambda article_title: page.locator(
+            f'//section[@id="related-documents"]//h3[@class="card--title"]/a[normalize-space('
+            f'text())="{article_title}"]'
+        )
 
     # KB Article page content actions.
     def click_on_a_particular_breadcrumb(self, breadcrumb_name: str):
@@ -158,3 +166,13 @@ class KBArticlePage(BasePage):
 
     def get_survey_message_text(self) -> str:
         return self._get_text_of_element(self.survey_message)
+
+    def is_related_articles_section_displayed(self) -> bool:
+        return self._is_element_visible(self.related_articles_section)
+
+    def get_list_of_related_articles(self) -> list[str]:
+        return [article.strip() for article in self._get_text_of_elements(
+            self.related_article_cards)]
+
+    def click_on_related_article_card(self, article_title: str):
+        self._click(self.related_article(article_title))

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
@@ -24,6 +24,17 @@ class KBArticleEditMetadata(BasePage):
         self.allow_discussion_checkbox = page.locator("input#id_allow_discussion")
         self.needs_change_checkbox = page.locator("input#id_needs_change")
         self.needs_change_textarea = page.locator("textarea#id_needs_change_comment")
+        self.related_documents_field = page.locator("input#search-related-ts-control")
+        self.related_documents_search_result = lambda search_term : page.locator(
+            f'//div[@id="search-related-ts-dropdown"]/div[normalize-space(.)="{search_term}"]'
+        )
+        self.related_documents_search_results = page.locator(
+            "div#search-related-ts-dropdown div")
+        self.added_related_documents = page.locator("div.ts-control div.item")
+        self.remove_related_documents_button = lambda related_document: page.locator(
+            f'//div[@class="item" and text()="{related_document}"]/a')
+        self.no_results_found_related_documents_message = page.locator(
+            "div#search-related-ts-dropdown div.no-results")
         self.save_changes_button = page.get_by_role("button", name="Save", exact=True)
         self.delete_group = lambda chosen_group: page.locator(
             f"//input[@id='id_restrict_to_groups-selectized']/../div[text()='{chosen_group}']/a")
@@ -101,6 +112,25 @@ class KBArticleEditMetadata(BasePage):
 
     def fill_needs_change_textarea(self, text: str):
         self._fill(self.needs_change_textarea, text)
+
+    def add_related_documents(self, document_name: str, submit: bool = True):
+        self._fill(self.related_documents_field, document_name)
+        if submit:
+            self._wait_for_locator(self.related_documents_search_result(document_name), 5000)
+            self._click(self.related_documents_search_result(document_name))
+
+    def is_no_related_documents_displayed(self) -> bool:
+        return self._is_element_visible(self.no_results_found_related_documents_message)
+
+    def get_related_documents_search_options(self) -> list[str]:
+        return self._get_text_of_elements(self.related_documents_search_results)
+
+    def get_related_documents(self) -> list[str]:
+        return [text.replace("\n×", "").strip() for text in self._get_text_of_elements(
+            self.added_related_documents)]
+
+    def remove_related_document(self, document_name: str):
+        self._click(self.remove_related_documents_button(document_name))
 
     def click_on_save_changes_button(self):
         self._click(self.save_changes_button)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_page.py
@@ -42,6 +42,9 @@ class EditKBArticlePage(BasePage):
     def click_on_edit_anyway_option(self):
         self._click(self.edit_by_another_user_edit_anyway_option)
 
+    def is_edit_anyway_option_visible(self) -> bool:
+        return self._is_element_visible(self.edit_by_another_user_edit_anyway_option)
+
     # Edit kb article page field actions.
     def get_edit_article_keywords_field_value(self) -> str:
         return self._get_element_input_value(self.edit_article_keywords_field)

--- a/playwright_tests/test_data/aaq_question.json
+++ b/playwright_tests/test_data/aaq_question.json
@@ -1,10 +1,10 @@
 {
   "valid_firefox_question": {
-    "subject": "Test Question ",
-    "subject_updated": "Test Question Updated",
+    "subject": "NVDA does not work with Firefox ",
+    "subject_updated": "NVDA does not work with Firefox Updated",
     "topic_value": "Accessibility",
-    "question_body": "'''I have a problem''' when I ''access'', the following link: [https://www.mediafax.ro adipiscing], the Firefox browser is not performing is unable to output the messages coming from the screen reader. I've tried reading the following article: [[Stage test owl|sed]] but it doesn't help me understand what is the root cause and how can I fixed the missing content. Can somebody please help me?",
-    "body_updated": "Updated body",
+    "question_body": "'''I have a problem''' when I ''access'', the following link: [https://www.mediafax.ro adipiscing], the Firefox browser is unable to output the messages coming from the screen reader. I've tried reading the following article: [[Stage test owl|sed]] but it doesn't help me understand what is the root cause and how can I fix the missing content. Can somebody please help me with this accessibility issue?",
+    "body_updated": "I have a problem when I access, any links on the internet, the Firefox browser is unable to output the messages coming from the screen reader. I've tried reading an article but it doesn't help me understand what is the root cause and how can I fix the missing content. Can somebody please help me with this accessibility issue? Updated",
     "simple_body_text": "Firefox doesn't work in combination with the NVDA screen reader",
     "image_name": "test.image.jpg",
     "image_path": "test_data/test-image.png",

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -265,11 +265,11 @@ def test_post_aaq_questions_for_all_freemium_products_topics(page: Page):
             for topic in sumo_pages.aaq_form_page.get_aaq_form_topic_options():
                 with allure.step(f"Submitting question for {product} product"):
                     question_info = sumo_pages.aaq_flow.submit_an_aaq_question(
-                        subject=utilities.aaq_question_test_data["valid_firefox_question"]
-                        ["subject"],
+                        subject=f"Issue related to the {topic} topic",
                         topic_name=topic,
-                        body=f"I have a problem with {topic}. It doesn't seem to work whatever I"
-                             f" try to do... Can you please help me?",
+                        body=f"I have a problem related to {topic}. But I don't know how to "
+                             f"explain it properly. I need some guidance in debugging this so "
+                             f"that I can provide more information.",
                         attach_image=False,
                         expected_locator=sumo_pages.question_page.questions_header
                     )


### PR DESCRIPTION
- Added related documents section locators & actions. 
- Updated the used AAQ question content.
- Expanded Playwright's coverage to "Related documents" section by: 
1: Verifying that Related documents can be successfully added & removed.
2: Verifying that related documents are successfully visible & removed from the "Related documents" section inside the kb article page.
3: Verifying that the current article cannot be added as a related document.
4: Verifying that related documents which have a restricted visibility are visible inside the "Related documents" section only for users which have the necessary permissions.