### PR TITLE
Replace simple search with semantic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - discovery.type=single-node
       - LOG4J_FORMAT_MSG_NO_LOOKUPS=true
       - xpack.security.enabled=false
+      - xpack.license.self_generated.type=trial
       - action.destructive_requires_name=false
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
       - network.host=0.0.0.0

--- a/kitsune/search/base.py
+++ b/kitsune/search/base.py
@@ -58,8 +58,12 @@ class SumoDocument(DSLDocument):
         cls.Index.base_name = f"{settings.ES_INDEX_PREFIX}_{name.lower()}"
         cls.Index.read_alias = f"{cls.Index.base_name}_read"
         cls.Index.write_alias = f"{cls.Index.base_name}_write"
-        # Bump the refresh interval to 1 minute
-        cls.Index.settings = {"refresh_interval": DEFAULT_ES_REFRESH_INTERVAL}
+        # Bump the refresh interval to 1 minute and increase field limit for semantic fields
+        cls.Index.settings = {
+            "refresh_interval": DEFAULT_ES_REFRESH_INTERVAL,
+            "mapping.nested_fields.limit": 1000,  # Increase from default 50 to support semantic fields
+            "mapping.total_fields.limit": 2000,   # Increase total field limit as well
+        }
 
         # this is the attribute elastic-dsl actually uses to determine which index
         # to query. we override the .search() method to get that to use the read

--- a/kitsune/search/documents.py
+++ b/kitsune/search/documents.py
@@ -6,7 +6,12 @@ from kitsune.questions.models import Answer, Question
 from kitsune.search import config
 from kitsune.search.base import SumoDocument
 from kitsune.search.es_utils import es_client
