### PR TITLE
Playwright update flows & extend coverage to kb article locale switcher

### DIFF
--- a/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
+++ b/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
@@ -18,14 +18,8 @@ class AAQFlow:
 
     # Submitting an aaq question for a product flow.
     # Mozilla VPN has an extra optional dropdown menu for choosing an operating system.
-    def _submit_an_aaq_question(self,
-                                subject: str,
-                                body: str,
-                                topic_name='',
-                                attach_image=False,
-                                is_premium=False,
-                                email="",
-                                is_loginless=False,
+    def _submit_an_aaq_question(self, subject: str, body: str, topic_name='', attach_image=False,
+                                is_premium=False, email="", is_loginless=False,
                                 expected_locator=None):
         question_subject = ''
         if is_premium:
@@ -33,11 +27,8 @@ class AAQFlow:
                                                                    email)
         else:
             question_subject = self.add__valid_data_to_all_aaq_fields_without_submitting(
-                subject,
-                topic_name,
-                body,
-                attach_image
-            )
+                subject, topic_name, body, attach_image)
+
         # Submitting the question.
         self.aaq_form_page.click_aaq_form_submit_button(expected_locator=expected_locator)
 
@@ -88,7 +79,9 @@ class AAQFlow:
                                                           is_loginless: bool, email: str):
         if is_loginless:
             self.aaq_form_page.fill_contact_email_field(email)
+
         self.aaq_form_page.select_random_topic_by_value()
+
         if self.aaq_form_page.is_os_dropdown_menu_visible():
             self.aaq_form_page.select_random_os_by_value()
         self.aaq_form_page.add_text_to_premium_aaq_form_subject_field(subject)
@@ -138,10 +131,8 @@ class AAQFlow:
         self.aaq_form_page.clear_the_question_body_textarea_field()
         self.aaq_form_page.add_text_to_aaq_textarea_field(reply_body)
 
