### PR TITLE
POC commit for semantic search

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - discovery.type=single-node
       - LOG4J_FORMAT_MSG_NO_LOOKUPS=true
       - xpack.security.enabled=false
+      - xpack.license.self_generated.type=trial
       - action.destructive_requires_name=false
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
       - network.host=0.0.0.0

--- a/kitsune/search/base.py
+++ b/kitsune/search/base.py
@@ -58,8 +58,12 @@ class SumoDocument(DSLDocument):
         cls.Index.base_name = f"{settings.ES_INDEX_PREFIX}_{name.lower()}"
         cls.Index.read_alias = f"{cls.Index.base_name}_read"
         cls.Index.write_alias = f"{cls.Index.base_name}_write"
-        # Bump the refresh interval to 1 minute
-        cls.Index.settings = {"refresh_interval": DEFAULT_ES_REFRESH_INTERVAL}
+        # Bump the refresh interval to 1 minute and increase field limit for semantic fields
+        cls.Index.settings = {
+            "refresh_interval": DEFAULT_ES_REFRESH_INTERVAL,
+            "mapping.nested_fields.limit": 1000,  # Increase from default 50 to support semantic fields
+            "mapping.total_fields.limit": 2000,   # Increase total field limit as well
+        }
 
         # this is the attribute elastic-dsl actually uses to determine which index
         # to query. we override the .search() method to get that to use the read

--- a/kitsune/search/documents.py
+++ b/kitsune/search/documents.py
@@ -6,7 +6,12 @@ from kitsune.questions.models import Answer, Question
 from kitsune.search import config
 from kitsune.search.base import SumoDocument
 from kitsune.search.es_utils import es_client
