### PR TITLE
6725 sorting forum posts issue

### DIFF
--- a/kitsune/questions/tests/test_views_sorting.py
+++ b/kitsune/questions/tests/test_views_sorting.py
@@ -1,0 +1,82 @@
+"""
+Unit test for question sorting by views with null handling.
+"""
+
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.db.models import IntegerField, Value
+from django.db.models.functions import Coalesce
+
+from kitsune.questions.models import Question, QuestionVisits
+from kitsune.products.models import Product
+
+
+class QuestionViewsSortingTestCase(TestCase):
+    """Test question sorting by views handles null values correctly."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass"
+        )
+
+        self.product = Product.objects.create(
+            title="Test Product",
+            slug="test-product",
+            description="Test product for testing",
+            display_order=1,
+        )
+
+        # Create test questions with different view counts
+        self.q_high_views = Question.objects.create(
+            title="Question with 500 views",
+            content="High views content",
+            creator=self.user,
+            product=self.product,
+        )
+
+        self.q_no_views = Question.objects.create(
+            title="Question with no views",
+            content="No views content",
+            creator=self.user,
+            product=self.product,
+        )
+
+        self.q_medium_views = Question.objects.create(
+            title="Question with 100 views",
+            content="Medium views content",
+            creator=self.user,
+            product=self.product,
+        )
+
+        # Add visit data (q_no_views intentionally has none to test null handling)
+        QuestionVisits.objects.create(question=self.q_high_views, visits=500)
+        QuestionVisits.objects.create(question=self.q_medium_views, visits=100)
+
+    def test_views_sorting_descending(self):
+        """Test that questions are sorted correctly by views in descending
+        order with nulls as 0."""
+        # Apply the same logic as in the view
+        question_qs = Question.objects.filter(
+            id__in=[self.q_high_views.id, self.q_no_views.id, self.q_medium_views.id]
+        )
+
+        question_qs = question_qs.annotate(
+            visits_nulls_as_zero=Coalesce(
+                "questionvisits__visits", Value(0), output_field=IntegerField()
+            )
+        )
+        question_qs = question_qs.order_by("-visits_nulls_as_zero")
+
+        ordered_questions = list(question_qs)
+
+        # Verify correct order: 500 views, 100 views, 0 views (null treated as 0)
+        self.assertEqual(len(ordered_questions), 3)
+        self.assertEqual(ordered_questions[0].id, self.q_high_views.id)
+        self.assertEqual(ordered_questions[1].id, self.q_medium_views.id)
+        self.assertEqual(ordered_questions[2].id, self.q_no_views.id)
+
+        # Verify the annotated values
+        self.assertEqual(getattr(ordered_questions[0], "visits_nulls_as_zero"), 500)
+        self.assertEqual(getattr(ordered_questions[1], "visits_nulls_as_zero"), 100)
+        self.assertEqual(getattr(ordered_questions[2], "visits_nulls_as_zero"), 0)

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -13,8 +13,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import EmptyPage, PageNotAnInteger
-from django.db.models import Q
-from django.db.models.functions import Now
+from django.db.models import IntegerField, Q, Value
+from django.db.models.functions import Coalesce, Now
 from django.http import (
     Http404,
     HttpRequest,
@@ -286,7 +286,20 @@ def question_list(request, product_slug=None, topic_slug=None):
     # Set the order.
     # Set a default value if a user requested a non existing order parameter
     order_by = ORDER_BY.get(order, ["updated"])[0]
-    question_qs = question_qs.order_by(order_by if sort == "asc" else "-%s" % order_by)
+
+    # Handle sorting by views specially to treat NULL visit counts as 0
+    if order == "views":
+        # Use COALESCE to treat NULL visits as 0
+        question_qs = question_qs.annotate(
+            visits_nulls_as_zero=Coalesce(
+                "questionvisits__visits", Value(0), output_field=IntegerField()
+            )
+        )
+        question_qs = question_qs.order_by(
+            "visits_nulls_as_zero" if sort == "asc" else "-visits_nulls_as_zero"
+        )
+    else:
+        question_qs = question_qs.order_by(order_by if sort == "asc" else "-%s" % order_by)
 
     try:
         questions_page = simple_paginate(request, question_qs, per_page=config.QUESTIONS_PER_PAGE)

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -289,7 +289,6 @@ def question_list(request, product_slug=None, topic_slug=None):
 
     # Handle sorting by views specially to treat NULL visit counts as 0
     if order == "views":
-        # Use COALESCE to treat NULL visits as 0
         question_qs = question_qs.annotate(
             visits_nulls_as_zero=Coalesce(
                 "questionvisits__visits", Value(0), output_field=IntegerField()


### PR DESCRIPTION
Nulls rise to the top of the sort order with Postgres - this corrects that issue for Questions by changing nulls to zero.