-from kitsune.search.fields import SumoLocaleAwareKeywordField, SumoLocaleAwareTextField
+from kitsune.search.fields import (
+    SemanticTextField,
+    SumoLocaleAwareKeywordField,
+    SumoLocaleAwareSemanticTextField,
+    SumoLocaleAwareTextField,
+)
 from kitsune.users.models import Profile
 from kitsune.wiki import models as wiki_models
 from kitsune.wiki.config import (
@@ -36,6 +41,12 @@ class WikiDocument(SumoDocument):
     keywords = SumoLocaleAwareTextField()
     slug = SumoLocaleAwareKeywordField(store=True)
     doc_id = SumoLocaleAwareKeywordField(store=True)
+
+    # Semantic text fields for Elasticsearch semantic search
+    title_semantic = SumoLocaleAwareSemanticTextField()
+    content_semantic = SumoLocaleAwareSemanticTextField()
+    summary_semantic = SumoLocaleAwareSemanticTextField()
+    keywords_semantic = SumoLocaleAwareSemanticTextField()
 
     class Index:
         pass
@@ -86,6 +97,22 @@ class WikiDocument(SumoDocument):
 
     def prepare_display_order(self, instance):
         return instance.original.display_order
+
+    # Semantic field preparation methods
+    def prepare_title_semantic(self, instance):
+        return instance.title
+
+    def prepare_content_semantic(self, instance):
+        return instance.html
+
+    def prepare_summary_semantic(self, instance):
+        if instance.current_revision:
+            return instance.summary
+        return ""
+
+    def prepare_keywords_semantic(self, instance):
+        """Return the current revision's keywords as a string."""
+        return getattr(instance.current_revision, "keywords", "")
 
     @classmethod
     def get_model(cls):
@@ -144,6 +171,11 @@ class QuestionDocument(SumoDocument):
 
     locale = field.Keyword()
 
+    # Semantic text fields for Elasticsearch semantic search
+    question_title_semantic = SumoLocaleAwareSemanticTextField()
+    question_content_semantic = SumoLocaleAwareSemanticTextField()
+    answer_content_semantic = SumoLocaleAwareSemanticTextField()
+
     class Index:
         pass
 
@@ -185,6 +217,26 @@ class QuestionDocument(SumoDocument):
         if field.startswith("question_"):
             field = field[len("question_") :]
         return super().get_field_value(field, *args)
+
+    # Semantic field preparation methods
+    def prepare_question_title_semantic(self, instance):
+        return instance.title
+
+    def prepare_question_content_semantic(self, instance):
+        return instance.content
+
+    def prepare_answer_content_semantic(self, instance):
+        return [
+            answer.content
+            for answer in (
+                # when bulk indexing use answer queryset prefetched in `get_queryset` method
+                # this is to avoid running an extra query for each question in the chunk
+                instance.es_question_answers_not_spam
+                if hasattr(instance, "es_question_answers_not_spam")
+                # fallback if non-spam answers haven't been prefetched
+                else instance.answers.filter(is_spam=False)
+            )
+        ]
 
     @classmethod
     def get_model(cls):
@@ -236,6 +288,8 @@ class AnswerDocument(QuestionDocument):
 
     is_solution = field.Boolean()
 
+    content_semantic = SumoLocaleAwareSemanticTextField()
+
     @classmethod
     def prepare(cls, instance, **kwargs):
         """Override super method to exclude certain docs."""
@@ -269,6 +323,14 @@ class AnswerDocument(QuestionDocument):
     def prepare_answer_content(self, instance):
         # clear answer_content field from QuestionDocument,
         # as we don't need the content of sibling answers in an AnswerDocument
+        return None
+
+    def prepare_content_semantic(self, instance):
+        return instance.content
+
+    def prepare_answer_content_semantic(self, instance):
+        # For AnswerDocument, we don't need answer_content_semantic since this IS an answer
+        # Override the inherited method to avoid the AttributeError
         return None
 
     def get_field_value(self, field, instance, *args):
@@ -325,6 +387,8 @@ class ProfileDocument(SumoDocument):
     product_ids = field.Keyword(multi=True)
     group_ids = field.Keyword(multi=True)
 
+    name_semantic = SemanticTextField()
+
     class Index:
         pass
 
@@ -358,6 +422,9 @@ class ProfileDocument(SumoDocument):
     def prepare_group_ids(self, instance):
         return [group.id for group in instance.user.groups.all()]
 
+    def prepare_name_semantic(self, instance):
+        return instance.name
+
     @classmethod
     def get_model(cls):
         return Profile
@@ -387,6 +454,9 @@ class ForumDocument(SumoDocument):
     updated = field.Date()
     updated_by_id = field.Keyword()
 
+    thread_title_semantic = SemanticTextField()
+    content_semantic = SemanticTextField()
+
     class Index:
         pass
 
@@ -398,6 +468,18 @@ class ForumDocument(SumoDocument):
             instance = instance.thread
             field = field[len("thread_") :]
         return super().get_field_value(field, instance, *args)
+
+    def prepare_thread_title_semantic(self, instance):
+        # instance could be a Post or Thread depending on context
+        # For Posts, get the thread title; for Threads, get the title directly
+        if hasattr(instance, 'thread') and instance.thread:
+            return instance.thread.title
+        else:
+            # instance is likely a Thread itself
+            return instance.title
+
+    def prepare_content_semantic(self, instance):
+        return instance.content
 
     @classmethod
     def get_model(cls):

--- a/kitsune/search/es_utils.py
+++ b/kitsune/search/es_utils.py
@@ -3,7 +3,7 @@ import inspect
 
 from celery import shared_task
 from django.conf import settings
-from elasticsearch import Elasticsearch
+from elasticsearch import ApiError, Elasticsearch
 from elasticsearch.dsl import Document, UpdateByQuery, analyzer, char_filter, token_filter
 from elasticsearch.helpers import bulk as es_bulk
 from elasticsearch.helpers.errors import BulkIndexError
@@ -150,10 +150,21 @@ def index_object(doc_type_name, obj_id):
         # just return
         return
 
-    if doc_type.update_document:
-        doc_type.prepare(obj).to_action("update", doc_as_upsert=True)
-    else:
-        doc_type.prepare(obj).to_action("index")
+    try:
+        if doc_type.update_document:
+            doc_type.prepare(obj).to_action("update", doc_as_upsert=True)
+        else:
+            doc_type.prepare(obj).to_action("index")
+    except ApiError as e:
+        # Handle model download timeout gracefully in tests/CI
+        # TODO: remove this when we have a better solution
+        if "Model download task is currently running" in str(e):
+            # Silently skip indexing during model download - this is expected behavior
+            # The model download happens once and then indexing will work normally
+            return
+        else:
+            # Re-raise other API errors
+            raise
 
 
 @shared_task

--- a/kitsune/search/fields.py
+++ b/kitsune/search/fields.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from django.conf import settings
-from elasticsearch.dsl import Keyword, Text
+from elasticsearch.dsl import Keyword, Text, field
 from elasticsearch.dsl import Object as DSLObject
 
 from kitsune.search.es_utils import es_analyzer_for_locale
@@ -9,6 +9,22 @@ from kitsune.search.es_utils import es_analyzer_for_locale
 SUPPORTED_LANGUAGES = list(settings.SUMO_LANGUAGES)
 # this is a test locale - no need to add it to ES
 SUPPORTED_LANGUAGES.remove("xx")
+
+# Default E5 multilingual model
+DEFAULT_MODEL = getattr(settings, 'ELASTICSEARCH_SEMANTIC_MODEL_ID', '.multilingual-e5-small-elasticsearch')
+
+
+def SemanticTextField(**params):
+    """
+    Create a semantic_text field for ES semantic search.
+
+    Args:
+        **params: Additional parameters for the field
+
+    Returns:
+        field.SemanticText: Configured semantic text field for ES model
+    """
+    return field.SemanticText(inference_id=DEFAULT_MODEL, **params)
 
 
 def _get_fields(field, locales, **params):
@@ -44,3 +60,24 @@ SumoKeywordField = partial(construct_locale_field, field=Keyword)
 # {'en-US': Text(analyzer_for_the_specific_locale)}
 SumoLocaleAwareTextField = partial(SumoTextField, locales=SUPPORTED_LANGUAGES)
 SumoLocaleAwareKeywordField = partial(SumoKeywordField, locales=SUPPORTED_LANGUAGES)
+
+
+# Semantic text field for multi-language support with ES
+def SumoLocaleAwareSemanticTextField(**params):
+    """
+    Create a locale-aware semantic text field using ES model.
+
+    This creates an object field with semantic_text subfields for each supported locale,
+    all using ES model for semantic search.
+
+    Args:
+        **params: Additional parameters for each semantic text field
+
+    Returns:
+        DSLObject: Object field containing ES semantic text fields for each locale
+    """
+    inner_fields = {}
+    for locale in SUPPORTED_LANGUAGES:
+        inner_fields[locale] = field.SemanticText(inference_id=DEFAULT_MODEL, **params)
+
+    return DSLObject(properties=inner_fields)

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -760,6 +760,9 @@ ES_INDEX_PREFIX = config("ES_INDEX_PREFIX", default="sumo")
 # Keep indexes up to date as objects are made/deleted.
 ES_LIVE_INDEXING = config("ES_LIVE_INDEXING", default=True, cast=bool)
 
+# Semantic Search Configuration
+USE_SEMANTIC_SEARCH = config("USE_SEMANTIC_SEARCH", default=True, cast=bool)
+
 SEARCH_MAX_RESULTS = 1000
 SEARCH_RESULTS_PER_PAGE = 10
 


### PR DESCRIPTION
* Set trial license in `docker-compose.yml` to avoid CI issue
* Increase `mapping.nested_fields.limit` and `mapping.total_fields.limit` to accomodate `semantic_text` needs
* Create `SumoLocaleAwareSemanticTextField` and `SemanticTextField` types
* Add semantic fields to document types
* Add `prepare_` methods for semantic fields in document types
* `es_utils.py` update to circumvent a CI/build issue - this needs a better solution but does work
* Add new search classes to `search.py`: `SemanticWikiSearch` and `SemanticQuestionSearch`
* Modify `views.py` to make semantic search the priority, and fall back to traditional search if there is an issue
* Add `USE_SEMANTIC_SEARCH` to `settings.py` in case we want to disable in some use cases

Prepare for stage