### PR TITLE
fix init of browser & os details for questions

### DIFF
--- a/kitsune/sumo/static/sumo/js/aaq.js
+++ b/kitsune/sumo/static/sumo/js/aaq.js
@@ -7,8 +7,8 @@ import RemoteTroubleshooting from "./remote";
 
 export default class AAQSystemInfo {
   static slugs = {
-    desktop: ["desktop", "firefox-enterprise"],
-    mobile: ["mobile", "ios", "focus"],
+    desktop: ["/firefox/", "/firefox-enterprise/"],
+    mobile: ["/mobile/", "/ios/", "/focus-firefox/"],
   };
 
   constructor(form) {


### PR DESCRIPTION
While working on mozilla/sumo#2397, I discovered that the initialization of the browser and OS details was failing for Firefox questions because the `AAQSystemInfo` JS class was looking for `desktop` rather than `firefox` in the URL. Also, the details should only be initialized for mobile if the user is on a mobile device, and for desktop if on a desktop device, but when changing `desktop` to `firefox`, the details would be initialized when asking a question for Firefox Focus on a desktop OS because `firefox` was found in `focus-firefox`. I wrapped each of the cases with `/.../` to resolve that and ensure complete matching.