### PR TITLE
Add RRF score filtering for gibberish queries in hybrid search

### DIFF
--- a/kitsune/search/config.py
+++ b/kitsune/search/config.py
@@ -378,3 +378,9 @@ DEFAULT_ES_REFRESH_INTERVAL = "60s"
 # If the best result score is below this threshold, fallback to traditional search
 SEMANTIC_SEARCH_MIN_SCORE = 2.5
 
+# Minimum score threshold for RRF hybrid search results
+# RRF scores are typically much lower than raw semantic scores (0.01-0.1 range)
+# If the best result score is below this threshold, treat as "no results"
+# Note: May need tuning based on actual RRF score distributions in production
+RRF_HYBRID_MIN_SCORE = 0.05
+

--- a/kitsune/search/views.py
+++ b/kitsune/search/views.py
@@ -205,6 +205,34 @@ def simple_search(request):
                 # Keep the original search results if fallback fails
                 pass
 
+    # For hybrid search, check if RRF scores indicate low-quality results (likely gibberish)
+    if search_type == "hybrid" and total > 0 and results:
+        try:
+            # Extract max score from results
+            max_score = 0
+            for r in results:
+                if isinstance(r, dict):
+                    score = r.get("score", 0)
+                else:
+                    # Try to get score from meta attribute
+                    meta = getattr(r, "meta", None)
+                    score = getattr(meta, "score", 0) if meta else 0
+                max_score = max(max_score, score)
+        except (AttributeError, TypeError, ValueError) as e:
+            log.debug(f"Error extracting RRF score: {e}")
+            max_score = 1.0  # Default to allowing results if we can't extract score
+
+        # RRF scores are much lower than semantic scores (typically 0.01-0.1 range)
+        if max_score < settings.RRF_HYBRID_MIN_SCORE:
+            log.info(
+                f"Filtering hybrid search results for query '{cleaned['q']}' - "
+                f"max RRF score {max_score:.4f} below threshold {settings.RRF_HYBRID_MIN_SCORE}"
+            )
+            # Treat as no results found - don't fallback to traditional since
+            # gibberish queries won't produce good results there either
+            total = 0
+            results = []
+
     # generate fallback results if necessary
     fallback_results = None
     if total == 0:

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -1389,3 +1389,9 @@ SHELL_PLUS_DONT_LOAD = ["silk"]
 # AI Translation
 AI_ENABLED_LOCALES = config("AI_ENABLED_LOCALES", default="", cast=Csv())
 HYBRID_ENABLED_LOCALES = config("HYBRID_ENABLED_LOCALES", default="", cast=Csv())
+
+# RRF Settings for hybrid search
+RRF_WINDOW_MAX_SIZE = config("RRF_WINDOW_MAX_SIZE", default=500, cast=int)
+RRF_RANK_CONSTANT = config("RRF_RANK_CONSTANT", default=20, cast=int)
+# Minimum score threshold for RRF hybrid search results - tune based on production data
+RRF_HYBRID_MIN_SCORE = config("RRF_HYBRID_MIN_SCORE", default=0.05, cast=float)


### PR DESCRIPTION
- Add RRF_HYBRID_MIN_SCORE threshold (default 0.05) to filter low-quality results
- Implement score checking for hybrid search mode in views.py
- Add logging to track filtered queries for threshold tuning
- Make threshold configurable via environment variable
- Move RRF settings to Django settings for consistency

This prevents meaningless strings from returning irrelevant search results by filtering out results with RRF scores below the configured threshold. Users will see 'No results found' instead of poor-quality matches.