-from kitsune.search.fields import SumoLocaleAwareKeywordField, SumoLocaleAwareTextField
+from kitsune.search.fields import (
+    SemanticTextField,
+    SumoLocaleAwareKeywordField,
+    SumoLocaleAwareSemanticTextField,
+    SumoLocaleAwareTextField,
+)
 from kitsune.users.models import Profile
 from kitsune.wiki import models as wiki_models
 from kitsune.wiki.config import (
@@ -36,6 +41,12 @@ class WikiDocument(SumoDocument):
     keywords = SumoLocaleAwareTextField()
     slug = SumoLocaleAwareKeywordField(store=True)
     doc_id = SumoLocaleAwareKeywordField(store=True)
+
+    # Semantic text fields for Elasticsearch semantic search
+    title_semantic = SumoLocaleAwareSemanticTextField()
+    content_semantic = SumoLocaleAwareSemanticTextField()
+    summary_semantic = SumoLocaleAwareSemanticTextField()
+    keywords_semantic = SumoLocaleAwareSemanticTextField()
 
     class Index:
         pass
@@ -86,6 +97,22 @@ class WikiDocument(SumoDocument):
 
     def prepare_display_order(self, instance):
         return instance.original.display_order
+
+    # Semantic field preparation methods
+    def prepare_title_semantic(self, instance):
+        return instance.title
+
+    def prepare_content_semantic(self, instance):
+        return instance.html
+
+    def prepare_summary_semantic(self, instance):
+        if instance.current_revision:
+            return instance.summary
+        return ""
+
+    def prepare_keywords_semantic(self, instance):
+        """Return the current revision's keywords as a string."""
+        return getattr(instance.current_revision, "keywords", "")
 
     @classmethod
     def get_model(cls):
@@ -144,6 +171,11 @@ class QuestionDocument(SumoDocument):
 
     locale = field.Keyword()
 
+    # Semantic text fields for Elasticsearch semantic search
+    question_title_semantic = SumoLocaleAwareSemanticTextField()
+    question_content_semantic = SumoLocaleAwareSemanticTextField()
+    answer_content_semantic = SumoLocaleAwareSemanticTextField()
+
     class Index:
         pass
 
@@ -185,6 +217,26 @@ class QuestionDocument(SumoDocument):
         if field.startswith("question_"):
             field = field[len("question_") :]
         return super().get_field_value(field, *args)
+
+    # Semantic field preparation methods
+    def prepare_question_title_semantic(self, instance):
+        return instance.title
+
+    def prepare_question_content_semantic(self, instance):
+        return instance.content
+
+    def prepare_answer_content_semantic(self, instance):
+        return [
+            answer.content
+            for answer in (
+                # when bulk indexing use answer queryset prefetched in `get_queryset` method
+                # this is to avoid running an extra query for each question in the chunk
+                instance.es_question_answers_not_spam
+                if hasattr(instance, "es_question_answers_not_spam")
+                # fallback if non-spam answers haven't been prefetched
+                else instance.answers.filter(is_spam=False)
+            )
+        ]
 
     @classmethod
     def get_model(cls):
@@ -236,6 +288,9 @@ class AnswerDocument(QuestionDocument):
 
     is_solution = field.Boolean()
 
+    # Semantic text field for Elasticsearch semantic search
+    content_semantic = SumoLocaleAwareSemanticTextField()
+
     @classmethod
     def prepare(cls, instance, **kwargs):
         """Override super method to exclude certain docs."""
@@ -270,6 +325,9 @@ class AnswerDocument(QuestionDocument):
         # clear answer_content field from QuestionDocument,
         # as we don't need the content of sibling answers in an AnswerDocument
         return None
+
+    def prepare_content_semantic(self, instance):
+        return instance.content
 
     def get_field_value(self, field, instance, *args):
         if field.startswith("question_"):
@@ -325,6 +383,9 @@ class ProfileDocument(SumoDocument):
     product_ids = field.Keyword(multi=True)
     group_ids = field.Keyword(multi=True)
 
+    # Semantic text field for Elasticsearch semantic search
+    name_semantic = SemanticTextField()
+
     class Index:
         pass
 
@@ -358,6 +419,9 @@ class ProfileDocument(SumoDocument):
     def prepare_group_ids(self, instance):
         return [group.id for group in instance.user.groups.all()]
 
+    def prepare_name_semantic(self, instance):
+        return instance.name
+
     @classmethod
     def get_model(cls):
         return Profile
@@ -387,6 +451,10 @@ class ForumDocument(SumoDocument):
     updated = field.Date()
     updated_by_id = field.Keyword()
 
+    # Semantic text fields for Elasticsearch semantic search
+    thread_title_semantic = SemanticTextField()
+    content_semantic = SemanticTextField()
+
     class Index:
         pass
 
@@ -398,6 +466,12 @@ class ForumDocument(SumoDocument):
             instance = instance.thread
             field = field[len("thread_") :]
         return super().get_field_value(field, instance, *args)
+
+    def prepare_thread_title_semantic(self, instance):
+        return instance.thread.title
+
+    def prepare_content_semantic(self, instance):
+        return instance.content
 
     @classmethod
     def get_model(cls):

--- a/kitsune/search/documents.py
+++ b/kitsune/search/documents.py
@@ -473,7 +473,13 @@ class ForumDocument(SumoDocument):
         return super().get_field_value(field, instance, *args)
 
     def prepare_thread_title_semantic(self, instance):
-        return instance.thread.title
+        # instance could be a Post or Thread depending on context
+        # For Posts, get the thread title; for Threads, get the title directly
+        if hasattr(instance, 'thread') and instance.thread:
+            return instance.thread.title
+        else:
+            # instance is likely a Thread itself
+            return instance.title
 
     def prepare_content_semantic(self, instance):
         return instance.content

--- a/kitsune/search/documents.py
+++ b/kitsune/search/documents.py
@@ -329,6 +329,11 @@ class AnswerDocument(QuestionDocument):
     def prepare_content_semantic(self, instance):
         return instance.content
 
+    def prepare_answer_content_semantic(self, instance):
+        # For AnswerDocument, we don't need answer_content_semantic since this IS an answer
+        # Override the inherited method to avoid the AttributeError
+        return None
+
     def get_field_value(self, field, instance, *args):
         if field.startswith("question_"):
             instance = instance.question

--- a/kitsune/search/fields.py
+++ b/kitsune/search/fields.py
@@ -11,7 +11,7 @@ SUPPORTED_LANGUAGES = list(settings.SUMO_LANGUAGES)
 SUPPORTED_LANGUAGES.remove("xx")
 
 # Default E5 multilingual model
-DEFAULT_E5_MODEL = getattr(settings, 'ELASTICSEARCH_SEMANTIC_MODEL_ID', '.multilingual-e5-small')
+DEFAULT_E5_MODEL = getattr(settings, 'ELASTICSEARCH_SEMANTIC_MODEL_ID', '.multilingual-e5-small-elasticsearch')
 
 
 def SemanticTextField(**params):

--- a/kitsune/search/fields.py
+++ b/kitsune/search/fields.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from django.conf import settings
-from elasticsearch.dsl import Keyword, Text
+from elasticsearch.dsl import Keyword, Text, field
 from elasticsearch.dsl import Object as DSLObject
 
 from kitsune.search.es_utils import es_analyzer_for_locale
@@ -9,6 +9,22 @@ from kitsune.search.es_utils import es_analyzer_for_locale
 SUPPORTED_LANGUAGES = list(settings.SUMO_LANGUAGES)
 # this is a test locale - no need to add it to ES
 SUPPORTED_LANGUAGES.remove("xx")
+
+# Default E5 multilingual model
+DEFAULT_E5_MODEL = getattr(settings, 'ELASTICSEARCH_SEMANTIC_MODEL_ID', '.multilingual-e5-small')
+
+
+def SemanticTextField(**params):
+    """
+    Create a semantic_text field for E5 multilingual semantic search.
+
+    Args:
+        **params: Additional parameters for the field
+
+    Returns:
+        field.SemanticText: Configured semantic text field for E5 multilingual model
+    """
+    return field.SemanticText(inference_id=DEFAULT_E5_MODEL, **params)
 
 
 def _get_fields(field, locales, **params):
@@ -44,3 +60,24 @@ SumoKeywordField = partial(construct_locale_field, field=Keyword)
 # {'en-US': Text(analyzer_for_the_specific_locale)}
 SumoLocaleAwareTextField = partial(SumoTextField, locales=SUPPORTED_LANGUAGES)
 SumoLocaleAwareKeywordField = partial(SumoKeywordField, locales=SUPPORTED_LANGUAGES)
+
+
+# Semantic text field for multi-language support with E5 multilingual model
+def SumoLocaleAwareSemanticTextField(**params):
+    """
+    Create a locale-aware semantic text field using E5 multilingual model.
+
+    This creates an object field with semantic_text subfields for each supported locale,
+    all using E5 multilingual model for semantic search.
+
+    Args:
+        **params: Additional parameters for each semantic text field
+
+    Returns:
+        DSLObject: Object field containing E5 semantic text fields for each locale
+    """
+    inner_fields = {}
+    for locale in SUPPORTED_LANGUAGES:
+        inner_fields[locale] = field.SemanticText(inference_id=DEFAULT_E5_MODEL, **params)
+
+    return DSLObject(properties=inner_fields)

--- a/kitsune/search/management/commands/setup_semantic_search.py
+++ b/kitsune/search/management/commands/setup_semantic_search.py
@@ -1,0 +1,175 @@
+"""
+Management command to set up E5 multilingual inference endpoint for semantic search.
+
+This command helps configure the E5 multilingual model required for semantic_text fields.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+from elasticsearch.exceptions import RequestError
+
+from kitsune.search.es_utils import es_client
+from kitsune.search.semantic_config import DEFAULT_EMBEDDING_MODEL, E5_MODELS
+
+
+class Command(BaseCommand):
+    help = 'Set up E5 multilingual inference endpoint for semantic search'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--model-id',
+            type=str,
+            default=DEFAULT_EMBEDDING_MODEL,
+            choices=list(E5_MODELS.keys()),
+            help=f'E5 model to use (default: {DEFAULT_EMBEDDING_MODEL})'
+        )
+        parser.add_argument(
+            '--check-endpoint',
+            action='store_true',
+            help='Check if E5 inference endpoint is already configured'
+        )
+        parser.add_argument(
+            '--num-allocations',
+            type=int,
+            default=1,
+            help='Number of model allocations (default: 1)'
+        )
+        parser.add_argument(
+            '--num-threads',
+            type=int,
+            default=1,
+            help='Number of threads per allocation (default: 1)'
+        )
+
+    def handle(self, *args, **options):
+        model_id = options['model_id']
+
+        if options['check_endpoint']:
+            self.check_e5_endpoint(model_id)
+            return
+
+        try:
+            es = es_client()
+            self.setup_e5_endpoint(
+                es,
+                model_id,
+                options['num_allocations'],
+                options['num_threads']
+            )
+        except Exception as e:
+            raise CommandError(f"Failed to set up E5 endpoint: {e}")
+
+    def check_e5_endpoint(self, model_id):
+        """Check if E5 endpoint exists and is deployed."""
+        try:
+            es = es_client()
+
+            # Check if model exists
+            es.ml.get_trained_models(model_id=model_id)
+            self.stdout.write(
+                self.style.SUCCESS(f"E5 model '{model_id}' exists")
+            )
+
+            # Check if model is deployed
+            stats = es.ml.get_trained_models_stats(model_id=model_id)
+            deployment_stats = stats.get('trained_model_stats', [])
+
+            if deployment_stats and len(deployment_stats) > 0:
+                deployment_stats_info = deployment_stats[0].get('deployment_stats', {})
+                deployment_state = deployment_stats_info.get('state', 'unknown')
+                if deployment_state == 'started':
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f"E5 model '{model_id}' is deployed and ready"
+                        )
+                    )
+                else:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"E5 model '{model_id}' exists but is not started "
+                            f"(state: {deployment_state})"
+                        )
+                    )
+            else:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"E5 model '{model_id}' exists but is not deployed"
+                    )
+                )
+
+            return True
+        except Exception as e:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"E5 model '{model_id}' not found or error occurred: {e}"
+                )
+            )
+            return False
+
+    def setup_e5_endpoint(self, es, model_id, num_allocations, num_threads):
+        """Set up and deploy E5 multilingual model."""
+        try:
+            # First, check if the model already exists
+            try:
+                es.ml.get_trained_models(model_id=model_id)
+                self.stdout.write(
+                    self.style.WARNING(f"E5 model '{model_id}' already exists")
+                )
+            except RequestError:
+                # Model doesn't exist, create it
+                self.stdout.write(f"Creating E5 model '{model_id}'...")
+                es.ml.put_trained_model(
+                    model_id=model_id,
+                    body={
+                        "input": {"field_names": ["text_field"]},
+                        "description": (
+                            f"E5 multilingual model for semantic search: {model_id}"
+                        )
+                    }
+                )
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Successfully created E5 model '{model_id}'"
+                    )
+                )
+
+            # Deploy the model
+            self.deploy_e5_model(es, model_id, num_allocations, num_threads)
+
+        except RequestError as e:
+            if "already exists" in str(e).lower():
+                self.stdout.write(
+                    self.style.WARNING(f"E5 model '{model_id}' already exists")
+                )
+                # Try to deploy it anyway
+                self.deploy_e5_model(es, model_id, num_allocations, num_threads)
+            else:
+                raise CommandError(f"Failed to create E5 model: {e}")
+
+    def deploy_e5_model(self, es, model_id, num_allocations, num_threads):
+        """Deploy the E5 model for inference."""
+        try:
+            self.stdout.write(f"Deploying E5 model '{model_id}'...")
+            es.ml.start_trained_model_deployment(
+                model_id=model_id,
+                body={
+                    "number_of_allocations": num_allocations,
+                    "threads_per_allocation": num_threads
+                },
+                wait_for="started",
+                timeout="10m"
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Successfully deployed E5 model '{model_id}' "
+                    f"with {num_allocations} allocation(s)"
+                )
+            )
+        except RequestError as e:
+            if "already started" in str(e).lower():
+                self.stdout.write(
+                    self.style.WARNING(f"E5 model '{model_id}' is already deployed")
+                )
+            else:
+                self.stdout.write(
+                    self.style.ERROR(f"Failed to deploy E5 model: {e}")
+                )

--- a/kitsune/search/semantic_config.py
+++ b/kitsune/search/semantic_config.py
@@ -9,7 +9,7 @@ from django.conf import settings
 
 # E5 Multilingual Model Configuration for Semantic Search
 E5_MODELS = {
-    '.multilingual-e5-small': {
+    '.multilingual-e5-small-elasticsearch': {
         'description': 'E5 Small - Multilingual text embedding model',
         'type': 'e5',
         'version': 'small',
@@ -18,7 +18,7 @@ E5_MODELS = {
         'languages': ['en', 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'es', 'et', 'fa', 'fi', 'fr', 'gl', 'gu', 'he', 'hi', 'hr', 'hu', 'hy', 'id', 'it', 'ja', 'ka', 'ko', 'ku', 'lt', 'lv', 'mk', 'mn', 'mr', 'ms', 'my', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sv', 'th', 'tr', 'uk', 'ur', 'vi', 'zh'],
         'use_case': 'Multilingual semantic search with good performance/size balance'
     },
-    '.multilingual-e5-base': {
+    '.multilingual-e5-base-elasticsearch': {
         'description': 'E5 Base - Multilingual text embedding model (larger, more accurate)',
         'type': 'e5',
         'version': 'base',
@@ -33,7 +33,7 @@ E5_MODELS = {
 DEFAULT_EMBEDDING_MODEL = getattr(
     settings,
     'ELASTICSEARCH_SEMANTIC_MODEL_ID',
-    '.multilingual-e5-small'
+    '.multilingual-e5-small-elasticsearch'
 )
 
 
@@ -48,7 +48,7 @@ def get_e5_model_config(model_id=None):
         dict: Model configuration including type and description.
     """
     model_id = model_id or DEFAULT_EMBEDDING_MODEL
-    return E5_MODELS.get(model_id, E5_MODELS['.multilingual-e5-small'])
+    return E5_MODELS.get(model_id, E5_MODELS['.multilingual-e5-small-elasticsearch'])
 
 
 def get_supported_e5_models():

--- a/kitsune/search/semantic_config.py
+++ b/kitsune/search/semantic_config.py
@@ -1,0 +1,73 @@
+"""
+Configuration for semantic search using Elasticsearch E5 multilingual model.
+
+This module contains settings for configuring semantic search with E5,
+Elasticsearch's multilingual text embedding model.
+"""
+
+from django.conf import settings
+
+# E5 Multilingual Model Configuration for Semantic Search
+E5_MODELS = {
+    '.multilingual-e5-small': {
+        'description': 'E5 Small - Multilingual text embedding model',
+        'type': 'e5',
+        'version': 'small',
+        'optimized_for': 'multilingual_search',
+        'vector_type': 'dense',
+        'languages': ['en', 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'es', 'et', 'fa', 'fi', 'fr', 'gl', 'gu', 'he', 'hi', 'hr', 'hu', 'hy', 'id', 'it', 'ja', 'ka', 'ko', 'ku', 'lt', 'lv', 'mk', 'mn', 'mr', 'ms', 'my', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sv', 'th', 'tr', 'uk', 'ur', 'vi', 'zh'],
+        'use_case': 'Multilingual semantic search with good performance/size balance'
+    },
+    '.multilingual-e5-base': {
+        'description': 'E5 Base - Multilingual text embedding model (larger, more accurate)',
+        'type': 'e5',
+        'version': 'base',
+        'optimized_for': 'multilingual_search',
+        'vector_type': 'dense',
+        'languages': ['en', 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'es', 'et', 'fa', 'fi', 'fr', 'gl', 'gu', 'he', 'hi', 'hr', 'hu', 'hy', 'id', 'it', 'ja', 'ka', 'ko', 'ku', 'lt', 'lv', 'mk', 'mn', 'mr', 'ms', 'my', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sv', 'th', 'tr', 'uk', 'ur', 'vi', 'zh'],
+        'use_case': 'High-quality multilingual semantic search with better accuracy'
+    }
+}
+
+# Default model - E5 Small is ideal for multilingual search with good performance
+DEFAULT_EMBEDDING_MODEL = getattr(
+    settings,
+    'ELASTICSEARCH_SEMANTIC_MODEL_ID',
+    '.multilingual-e5-small'
+)
+
+
+def get_e5_model_config(model_id=None):
+    """
+    Get configuration for E5 model.
+
+    Args:
+        model_id (str): The model identifier. If None, uses DEFAULT_EMBEDDING_MODEL.
+
+    Returns:
+        dict: Model configuration including type and description.
+    """
+    model_id = model_id or DEFAULT_EMBEDDING_MODEL
+    return E5_MODELS.get(model_id, E5_MODELS['.multilingual-e5-small'])
+
+
+def get_supported_e5_models():
+    """Get list of supported E5 models."""
+    return list(E5_MODELS.keys())
+
+
+def get_semantic_search_config():
+    """
+    Get the E5 multilingual semantic search configuration.
+
+    Returns:
+        dict: Configuration dictionary with E5 settings.
+    """
+    return {
+        'default_model': DEFAULT_EMBEDDING_MODEL,
+        'model_config': get_e5_model_config(),
+        'supported_models': list(E5_MODELS.keys()),
+        'multilingual_support': True,
+        'vector_type': 'dense',
+        'search_type': 'multilingual_semantic'
+    }

--- a/kitsune/search/semantic_search.py
+++ b/kitsune/search/semantic_search.py
@@ -1,0 +1,560 @@
+"""
+E5 Multilingual Semantic Search Functions
+
+This module provides semantic search capabilities using Elasticsearch's E5 multilingual model.
+Includes both pure semantic search and hybrid (semantic + traditional text) search functions
+for all SUMO document types.
+
+Functions support all 76 SUMO locales through the E5 multilingual model's native
+cross-language understanding capabilities.
+"""
+
+from elasticsearch.dsl import Q as DSLQ
+
+from kitsune.search.documents import ForumDocument, ProfileDocument, QuestionDocument, WikiDocument
+
+
+def _build_semantic_query(semantic_field, query_text, locale='en-US'):
+    """
+    Build a semantic query for the specified field and locale.
+
+    Args:
+        semantic_field (str): The semantic field name (e.g., 'content_semantic')
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+
+    Returns:
+        elasticsearch.dsl.Q: Semantic query object
+    """
+    field_name = f"{semantic_field}.{locale}"
+    return DSLQ('semantic', field=field_name, query=query_text)
+
+
+def _build_text_query(text_fields, query_text, locale='en-US'):
+    """
+    Build a traditional text query across multiple fields for the specified locale.
+
+    Args:
+        text_fields (list): List of text field names
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+
+    Returns:
+        elasticsearch.dsl.Q: Text query object
+    """
+    localized_fields = [f"{field}.{locale}" for field in text_fields]
+    return DSLQ('multi_match', query=query_text, fields=localized_fields, type='best_fields')
+
+
+# =============================================================================
+# WIKI DOCUMENT SEARCH FUNCTIONS
+# =============================================================================
+
+def semantic_search_wiki(query_text, locale='en-US', size=10):
+    """
+    Pure E5 semantic search on wiki documents.
+
+    Searches across title_semantic, content_semantic, summary_semantic, and
+    keywords_semantic fields for comprehensive semantic matching.
+
+    Args:
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+        size (int): Number of results to return (defaults to 10)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = WikiDocument.search()
+
+    # Build semantic queries for all wiki semantic fields
+    title_query = _build_semantic_query('title_semantic', query_text, locale)
+    content_query = _build_semantic_query('content_semantic', query_text, locale)
+    summary_query = _build_semantic_query('summary_semantic', query_text, locale)
+    keywords_query = _build_semantic_query('keywords_semantic', query_text, locale)
+
+    # Combine semantic queries with field importance boosting
+    combined_query = (
+        title_query | content_query | summary_query | keywords_query
+    )
+
+    return search.query(combined_query).extra(size=size)
+
+
+def hybrid_search_wiki(query_text, locale='en-US', size=10, semantic_weight=0.6):
+    """
+    Hybrid search combining E5 semantic and traditional text search on wiki documents.
+
+    Args:
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+        size (int): Number of results to return (defaults to 10)
+        semantic_weight (float): Weight for semantic results (0.0-1.0, defaults to 0.6)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = WikiDocument.search()
+
+    # Semantic component
+    semantic_query = (
+        _build_semantic_query('title_semantic', query_text, locale) |
+        _build_semantic_query('content_semantic', query_text, locale) |
+        _build_semantic_query('summary_semantic', query_text, locale) |
+        _build_semantic_query('keywords_semantic', query_text, locale)
+    )
+
+    # Text component
+    text_query = _build_text_query(
+        ['title', 'content', 'summary', 'keywords'],
+        query_text,
+        locale
+    )
+
+    # Combine with weights
+    text_weight = 1.0 - semantic_weight
+    combined_query = DSLQ('bool', should=[
+        DSLQ('constant_score', filter=semantic_query, boost=semantic_weight),
+        DSLQ('constant_score', filter=text_query, boost=text_weight)
+    ])
+
+    return search.query(combined_query).extra(size=size)
+
+
+# =============================================================================
+# QUESTION DOCUMENT SEARCH FUNCTIONS
+# =============================================================================
+
+def semantic_search_questions(query_text, locale='en-US', size=10):
+    """
+    Pure E5 semantic search on question documents.
+
+    Searches across question_title_semantic, question_content_semantic, and
+    answer_content_semantic fields.
+
+    Args:
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+        size (int): Number of results to return (defaults to 10)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = QuestionDocument.search()
+
+    # Build semantic queries for question fields
+    title_query = _build_semantic_query('question_title_semantic', query_text, locale)
+    content_query = _build_semantic_query('question_content_semantic', query_text, locale)
+    answer_query = _build_semantic_query('answer_content_semantic', query_text, locale)
+
+    combined_query = title_query | content_query | answer_query
+
+    return search.query(combined_query).extra(size=size)
+
+
+def hybrid_search_questions(query_text, locale='en-US', size=10, semantic_weight=0.6):
+    """
+    Hybrid search combining E5 semantic and traditional text search on question documents.
+
+    Args:
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+        size (int): Number of results to return (defaults to 10)
+        semantic_weight (float): Weight for semantic results (0.0-1.0, defaults to 0.6)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = QuestionDocument.search()
+
+    # Semantic component
+    semantic_query = (
+        _build_semantic_query('question_title_semantic', query_text, locale) |
+        _build_semantic_query('question_content_semantic', query_text, locale) |
+        _build_semantic_query('answer_content_semantic', query_text, locale)
+    )
+
+    # Text component
+    text_query = _build_text_query(
+        ['question_title', 'question_content', 'answer_content'],
+        query_text,
+        locale
+    )
+
+    # Combine with weights
+    text_weight = 1.0 - semantic_weight
+    combined_query = DSLQ('bool', should=[
+        DSLQ('constant_score', filter=semantic_query, boost=semantic_weight),
+        DSLQ('constant_score', filter=text_query, boost=text_weight)
+    ])
+
+    return search.query(combined_query).extra(size=size)
+
+
+# =============================================================================
+# ANSWER DOCUMENT SEARCH FUNCTIONS
+# =============================================================================
+
+def semantic_search_answers(query_text, locale='en-US', size=10):
+    """
+    Pure E5 semantic search on answer documents.
+
+    Note: AnswerDocument inherits from QuestionDocument, so it has the same semantic fields.
+    This function specifically targets answer content.
+
+    Args:
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+        size (int): Number of results to return (defaults to 10)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = QuestionDocument.search()
+
+    # Focus on answer content semantic field and filter for actual answers
+    answer_query = _build_semantic_query('content_semantic', query_text, locale)
+
+    # Filter to only return answer documents (not question documents)
+    return search.query(answer_query).filter('exists', field='content_semantic').extra(size=size)
+
+
+def hybrid_search_answers(query_text, locale='en-US', size=10, semantic_weight=0.6):
+    """
+    Hybrid search combining E5 semantic and traditional text search on answer documents.
+
+    Args:
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+        size (int): Number of results to return (defaults to 10)
+        semantic_weight (float): Weight for semantic results (0.0-1.0, defaults to 0.6)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = QuestionDocument.search()
+
+    # Semantic component - focus on answer content
+    semantic_query = _build_semantic_query('content_semantic', query_text, locale)
+
+    # Text component - focus on answer content
+    text_query = _build_text_query(['answer_content'], query_text, locale)
+
+    # Combine with weights
+    text_weight = 1.0 - semantic_weight
+    combined_query = DSLQ('bool', should=[
+        DSLQ('constant_score', filter=semantic_query, boost=semantic_weight),
+        DSLQ('constant_score', filter=text_query, boost=text_weight)
+    ])
+
+    # Filter to only return answer documents
+    return search.query(combined_query).filter('exists', field='content_semantic').extra(size=size)
+
+
+# =============================================================================
+# PROFILE DOCUMENT SEARCH FUNCTIONS
+# =============================================================================
+
+def semantic_search_profiles(query_text, size=10):
+    """
+    Pure E5 semantic search on user profile documents.
+
+    Note: ProfileDocument uses regular SemanticTextField (not locale-aware) since
+    user names are typically not localized.
+
+    Args:
+        query_text (str): The search query text
+        size (int): Number of results to return (defaults to 10)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = ProfileDocument.search()
+
+    # Profile name semantic search (no locale specification needed)
+    name_query = DSLQ('semantic', field='name_semantic', query=query_text)
+
+    return search.query(name_query).extra(size=size)
+
+
+def hybrid_search_profiles(query_text, size=10, semantic_weight=0.6):
+    """
+    Hybrid search combining E5 semantic and traditional text search on profile documents.
+
+    Args:
+        query_text (str): The search query text
+        size (int): Number of results to return (defaults to 10)
+        semantic_weight (float): Weight for semantic results (0.0-1.0, defaults to 0.6)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = ProfileDocument.search()
+
+    # Semantic component
+    semantic_query = DSLQ('semantic', field='name_semantic', query=query_text)
+
+    # Text component (assuming there's a 'name' text field)
+    text_query = DSLQ('match', name=query_text)
+
+    # Combine with weights
+    text_weight = 1.0 - semantic_weight
+    combined_query = DSLQ('bool', should=[
+        DSLQ('constant_score', filter=semantic_query, boost=semantic_weight),
+        DSLQ('constant_score', filter=text_query, boost=text_weight)
+    ])
+
+    return search.query(combined_query).extra(size=size)
+
+
+# =============================================================================
+# FORUM DOCUMENT SEARCH FUNCTIONS
+# =============================================================================
+
+def semantic_search_forums(query_text, size=10):
+    """
+    Pure E5 semantic search on forum documents.
+
+    Note: ForumDocument uses regular SemanticTextField (not locale-aware).
+
+    Args:
+        query_text (str): The search query text
+        size (int): Number of results to return (defaults to 10)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = ForumDocument.search()
+
+    # Build semantic queries for forum fields
+    title_query = DSLQ('semantic', field='thread_title_semantic', query=query_text)
+    content_query = DSLQ('semantic', field='content_semantic', query=query_text)
+
+    combined_query = title_query | content_query
+
+    return search.query(combined_query).extra(size=size)
+
+
+def hybrid_search_forums(query_text, size=10, semantic_weight=0.6):
+    """
+    Hybrid search combining E5 semantic and traditional text search on forum documents.
+
+    Args:
+        query_text (str): The search query text
+        size (int): Number of results to return (defaults to 10)
+        semantic_weight (float): Weight for semantic results (0.0-1.0, defaults to 0.6)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object ready for execution
+    """
+    search = ForumDocument.search()
+
+    # Semantic component
+    semantic_query = (
+        DSLQ('semantic', field='thread_title_semantic', query=query_text) |
+        DSLQ('semantic', field='content_semantic', query=query_text)
+    )
+
+    # Text component (assuming there are 'thread_title' and 'content' text fields)
+    text_query = DSLQ('multi_match',
+                     query=query_text,
+                     fields=['thread_title', 'content'],
+                     type='best_fields')
+
+    # Combine with weights
+    text_weight = 1.0 - semantic_weight
+    combined_query = DSLQ('bool', should=[
+        DSLQ('constant_score', filter=semantic_query, boost=semantic_weight),
+        DSLQ('constant_score', filter=text_query, boost=text_weight)
+    ])
+
+    return search.query(combined_query).extra(size=size)
+
+
+# =============================================================================
+# CROSS-CONTENT SEARCH FUNCTIONS
+# =============================================================================
+
+def semantic_search_all_content(query_text, locale='en-US', size=10):
+    """
+    E5 semantic search across all content types.
+
+    Returns results from Wiki, Questions, Answers, Profiles, and Forums
+    in a single unified result set with cross-language capabilities.
+
+    Args:
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+        size (int): Number of results to return per content type (defaults to 10)
+
+    Returns:
+        dict: Dictionary with keys 'wiki', 'questions', 'answers', 'profiles', 'forums'
+              containing Search objects ready for execution
+    """
+    return {
+        'wiki': semantic_search_wiki(query_text, locale, size),
+        'questions': semantic_search_questions(query_text, locale, size),
+        'answers': semantic_search_answers(query_text, locale, size),
+        'profiles': semantic_search_profiles(query_text, size),
+        'forums': semantic_search_forums(query_text, size)
+    }
+
+
+def hybrid_search_all_content(query_text, locale='en-US', size=10, semantic_weight=0.6):
+    """
+    Hybrid semantic + text search across all content types.
+
+    Returns results from Wiki, Questions, Answers, Profiles, and Forums
+    using hybrid search with configurable semantic weighting.
+
+    Args:
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+        size (int): Number of results to return per content type (defaults to 10)
+        semantic_weight (float): Weight for semantic results (0.0-1.0, defaults to 0.6)
+
+    Returns:
+        dict: Dictionary with keys 'wiki', 'questions', 'answers', 'profiles', 'forums'
+              containing Search objects ready for execution
+    """
+    return {
+        'wiki': hybrid_search_wiki(query_text, locale, size, semantic_weight),
+        'questions': hybrid_search_questions(query_text, locale, size, semantic_weight),
+        'answers': hybrid_search_answers(query_text, locale, size, semantic_weight),
+        'profiles': hybrid_search_profiles(query_text, size, semantic_weight),
+        'forums': hybrid_search_forums(query_text, size, semantic_weight)
+    }
+
+
+# =============================================================================
+# ADVANCED SEARCH UTILITIES
+# =============================================================================
+
+def cross_language_semantic_search(query_text, target_locales=None, content_type='wiki', size=10):
+    """
+    Cross-language semantic search using E5's multilingual capabilities.
+
+    Search in one language and find relevant content in other languages.
+    Perfect for SUMO's multilingual support needs.
+
+    Args:
+        query_text (str): The search query text (in any supported language)
+        target_locales (list): List of locale codes to search in (defaults to top 10 SUMO locales)
+        content_type (str): Type of content to search ('wiki', 'questions', 'answers', defaults to 'wiki')
+        size (int): Number of results to return per locale (defaults to 10)
+
+    Returns:
+        dict: Dictionary with locale codes as keys, containing search results
+    """
+    if target_locales is None:
+        # Default to top SUMO locales
+        target_locales = ['en-US', 'es', 'pt-BR', 'de', 'fr', 'ja', 'zh-CN', 'ru', 'pl', 'it']
+
+    results = {}
+
+    for locale in target_locales:
+        if content_type == 'wiki':
+            results[locale] = semantic_search_wiki(query_text, locale, size)
+        elif content_type == 'questions':
+            results[locale] = semantic_search_questions(query_text, locale, size)
+        elif content_type == 'answers':
+            results[locale] = semantic_search_answers(query_text, locale, size)
+        else:
+            raise ValueError(f"Unsupported content_type: {content_type}")
+
+    return results
+
+
+def semantic_search_with_filters(query_text, locale='en-US', content_type='wiki',
+                                filters=None, size=10):
+    """
+    Semantic search with additional Elasticsearch filters.
+
+    Allows combining E5 semantic search with traditional filters like date ranges,
+    categories, product IDs, etc.
+
+    Args:
+        query_text (str): The search query text
+        locale (str): The locale code (defaults to 'en-US')
+        content_type (str): Type of content to search ('wiki', 'questions', 'answers')
+        filters (dict): Dictionary of filters to apply (e.g., {'category': 'troubleshooting'})
+        size (int): Number of results to return (defaults to 10)
+
+    Returns:
+        elasticsearch.dsl.Search: Search object with semantic query and filters applied
+    """
+    # Get base semantic search
+    if content_type == 'wiki':
+        search = semantic_search_wiki(query_text, locale, size)
+    elif content_type == 'questions':
+        search = semantic_search_questions(query_text, locale, size)
+    elif content_type == 'answers':
+        search = semantic_search_answers(query_text, locale, size)
+    else:
+        raise ValueError(f"Unsupported content_type: {content_type}")
+
+    # Apply additional filters
+    if filters:
+        for field, value in filters.items():
+            if isinstance(value, list):
+                search = search.filter('terms', **{field: value})
+            else:
+                search = search.filter('term', **{field: value})
+
+    return search
+
+
+# =============================================================================
+# EXAMPLE USAGE AND TESTING FUNCTIONS
+# =============================================================================
+
+def test_semantic_search_examples():
+    """
+    Example usage of E5 multilingual semantic search functions.
+
+    This function demonstrates how to use various semantic search functions
+    and can be used for testing E5 functionality.
+    """
+    # Basic semantic search examples
+    print("=== Basic Semantic Search Examples ===")
+
+    # Wiki semantic search
+    wiki_results = semantic_search_wiki("Firefox crashes when opening", locale='en-US', size=5)
+    print(f"Wiki semantic search: {len(list(wiki_results.execute()))} results")
+
+    # Question semantic search
+    question_results = semantic_search_questions("browser freezing", locale='en-US', size=5)
+    print(f"Question semantic search: {len(list(question_results.execute()))} results")
+
+    # Hybrid search examples
+    print("\n=== Hybrid Search Examples ===")
+
+    # Wiki hybrid search with different semantic weights
+    hybrid_light = hybrid_search_wiki("slow performance", semantic_weight=0.3, size=5)
+    hybrid_heavy = hybrid_search_wiki("slow performance", semantic_weight=0.8, size=5)
+    print(f"Hybrid search (30% semantic): {len(list(hybrid_light.execute()))} results")
+    print(f"Hybrid search (80% semantic): {len(list(hybrid_heavy.execute()))} results")
+
+    # Cross-language search examples
+    print("\n=== Cross-Language Search Examples ===")
+
+    # Search in Spanish, find results in multiple languages
+    cross_lang_results = cross_language_semantic_search(
+        "problemas de rendimiento del navegador",  # Spanish: "browser performance problems"
+        target_locales=['en-US', 'es', 'fr'],
+        content_type='wiki',
+        size=3
+    )
+    for locale, results in cross_lang_results.items():
+        print(f"Cross-language results for {locale}: {len(list(results.execute()))} results")
+
+    # Comprehensive search across all content types
+    print("\n=== All Content Types Search ===")
+
+    all_content = semantic_search_all_content("installation problems", size=3)
+    for content_type, results in all_content.items():
+        try:
+            count = len(list(results.execute()))
+            print(f"{content_type.capitalize()}: {count} results")
+        except Exception as e:
+            print(f"{content_type.capitalize()}: Error - {e}")


### PR DESCRIPTION
Add `semantic_text` fields to search models
Add management command to set up E5 inference endpoint `setup_semantic_search`
Add `semantic_search.py` which contains a variety of methods to test semantic and hybrid search