-        if submit_reply:
-            self.aaq_form_page.click_on_update_answer_button()
-        else:
-            self.aaq_form_page.click_aaq_form_cancel_button()
+        self.aaq_form_page.click_on_update_answer_button() if submit_reply else (
+            self.aaq_form_page.click_aaq_form_cancel_button())
 
     def delete_question_reply(self, **kwargs):
         return self.utilities.re_call_function_on_error(
@@ -152,22 +143,17 @@ class AAQFlow:
         self.question_page.click_on_reply_more_options_button(answer_id)
         self.question_page.click_on_delete_this_post_for_a_certain_reply(answer_id)
 
-        if delete_reply:
-            self.question_page.click_delete_this_question_button()
-        else:
-            self.question_page.click_on_cancel_delete_button()
+        self.question_page.click_delete_this_question_button() if delete_reply else (
+            self.question_page.click_on_cancel_delete_button())
 
     def post_question_reply_flow(self, **kwargs):
         return self.utilities.re_call_function_on_error(
             lambda: self._post_question_reply_flow(**kwargs)
         )
 
-    def _post_question_reply_flow(self,
-                                  repliant_username: str,
-                                  reply='',
-                                  submit_reply=True,
-                                  quoted_reply=False,
-                                  reply_for_id='') -> str:
+    def _post_question_reply_flow(self, repliant_username: str, reply='', submit_reply=True,
+                                  quoted_reply=False, reply_for_id='') -> str:
+
         if quoted_reply:
             self.question_page.click_on_reply_more_options_button(reply_for_id)
             self.question_page.click_on_quote_for_a_certain_reply(reply_for_id)

--- a/playwright_tests/flows/contributor_threads_flows/contributor_threads_flows.py
+++ b/playwright_tests/flows/contributor_threads_flows/contributor_threads_flows.py
@@ -37,12 +37,15 @@ class ContributorThreadFlow:
         """
         if "/new" not in self.utilities.get_page_url():
             self.forum_discussions_page.click_on_new_thread_button()
+
         self.new_thread_page.fill_title_input_field(thread_title)
         self.new_thread_page.fill_content_textarea_field(thread_body)
-        if cancel:
-            self.new_thread_page.click_on_cancel_button()
-        else:
-            self.new_thread_page.click_on_post_thread_button()
+
+        action = self.new_thread_page.click_on_cancel_button if cancel else (
+            self.new_thread_page.click_on_post_thread_button)
+        action()
+
+        if not cancel:
             return re.search(r'last=(\d+)', self.utilities.get_page_url()).group(1)
 
     def move_thread_to_a_different_forum(self, target_forum: str):

--- a/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
@@ -26,18 +26,10 @@ class EditArticleMetaFlow:
             lambda: self._edit_article_metadata(**kwargs)
         )
 
-    def _edit_article_metadata(self, title=None,
-                               slug=None,
-                               category=None,
-                               product=None,
-                               topics=None,
-                               obsolete=False,
-                               discussions=True,
-                               needs_change=False,
-                               needs_change_comment=False,
-                               restricted_to_groups: list[str] = None,
-                               related_documents: list[str] = None,
-                               single_group=""):
+    def _edit_article_metadata(self, title=None, slug=None, category=None, product=None,
+                               topics=None, obsolete=False, discussions=True, needs_change=False,
+                               needs_change_comment=False, restricted_to_groups: list[str] = None,
+                               related_documents: list[str] = None, single_group=""):
 
         if KBArticleRevision.KB_EDIT_METADATA not in self.utilities.get_page_url():
             self.kb_article_page.click_on_edit_article_metadata()
@@ -45,13 +37,10 @@ class EditArticleMetaFlow:
         if self.edit_kb_article_page.is_edit_anyway_option_visible():
             self.edit_kb_article_page.click_on_edit_anyway_option()
 
-        if restricted_to_groups:
-            for group in restricted_to_groups:
-                (self.kb_article_edit_metadata_page
-                 .add_and_select_restrict_visibility_group_metadata(group))
-        if single_group != "":
-            self.kb_article_edit_metadata_page.add_and_select_restrict_visibility_group_metadata(
-                single_group)
+        if restricted_to_groups or single_group:
+            for group in (restricted_to_groups or []) + ([single_group] if single_group else []):
+                (self.kb_article_edit_metadata_page.
+                 add_and_select_restrict_visibility_group_metadata(group))
 
         if title:
             self.kb_article_edit_metadata_page.add_text_to_title_field(title)
@@ -76,37 +65,25 @@ class EditArticleMetaFlow:
                     topics
                 )
 
-        if obsolete:
-            if not self.kb_article_edit_metadata_page.is_obsolete_checkbox_checked():
-                self.kb_article_edit_metadata_page.click_on_obsolete_checkbox()
-        else:
-            if self.kb_article_edit_metadata_page.is_obsolete_checkbox_checked():
-                self.kb_article_edit_metadata_page.click_on_obsolete_checkbox()
+        if self.kb_article_edit_metadata_page.is_obsolete_checkbox_checked() != obsolete:
+            self.kb_article_edit_metadata_page.click_on_obsolete_checkbox()
 
-        if discussions:
-            if not self.kb_article_edit_metadata_page.is_allow_discussion_checkbox_checked():
-                self.kb_article_edit_metadata_page.click_on_allow_discussion_on_article_checkbox()
-        else:
-            if self.kb_article_edit_metadata_page.is_allow_discussion_checkbox_checked():
-                self.kb_article_edit_metadata_page.click_on_allow_discussion_on_article_checkbox()
+        if self.kb_article_edit_metadata_page.is_allow_discussion_checkbox_checked() != \
+           discussions:
+            self.kb_article_edit_metadata_page.click_on_allow_discussion_on_article_checkbox()
 
-        # If it needs change we are going to ensure that the needs change checkbox is checked.
+        # Ensure the needs change checkbox and textarea are updated accordingly.
         if needs_change:
             if not self.kb_article_edit_metadata_page.is_needs_change_checkbox():
                 self.kb_article_edit_metadata_page.click_needs_change_checkbox()
-                # If it needs change with comment we are also adding the comment.
-            if needs_change_comment:
-                self.kb_article_edit_metadata_page.fill_needs_change_textarea(
-                    self.utilities.kb_revision_test_data['needs_change_message']
-                )
+            # If it needs change with comment we are also adding the comment.
             # If it doesn't need comment we are ensuring that the textarea field is empty.
-            else:
-                self.kb_article_edit_metadata_page.fill_needs_change_textarea('')
-
-        # If it doesn't need change we are ensuring that the checkbox is not checked.
-        else:
-            if self.kb_article_edit_metadata_page.is_needs_change_checkbox():
-                self.kb_article_edit_metadata_page.click_needs_change_checkbox()
+            self.kb_article_edit_metadata_page.fill_needs_change_textarea(
+                self.utilities.kb_revision_test_data[
+                    'needs_change_message'] if needs_change_comment else ''
+            )
+        elif self.kb_article_edit_metadata_page.is_needs_change_checkbox():
+            self.kb_article_edit_metadata_page.click_needs_change_checkbox()
 
         if related_documents:
             for document in related_documents:

--- a/playwright_tests/flows/explore_articles_flows/article_flows/kb_article_threads_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/kb_article_threads_flow.py
@@ -28,12 +28,9 @@ class KbThreads:
         self.kb_article_page.click_on_editing_tools_discussion_option()
         article_discussion_url = self.utilities.get_page_url()
         self.kb_article_discussion_page.click_on_post_a_new_thread_option()
-        if title == '':
-            thread_title = (self.utilities.kb_new_thread_test_data['new_thread_title'] + self
-                            .utilities.generate_random_number(0, 5000))
-        else:
-            thread_title = (title + self.utilities
-                            .generate_random_number(0, 5000))
+
+        thread_title = (title or self.utilities.kb_new_thread_test_data[
+            'new_thread_title']) + self.utilities.generate_random_number(0, 5000)
         thread_body = self.utilities.kb_new_thread_test_data['new_thread_body']
 
         # Adding text to the title field.
@@ -63,10 +60,10 @@ class KbThreads:
         self.kb_article_discussion_page.click_on_edit_this_thread_option()
         self.kb_article_discussion_page.add_text_to_edit_article_thread_title_field(thread_title)
 
-        if submit_edit:
-            self.kb_article_discussion_page.click_on_edit_article_thread_update_button()
-        else:
-            self.kb_article_discussion_page.click_on_edit_article_thread_cancel_button()
+        action = (self.kb_article_discussion_page.
+                  click_on_edit_article_thread_update_button) if submit_edit else (
+            self.kb_article_discussion_page.click_on_edit_article_thread_cancel_button)
+        action()
 
     def post_reply_to_thread(self, text: str, post_reply=True) -> dict[str, Any]:
         self.kb_article_discussion_page.fill_the_thread_post_a_reply_textarea(text)

--- a/playwright_tests/flows/explore_articles_flows/article_flows/kb_localization_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/kb_localization_flow.py
@@ -28,46 +28,28 @@ class KbArticleTranslationFlow:
             self.kb_article_page.click_on_translate_article_option()
             self.translate_article_page.click_on_locale_from_list(locale)
 
-        if title != '':
-            translation_title = title
-            self.translate_article_page.fill_translation_title_field(translation_title)
+        translation_title = title or (
+            self.utilities.kb_article_test_data['translated_title'] + self.utilities.
+            generate_random_number(1, 1000))
+        self.translate_article_page.fill_translation_title_field(translation_title)
 
-        else:
-            translation_title = (self.utilities.kb_article_test_data['translated_title'] + self.
-                                 utilities.generate_random_number(1, 1000))
-            self.translate_article_page.fill_translation_title_field(translation_title)
-
-        if slug != '':
-            translation_slug = slug
-            self.translate_article_page.fill_translation_slug_field(translation_slug)
-        else:
-            translation_slug = (self.utilities.kb_article_test_data['translated_slug'] + self.
-                                utilities.generate_random_number(1, 1000))
-            self.translate_article_page.fill_translation_slug_field(translation_slug)
+        translation_slug = slug or (
+            self.utilities.kb_article_test_data['translated_slug'] + self.
+            utilities.generate_random_number(1, 1000))
+        self.translate_article_page.fill_translation_slug_field(translation_slug)
 
         if not allow_discussions:
             self.translate_article_page.click_on_allow_translated_article_comments_checkbox()
 
-        if keyword != '':
-            translation_keyword = keyword
-            self.translate_article_page.fill_translated_article_keyword(translation_keyword)
-        else:
-            translation_keyword = self.utilities.kb_article_test_data['translated_keyword']
-            self.translate_article_page.fill_translated_article_keyword(translation_keyword)
+        translation_keyword = keyword or self.utilities.kb_article_test_data['translated_keyword']
+        self.translate_article_page.fill_translated_article_keyword(translation_keyword)
 
-        if summary != '':
-            translation_summary = summary
-            self.translate_article_page.fill_translated_article_summary(translation_summary)
-        else:
-            translation_summary = self.utilities.kb_article_test_data['translated_search_summary']
-            self.translate_article_page.fill_translated_article_summary(translation_summary)
+        translation_summary = summary or self.utilities.kb_article_test_data[
+            'translated_search_summary']
+        self.translate_article_page.fill_translated_article_summary(translation_summary)
 
-        if body != '':
-            translation_body = body
-            self.translate_article_page.fill_body_translation_field(translation_body)
-        else:
-            translation_body = self.utilities.kb_article_test_data['translated_body']
-            self.translate_article_page.fill_body_translation_field(translation_body)
+        translation_body = body or self.utilities.kb_article_test_data['translated_body']
+        self.translate_article_page.fill_body_translation_field(translation_body)
 
         if save_as_draft:
             self.translate_article_page.click_on_save_translation_as_draft_button()

--- a/playwright_tests/flows/messaging_system_flows/messaging_system_flow.py
+++ b/playwright_tests/flows/messaging_system_flows/messaging_system_flow.py
@@ -11,11 +11,8 @@ class MessagingSystemFlows:
         self.inbox_page = InboxPage(page)
 
     # Send message form with data flow.
-    def complete_send_message_form_with_data(self,
-                                             recipient_username='',
-                                             message_body='',
-                                             submit_message=True,
-                                             expected_url=None):
+    def complete_send_message_form_with_data(self, recipient_username='', message_body='',
+                                             submit_message=True, expected_url=None):
         """Complete the send message form with data.
 
         Args:
@@ -25,13 +22,11 @@ class MessagingSystemFlows:
             expected_url (str): The expected URL after the click event.
         """
         if recipient_username:
-            if isinstance(recipient_username, list):
-                for recipient in recipient_username:
-                    self.new_message_page.type_into_new_message_to_input_field(recipient)
-                    self.new_message_page.click_on_a_searched_user(recipient)
-            else:
-                self.new_message_page.type_into_new_message_to_input_field(recipient_username)
-                self.new_message_page.click_on_a_searched_user(recipient_username)
+            recipients = recipient_username if isinstance(recipient_username, list) else [
+                recipient_username]
+            for recipient in recipients:
+                self.new_message_page.type_into_new_message_to_input_field(recipient)
+                self.new_message_page.click_on_a_searched_user(recipient)
 
         if message_body:
             self.new_message_page.fill_into_new_message_body_textarea(message_body)
@@ -40,13 +35,8 @@ class MessagingSystemFlows:
             self.new_message_page.click_on_new_message_send_button(
                 expected_url=expected_url)
 
-    def delete_message_flow(self, username='',
-                            excerpt='',
-                            delete_message=True,
-                            from_sent_list=False,
-                            from_inbox_list=False,
-                            expected_url=None
-                            ):
+    def delete_message_flow(self, username='', excerpt='', delete_message=True,
+                            from_sent_list=False, from_inbox_list=False, expected_url=None):
         """Delete a message flow.
 
         Args:
@@ -58,15 +48,15 @@ class MessagingSystemFlows:
             expected_url (str): The expected URL after the click event.
         """
         if from_sent_list:
-            if username:
-                self.sent_message_page.click_on_sent_message_delete_button_by_user(username)
-            elif excerpt:
-                self.sent_message_page.click_on_sent_message_delete_button_by_excerpt(excerpt)
+            if username or excerpt:
+                self.sent_message_page.click_on_sent_message_delete_button_by_user(
+                    username) if username else \
+                    self.sent_message_page.click_on_sent_message_delete_button_by_excerpt(excerpt)
 
-        if from_inbox_list:
+        if from_inbox_list and (username or excerpt):
             if username:
                 self.inbox_page.click_on_inbox_message_delete_button_by_username(username)
-            elif excerpt:
+            else:
                 self.inbox_page.click_on_inbox_message_delete_button_by_excerpt(excerpt)
 
         if delete_message:

--- a/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
@@ -30,7 +30,7 @@ class SubmitKBArticlePage(BasePage):
         self.kb_article_insert_media_modal_insert_button = page.get_by_role(
             "button").filter(has_text="Insert Media")
         self.kb_article_toggle_syntax_highlighting = page.locator(
-            "//a[contains(text(), 'Toggle syntax highlight')]"
+            "//div[@id='editor_wrapper']/following-sibling::a"
         )
         self.kb_article_expiry_date = page.locator("input#id_expires")
         self.kb_article_preview_content_button = page.locator(


### PR DESCRIPTION
- Several improvements to the page flows, focusing on simplifying methods and improving readability.
- Expanding playwright coverage to include the verification whether SUMO successfully handles a locale switch between kb article translations & locales in which the article was not yet translated.