### PR TITLE
- Playwright expand search test coverage

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,6 +38,7 @@ on:
                     - kbDashboard
                     - exploreByTopics
                     - searchTests
+                    - contributorForumSearch
                     - userGroupsTests
                     - antiSpamTests
                     - contributorDiscussions
@@ -101,7 +102,7 @@ jobs:
         run: |
             source ../.venv/bin/activate
             declare dispatch_test_suite="${{inputs.TestSuite}}"
-            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productSupportPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics" "searchTests" "userGroupsTests" "antiSpamTests" "contributorDiscussions" "contributorDiscussionsThreads")
+            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productSupportPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics" "searchTests" "contributorForumSearch" "userGroupsTests" "antiSpamTests" "contributorDiscussions" "contributorDiscussionsThreads")
             if [ "$dispatch_test_suite" == "All" ] || [ "${{ github.event_name}}" == "schedule" ] ; then
                 for test in "${all_test_suites[@]}"; do
                     if ! pytest -m ${test} --numprocesses 6 --browser ${{ env.BROWSER }} --reruns 2 -v; then

--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -286,7 +286,7 @@ class BasePage:
         self.wait_for_dom_to_load()
         return locator.is_checked()
 
-    def _wait_for_locator(self, locator: Locator, timeout=3500):
+    def _wait_for_locator(self, locator: Locator, timeout=3500, raise_exception=False):
         """
         This helper function waits for a given element locator to be visible based on a given
         timeout.
@@ -295,6 +295,8 @@ class BasePage:
             locator.wait_for(state="visible", timeout=timeout)
         except PlaywrightTimeoutError:
             print(f"{locator} is not displayed")
+            if raise_exception:
+                raise
 
     def _move_mouse_to_location(self, x: int, y: int):
         """

--- a/playwright_tests/core/utilities.py
+++ b/playwright_tests/core/utilities.py
@@ -306,7 +306,8 @@ class Utilities:
                 if FxAPageMessages.AUTH_PAGE_URL in self.get_page_url():
                     break
                 else:
-                    top_navbar._wait_for_locator(top_navbar.signin_signup_button)
+                    top_navbar._wait_for_locator(top_navbar.signin_signup_button,
+                                                 raise_exception=True)
                 break
             except PlaywrightTimeoutError:
                 print("Cookies were not successfully deleted. Retrying...")
@@ -663,3 +664,10 @@ class Utilities:
             return {"event": message.split(": ", 1)[1].rstrip(':')}
         elif message.startswith('parameters:'):
             return {"parameters": json.loads(message.split(": ", 1)[1])}
+
+    def fetch_scrolly(self) -> int:
+        """
+        This helper function returns the number of pixels by which the document is currently
+        scrolled vertically.
+        """
+        return self.page.evaluate("() => window.scrollY")

--- a/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
+++ b/playwright_tests/flows/ask_a_question_flows/aaq_flows/aaq_flow.py
@@ -31,7 +31,8 @@ class AAQFlow:
                 subject, topic_name, body, attach_image)
 
         # Submitting the question.
-        self.aaq_form_page.click_aaq_form_submit_button(expected_locator=expected_locator)
+        with self.utilities.page.expect_navigation():
+            self.aaq_form_page.click_aaq_form_submit_button(expected_locator=expected_locator)
 
         # If the submission was done for freemium products we are retrieving the Question Subject,
         # Question url & Question Body for further test usage.

--- a/playwright_tests/messages/ask_a_question_messages/AAQ_messages/question_page_messages.py
+++ b/playwright_tests/messages/ask_a_question_messages/AAQ_messages/question_page_messages.py
@@ -6,6 +6,8 @@ class QuestionPageMessages:
     LOCKED_THREAD_BANNER = "This thread was closed. Please ask a new question if you need help."
     ARCHIVED_THREAD_BANNER = ("This thread was archived. Please ask a new question if you need "
                               "help.")
+    LOCKED_AND_ARCHIVED_BANNER = ("This thread was closed and archived. Please ask a new question"
+                                  " if you need help.")
     CHOSEN_SOLUTION_BANNER = "Thank you for choosing a solution!"
     CHOSEN_SOLUTION_CARD = "Chosen solution"
     CHOSEN_SOLUTION_REPLY_CARD = "Chosen Solution"

