### PR TITLE
improve topic classification prompt

### DIFF
--- a/kitsune/llm/questions/prompt.py
+++ b/kitsune/llm/questions/prompt.py
@@ -91,6 +91,7 @@ Below is a JSON-formatted list of topics you MUST choose from. Each topic includ
 - **title**: Name of the topic.
 - **description**: Explanation of what the topic covers.
 - **examples** (optional): Sample questions that fit clearly into the topic.
+- **subtopics**: The lower-level topics, if any, of the topic.
 
 ```json
 {topics}
@@ -103,17 +104,19 @@ For each question:
    - Title
    - Description
    - Examples (when provided)
-3. **Select exactly one topic** that best matches the question's intent.
+3. **Select exactly one topic** that best matches the question's intent, following this rule:
+   - **Always prefer the most specific (lowest-level) topic that best matches the question's intent**.
+   - Only select a broader (higher-level) topic if none of its lower-level topics best matches the question's intent.
 4. **Default to "Undefined" if**:
-   - The question is unrelated to Mozilla's "{product}"
-   - The question lacks sufficient information for classification
-   - No existing topic appropriately captures the question's intent
+   - The question is unrelated to Mozilla's "{product}".
+   - The question lacks sufficient information for classification.
+   - No existing topic appropriately captures the question's intent.
 
 # Decision Criteria
 - Always prioritize the primary intent of the question over secondary or minor aspects.
-- Consider both explicit and implicit product features mentioned
-- Match to the most specific applicable topic when multiple topics seem relevant
-- Look for keywords that align with topic descriptions and examples
+- Consider both explicit and implicit product features mentioned.
+- Match to the most specific applicable topic when multiple topics seem relevant.
+- Look for keywords that align with topic descriptions and examples.
 
 # Response Format
 {format_instructions}
@@ -155,7 +158,12 @@ class SpamResult(BaseModel):
 
 
 class TopicResult(BaseModel):
-    topic: str = Field(description="The title of the topic or subtopic selected for the question.")
+    topic: str = Field(
+        description=(
+            "The title of the selected topic or subtopic. If a subtopic is selected, include"
+            " only its own title — do not include the titles of any of its parent topics."
+        )
+    )
     reason: str = Field(description="The reason for selecting the topic.")
 
 


### PR DESCRIPTION
mozilla/sumo#2424

## Notes
I tested this new topic-classification prompt in production on all of the specific questions identified in the topic pipeline baseline review, and multiple times for each question. After over 350 runs, all of the runs returned the most specific topic that was expected, and none of them returned a hierarchical string of topics.

I also found an interesting case (https://support.mozilla.org/en-US/questions/1515430) that tests for the ability to select a more general topic when that's most appropriate. That question reports that the user has been unable to download or print anything, so both the `Download failure` and `Print` subtopics under the `Downloads` topic are too specific. Instead the most specific topic above both of them should be selected, and with this new prompt, `Downloads` was consistently selected. 🎉 