### PR TITLE
strengthen LLM output parsing

### DIFF
--- a/kitsune/llm/tests/test_utils.py
+++ b/kitsune/llm/tests/test_utils.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch, Mock
+
+from langchain.schema.output_parser import OutputParserException
+
+from kitsune.llm.utils import build_chain_with_retry
+from kitsune.sumo.tests import TestCase
+
+
+@patch("kitsune.llm.utils.coerce_to_runnable", side_effect=lambda x: x)
+class BuildChainWithRetryTestCase(TestCase):
+
+    def setUp(self):
+        self.prompt = Mock()
+        self.llm = Mock()
+        self.parser = Mock()
+        self.prompt.__or__ = Mock(return_value=self.llm)
+        self.llm.__or__ = Mock(return_value=self.parser)
+
+    def test_build_chain_with_retry(self, coerce_mock):
+        expected_result = dict(is_something=True, reason="Because")
+        self.parser.invoke.side_effect = [OutputParserException("error"), expected_result]
+        chain = build_chain_with_retry(self.prompt, self.llm, self.parser)
+        self.assertEqual(chain.invoke({}), expected_result)
+
+    def test_build_chain_with_retry_when_max_retries_exceeded(self, coerce_mock):
+        self.parser.invoke.side_effect = [
+            OutputParserException("first error"),
+            OutputParserException("second error"),
+        ]
+        chain = build_chain_with_retry(self.prompt, self.llm, self.parser)
+        self.assertIsNone(chain.invoke({}))
+
+    def test_build_chain_with_retry_when_max_retries_exceeded_and_default(self, coerce_mock):
+        self.parser.invoke.side_effect = [
+            OutputParserException("first error"),
+            OutputParserException("second error"),
+        ]
+        default_result = dict(default=True)
+        chain = build_chain_with_retry(
+            self.prompt, self.llm, self.parser, default_result=default_result
+        )
+        self.assertEqual(chain.invoke({}), default_result)
+
+    def test_build_chain_with_retry_when_max_retries_adjusted(self, coerce_mock):
+        expected_result = dict(is_something=True, reason="Because")
+        self.parser.invoke.side_effect = [
+            OutputParserException("first error"),
+            OutputParserException("second error"),
+            expected_result,
+        ]
+        chain = build_chain_with_retry(self.prompt, self.llm, self.parser, max_retries=2)
+        self.assertEqual(chain.invoke({}), expected_result)


### PR DESCRIPTION
mozilla/sumo#2370

## Notes
The `OutputParserException` errors are happening within all three of our pipelines: spam detection, topic classification, and product classification. The most common case is that `"` characters are not escaped within the `reason` (which is wrapped in double quotes), so the JSON decoding fails, but I've also seen a case where there is literally nothing to decode and others cases where expected keys (for example, `maybe_misclassified`) are missing.

This PR attacks the problem in two ways.

First, it reduces the chance of parser exceptions by using the `PydanticOutputParser`, which provides (via its `get_format_instructions` method) a strict JSON schema for the LLM to follow. Just as importantly, I appended an additional formatting instruction explaining that special characters like `"` must be escaped within JSON string values.

Second, if any parser exceptions occur, the entire pipeline is retried (by default only once). I explored using LangChain's `RetryWithErrorOutputParser` for this, but was not impressed, both with its interface (which renders it nearly unusable within our LCEL pipelines) as well as its prompt. It was much simpler and clearer to create the `build_chain_with_retry` utility function instead.

The combination of the two approaches should hopefully make these exceptions very rare.