### PR TITLE
Fix search pagination, filtering, and result count

### DIFF
--- a/kitsune/search/jinja2/search/results.html
+++ b/kitsune/search/jinja2/search/results.html
@@ -24,10 +24,10 @@
       {% if num_results > 0 %}
         <p class="sumo-page-intro">
           {% if results_capped %}
-            {# L10n: {n} is the number of search results (capped), {q} is the search query, {product} is the product. #}
-            Found over <strong>{{ num_results }}</strong> results for <strong>{{ q }}</strong> for <strong>{{ product_titles }}</strong>
+            {# L10n: {n} is the number of search results (capped), {q} is the search query, {product} is the product titles. #}
+            {{ _('Found over <strong>{n}</strong> results for <strong>{q}</strong> for <strong>{product}</strong>')|fe(n=num_results, q=q, product=product_titles) }}
           {% else %}
-            {# L10n: {n} is the number of search results, {q} is the search query, {product} is the product. #}
+            {# L10n: {n} is the number of search results, {q} is the search query, {product} is the product titles. #}
             {{ ngettext('Found <strong>{n}</strong> result for <strong>{q}</strong> for <strong>{product}</strong>',
                         'Found <strong>{n}</strong> results for <strong>{q}</strong> for <strong>{product}</strong>',
                         num_results)|fe(n=num_results, q=q, product=product_titles) }}

--- a/kitsune/search/views.py
+++ b/kitsune/search/views.py
@@ -205,33 +205,8 @@ def simple_search(request):
                 # Keep the original search results if fallback fails
                 pass
 
-    # For hybrid search, check if RRF scores indicate low-quality results (likely gibberish)
-    if search_type == "hybrid" and total > 0 and results:
-        try:
-            # Extract max score from results
-            max_score = 0
-            for r in results:
-                if isinstance(r, dict):
-                    score = r.get("score", 0)
-                else:
-                    # Try to get score from meta attribute
-                    meta = getattr(r, "meta", None)
-                    score = getattr(meta, "score", 0) if meta else 0
-                max_score = max(max_score, score)
-        except (AttributeError, TypeError, ValueError) as e:
-            log.debug(f"Error extracting RRF score: {e}")
-            max_score = 1.0  # Default to allowing results if we can't extract score
-
-        # RRF scores are much lower than semantic scores (typically 0.01-0.1 range)
-        if max_score < settings.RRF_HYBRID_MIN_SCORE:
-            log.info(
-                f"Filtering hybrid search results for query '{cleaned['q']}' - "
-                f"max RRF score {max_score:.4f} below threshold {settings.RRF_HYBRID_MIN_SCORE}"
-            )
-            # Treat as no results found - don't fallback to traditional since
-            # gibberish queries won't produce good results there either
-            total = 0
-            results = []
+    # Note: Quality filtering is now handled at the query level using minimum_should_match
+    # requirements in the search strategies, not through post-search score filtering.
 
     # generate fallback results if necessary
     fallback_results = None

--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -1394,4 +1394,6 @@ HYBRID_ENABLED_LOCALES = config("HYBRID_ENABLED_LOCALES", default="", cast=Csv()
 RRF_WINDOW_MAX_SIZE = config("RRF_WINDOW_MAX_SIZE", default=500, cast=int)
 RRF_RANK_CONSTANT = config("RRF_RANK_CONSTANT", default=20, cast=int)
 # Minimum score threshold for RRF hybrid search results - tune based on production data
-RRF_HYBRID_MIN_SCORE = config("RRF_HYBRID_MIN_SCORE", default=0.06, cast=float)
+# RRF scores range from ~0.048 (rank 1) to ~0.002 (rank 500) with k=20
+# Setting to 0.01 filters only results ranked worse than ~100
+RRF_HYBRID_MIN_SCORE = config("RRF_HYBRID_MIN_SCORE", default=0.01, cast=float)


### PR DESCRIPTION
  - Fix blank pages on pagination (page 9+) by adjusting RRF window dynamically
  - Implement query-level quality filtering with minimum_should_match
  - Fix "Found over X results" display with proper localization
  - Remove incorrect RRF score filtering that broke pagination

  Pagination now works for all pages, gibberish queries are filtered out,
  and result counts display correctly with "over" when exceeding limits.