--- a/playwright_tests/messages/search_page_messages.py
+++ b/playwright_tests/messages/search_page_messages.py
@@ -1,0 +1,33 @@
+class SearchPageMessage:
+    EMPTY_SEARCH_RESULTS_MESSAGE = ("Try searching again with a different keyword, or browse our"
+                                    " featured articles below instead.")
+
+    def expected_found_search_results_message(self, search_results_count: str,
+                                              search_string: str,
+                                              product_filter_option: str) -> str:
+        """
+        Returns the expected search results string when a search result for the searched string is
+        successfully returned.
+
+        Args:
+            search_results_count (str): The expected search results counter inside the
+            search message.
+            search_string (str): The search string used inside the searchbar.
+            product_filter_option (str): The applied product filter.
+        """
+        return (f"Found {search_results_count} "
+                f"{'result' if search_results_count == '1' else 'results'} for ‘{search_string}’ "
+                f"for ‘{product_filter_option}’")
+
+
+    def expected_no_results_search_results_message(self, search_string: str,
+                                                   product_filter_option: str) -> str:
+        """
+        Returns the expected search results string when a search result for the searched string is
+        returning no search results.
+
+        Args:
+            search_string (str): The search string used inside the searchbar.
+            product_filter_option (str): The applied product filter.
+        """
+        return f"Sorry! 0 results found for ‘{search_string}’ for ‘{product_filter_option}’"

--- a/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
+++ b/playwright_tests/pages/ask_a_question/posted_question_pages/questions_page.py
@@ -54,6 +54,10 @@ class QuestionPage(BasePage):
 
         # Question details locators.
         self.question_details_button = page.locator("button[aria-controls='question-details']")
+        self.question_details_product = page.locator("//div[@id='question-details']//span"
+                                                     "[text()='Product:']/following-sibling::span")
+        self.question_details_topic = page.locator("//div[@id='question-details']//span"
+                                                   "[text()='Topic:']/following-sibling::span")
         self.more_system_details_modal = page.locator("div[class='mzp-c-modal']")
         self.more_system_details_option = page.locator("a#show-more-details")
         self.close_additional_system_details_button = page.locator(
@@ -275,6 +279,9 @@ class QuestionPage(BasePage):
     def get_chosen_solution_section_locator(self) -> Locator:
         return self.problem_solved_reply_section
 
+    def is_solution_section_displayed(self) -> bool:
+        return self._is_element_visible(self.problem_solved_reply_section)
+
     def get_solved_problem_banner_text(self) -> str:
         return self._get_text_of_element(self.problem_solved_banner_text)
 
@@ -400,6 +407,12 @@ class QuestionPage(BasePage):
     def click_on_question_details_button(self):
         self._click(self.question_details_button)
 
+    def get_question_details_product(self) -> str:
+        return self._get_text_of_element(self.question_details_product)
+
+    def get_question_details_topic(self) -> str:
+        return self._get_text_of_element(self.question_details_topic)
+
     def click_on_more_system_details_option(self):
         self._click(self.more_system_details_option)
 
@@ -509,6 +522,9 @@ class QuestionPage(BasePage):
 
     def get_thread_locked_locator(self) -> Locator:
         return self.lock_this_thread_banner
+
+    def is_thread_locked_banner_displayed(self) -> bool:
+        return self._is_element_visible(self.lock_this_thread_banner)
 
     def get_archive_this_question_locator(self) -> Locator:
         return self.archive_this_question_option

--- a/playwright_tests/pages/common_elements/common_web_elements.py
+++ b/playwright_tests/pages/common_elements/common_web_elements.py
@@ -48,6 +48,16 @@ class CommonWebElements(BasePage):
             f"//div[@class='card--topic']/div[@class='topic-header']/h3[@class='card--title']/a"
             f"[normalize-space(text())='{card_title}']/../../following-sibling::a")
 
+        # Pagination page locators
+        self.pagination_item = lambda pagination_item: page.locator(
+            "ol[class='pagination']").get_by_role("link").filter(has_text=pagination_item)
+        self.selected_pagination_item = page.locator(
+            "ol[class='pagination'] li[class='selected']").get_by_role("link")
+        self.previous_pagination_item = page.locator(
+            "//ol[@class='pagination']//span[text()='Previous']/..")
+        self.next_pagination_item= page.locator(
+            "//ol[@class='pagination']//span[text()='Next']/..")
+
     # Actions against the Avoid Spam Banner
     def get_scam_banner_text(self) -> str:
         """Returns the scam banner text."""
@@ -154,3 +164,23 @@ class CommonWebElements(BasePage):
                 return False
         utilities.navigate_back()
         return True
