### PR TITLE
Fix styleguide build and deploy it alongs docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches:
       - main
-    paths: # avoid extra builds
+    paths: # avoid building unless needed
       - docs/**
       - mkdocs.yml
+      - kitsune/sumo/static/sumo/scss/**
+      - styleguide/**
       - .github/workflows/publish-docs.yml
 
 permissions:
@@ -24,6 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -32,6 +38,8 @@ jobs:
         uses: actions/configure-pages@v5
       - run: pip install mkdocs-material 
       - run: mkdocs build -d dist
+      - run: npm ci
+      - run: npm run build:styleguide && mkdir dist/_kss && cp -r styleguide/build/. dist/_kss/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/styleguide/kss-config.json
+++ b/styleguide/kss-config.json
@@ -10,6 +10,6 @@
   "js": [
     "static/common.js"
   ],
-  "homepage": "../../../../../styleguide/styleguide-examples/styleguide-index.md",
+  "homepage": "./styleguide-examples/styleguide-index.md",
   "builder": "kss-template"
 }

--- a/styleguide/kss-template/kss-assets/scss/layout/_kss-content.scss
+++ b/styleguide/kss-template/kss-assets/scss/layout/_kss-content.scss
@@ -1,5 +1,3 @@
-@use 'protocol/css/includes/lib' as p;
-
 // ------------------------------------------------------------------------------
 // Content-area components
 // ------------------------------------------------------------------------------
@@ -335,6 +333,7 @@ a:hover {
 
   summary {
     padding-left: 10px;
+    cursor: pointer;
   }
 
   pre {
@@ -386,7 +385,7 @@ a:hover {
     font-weight: normal;
     font-size: 12px;
     border: 1px solid #eee;
-    border-radius: p.$border-radius-xs;
+    border-radius: 2px;
     text-align: center;
     margin-bottom: 4px;
     cursor: copy;


### PR DESCRIPTION
Publishes #6696

The KSS stack seemed to have a few wrinkles blocking successful builds, but merely trivial ones to not have this being uptodate, building, and available online for reference.

(I've chosen the `/_kss` namespace to hopefully not interfere with the mkdocs site built in the same workdir. Something like `/styleguide` would def look better, but that has the risk of ability to clash with a page of this name being added in the future. But more than happy to tweak!)

Preview deploy: https://janbrasna.github.io/kitsune/_kss/

_(I'll update the outbound links, and add an inbound link from mkdocs in a separate step, after this is deployed, to not have 404 validator errors for URLs not yet existing.)_