### PR TITLE
Configure Dependabot to recognize `uv.lock` files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
mozilla/sumo#2434

Adds support for `uv.lock` files as [recommended by Astral](https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependabot).

Support for `uv` seems to be limited such that Dependabot will only update the dependencies in the `pyproject.toml` file, not the full dependency tree in `uv.lock`. For example, see https://github.com/dependabot/dependabot-core/issues/11913. Perhaps that's enough for us?