+
+    def click_on_pagination_item(self, pagination_item: str):
+        """Clicking on the pagination item"""
+        self._click(self.pagination_item(pagination_item))
+
+    def get_selected_pagination_item(self) -> str:
+        """Returning the selected pagination item"""
+        return self._get_text_of_element(self.selected_pagination_item)
+
+    def click_on_previous_pagination_item(self):
+        """Clicking on the previous pagination item."""
+        self._click(self.previous_pagination_item)
+
+    def click_on_next_pagination_item(self):
+        """Clicking on the next pagination item."""
+        self._click(self.next_pagination_item)
+
+    def is_next_pagination_item_visible(self) -> bool:
+        """Return if the next pagination item is visible or not."""
+        return self._is_element_visible(self.next_pagination_item)

--- a/playwright_tests/pages/contribute/contribute_pages/contributor_discussions/forum_discussions_page.py
+++ b/playwright_tests/pages/contribute/contribute_pages/contributor_discussions/forum_discussions_page.py
@@ -1,6 +1,6 @@
 import re
 
-from playwright.sync_api import Page
+from playwright.sync_api import Page, ElementHandle
 
 from playwright_tests.core.basepage import BasePage
 
@@ -22,6 +22,10 @@ class ForumDiscussionsPage(BasePage):
         # Locators related to the search section.
         self.search_this_forum_search_field = page.locator("form#find-thread input#search-q")
         self.search_this_forum_search_button = page.locator("form#find-thread input.search-button")
+        self.search_results_headers = page.locator(
+            "//div[@id='search-results']//h3[@class='sumo-card-heading']/a")
+        self.search_results_body = page.locator(
+            "//div[@id='search-results']//div[@class='topic-article--text']/p")
 
         # Locators related to the threads table.
         self.thread_title = lambda thread_name : page.locator(
@@ -81,3 +85,16 @@ class ForumDiscussionsPage(BasePage):
         option = super()._get_text_of_element(
             self.forum_side_nav_selected_option)
         return re.sub(r'\s+', ' ', option).strip()
+
+    def search_in_community_discussion(self, search_string: str):
+        self._fill(self.search_this_forum_search_field, search_string)
+        self._click(self.search_this_forum_search_button)
+
+    def get_all_thread_titles_from_search_results(self) -> list[str]:
+        return self._get_text_of_elements(self.search_results_headers)
+
+    def get_all_thread_titles_from_search_results_handles(self) -> list[ElementHandle]:
+        return self._get_element_handles(self.search_results_headers)
+
+    def get_all_thread_content_from_search_results(self) -> list[str]:
+        return self._get_text_of_elements(self.search_results_body)

--- a/playwright_tests/pages/contribute/contributor_tools_pages/community_hub_page.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/community_hub_page.py
@@ -1,0 +1,35 @@
+from playwright.sync_api import Page
+from playwright_tests.core.basepage import BasePage
+
+
+class CommunityHubPage(BasePage):
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+        # Locators belonging to the Community Hub searchbar.
+        self.find_contributor_searchbar = page.locator(
+            "//form[@id='find-contributor']//input[@id='search']")
+
+        # Locators belonging to search result cards
+        self.user_titles_from_returned_cards = page.locator(
+            "section[class='card elevation-01 results-user'] h2[class='card--title']")
+
+
+    def search_for_contributor(self, search_string: str):
+        """
+        Search for a contributor
+
+        Args:
+            search_string (str): Search string.
+        """
+        self._fill(self.find_contributor_searchbar, search_string)
+        self._press_a_key(self.find_contributor_searchbar, "Enter")
+
+    def clear_search(self):
+        """Clear the searchbar."""
+        self._clear_field(self.find_contributor_searchbar)
+
+    def get_all_users_from_user_cards(self) -> list[str]:
+        """Returns all user titles from user cards."""
+        return self._get_text_of_elements(self.user_titles_from_returned_cards)
+

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -70,6 +70,8 @@ from playwright_tests.pages.contribute.contribute_pages.ways_to_contribute_pages
 from playwright_tests.pages.contribute.contributor_tools_pages.article_discussions_page import (
     ArticleDiscussionsPage,
 )
+from playwright_tests.pages.contribute.contributor_tools_pages.community_hub_page import \
+    CommunityHubPage
 from playwright_tests.pages.contribute.contributor_tools_pages.kb_dashboard_page import KBDashboard
 from playwright_tests.pages.contribute.contributor_tools_pages.l10n_most_visited_translations import (
     MostVisitedTranslations,
@@ -180,6 +182,9 @@ class SumoPages:
 
         # Contribute page.
         self.contribute_page = ContributePage(page)
+
+        # Community hub page.
+        self.community_hub_page = CommunityHubPage(page)
 
         # AAQ Pages
         self.aaq_form_page = AAQFormPage(page)

--- a/playwright_tests/pages/top_navbar.py
+++ b/playwright_tests/pages/top_navbar.py
@@ -52,6 +52,7 @@ class TopNavbar(BasePage):
             "//h4[text()='Browse by product']/../following-sibling::ul/li/a")
         self.browse_all_forum_threads_by_topics_top_navbar_options = page.locator(
             "//h4[text()='Browse all forum threads by topic']/../following-sibling::ul/li/a")
+
         # Locators belonging to the 'Contribute' top-navbar section.
         self.contribute_option = page.get_by_role("link").filter(has_text="Contribute")
         self.contributor_discussions_top_navbar_header = page.locator(
@@ -76,6 +77,9 @@ class TopNavbar(BasePage):
         self.guides_option = page.locator(
             "ul[class='mzp-c-menu-item-list sumo-nav--sublist']").get_by_role("link").filter(
             has_text="Guides")
+        self.community_hub_option = page.locator(
+            "ul[class='mzp-c-menu-item-list sumo-nav--sublist']").get_by_role("link").filter(
+            has_text="Community hub")
 
         # Locators belonging to the 'Sign In/Up' top-navbar section.
         self.signin_signup_button = page.locator("div#profile-navigation").get_by_role(
@@ -217,6 +221,11 @@ class TopNavbar(BasePage):
         """Click on the 'Guides' option"""
         self.hover_over_contribute_top_navbar()
         self._click(self.guides_option)
+
+    def click_on_community_hub_option(self):
+        """Click on the 'Community hub' option"""
+        self.hover_over_contribute_top_navbar()
+        self._click(self.community_hub_option)
 
     """
         Actions against the sign-in/sign-up top-navbar section.

--- a/playwright_tests/pages/user_pages/my_profile_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_page.py
@@ -158,7 +158,7 @@ class MyProfilePage(BasePage):
         return self._get_text_of_element(self.questions_link)
 
     def is_question_displayed(self) -> bool:
-        """Check if the question is displayed."""
+        """Check if the question link is displayed."""
         return self._is_element_visible(self.questions_link)
 
     def get_my_profile_solutions_text(self) -> str:
@@ -192,6 +192,10 @@ class MyProfilePage(BasePage):
     def click_my_profile_answers_link(self):
         """Click on the profile answers link."""
         self._click(self.answers_link)
+
+    def is_my_profile_answers_link_visible(self) -> bool:
+        """Verifying if the profile answers link option is visible."""
+        return self._is_element_visible(self.answers_link)
 
     def click_on_my_profile_questions_link(self):
         """Click on the profile questions link."""

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -31,6 +31,7 @@ markers =
     create_delete_article: Fixture used for creating and deleting test articles.
     exploreByTopics: Tests belonging to the explore help articles by topics page.
     searchTests: Tests belonging to the search functionality.
+    contributorForumSearch: Tests belonging to the contributor forums search functionality.
     userGroupsTests: Tests belonging to the user groups section.
     antiSpamTests: Tests belonging to the anti-spam measures section.
     contributorDiscussions: Tests belonging to the contributor discussions forums page.

--- a/playwright_tests/test_data/search_synonym.py
+++ b/playwright_tests/test_data/search_synonym.py
@@ -8,6 +8,7 @@ class SearchSynonyms:
         'cache': ['cash', 'cookies'],
         'popup': ['pop up'],
         'pop up': ['popup'],
+        'pop-up':['pop-ups', 'popups'],
         'popups': ['pop-up', 'pop-ups', 'pop ups', 'pops up'],
 
         # Actions

--- a/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/aaq_tests/test_aaq_form_page.py
@@ -346,10 +346,11 @@ def test_share_firefox_data_functionality(page: Page, create_user_factory):
         sumo_pages.aaq_form_page.add_text_to_troubleshooting_information_textarea(
             utilities.aaq_question_test_data["troubleshooting_information"]
         )
-        utilities.re_call_function_on_error(
-            sumo_pages.aaq_form_page.click_aaq_form_submit_button,
-            expected_locator=sumo_pages.question_page.questions_header
-        )
+        with utilities.page.expect_navigation():
+            utilities.re_call_function_on_error(
+                sumo_pages.aaq_form_page.click_aaq_form_submit_button,
+                expected_locator=sumo_pages.question_page.questions_header
+            )
 
     with allure.step("Verifying that the troubleshooting information is displayed"):
         sumo_pages.question_page.click_on_question_details_button()
@@ -441,10 +442,11 @@ def test_system_details_information(page: Page, create_user_factory):
                 with check, allure.step("Submitting the AAQ question and verifying that the "
                                         "correct provided troubleshooting information is "
                                         "displayed"):
-                    utilities.re_call_function_on_error(
-                        sumo_pages.aaq_form_page.click_aaq_form_submit_button,
-                        expected_locator=sumo_pages.question_page.questions_header
-                    )
+                    with utilities.page.expect_navigation():
+                        utilities.re_call_function_on_error(
+                            sumo_pages.aaq_form_page.click_aaq_form_submit_button,
+                            expected_locator=sumo_pages.question_page.questions_header
+                        )
 
                     sumo_pages.question_page.click_on_question_details_button()
                     assert sumo_pages.question_page.get_system_details_information(
@@ -485,11 +487,12 @@ def test_premium_products_aaq(page: Page):
                     is_premium=True
                 )
                 if utilities.get_page_url() == premium_form_link:
-                    utilities.re_call_function_on_error(
-                        sumo_pages.aaq_form_page.click_aaq_form_submit_button,
-                        with_force=True,
-                        expected_locator=sumo_pages.question_page.questions_header
-                    )
+                    with utilities.page.expect_navigation():
+                        utilities.re_call_function_on_error(
+                            sumo_pages.aaq_form_page.click_aaq_form_submit_button(),
+                            with_force=True,
+                            expected_locator=sumo_pages.question_page.questions_header
+                        )
 
         with allure.step("Verifying that the correct success message is displayed"):
             assert sumo_pages.aaq_form_page.get_premium_card_submission_message(

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
@@ -289,7 +289,7 @@ def test_restricted_visibility_in_recent_revisions(page: Page, is_template,
 
 
 # C2466524
-@pytest.mark.kbRestrictedVisibility1
+@pytest.mark.kbRestrictedVisibility
 @pytest.mark.parametrize("is_template", [False, True])
 def test_kb_restricted_visibility_media_gallery(page: Page, is_template,
                                                 create_user_factory):

--- a/playwright_tests/tests/search_tests/test_contributor_forums_seach.py
+++ b/playwright_tests/tests/search_tests/test_contributor_forums_seach.py
@@ -1,0 +1,310 @@
+import random
+
+import allure
+import pytest
+from playwright.sync_api import Page
+from pytest_check import check
+from playwright_tests.core.utilities import Utilities
+from playwright_tests.messages.contribute_messages.con_discussions.con_discussions_messages import \
+    ConDiscussionsMessages
+from playwright_tests.pages.sumo_pages import SumoPages
+
+
+# C1359175
+@pytest.mark.contributorForumSearch
+def test_by_thread_title(page: Page, create_user_factory):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    test_user = create_user_factory(groups=["forum-contributors"])
+    thread_title = "contribution"
+
+    with allure.step(f"Signing in with {test_user['username']} and navigating to the contributor"
+                     f"forums"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.top_navbar.click_on_contributor_discussions_top_navbar_option()
+
+    with allure.step("Navigating to the 'SUMO community discussions' forum"):
+        sumo_pages.contributor_discussions_page.click_on_an_available_contributor_forum(
+            "SUMO community discussions")
+
+    with check, allure.step("Searching for the test string and verifying that all search results"
+                            "include the searched term"):
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            f"field:thread_title:{thread_title}")
+        assert all(thread_title in thread_title for thread_title in sumo_pages.
+                   forum_discussions_page.get_all_thread_titles_from_search_results())
+
+
+# C1350866, C1350867, C1350868
+@pytest.mark.contributorForumSearch
+def test_and_or_not_operators_in_community_forums(page: Page, create_user_factory):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    test_user = create_user_factory(groups=["forum-contributors"])
+    target_user_first_name = "Ryan"
+    target_user_last_name = "Johnson"
+
+    with allure.step(f"Navigating to the 'Community hub' page and searching "
+                     f"for {target_user_first_name} + {target_user_last_name}"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.top_navbar.click_on_community_hub_option()
+        sumo_pages.community_hub_page.search_for_contributor(
+            target_user_first_name + ' ' + target_user_last_name)
+        cards = sumo_pages.community_hub_page.get_all_users_from_user_cards()
+
+    with check, allure.step(f"Verifying that the {target_user_first_name} + ' ' +"
+                            f" {target_user_last_name} is in all returned user cards"):
+        assert all(
+            target_user_first_name.lower() in card.lower() and target_user_last_name
+            .lower() in card.lower() for card in cards)
+
+    with check, allure.step("Using AND operator to search for full name and verifying that the "
+                            "same list is returned"):
+        sumo_pages.community_hub_page.clear_search()
+        sumo_pages.community_hub_page.search_for_contributor(
+            target_user_first_name + " AND " + target_user_last_name)
+        assert cards == sumo_pages.community_hub_page.get_all_users_from_user_cards()
+
+    with check, allure.step("Using the OR operator to search for full name and verifying that "
+                            "cards containing the first name or the last name are returned"):
+        sumo_pages.community_hub_page.clear_search()
+        sumo_pages.community_hub_page.search_for_contributor(
+            target_user_first_name + " OR " + target_user_last_name)
+        cards = sumo_pages.community_hub_page.get_all_users_from_user_cards()
+        assert all(
+            target_user_first_name.lower() in card.lower() or target_user_last_name.
+            lower() in card.lower() for card in cards)
+
+    with check, allure.step("Using the NOT operator to search for full name and verifying that "
+                            "only the first name is returned"):
+        sumo_pages.community_hub_page.clear_search()
+        sumo_pages.community_hub_page.search_for_contributor(
+            target_user_first_name + " NOT " + target_user_last_name)
+        cards = sumo_pages.community_hub_page.get_all_users_from_user_cards()
+        assert all(target_user_first_name.lower() in card.lower() for card in cards)
+        assert all(target_user_last_name.lower() not in card.lower() for card in cards)
+
+
+# C1350863, C1350992, C1350865, C1350864
+@pytest.mark.contributorForumSearch
+def test_and_or_not_operators_in_contributor_forums(page: Page, create_user_factory):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    test_user = create_user_factory(groups=["forum-contributors"])
+    search_term_one = "test"
+    search_term_two = "thread"
+
+    with allure.step(f"Signing in with {test_user['username']} and navigating to the contributor"
+                     f"forums"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.top_navbar.click_on_contributor_discussions_top_navbar_option()
+
+    with allure.step("Navigating to the 'SUMO community discussions' forum"):
+        sumo_pages.contributor_discussions_page.click_on_an_available_contributor_forum(
+            "SUMO community discussions")
+
+    with check, allure.step("Searching for the test string and verifying that all search results"
+                            "include the searched term"):
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            search_term_one + ' ' + search_term_two)
+        assert any(
+            all(term in item.lower() for term in [search_term_one, search_term_two]
+                ) for item in sumo_pages.forum_discussions_page.
+            get_all_thread_titles_from_search_results() or any(
+                all(term in item.lower() for term in [search_term_one, search_term_two]
+                    ) for item in sumo_pages.forum_discussions_page.
+                get_all_thread_content_from_search_results()))
+
+    with check, allure.step("Navigating back, searching for the search term by using the AND"
+                            " operator and verifying that all search results include the search "
+                            "term"):
+        utilities.navigate_back()
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            search_term_one + ' AND ' + search_term_two)
+        assert (
+            any(search_term_one in item.lower() and search_term_two in item
+                .lower() for item in sumo_pages.forum_discussions_page.
+                get_all_thread_titles_from_search_results()
+                ) or any(search_term_one in item.lower() and search_term_two in item.
+                         lower() for item in sumo_pages.forum_discussions_page.
+                         get_all_thread_content_from_search_results())
+        )
+
+    with check, allure.step("Navigating back, searching for the search term by using the 'OR' "
+                            "operator and verifying that the search results include the first or "
+                            "second search term"):
+        utilities.navigate_back()
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            search_term_one + ' OR ' + search_term_two)
+        assert(
+            any(search_term_one in item.lower() or search_term_two in item.
+                lower() for item in sumo_pages.forum_discussions_page.
+                get_all_thread_titles_from_search_results()
+                ) or any(search_term_one in item.lower() or search_term_two in item.
+                         lower() for item in sumo_pages.forum_discussions_page.
+                         get_all_thread_content_from_search_results())
+        )
+
+    with check, allure.step("Navigating back, searching for the search term by using the 'NOT'"
+                            "operator and verifying that the search results include the first "
+                            "but not the second search term"):
+        utilities.navigate_back()
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            search_term_one + ' NOT ' + search_term_two)
+        assert(
+            any(search_term_one in item.lower() for item in sumo_pages.forum_discussions_page.
+                get_all_thread_titles_from_search_results()
+                ) or any(search_term_one in item.lower() for item in sumo_pages.
+                         forum_discussions_page.get_all_thread_content_from_search_results())
+        ) and not (
+            any(search_term_two in item.lower().split() for item in sumo_pages.
+                forum_discussions_page.get_all_thread_titles_from_search_results()
+                ) or any(search_term_two in item.lower().split() for item in sumo_pages.
+                         forum_discussions_page.get_all_thread_content_from_search_results())
+        )
+
+    with check, allure.step("Navigating back, searching for the search term by matching the exact "
+                            "search string and verifying that the search results contain the "
+                            "search strings"):
+        utilities.navigate_back()
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            f'"{search_term_one} '+ f'{search_term_two}"')
+        assert(
+            any(search_term_one + " " + search_term_two in item.lower() for item in sumo_pages.
+                forum_discussions_page.get_all_thread_titles_from_search_results()
+                ) or any(search_term_one + " " + search_term_two in item.
+                         lower() for item in sumo_pages.forum_discussions_page.
+                         get_all_thread_content_from_search_results())
+        )
+
+# C1329242
+@pytest.mark.contributorForumSearch
+def test_searching_in_contributor_forums_return_results_only_to_that_forum(page,
+                                                                           create_user_factory):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    thread_title = "Test Contributor Thread " + utilities.generate_random_number(1, 1000)
+    test_user = create_user_factory(groups=["forum-contributors"])
+
+    utilities.start_existing_session(cookies=test_user)
+    with allure.step("Navigating to Contributor Discussions"):
+        utilities.navigate_to_link(ConDiscussionsMessages.PAGE_URL)
+
+    with allure.step("Clicking on the SUMO community discussions forum"):
+        sumo_pages.contributor_discussions_page.click_on_an_available_contributor_forum(
+            "SUMO community discussions")
+
+    with allure.step("Creating a new forum thread"):
+        sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title=thread_title,
+            thread_body="Contributor Thread body test"
+        )
+        utilities.wait_for_given_timeout(65000)
+
+    with allure.step("Navigating back to the SUMO community discussions page"):
+        sumo_pages.forum_thread_page.click_on_a_breadcrumb_link("SUMO community discussions")
+
+    with check, allure.step("Searching this forum for the posted thread and verifying that the "
+                            "thread is returned"):
+        sumo_pages.forum_discussions_page.search_in_community_discussion(thread_title)
+        assert (thread_title in sumo_pages.forum_discussions_page.
+                get_all_thread_titles_from_search_results())
+
+    with allure.step("Navigating back to the Contributor Discussions page"):
+        utilities.navigate_to_link(ConDiscussionsMessages.PAGE_URL)
+
+    with allure.step("Clicking on the Support Forum discussions thread"):
+        sumo_pages.contributor_discussions_page.click_on_an_available_contributor_forum(
+            "Support Forum discussions")
+
+    with check, allure.step("Searching this forum for the posted thread and verifying that the "
+                            "thread is returned"):
+        sumo_pages.forum_discussions_page.search_in_community_discussion(thread_title)
+        assert (thread_title not in sumo_pages.forum_discussions_page.
+                get_all_thread_titles_from_search_results())
+
+
+# C1359176
+@pytest.mark.contributorForumSearch
+def test_by_thread_locked_status(page: Page, create_user_factory):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    test_user = create_user_factory(groups=["forum-contributors"],
+                                    permissions=["lock_forum_thread"])
+
+    with allure.step(f"Signing in with {test_user['username']} and navigating to the contributor"
+                     f"forums"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.top_navbar.click_on_contributor_discussions_top_navbar_option()
+
+    with allure.step("Navigating to the 'SUMO community discussions' forum"):
+        sumo_pages.contributor_discussions_page.click_on_an_available_contributor_forum(
+            "SUMO community discussions")
+        forum_url = utilities.get_page_url()
+
+    with check, allure.step("Searching for locked threads and verifying that the returned search"
+                            "results are locked."):
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            "field:thread_is_locked:true")
+        results = (sumo_pages.forum_discussions_page.
+                   get_all_thread_titles_from_search_results_handles())
+        random.choice(results).click()
+
+        assert sumo_pages.forum_thread_page.is_unlock_this_thread_option_visible()
+        assert "Locked" in sumo_pages.forum_thread_page.get_thread_meta_information()
+
+    with check, allure.step("Navigating back to the forum page, searching for unlocked threads "
+                            "and verifying that the returned search results are unlocked."):
+        utilities.navigate_to_link(forum_url)
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            "field:thread_is_locked:false")
+        results = (sumo_pages.forum_discussions_page.
+                   get_all_thread_titles_from_search_results_handles())
+        random.choice(results).click()
+
+        assert sumo_pages.forum_thread_page.is_lock_this_thread_option_visible()
+        assert "Locked" not in sumo_pages.forum_thread_page.get_thread_meta_information()
+
+
+# C1359177
+@pytest.mark.contributorForumSearch
+def test_by_sticky_status(page: Page, create_user_factory):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    test_user = create_user_factory(groups=["forum-contributors"],
+                                    permissions=["sticky_forum_thread"])
+
+    with allure.step(f"Signing in with {test_user['username']} and navigating to the contributor"
+                     f"forums"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.top_navbar.click_on_contributor_discussions_top_navbar_option()
+
+    with allure.step("Navigating to the 'SUMO community discussions' forum"):
+        sumo_pages.contributor_discussions_page.click_on_an_available_contributor_forum(
+            "SUMO community discussions")
+        forum_url = utilities.get_page_url()
+
+    with check, allure.step("Searching for sticky threads and verifying that the returned search"
+                            "results are sticky."):
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            "field:thread_is_sticky:true")
+        results = (sumo_pages.forum_discussions_page.
+                   get_all_thread_titles_from_search_results_handles())
+        random.choice(results).click()
+
+        assert sumo_pages.forum_thread_page.is_unsticky_this_thread_option_visible()
+        assert "Sticky" in sumo_pages.forum_thread_page.get_thread_meta_information()
+
+    with check, allure.step("Navigating back to the forum page, searching for non sticky threads "
+                            "and verifying that the returned search results are not sticky."):
+        utilities.navigate_to_link(forum_url)
+        sumo_pages.forum_discussions_page.search_in_community_discussion(
+            "field:thread_is_sticky:false")
+        results = (sumo_pages.forum_discussions_page.
+                   get_all_thread_titles_from_search_results_handles())
+        random.choice(results).click()
+
+        assert sumo_pages.forum_thread_page.is_sticky_this_thread_option_visible()
+        assert "Sticky" not in sumo_pages.forum_thread_page.get_thread_meta_information()
+
+

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -3,6 +3,8 @@ import pytest
 from pytest_check import check
 from playwright.sync_api import expect, Page
 from playwright_tests.core.utilities import Utilities
+from playwright_tests.messages.contribute_messages.con_discussions.off_topic import \
+    OffTopicForumMessages
 from playwright_tests.messages.homepage_messages import HomepageMessages
 from playwright_tests.messages.my_profile_pages_messages.edit_my_profile_page_messages import \
     EditMyProfilePageMessages
@@ -129,6 +131,37 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page,
         sumo_pages.question_page.click_delete_this_question_question_tools_option()
         sumo_pages.question_page.click_delete_this_question_button()
         expect(sumo_pages.product_support_page.product_product_title_element()).to_be_visible()
+
+
+# C1318760
+@pytest.mark.userProfile
+def test_number_of_answers_and_questions_for_contributor_thread_contributions(page: Page,
+                                                                              create_user_factory):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+    test_user = create_user_factory(groups=["forum-contributors"])
+
+    with allure.step("Signing in with a contributor account and navigating to the Off topic"
+                     "forum"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+
+    with allure.step("Creating a new thread"):
+        thread_title = (utilities.discussion_thread_data['thread_title'] + utilities.
+                        generate_random_number(1, 1000))
+        sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title=thread_title,
+            thread_body=utilities.discussion_thread_data['thread_body'])
+
+    with allure.step("Creating a new thread reply"):
+        sumo_pages.contributor_thread_flow.post_thread_reply(
+            reply_body=utilities.discussion_thread_data['thread_body'])
+
+    with allure.step("Navigating to the profile page and verifying that the answer and questions "
+                     "counter has not incremented"):
+        sumo_pages.top_navbar.click_on_view_profile_option()
+        assert not sumo_pages.my_profile_page.is_question_displayed()
+        assert not sumo_pages.my_profile_page.is_my_profile_answers_link_visible()
 
 
 # C890832,  C2094281, C891410, C2245210, C2245211, C2245212, C2245209


### PR DESCRIPTION
Added the following assertions:
* Verify that the number of answers and questions at profile level are not influenced by Contributor thread posts.
* Verify that the search successfully returns the expected search results when using the following advanced search syntax: `field:question_num_votes`, `field:question_tag_ids`, field:question_topic_id`, field:question_product_id`, `field:question_has_solution`, `field:question_is_locked`, `field:question_is_archived`, `field:doc_id.en-US`
* Verify that archived questions are not returned in simple search (only when using the `field:question_title.en-US` or `field:question_content.en-US` advanced search syntax)
* Verifying the product filter functionality from the search page.
* Verifying that obsolete marked articles are not returned in search results. Also verifying that unmarking an article from being obsolete is going to successfully expose the article inside the search results.
* Verifying that the users scroll position is going to be moved to the top of the page when interacting with the search pagination options.
* Expanding the search functionality test coverage over the searchbar available inside the Contributor forums and Community Hub page.
* Adding locators and page objects.
* Improving the stability of some tests.