### PR TITLE
Playwright: expand coverage to user-deletion content re-assignment

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,6 +43,7 @@ on:
                     - antiSpamTests
                     - contributorDiscussions
                     - contributorDiscussionsThreads
+                    - userDeletion
                     - smokeTest
 
 env:
@@ -102,7 +103,7 @@ jobs:
         run: |
             source ../.venv/bin/activate
             declare dispatch_test_suite="${{inputs.TestSuite}}"
-            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productSupportPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics" "searchTests" "contributorForumSearch" "userGroupsTests" "antiSpamTests" "contributorDiscussions" "contributorDiscussionsThreads")
+            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productSupportPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics" "searchTests" "contributorForumSearch" "userGroupsTests" "antiSpamTests" "contributorDiscussions" "contributorDiscussionsThreads", "userDeletion")
             if [ "$dispatch_test_suite" == "All" ] || [ "${{ github.event_name}}" == "schedule" ] ; then
                 for test in "${all_test_suites[@]}"; do
                     if ! pytest -m ${test} --numprocesses 6 --browser ${{ env.BROWSER }} --reruns 2 -v; then

--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -150,6 +150,10 @@ class BasePage:
                 else:
                     raise Exception("Max retries exceeded. Could not interact with the checkbox")
 
+    def _is_element_disabled(self, locator: Locator) -> bool:
+        """Return whether the locator is disabled or not"""
+        return locator.is_disabled()
+
     def _click(self, element: str | Locator | ElementHandle, expected_locator=None,
                expected_url=None, with_force=False, retries=3, delay=2000):
         """
@@ -170,7 +174,7 @@ class BasePage:
                 if expected_locator:
                     self._wait_for_locator(expected_locator, timeout=3000)
                 if expected_url:
-                    self.page.wait_for_url(expected_url, timeout=3000)
+                    self.page.wait_for_url(expected_url, timeout=10000)
                 break
             except PlaywrightTimeoutError:
                 if expected_locator:

--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
@@ -265,11 +265,14 @@ class AddKbArticleFlow:
                 }
 
     def kb_article_creation_via_api(self, page: Page, approve_revision=False, is_template=False,
-                                    product=None, topic=None, category=None) -> dict[str, Any]:
+                                    product=None, topic=None, category=None, ready_for_l10n=False,
+                                    significance_type='') -> dict[str, Any]:
         """
         Create a new KB article via API.
         :param page: Page object.
         :param approve_revision: Approve the first revision of the article.
+        :param ready_for_l10n: Mark the revision as ready for localization.
+        :param significance_type: Add the significance type of the revision.
         :param is_template: Create a KB template.
         :param product: Product ID.
         :param topic: Topic ID.
@@ -314,7 +317,8 @@ class AddKbArticleFlow:
 
         first_revision_id = self.kb_article_show_history_page.get_last_revision_id()
         if approve_revision:
-            self.approve_kb_revision(revision_id=first_revision_id)
+            self.approve_kb_revision(revision_id=first_revision_id, ready_for_l10n=ready_for_l10n)
+
 
         return {"article_title": kb_title,
                 "article_content": kb_article_test_data["article_content"],

--- a/playwright_tests/flows/messaging_system_flows/messaging_system_flow.py
+++ b/playwright_tests/flows/messaging_system_flows/messaging_system_flow.py
@@ -26,14 +26,14 @@ class MessagingSystemFlows:
             recipients = recipient_username if isinstance(recipient_username, list) else [
                 recipient_username]
             for recipient in recipients:
-                self.new_message_page.type_into_new_message_to_input_field(recipient)
+                self.new_message_page.type_into_to_input_field(recipient)
                 self.new_message_page.click_on_a_searched_user(recipient)
 
         if message_body:
-            self.new_message_page.fill_into_new_message_body_textarea(message_body)
+            self.new_message_page.fill_into_message_textarea(message_body)
 
         if submit_message:
-            self.new_message_page.click_on_new_message_send_button(
+            self.new_message_page.click_on_send_button(
                 expected_url=expected_url)
 
     def delete_message_flow(self, username='', excerpt='', delete_message=True,
@@ -56,9 +56,9 @@ class MessagingSystemFlows:
 
         if from_inbox_list and (username or excerpt):
             if username:
-                self.inbox_page.click_on_inbox_message_delete_button_by_username(username)
+                self.inbox_page.click_on_message_delete_button_by_username(username)
             else:
-                self.inbox_page.click_on_inbox_message_delete_button_by_excerpt(excerpt)
+                self.inbox_page.click_on_message_delete_button_by_excerpt(excerpt)
 
         if delete_message:
             self.sent_message_page.click_on_delete_page_delete_button(expected_url=expected_url)

--- a/playwright_tests/flows/user_profile_flows/edit_profile_data_flow.py
+++ b/playwright_tests/flows/user_profile_flows/edit_profile_data_flow.py
@@ -1,5 +1,4 @@
-from playwright.sync_api import Page
-
+from playwright.sync_api import Page, TimeoutError
 from playwright_tests.core.utilities import Utilities
 from playwright_tests.messages.my_profile_pages_messages.edit_my_profile_page_messages import \
     EditMyProfilePageMessages
@@ -12,7 +11,6 @@ from playwright_tests.pages.user_pages.my_profile_edit_settings_page import (
     MyProfileEditSettingsPage,
 )
 from playwright_tests.pages.user_pages.my_profile_user_navbar import UserNavbar
-
 
 class EditProfileDataFlow:
     def __init__(self, page: Page):
@@ -128,13 +126,15 @@ class EditProfileDataFlow:
 
         self.profile_contribution_areas.click_on_update_contribution_areas_button()
 
-    def close_account(self, username: str):
+    def close_account(self):
         """
         Navigates to the settings profile option and closes the account.
         """
         if self.utilities.get_page_url() != EditMyProfilePageMessages.STAGE_EDIT_MY_PROFILE_URL:
             self.utilities.navigate_to_link(EditMyProfilePageMessages.STAGE_EDIT_MY_PROFILE_URL)
-
         self.edit_profile_page.click_close_account_option()
-        self.edit_profile_page.add_username_to_close_account_modal(username)
-        self.edit_profile_page.click_close_account_button()
+        self.edit_profile_page.add_confirmation_code_to_close_account_modal()
+        try:
+            self.edit_profile_page.click_close_account_button()
+        except TimeoutError:
+            print("Load not complete")

--- a/playwright_tests/messages/mess_system_pages_messages/inbox_page_messages.py
+++ b/playwright_tests/messages/mess_system_pages_messages/inbox_page_messages.py
@@ -9,3 +9,5 @@ class InboxPageMessages:
     MULTIPLE_MESSAGES_DELETION_BANNER_TEXT = "The messages were deleted!"
     NO_MESSAGES_SELECTED_BANNER_TEXT = "No messages selected. Please try again."
     NAVBAR_INBOX_SELECTED_BG_COLOR = "rgb(237, 237, 240)"
+    READ_MESSAGE_DELETED_USER_INFO = ("You can no longer reply to the sender of this message. The"
+                                      " user is no longer active. ")

--- a/playwright_tests/messages/mess_system_pages_messages/read_message_page_messages.py
+++ b/playwright_tests/messages/mess_system_pages_messages/read_message_page_messages.py
@@ -1,0 +1,3 @@
+class ReadMessagePageMessages:
+    DELETED_USER_INFO = ("You can no longer reply to the sender of this message. The user is no "
+                         "longer active.")

--- a/playwright_tests/pages/contribute/contribute_pages/contributor_discussions/forum_discussions_page.py
+++ b/playwright_tests/pages/contribute/contribute_pages/contributor_discussions/forum_discussions_page.py
@@ -98,3 +98,6 @@ class ForumDiscussionsPage(BasePage):
 
     def get_all_thread_content_from_search_results(self) -> list[str]:
         return self._get_text_of_elements(self.search_results_body)
+
+    def get_last_post_by_text(self, thread_name: str) -> str:
+        return self._get_text_of_element(self.last_post_by(thread_name))

--- a/playwright_tests/pages/contribute/contribute_pages/contributor_discussions/forum_thread_page.py
+++ b/playwright_tests/pages/contribute/contribute_pages/contributor_discussions/forum_thread_page.py
@@ -154,6 +154,16 @@ class ForumThreadPage(BasePage):
         """
         return self._get_text_of_element(self.modified_by(post_id))
 
+    def is_modified_by_section_displayed(self, post_id: str) -> bool:
+        """
+            Return whether the modified by section is displayed or not.
+            Args:
+                post_id (str): The ID of the post.
+            Returns:
+                bool: If the locator is displayed or not
+        """
+        return self._is_element_visible(self.modified_by(post_id))
+
     def is_edit_thread_title_option_visible(self) -> bool:
         """
             Check if the edit thread title option is visible.
@@ -472,3 +482,23 @@ class ForumThreadPage(BasePage):
                 str: The thread post quote text.
         """
         return self._get_text_of_element(self.quoted_thread_post_quote(post_id))
+
+    def get_post_author(self, post_id: str) -> str:
+        """
+         Get the author of a kb thread post.
+         Args:
+             post_id (str): The ID of the post.
+            Returns:
+                str: The author of the post.
+        """
+        return self._get_text_of_element(self.post_author(post_id))
+
+    def get_post_content(self, post_id: str) -> str:
+        """
+        Get the content of the thread post.
+        Args:
+            post_id (str): The ID of the post.
+        Returns:
+            str: The content of the post.
+        """
+        return self._get_text_of_element(self.post_content(post_id)).strip()

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
@@ -17,6 +17,9 @@ class KBArticleShowHistoryPage(BasePage):
         self.l10n_modal = page.locator("div[class='mzp-c-modal-window']")
         self.revision_editor = lambda revision_id, username: page.locator(
             f"tr#{revision_id}").get_by_role("link").filter(has_text=username)
+        self.revision_creator = lambda revision_id: page.locator(
+            f"//tr[@id='{revision_id}']//td[@class='creator']/a"
+        )
         self.ready_for_localization_button = lambda revision_id: page.locator(
             f"tr#{revision_id} td[class='l10n'] a")
         self.ready_for_localization_status = lambda revision_id: page.locator(
@@ -131,6 +134,9 @@ class KBArticleShowHistoryPage(BasePage):
     def click_on_a_revision_date(self, revision_id):
         self._click(self.revision_date(revision_id))
 
+    def is_revision_displayed(self, revision_id) -> bool:
+        return self._is_element_visible(self.revision(revision_id))
+
     def get_revision_time(self, revision_id) -> str:
         return self._get_text_of_element(self.revision_time(revision_id))
 
@@ -202,3 +208,7 @@ class KBArticleShowHistoryPage(BasePage):
 
     def get_revision_significance(self, revision_id: str) -> str:
         return self._get_text_of_element(self.revision_significance(revision_id)).strip()
+
+    def get_revision_creator(self, revision_id: str) -> str:
+        """Get the revision creator based on the revision id."""
+        return self._get_element_inner_text_from_page(self.revision_creator(revision_id))

--- a/playwright_tests/pages/messaging_system_pages/inbox_page.py
+++ b/playwright_tests/pages/messaging_system_pages/inbox_page.py
@@ -7,28 +7,34 @@ class InboxPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
-        # Breadcrumb locators.
-        self.inbox_page_breadcrumbs = page.locator("ol#breadcrumbs li")
+        """Locators belonging to the Inbox page breadcrumbs."""
+        self.page_breadcrumbs = page.locator("ol#breadcrumbs li")
 
-        # Inbox page locators.
-        self.inbox_page_main_heading = page.locator("h1.sumo-page-heading")
-        self.inbox_no_messages_text = page.locator("article#inbox p")
-        self.inbox_page_scam_alert_banner_text = page.locator("div#id_scam_alert p.heading")
-        self.inbox_page_scam_alert_close_button = page.locator(
+        """Locators belonging to the Inbox scam banner."""
+        self.scam_alert_banner_text = page.locator("div#id_scam_alert p.heading")
+        self.scam_alert_close_button = page.locator(
             "button[data-close-id='id_scam_alert']")
-        self.inbox_page_message_action_banner = page.locator("ul.user-messages li p")
-        self.inbox_page_message_action_banner_close_button = page.locator(
+
+        """Locators belonging to the Inbox action banner."""
+        self.message_action_banner = page.locator("ul.user-messages li p")
+        self.message_action_banner_close_button = page.locator(
             "button.mzp-c-notification-bar-button")
 
-        # Inbox button locators.
-        self.inbox_new_message_button = page.locator("article#inbox").get_by_role("link").filter(
-            has_text="New Message")
-        self.inbox_mark_selected_as_read_button = page.locator("input[name='mark_read']")
-        self.inbox_delete_selected_button = page.locator("input[name='delete']")
-        self.inbox_delete_page_delete_button = page.locator("button[name='delete']")
-        self.inbox_delete_page_cancel_button = page.get_by_role("link").filter(has_text="Cancel")
+        """General locators for the Inbox page"""
+        self.main_heading = page.locator("h1.sumo-page-heading")
+        self.no_messages_text = page.locator("article#inbox p")
 
-        # Inbox messages.
+        """Locators for buttons belonging to the Inbox page."""
+        self.new_message_button = page.locator("article#inbox").get_by_role("link").filter(
+            has_text="New Message")
+        self.mark_selected_as_read_button = page.locator("input[name='mark_read']")
+        self.delete_selected_button = page.locator("input[name='delete']")
+
+        """Locators belonging to the delete confirmation page."""
+        self.delete_confirmation_page_delete_button = page.locator("button[name='delete']")
+        self.delete_confirmation_page_cancel_button = page.get_by_role("link").filter(has_text="Cancel")
+
+        """Locators belonging to the Inbox table."""
         self.inbox_messages = page.locator("li.email-row:not(.header)")
         self.inbox_messages_section = page.locator("ol.inbox-table")
         self.inbox_messages_delete_button = page.locator("div[class='email-cell delete'] a.delete")
@@ -36,9 +42,11 @@ class InboxPage(BasePage):
         self.all_unread_messages = page.locator("li[class='email-row unread']")
         self.all_read_messages_excerpt = page.locator(
             "ol.inbox-table li:not(.unread) div[class='email-cell excerpt'] a")
-        self.inbox_subject = lambda username: page.locator(
+        self.inbox_message_by_sender = lambda username: page.locator(
             f"//div[@class='email-cell from']//a[contains(text(),'{username}')]/../..//"
             f"a[@class='read']")
+        self.inbox_message_by_excerpt = lambda excerpt: page.locator(
+            "div[class='email-cell excerpt']").get_by_role("link", name=excerpt, exact=True)
         self.delete_by_username = lambda username: page.locator(
             f"//div[@class='email-cell from']//a[contains(text(),'{username}')]/../..//a[@class="
             f"'delete']")
@@ -50,144 +58,208 @@ class InboxPage(BasePage):
         self.message_checkbox_by_excerpt = lambda excerpt: page.locator(
             f"//div[@class='email-cell excerpt']/a[normalize-space(text())='{excerpt}']/../../"
             f"div[@class='email-cell check']/input")
-        self.message_by_excerpt = lambda excerpt: page.locator(
-            "div[class='email-cell excerpt']").get_by_role("link", name=excerpt, exact=True)
+        self.deleted_username_by_excerpt = lambda excerpt: page.locator(
+            f"//div[@class='email-cell excerpt']/a[normalize-space(text())='{excerpt}']/../../"
+            f"div[@class='email-cell from']")
+        self.sender_by_message_excerpt = lambda excerpt: page.locator(
+            f"//div[@class='email-cell excerpt']/a[normalize-space(text())='{excerpt}']/../../"
+            f"div[@class='email-cell from']/a")
+        self.deleted_sender_by_message_excerpt = lambda excerpt: page.locator(
+            f"//div[@class='email-cell excerpt']/a[normalize-space(text())='{excerpt}']/../../"
+            f"div[@class='email-cell from']")
 
-    # Inbox page scam alert actions.
-    def get_text_inbox_scam_alert_banner_text(self) -> str:
+        """Locators belonging to the read inbox messages page."""
+        self.message_sender = page.locator("//div[@class='user from']/a")
+        self.message_deleted_user_sender = page.locator("//div[@class='user from']")
+        self.message_content = page.locator("//div[@class='message']")
+        self.message_received_date = page.locator("div[@class='user from']/time")
+        self.message_user_information = page.locator("//section[@id='read-message']/i")
+
+    """Actions against the Inbox scam banner."""
+    def get_scam_alert_banner_text(self) -> str:
         """Get the text of the scam alert banner."""
-        return self._get_text_of_element(self.inbox_page_scam_alert_banner_text)
+        return self._get_text_of_element(self.scam_alert_banner_text)
 
-    def click_on_inbox_scam_alert_close_button(self):
+    def click_on_scam_alert_close_button(self):
         """Click on the close button of the scam alert banner."""
-        self._click(self.inbox_page_scam_alert_close_button)
+        self._click(self.scam_alert_close_button)
 
-    # Inbox page actions.
-    def get_text_inbox_page_message_banner_text(self) -> str:
-        """Get the text of the message action banner."""
-        return self._get_text_of_element(self.inbox_page_message_action_banner)
+    def get_scam_banner_message_locator(self) -> Locator:
+        """Get the locator of the inbox message scam banner."""
+        return self.scam_alert_banner_text
 
-    def get_text_of_inbox_page_main_header(self) -> str:
+    """Actions against the general Inbox page locators."""
+    def get_text_of_main_header(self) -> str:
         """Get the text of the main header of the inbox page."""
-        return self._get_text_of_element(self.inbox_page_main_heading)
+        return self._get_text_of_element(self.main_heading)
 
-    def get_text_of_inbox_no_message_header(self) -> str:
+    def get_text_of_no_message_header(self) -> str:
         """Get the text of the no message header."""
-        return self._get_text_of_element(self.inbox_no_messages_text)
+        return self._get_text_of_element(self.no_messages_text)
 
-    # Inbox messages actions.
-    def get_inbox_message_subject(self, username: str) -> str:
-        """Get the subject of the inbox message.
+    def is_no_message_header_displayed(self) -> bool:
+        """Check if the no message header is displayed."""
+        return self._is_element_visible(self.no_messages_text)
 
-        Args:
-            username: The username of the message sender.
+    """Actions against the Inbox action-banner."""
+    def get_action_banner_text(self) -> str:
+        """Get the text of the message action banner."""
+        return self._get_text_of_element(self.message_action_banner)
+
+    """Actions against the general buttons inside the Inbox page."""
+    def click_on_new_message_button(self):
+        """Click on the new message button."""
+        self._click(self.new_message_button)
+
+    def click_on_mark_selected_as_read_button(self):
+        """Click on the mark selected as read button."""
+        self._click(self.mark_selected_as_read_button)
+
+    def click_on_delete_selected_button(self, expected_locator=None):
         """
-        return self._get_text_of_element(self.inbox_subject(username))
+            Click on the delete selected button.
+            Args:
+                expected_locator (Locator) : The expected locator after the click event.
+        """
+        self._click(self.delete_selected_button, expected_locator=expected_locator)
 
-    def click_on_inbox_message_delete_button_by_username(self, username: str):
-        """Click on the delete button of the inbox message.
 
-        Args:
-            username: The username of the message sender.
+    def delete_all_inbox_messages_via_delete_selected_button(self, excerpt='', expected_url=None):
+        """
+            Delete all the inbox messages via the delete selected button.
+            Args:
+                excerpt (str): The excerpt of the message.
+                expected_url (str): The expected URL after deleting all the messages.
+        """
+        self.wait_for_dom_to_load()
+        if excerpt != '':
+            inbox_messages_count = self.get_inbox_message_element_handles_based_on_excerpt(excerpt)
+        else:
+            inbox_messages_count = self._get_element_handles(self.inbox_messages)
+        counter = 0
+        for i in range(len(inbox_messages_count)):
+            if excerpt != '':
+                inbox_checkbox = self.get_message_select_checkbox_element(excerpt)
+            else:
+                inbox_checkbox = self.get_message_select_checkbox_element()
+            element = inbox_checkbox[counter]
+            self._checkbox_interaction(element, True)
+            counter += 1
+
+        self.click_on_delete_selected_button()
+        self.click_on_delete_button_inside_the_confirmation_page(expected_url=expected_url)
+
+    """Actions against the Inbox table."""
+    def get_sender_by_excerpt(self, excerpt: str) -> str:
+        """
+            Get the message sender based on a given excerpt.
+            Args:
+                excerpt (str): The excerpt of the message.
+        """
+        return self._get_text_of_element(self.deleted_sender_by_message_excerpt(excerpt))
+
+    def get_message_subject(self, username: str) -> str:
+        """
+            Get the subject of the inbox message based on the sender's username.
+            Args:
+                username (str): The username of the message sender.
+        """
+        return self._get_text_of_element(self.inbox_message_by_sender(username))
+
+    def click_on_message_delete_button_by_username(self, username: str):
+        """
+        Click on the delete button of the inbox message based on the sender's username.
+            Args:
+                username (str): The username of the message sender.
         """
         self._click(self.delete_by_username(username))
 
-    def click_on_inbox_message_delete_button_by_excerpt(self, excerpt: str):
-        """Click on the delete button of the inbox message.
-
-        Args:
-            excerpt: The excerpt of the message.
+    def click_on_message_delete_button_by_excerpt(self, excerpt: str):
+        """
+            Click on the delete button of the inbox message based on the message excerpt.
+            Args:
+                excerpt (str): The excerpt of the message.
         """
         self._click(self.delete_by_excerpt(excerpt))
 
-    def click_on_inbox_new_message_button(self):
-        """Click on the new message button."""
-        self._click(self.inbox_new_message_button)
-
-    def click_on_inbox_mark_selected_as_read_button(self):
-        """Click on the mark selected as read button."""
-        self._click(self.inbox_mark_selected_as_read_button)
-
-    def click_on_inbox_delete_selected_button(self, expected_locator=None):
-        """Click on the delete selected button.
-
-        Args:
-            expected_locator: The expected locator after the click event.
+    def click_on_message_sender_username(self, username: str):
         """
-        self._click(self.inbox_delete_selected_button, expected_locator=expected_locator)
-
-    def click_on_inbox_message_sender_username(self, username: str):
-        """Click on the username of the message sender.
-
-        Args:
-            username: The username of the message sender.
+            Click on the username of the message sender.
+            Args:
+                username (str): The username of the message sender.
         """
         self._click(self.sender_username(username))
 
-    def inbox_message_select_checkbox_element(self, excerpt='') -> list[ElementHandle]:
-        """Get the element handle of the inbox message select checkbox.
-
-        Args:
-            excerpt: The excerpt of the message.
+    def get_message_select_checkbox_element(self, excerpt='') -> list[ElementHandle]:
+        """
+            Get the element handle of the select checkbox based on the message excerpt.
+            Args:
+                excerpt (str): The excerpt of the message.
         """
         if excerpt != '':
             return self._get_element_handles(self.message_checkbox_by_excerpt(excerpt))
         else:
             return self._get_element_handles(self.inbox_delete_checkbox)
 
-    def click_on_inbox_message_subject(self, username: str):
-        """Click on the subject of the inbox message.
-
-        Args:
-            username: The username of the message sender.
+    def click_on_message_by_username(self, username: str):
         """
-        self._click(self.inbox_subject(username))
-
-    def click_on_delete_page_delete_button(self, expected_url=None):
-        """Click on the delete button on the delete message page.
-
-        Args:
-            expected_url: The expected URL after deleting the message.
+            Click on the subject of the inbox message based on the sender's username.
+            Args:
+                username (str): The username of the message sender.
         """
-        self._click(self.inbox_delete_page_delete_button, expected_url=expected_url)
+        self._click(self.inbox_message_by_sender(username))
 
-    def click_on_delete_page_cancel_button(self):
-        """Click on the cancel button on the delete message page."""
-        # Hitting the "Enter" button instead of click due to an issue (the banner does not close
-        # on click)
-        self._press_a_key(self.inbox_delete_page_cancel_button, 'Enter')
-
-    def is_no_message_header_displayed(self) -> bool:
-        """Check if the no message header is displayed."""
-        return self._is_element_visible(self.inbox_no_messages_text)
-
-    def inbox_message_banner(self) -> Locator:
-        """Get the locator of the inbox message banner."""
-        return self.inbox_page_scam_alert_banner_text
-
-    def inbox_message(self, username: str) -> Locator:
-        """Get the locator of the inbox message.
-
+    def click_on_message_by_excerpt(self, excerpt: str):
+        """
+        Clicking on a message which has a certain excerpt.
         Args:
-            username: The username of the message sender.
+            excerpt (str): The message excerpt.
+        """
+        self._click(self.inbox_message_by_excerpt(excerpt))
+
+    """Actions against the delete confirmation page."""
+    def click_on_delete_button_inside_the_confirmation_page(self, expected_url=None):
+        """
+            Click on the delete button inside the delete message confirmation page.
+            Args:
+                expected_url (str): The expected URL after deleting the message.
+        """
+        self._click(self.delete_confirmation_page_delete_button, expected_url=expected_url)
+
+    def click_on_cancel_button_inside_the_confirmation_page(self):
+        """
+            Click on the cancel button inside the delete message confirmation page.
+
+            Note: Hitting the "Enter" key button instead of click due to an issue in which the
+            banner does not close on click events).
+        """
+        self._press_a_key(self.delete_confirmation_page_cancel_button, 'Enter')
+
+    def get_inbox_message_locator_based_on_sender(self, username: str) -> Locator:
+        """
+            Get the locator of the inbox message based on the sender's username.
+            Args:
+                username (str): The username of the message sender.
         """
         return self.sender_username(username)
 
-    def _inbox_message_based_on_excerpt(self, excerpt: str) -> Locator:
-        """Get the locator of the inbox message based on the excerpt.
-
-        Args:
-            excerpt: The excerpt of the message.
+    def get_inbox_message_locator_based_on_excerpt(self, excerpt: str) -> Locator:
         """
-        return self.message_by_excerpt(excerpt)
-
-    def _inbox_message_element_handles(self, excerpt: str) -> list[ElementHandle]:
-        """Get the element handles of the inbox message based on the excerpt.
-
-        Args:
-            excerpt: The excerpt of the message.
+            Get the locator of the inbox message based on the excerpt.
+            Args:
+                excerpt (str): The excerpt of the message.
         """
-        return self._get_element_handles(self.message_by_excerpt(excerpt))
+        return self.inbox_message_by_excerpt(excerpt)
+
+
+    def get_inbox_message_element_handles_based_on_excerpt(self,
+                                                           excerpt: str) -> list[ElementHandle]:
+        """
+            Get the element handles of the inbox messages based on the excerpt.
+            Args:
+                excerpt (str): The excerpt of the messages.
+        """
+        return self._get_element_handles(self.inbox_message_by_excerpt(excerpt))
 
     def are_inbox_messages_displayed(self) -> bool:
         """Check if the inbox messages are displayed."""
@@ -197,55 +269,25 @@ class InboxPage(BasePage):
         """Get the excerpt of all the read messages."""
         return self._get_text_of_elements(self.all_read_messages_excerpt)
 
-    def delete_all_inbox_messages(self, expected_url=None):
-        """Delete all the inbox messages.
-
-        Args:
-            expected_url: The expected URL after deleting all the messages.
+    def check_a_particular_message_based_on_excerpt(self, excerpt=''):
         """
-        inbox_messages_count = self._get_element_handles(self.inbox_messages)
-        for i in range(len(inbox_messages_count)):
-            inbox_elements_delete_button = self._get_element_handles(
-                self.inbox_messages_delete_button)
-            delete_button = inbox_elements_delete_button[i]
-
-            self._click(delete_button)
-            self.click_on_delete_page_delete_button(expected_url=expected_url)
-
-    def check_a_particular_message(self, excerpt=''):
-        """Check a particular message.
-
-        Args:
-            excerpt: The excerpt of the message.
+            Click on the checkbox for an inbox message based on the excerpt.
+            Args:
+                excerpt (str): The excerpt of the message.
         """
-        inbox_checkbox = self.inbox_message_select_checkbox_element(excerpt)
+        inbox_checkbox = self.get_message_select_checkbox_element(excerpt)
         self._checkbox_interaction(inbox_checkbox[0], True)
-
-    def delete_all_inbox_messages_via_delete_selected_button(self, excerpt='', expected_url=None):
-        """Delete all the inbox messages via the delete selected button.
-
-        Args:
-            excerpt: The excerpt of the message.
-            expected_url: The expected URL after deleting all the messages.
-        """
-        self.wait_for_dom_to_load()
-        if excerpt != '':
-            inbox_messages_count = self._inbox_message_element_handles(excerpt)
-        else:
-            inbox_messages_count = self._get_element_handles(self.inbox_messages)
-        counter = 0
-        for i in range(len(inbox_messages_count)):
-            if excerpt != '':
-                inbox_checkbox = self.inbox_message_select_checkbox_element(excerpt)
-            else:
-                inbox_checkbox = self.inbox_message_select_checkbox_element()
-            element = inbox_checkbox[counter]
-            self._checkbox_interaction(element, True)
-            counter += 1
-
-        self.click_on_inbox_delete_selected_button()
-        self.click_on_delete_page_delete_button(expected_url=expected_url)
 
     def get_all_unread_messages(self) -> list[Locator]:
         """Get all the unread messages."""
         return self.all_unread_messages.all()
+
+
+    """Actions against the read inbox message page."""
+    def get_the_deleted_user_message_sender_text(self) -> str:
+        """Returns the name of the message sender (which should be the deleted user)"""
+        return self._get_text_of_element(self.message_deleted_user_sender)
+
+    def get_the_deleted_user_information_text(self) -> str:
+        """Returns the deleted user information message"""
+        return self._get_text_of_element(self.message_user_information)

--- a/playwright_tests/pages/messaging_system_pages/new_message.py
+++ b/playwright_tests/pages/messaging_system_pages/new_message.py
@@ -7,170 +7,173 @@ class NewMessagePage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
-        # New message page locators.
-        self.new_message_page_header = page.locator("h1.sumo-page-heading")
-        self.new_message_to_input_field = page.locator("input#token-input-id_to")
-        self.new_message_textarea_input_field = page.locator("textarea#id_message")
-        self.new_message_textarea_remaining_characters = page.locator("div#remaining-characters")
-        self.new_message_cancel_button = page.get_by_role("link").filter(has_text="Cancel")
-        self.new_message_send_button = page.locator("button[name='send']")
-        self.new_message_preview_section = page.locator("section#preview")
-        self.new_message_preview_section_content = page.locator("div.message")
-        self.new_message_search_for_a_user_option = page.locator(
-            "div.token-input-dropdown-facebook")
-        self.new_message_search_results_bolded_characters = page.locator("div.name_search b")
-        self.new_message_search_results_text = page.locator("div.name_search")
-        self.sent_message_page_to_user_text = page.locator("li.token-input-token-facebook p")
-        self.sent_messages_page_no_user_text = page.locator(
+        """General locators belonging to the New Message page."""
+        self.page_header = page.locator("h1.sumo-page-heading")
+
+        """Locators belonging to the New Message page input fields."""
+        self.to_input_field = page.locator("input#token-input-id_to")
+        self.search_for_a_user_dropdown = page.locator("div.token-input-dropdown-facebook")
+        self.user_search_results_bolded_characters = page.locator("div.name_search b")
+        self.user_search_results_text = page.locator("div.name_search")
+        self.added_to_user_text = page.locator("li.token-input-token-facebook p")
+        self.no_user_search_results_text = page.locator(
             "div.token-input-dropdown-facebook p").filter(has_text="No results")
-        self.sent_message_page_to_user_delete_button = page.locator(
-            "span.token-input-delete-token-facebook")
+        self.added_user_delete_button = page.locator("span.token-input-delete-token-facebook")
         self.searched_user = lambda username: page.locator(
             f"//div[@class='name_search' and text()='{username}']")
+        self.textarea_input_field = page.locator("textarea#id_message")
+        self.textarea_remaining_characters_message = page.locator("div#remaining-characters")
+        self.cancel_button = page.get_by_role("link").filter(has_text="Cancel")
+        self.send_button = page.locator("button[name='send']")
 
-        #  Preview Section
-        self.new_message_preview_username = page.locator("div[class*='user from'] a")
-        self.new_message_preview_time = page.locator("div[class*='user from'] time")
-        self.new_message_preview_data_first_paragraph_content = page.locator("div.message p").first
-        self.new_message_preview_data_first_paragraph_strong_content = page.locator(
+        """Locators belonging to the New Message preview section."""
+        self.preview_section = page.locator("section#preview")
+        self.preview_section_content = page.locator("div.message")
+
+        """Locators belonging to the New Message preview section."""
+        self.preview_username = page.locator("div[class*='user from'] a")
+        self.preview_deleted_username = page.locator("div[class*='user from']")
+        self.preview_time = page.locator("div[class*='user from'] time")
+        self.preview_data_first_paragraph_content = page.locator("div.message p").first
+        self.preview_data_first_paragraph_strong_content = page.locator(
             "div.message p").first.locator("strong")
-        self.new_message_preview_data_first_paragraph_italic_content = page.locator(
+        self.preview_data_first_paragraph_italic_content = page.locator(
             "div.message p").first.locator("em")
-        self.new_message_numbered_list_items = page.locator("div.message ol li")
-        self.new_message_bulleted_list_items = page.locator("div.message ul li")
-        self.new_message_preview_external_link = page.get_by_role("link").filter(
-            has_text="Test external link")
-        self.new_message_preview_internal_link = page.get_by_role("link").filter(
-            has_text="Test internal Link")
-        self.new_message_preview_button = page.locator("input#preview-btn")
+        self.preview_numbered_list_items = page.locator("div.message ol li")
+        self.preview_bulleted_list_items = page.locator("div.message ul li")
+        self.preview_external_link = page.get_by_role("link").filter(has_text="Test external link")
+        self.preview_internal_link = page.get_by_role("link").filter(has_text="Test internal Link")
+        self.preview_button = page.locator("input#preview-btn")
 
-    # New message page actions.
-    def get_text_of_test_data_first_paragraph_text(self) -> str:
-        """Get text of the first paragraph in the preview section."""
-        return self._get_text_of_element(self.new_message_preview_data_first_paragraph_content)
+    """Actions against the general New Message page locators."""
+    def get_header_text(self) -> str:
+        """Get the text of the new message page header."""
+        return self._get_text_of_element(self.page_header)
 
-    def get_text_of_test_data_first_p_strong_text(self) -> str:
-        """Get text of the first bolded paragraph in the preview section."""
-        return self._get_text_of_element(
-            self.new_message_preview_data_first_paragraph_strong_content)
+    """Actions against the New Message "To" input field."""
+    def get_to_user_text(self) -> str:
+        """Get the text of the targeted user from the 'To' field."""
+        return self._get_text_of_element(self.added_to_user_text)
 
-    def get_text_of_test_data_first_p_italic_text(self) -> str:
-        """Get text of the first italicised paragraph in the preview section."""
-        return self._get_text_of_element(
-            self.new_message_preview_data_first_paragraph_italic_content)
-
-    def get_text_of_numbered_list_items(self) -> list[str]:
-        """Get text of the numbered list items in the preview section."""
-        return self._get_text_of_elements(self.new_message_numbered_list_items)
-
-    def get_text_of_bulleted_list_items(self) -> list[str]:
-        """Get text of the bulleted list items in the preview section."""
-        return self._get_text_of_elements(self.new_message_bulleted_list_items)
-
-    def get_text_of_message_preview_username(self) -> str:
-        """Get text of the username in the preview section."""
-        return self._get_text_of_element(self.new_message_preview_username)
-
-    def get_user_to_text(self) -> str:
-        """Get text of the user to in the sent message page."""
-        return self._get_text_of_element(self.sent_message_page_to_user_text)
-
-    def get_no_user_to_locator(self) -> Locator:
-        """Get locator of the no user to in the sent message page."""
-        return self.sent_messages_page_no_user_text
-
-    def get_new_message_page_header_text(self) -> str:
-        """Get text of the new message page header."""
-        return self._get_text_of_element(self.new_message_page_header)
-
-    def get_characters_remaining_text(self) -> str:
-        """Get text of the characters remaining in the textarea."""
-        return self._get_text_of_element(self.new_message_textarea_remaining_characters)
-
-    def get_characters_remaining_text_element(self) -> Locator:
-        """Get locator of the characters remaining in the textarea."""
-        return self.new_message_textarea_remaining_characters
-
-    def get_text_of_new_message_preview_section(self) -> str:
-        """Get text of the new message preview section."""
-        return self._get_text_of_element(self.new_message_preview_section_content)
+    def get_no_user_message_locator(self) -> Locator:
+        """Get the locator of the no user message from the 'To' search field."""
+        return self.no_user_search_results_text
 
     def get_text_of_search_result_bolded_character(self) -> str:
-        """Get text of the search result bolded character."""
-        return self._get_text_of_element(self.new_message_search_results_bolded_characters)
+        """Get the text of the search result bolded character."""
+        return self._get_text_of_element(self.user_search_results_bolded_characters)
 
-    def get_tet_of_search_results_text(self) -> list[str]:
-        """Get text of the search results."""
-        return self._get_text_of_elements(self.new_message_search_results_text)
+    def get_text_of_search_results(self) -> list[str]:
+        """Get the text of the 'To' search results."""
+        return self._get_text_of_elements(self.user_search_results_text)
 
     def click_on_username_to_delete_button(self):
-        """Click on the username to delete button."""
-        self._click(self.sent_message_page_to_user_delete_button)
-
-    def click_on_new_message_cancel_button(self):
-        """Click on the new message cancel button."""
-        self._click(self.new_message_cancel_button)
-
-    def click_on_new_message_preview_button(self):
-        """Click on the new message preview button."""
-        self._click(self.new_message_preview_button)
-
-    def click_on_new_message_send_button(self, expected_url=None):
-        """Click on the new message send button.
-
-        Args:
-            expected_url (str): The expected URL after the click event.
-        """
-        self._click(self.new_message_send_button, expected_url=expected_url)
+        """Click on the delete button from an added user inside the 'To' field."""
+        self._click(self.added_user_delete_button)
 
     def click_on_a_searched_user(self, username: str):
-        """Click on a searched user.
-
-        Args:
-            username (str): The username to click on.
+        """
+            Click on a searched user.
+            Args:
+                username (str): The username to click on.
         """
         self._click(self.searched_user(username))
 
+    def type_into_to_input_field(self, text: str):
+        """
+            Type into the 'To' field from the New Messages page.
+            Args:
+                text (str): The text to type into the input field.
+        """
+        self._type(self.to_input_field, text, 0)
+
+    """Actions against the New Message textarea field."""
+    def get_characters_remaining_text(self) -> str:
+        """Get the text of the characters remaining message from the New Message textarea."""
+        return self._get_text_of_element(self.textarea_remaining_characters_message)
+
+    def get_characters_remaining_text_locator(self) -> Locator:
+        """Get the locator of the characters remaining message from the New Message textarea."""
+        return self.textarea_remaining_characters_message
+
+    def click_cancel_button(self):
+        """Click on the 'Cancel' button from the New Messages page."""
+        self._click(self.cancel_button)
+
+    def click_on_preview_button(self):
+        """Click on the 'Preview' button from the New Messages page."""
+        self._click(self.preview_button)
+
+    def click_on_send_button(self, expected_url=None):
+        """
+            Click on the 'Send' button from the New Messages page.
+            Args:
+                expected_url (str) (optional): The expected URL after the click event.
+        """
+        self._click(self.send_button, expected_url=expected_url)
+
+
+    def fill_into_message_textarea(self, text: str):
+        """
+            Fill into the 'Message' textarea from the New Message page.
+            Args:
+                text (str): The text to fill into the textarea.
+        """
+        self._fill(self.textarea_input_field, text)
+
+    def type_into_textarea_body(self, text: str):
+        """
+            Type into the 'Message' textarea from the New Message page.
+            Args:
+                text (str): The text to type into the textarea.
+        """
+        self._type(self.textarea_input_field, text, 0)
+
+    """Actions against the New message preview section."""
+    def get_text_of_previewed_data_first_paragraph(self) -> str:
+        """Get the text of the first paragraph in the preview section."""
+        return self._get_text_of_element(self.preview_data_first_paragraph_content)
+
+    def get_text_of_previewed_data_first_p_strong(self) -> str:
+        """Get the text of the first bolded paragraph in the preview section."""
+        return self._get_text_of_element(self.preview_data_first_paragraph_strong_content)
+
+    def get_text_of_previewed_data_first_p_italic(self) -> str:
+        """Get the text of the first italicised paragraph in the preview section."""
+        return self._get_text_of_element(self.preview_data_first_paragraph_italic_content)
+
+    def get_text_of_previewed_data_numbered_list_items(self) -> list[str]:
+        """Get the text of the numbered list items in the preview section."""
+        return self._get_text_of_elements(self.preview_numbered_list_items)
+
+    def get_text_of_previewed_data_bulleted_list_items(self) -> list[str]:
+        """Get the text of the bulleted list items in the preview section."""
+        return self._get_text_of_elements(self.preview_bulleted_list_items)
+
+    def get_text_of_preview_data_username(self) -> str:
+        """Get the text of the username in the preview section."""
+        return self._get_text_of_element(self.preview_username)
+
+    def get_text_of_new_message_preview_section(self) -> str:
+        """Get the text of the whole New Message preview section."""
+        return self._get_text_of_element(self.preview_section_content)
+
     def click_on_preview_internal_link(self):
-        """Click on the preview internal link."""
-        self._click(self.new_message_preview_internal_link)
+        """Click on the internal link from the New Message preview section."""
+        self._click(self.preview_internal_link)
 
-    def type_into_new_message_to_input_field(self, text: str):
-        """Type into the new message to input field.
-
-        Args:
-            text (str): The text to type into the input field.
-        """
-        self._type(self.new_message_to_input_field, text, 0)
-
-    def fill_into_new_message_body_textarea(self, text: str):
-        """Fill into the new message body textarea.
-
-        Args:
-            text (str): The text to fill into the textarea.
-        """
-        self._fill(self.new_message_textarea_input_field, text)
-
-    def type_into_new_message_body_textarea(self, text: str):
-        """Type into the new message body textarea.
-
-        Args:
-            text (str): The text to type into the textarea
-        """
-        self._type(self.new_message_textarea_input_field, text, 0)
-
-    def message_preview_section_element(self) -> Locator:
-        """Get locator of the message preview section."""
-        return self.new_message_preview_section
+    def get_preview_section_locator(self) -> Locator:
+        """Get the locator of the message preview section."""
+        return self.preview_section
 
     def is_message_preview_time_displayed(self) -> bool:
         """Check if the message preview time is displayed."""
-        return self._is_element_visible(self.new_message_preview_time)
+        return self._is_element_visible(self.preview_time)
 
-    def new_message_preview_internal_link_test_data_element(self) -> Locator:
-        """Get locator of the new message preview internal link."""
-        return self.new_message_preview_internal_link
+    def get_preview_internal_link_test_data_locator(self) -> Locator:
+        """Get the locator of the internal link displayed inside the New Message page preview."""
+        return self.preview_internal_link
 
-    def new_message_preview_external_link_test_data_element(self) -> Locator:
-        """Get locator of the new message preview external link."""
-        return self.new_message_preview_external_link
+    def get_preview_external_link_test_data_locator(self) -> Locator:
+        """Get the locator of the external link displayed inside the New Message page preview"""
+        return self.preview_external_link

--- a/playwright_tests/pages/messaging_system_pages/sent_messages.py
+++ b/playwright_tests/pages/messaging_system_pages/sent_messages.py
@@ -8,21 +8,31 @@ class SentMessagePage(BasePage):
         super().__init__(page)
 
         # Sent messages page locators.
-        self.sent_messages_breadcrumbs = page.locator("ol#breadcrumbs li")
-        self.sent_messages_page_header = page.locator("h1.sumo-page-subheading")
-        self.sent_messages_no_messages_message = page.locator("article#outbox p")
-        self.sent_messages_delete_selected_button = page.get_by_role("button").filter(
-            has_text="Delete Selected")
-        self.sent_messages_delete_page_delete_button = page.locator("button[name='delete']")
-        self.sent_messages_delete_page_cancel_button = page.get_by_role("link").filter(
+
+        """Locators belonging to the breadcrumbs section."""
+        self.all_breadcrumbs = page.locator("ol#breadcrumbs li")
+
+        """Locators belonging to the Sent Messages banner."""
+        self.banner_text = page.locator("ul.user-messages li p")
+        self.banner_close_button = page.locator("button.mzp-c-notification-bar-button")
+
+        """General locators belonging to the Sent Messages page."""
+        self.page_header = page.locator("h1.sumo-page-subheading")
+        self.no_messages_message = page.locator("article#outbox p")
+
+        """Locators belonging to the Sent Messages buttons."""
+        self.delete_selected_button = page.get_by_role("button").filter(has_text="Delete Selected")
+        self.delete_button = page.locator("button[name='delete']")
+
+        """Locators belonging to the Sent Messages delete confirmation page."""
+        self.delete_confirmation_cancel_button = page.get_by_role("link").filter(
             has_text="Cancel")
-        self.sent_messages_page_message_banner_text = page.locator("ul.user-messages li p")
-        self.sent_message_page_message_banner_close_button = page.locator(
-            "button.mzp-c-notification-bar-button")
+
+        """Locators belonging to the Sent Messages table."""
         self.sent_messages = page.locator("li.email-row:not(.header)")
         self.sent_messages_section = page.locator("ol.outbox-table")
         self.sent_messages_delete_button = page.locator("ol.outbox-table a.delete")
-        self.sent_messages_delete_checkbox = page.locator("div.checkbox label")
+        self.sent_messages_checkboxes = page.locator("div.checkbox label")
         self.sent_message_subject = lambda username: page.locator(
             f"//div[@class='email-cell to']//a[contains(text(),'{username}')]/../../div[@class="
             f"'email-cell excerpt']/a")
@@ -45,41 +55,52 @@ class SentMessagePage(BasePage):
         self.sent_message_by_group = lambda group_name, excerpt: page.locator(
             f"//div[@class='email-cell to-groups']//a[contains(text(),'{group_name}')]/../../div[@"
             f"class='email-cell excerpt']/a[normalize-space(text())='{excerpt}']")
+        self.recipient_based_on_excerpt = lambda excerpt: page.locator(
+            f"//div[@class='email-cell excerpt']/a[normalize-space(text())='{excerpt}']/../../"
+            f"div[@class='email-cell to']/a")
+        self.deleted_user_recipient_based_on_excerpt = lambda excerpt: page.locator(
+            f"//div[@class='email-cell excerpt']/a[normalize-space(text())='{excerpt}']/../../"
+            f"div[@class='email-cell to']")
 
-        # Read Sent Messages page
+        """Locators belonging to the read Sent Messages page."""
         self.to_groups_list_items = page.locator("span.to-group a")
         self.to_user_list_items = page.locator("span.to a")
+        self.to_deleted_user_list_item = page.locator("span.to")
 
-    # Sent messages page actions.
-    def get_sent_messages_page_deleted_banner_text(self) -> str:
-        """Get the text of the banner that appears when a message is deleted."""
-        return self._get_text_of_element(self.sent_messages_page_message_banner_text)
+    """Actions against the Sent Messages page banner."""
+    def get_sent_message_deleted_banner_text(self) -> str:
+        """Get the text of the banner that appears when a sent message is deleted."""
+        return self._get_text_of_element(self.banner_text)
 
-    def get_sent_messages_page_header(self) -> str:
-        """Get the header text of the sent messages page."""
-        return self._get_text_of_element(self.sent_messages_page_header)
+    """Actions against the Sent Messages general page locators."""
+    def get_page_header(self) -> str:
+        """Get the header text of the Sent Messages page."""
+        return self._get_text_of_element(self.page_header)
 
-    def get_sent_messages_no_message_text(self) -> str:
+    def get_no_message_text(self) -> str:
         """Get the text of the message that appears when there are no messages in the
-        sent messages page.
+        Sent Messages page.
         """
-        return self._get_text_of_element(self.sent_messages_no_messages_message)
+        return self._get_text_of_element(self.no_messages_message)
 
+    """Actions against the Sent Messages page buttons."""
+    def click_on_delete_selected_button(self, expected_locator=None):
+        """
+            Click on the delete selected button from the Sent Messages page.
+            Args:
+                expected_locator (str) (optional): The expected locator after the click event.
+        """
+        self._click(self.delete_selected_button, expected_locator=expected_locator)
+
+    """Actions against the Sent Messages table."""
     def get_sent_message_subject(self, username: str) -> str:
-        """Get the subject of the sent message by the username of the recipient.
-
-        Args:
-            username (str): The username of the recipient.
+        """
+            Get the subject of the sent message based on the username of the message recipient.
+            Args:
+                username (str): The username of the recipient.
         """
         return self._get_text_of_element(self.sent_message_subject(username))
 
-    def click_on_delete_selected_button(self, expected_locator=None):
-        """Click on the delete selected button on the sent messages page.
-
-        Args:
-            expected_locator (str): The expected locator after the click event.
-        """
-        self._click(self.sent_messages_delete_selected_button, expected_locator=expected_locator)
 
     def click_on_sent_message_delete_button_by_user(self, username: str):
         """Click on the delete button of a sent message by the username of the recipient.
@@ -103,7 +124,7 @@ class SentMessagePage(BasePage):
 
     def sent_message_select_checkbox(self) -> list[ElementHandle]:
         """Get element handle list of the selected sent messages checkboxes."""
-        return self._get_element_handles(self.sent_messages_delete_checkbox)
+        return self._get_element_handles(self.sent_messages_checkboxes)
 
     def sent_message_select_checkbox_element(self, excerpt: str) -> list[ElementHandle]:
         """Get element handle list of the selected sent messages checkboxes by excerpt.
@@ -135,11 +156,11 @@ class SentMessagePage(BasePage):
         Args:
             expected_url (str): The expected URL after the deletion.
         """
-        self._click(self.sent_messages_delete_page_delete_button, expected_url=expected_url)
+        self._click(self.delete_button, expected_url=expected_url)
 
     def click_on_delete_page_cancel_button(self):
         """Click on the cancel button on the delete message page."""
-        self._click(self.sent_messages_delete_page_cancel_button)
+        self._click(self.delete_confirmation_cancel_button)
 
     def sent_messages_by_username(self, username: str) -> Locator:
         """Get the locator of the sent messages by the username of the recipient.
@@ -177,7 +198,7 @@ class SentMessagePage(BasePage):
 
     def sent_message_banner(self) -> Locator:
         """Get the locator of the sent message banner."""
-        return self.sent_messages_page_message_banner_text
+        return self.banner_text
 
     def are_sent_messages_displayed(self) -> bool:
         """Check if the sent messages are displayed."""
@@ -220,7 +241,27 @@ class SentMessagePage(BasePage):
         self.click_on_delete_selected_button()
         self.click_on_delete_page_delete_button(expected_url=expected_url)
 
-    # Read Sent Message page
+    def get_recipient_based_on_excerpt(self, excerpt: str) -> str:
+        """
+            Get text of recipient based on excerpt.
+            Args:
+                excerpt (str): The message excerpt.
+            Returns:
+                (str): Message recipient.
+        """
+        return self._get_text_of_element(self.recipient_based_on_excerpt(excerpt))
+
+    def get_deleted_user_recipient_based_on_excerpt(self, excerpt: str) -> str:
+        """
+            Get text of deleted user recipient based on excerpt.
+            Args:
+                excerpt (str): The message excerpt.
+            Returns:
+                (str): Message recipient.
+        """
+        return self._get_text_of_element(self.deleted_user_recipient_based_on_excerpt(excerpt))
+
+    """Actions against the read sent message page."""
     def get_text_of_all_sent_groups(self) -> list[str]:
         """Get the text of all the sent groups."""
         return self._get_text_of_elements(self.to_groups_list_items)
@@ -228,3 +269,7 @@ class SentMessagePage(BasePage):
     def get_text_of_all_recipients(self) -> list[str]:
         """Get the text of all the recipients."""
         return self._get_text_of_elements(self.to_user_list_items)
+
+    def get_deleted_user(self) -> str:
+        """Get the text of the deleted user recipient inside the read sent message page"""
+        return self._get_text_of_element(self.to_deleted_user_list_item)

--- a/playwright_tests/pages/user_pages/my_profile_edit.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit.py
@@ -44,10 +44,16 @@ class MyProfileEdit(BasePage):
         self.cancel_button = page.get_by_role("button").filter(has_text="Cancel")
         self.update_my_profile_button = page.get_by_role("button").filter(
             has_text="Update My Profile")
+
+        # Locators belonging to the close account modal.
         self.close_account_and_delete_all_profile_information_link = page.locator(
             "p.delete-account-link a")
-        self.close_account_username_modal = page.locator("input#delete-profile-username-input")
-        self.close_account_delete_button = page.locator("input#delete-profile-button")
+        self.close_account_username_modal = page.locator("input#delete-profile-confirmation-input")
+        self.close_account_username_modal_confirmation_code = page.locator(
+            "//div[@id='delete-profile']//strong")
+        self.close_account_delete_button = page.locator("button#delete-profile-button")
+        self.close_modal_button = page.locator("button[class='mzp-c-modal-button-close']")
+
         self.all_input_edit_profile_input_fields = page.locator(
             "//form[not(contains(@action, '/en-US/users/close_account'))]/div[@class='field']/"
             "input[not(contains(@id, 'id_username'))]"
@@ -259,13 +265,37 @@ class MyProfileEdit(BasePage):
         """Click the close account and delete all profile information link"""
         self._click(self.close_account_and_delete_all_profile_information_link)
 
-    def add_username_to_close_account_modal(self, username: str):
-        """Add the username to the close account modal"""
-        self._fill(self.close_account_username_modal, username)
+    def add_confirmation_code_to_close_account_modal(self, invalid_code=False):
+        """
+        Add the confirmation code to the close account modal.
+            Args:
+                invalid_code (bool): If set to true to be used in tests which are covering the
+                submission of an invalid code inside the user deletion modal.
+        """
+        self._wait_for_given_timeout(1000)
+        code = self._get_text_of_element(self.close_account_username_modal_confirmation_code)
+        if invalid_code:
+            code += "A"
+
+        self._type(self.close_account_username_modal, code, 10)
+
+    def clear_confirmation_code_from_close_account_modal(self):
+        """Clearing the confirmation code from the close account modal"""
+        self._clear_field(self.close_account_username_modal)
 
     def click_close_account_button(self):
         """Click the close account button in the close account modal"""
-        self._click(self.close_account_delete_button)
+        self._click(self.close_account_delete_button,
+                    expected_url="https://support.allizom.org/en-US/users/close_account",
+                    retries=2)
+
+    def is_delete_your_account_button_disabled(self) -> bool:
+        """Returning whether the 'Delete Your Account' button is disabled or not."""
+        return self._is_element_disabled(self.close_account_delete_button)
+
+    def click_on_close_modal_button(self):
+        """Clicking on the 'X' button from the close account modal"""
+        self._click(self.close_modal_button)
 
     def click_manage_firefox_account_button(self):
         """Click the manage firefox account button"""

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -37,4 +37,5 @@ markers =
     contributorDiscussions: Tests belonging to the contributor discussions forums page.
     contributorDiscussionsThreads: Tests belonging to the contributor discussions threads.
     smokeTest: Tests belonging to the smoke test suite.
+    userDeletion: Tests belonging to the user deletion suite.
 addopts = --alluredir=./reports/allure_reports --tb=no

--- a/playwright_tests/test_data/general_data.json
+++ b/playwright_tests/test_data/general_data.json
@@ -109,5 +109,6 @@
     "article_discussions": "https://support.allizom.org/en-US/kb/all/discussions"
   },
   "groups": "https://support.allizom.org/en-US/groups/",
-  "test_article_link": "https://support.allizom.org/en-US/kb/donotdelete"
+  "test_article_link": "https://support.allizom.org/en-US/kb/donotdelete",
+  "system_account_name": "SuMo Bot"
 }

--- a/playwright_tests/test_data/profile_edit.json
+++ b/playwright_tests/test_data/profile_edit.json
@@ -1,4 +1,5 @@
 {
+  "close_account_page": "https://support.allizom.org/en-US/users/close_account",
   "valid_user_edit": {
     "username": "modifiedUsernameAutoTestt",
     "display_name": "Modified display name",

--- a/playwright_tests/test_data/search_synonym.py
+++ b/playwright_tests/test_data/search_synonym.py
@@ -6,9 +6,9 @@ class SearchSynonyms:
 
         # Technical terms
         'cache': ['cash', 'cookies'],
-        'popup': ['pop up'],
+        'popup': ['pop up', "pop-ups"],
         'pop up': ['popup'],
-        'pop-up':['pop-ups', 'popups'],
+        'pop-up':['pop-ups', 'popups', 'popup'],
         'popups': ['pop-up', 'pop-ups', 'pop ups', 'pops up'],
 
         # Actions

--- a/playwright_tests/tests/contribute_tests/contributor_discussions/test_contributor_discussions_threads.py
+++ b/playwright_tests/tests/contribute_tests/contributor_discussions/test_contributor_discussions_threads.py
@@ -872,7 +872,7 @@ def test_private_message_option(page: Page, create_user_factory):
                             "is displayed inside the inbox section"):
         utilities.start_existing_session(cookies=test_user)
         sumo_pages.top_navbar.click_on_inbox_option()
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message)).to_be_visible()
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message)).to_be_visible()
 
     with check, allure.step("Navigating back to the thread, signing out and verifying that the "
                             "'Private message' option redirects the user to the auth page"):

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -29,14 +29,14 @@ def test_no_messages_here_text_is_displayed_when_no_messages_are_available(page:
         sumo_pages.top_navbar.click_on_inbox_option()
 
     with check, allure.step("Verifying that the correct message is displayed"):
-        assert (sumo_pages.inbox_page.get_text_of_inbox_no_message_header() == InboxPageMessages.
+        assert (sumo_pages.inbox_page.get_text_of_no_message_header() == InboxPageMessages.
                 NO_MESSAGES_IN_INBOX_TEXT)
 
     with allure.step("Navigating to the 'Sent Messages' page"):
         sumo_pages.mess_system_user_navbar.click_on_messaging_system_nav_sent_messages()
 
     with allure.step("Verifying that the correct page message is displayed"):
-        assert sumo_pages.sent_message_page.get_sent_messages_no_message_text(
+        assert sumo_pages.sent_message_page.get_no_message_text(
         ) == SentMessagesPageMessages.NO_MESSAGES_IN_SENT_MESSAGES_TEXT
 
 
@@ -67,7 +67,7 @@ def test_private_messages_can_be_sent_via_user_profiles(page: Page, is_firefox,
     with allure.step("Verifying that the receiver is automatically added inside the 'To' field"):
         # Firefox GH runner fails here. We are running this assertion only in Chrome for now
         if not is_firefox:
-            assert sumo_pages.new_message_page.get_user_to_text() == test_user_two["username"]
+            assert sumo_pages.new_message_page.get_to_user_text() == test_user_two["username"]
 
     with allure.step("Sending a message to the user"):
         sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
@@ -77,7 +77,7 @@ def test_private_messages_can_be_sent_via_user_profiles(page: Page, is_firefox,
 
     with check, allure.step("Verifying that the correct message sent banner is displayed"):
         assert (sumo_pages.inbox_page.
-                get_text_inbox_page_message_banner_text() == InboxPageMessages.
+                get_action_banner_text() == InboxPageMessages.
                 MESSAGE_SENT_BANNER_TEXT)
 
     with allure.step("Clicking on the 'Sent Messages option"):
@@ -96,7 +96,7 @@ def test_private_messages_can_be_sent_via_user_profiles(page: Page, is_firefox,
 
     with check, allure.step("Verifying that the correct banner is displayed"):
         assert (sumo_pages.sent_message_page.
-                get_sent_messages_page_deleted_banner_text() == SentMessagesPageMessages.
+                get_sent_message_deleted_banner_text() == SentMessagesPageMessages.
                 DELETE_MESSAGE_BANNER_TEXT)
 
     with allure.step("Verifying that messages from user two are not displayed"):
@@ -110,7 +110,7 @@ def test_private_messages_can_be_sent_via_user_profiles(page: Page, is_firefox,
         sumo_pages.top_navbar.click_on_inbox_option()
 
     with allure.step("Verifying that the inbox contains the previously sent messages"):
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_visible()
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)).to_be_visible()
 
     with allure.step("Fetching the unread messages count and verifying that the counter displays"
                      " the correct data"):
@@ -126,11 +126,11 @@ def test_private_messages_can_be_sent_via_user_profiles(page: Page, is_firefox,
         )
 
     with allure.step("Verifying that the messages are no longer displayed inside the inbox"):
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(excerpt=message_body)
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(excerpt=message_body)
                ).to_be_hidden()
 
     with allure.step("Verifying that the correct banner is displayed"):
-        assert sumo_pages.sent_message_page.get_sent_messages_page_deleted_banner_text(
+        assert sumo_pages.sent_message_page.get_sent_message_deleted_banner_text(
         ) == SentMessagesPageMessages.DELETE_MESSAGE_BANNER_TEXT
 
 
@@ -162,7 +162,7 @@ def test_private_message_can_be_sent_via_new_message_page(page: Page, create_use
 
     with check, allure.step("Verifying that the correct banner is displayed"):
         assert (sumo_pages.inbox_page.
-                get_text_inbox_page_message_banner_text() == InboxPageMessages.
+                get_action_banner_text() == InboxPageMessages.
                 MESSAGE_SENT_BANNER_TEXT)
 
     with allure.step("Verifying that the sent message is displayed inside the sent messages "
@@ -181,7 +181,7 @@ def test_private_message_can_be_sent_via_new_message_page(page: Page, create_use
                      "displayed inside the inbox section"):
         utilities.start_existing_session(cookies=test_user_two)
         sumo_pages.top_navbar.click_on_inbox_option()
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)
                ).to_be_visible()
 
     with allure.step("Clearing the inbox"):
@@ -279,11 +279,11 @@ def test_new_message_field_validation(page: Page, create_user_factory):
 
     with allure.step("Verifying that the characters remaining color is the expected one"):
         expect(
-            sumo_pages.new_message_page.get_characters_remaining_text_element()
+            sumo_pages.new_message_page.get_characters_remaining_text_locator()
         ).to_have_css("color", NewMessagePageMessages.ENOUGH_CHARACTERS_REMAINING_COLOR)
 
     with allure.step("Adding 9990 characters inside the input field"):
-        sumo_pages.new_message_page.fill_into_new_message_body_textarea(
+        sumo_pages.new_message_page.fill_into_message_textarea(
             text=utilities.user_message_test_data["valid_user_message"][
                 "9990_characters_long_message"
             ])
@@ -293,7 +293,7 @@ def test_new_message_field_validation(page: Page, create_user_factory):
         ) in NewMessagePageMessages.TEN_CHARACTERS_REMAINING_MESSAGE
 
     with allure.step("Verifying that the characters remaining color is the expected one"):
-        expect(sumo_pages.new_message_page.get_characters_remaining_text_element()
+        expect(sumo_pages.new_message_page.get_characters_remaining_text_locator()
                ).to_have_css("color", NewMessagePageMessages.ENOUGH_CHARACTERS_REMAINING_COLOR)
 
     # elif self.browser == "firefox":
@@ -306,7 +306,7 @@ def test_new_message_field_validation(page: Page, create_user_factory):
     #     )
 
     with allure.step("Adding one character inside the textarea field"):
-        sumo_pages.new_message_page.type_into_new_message_body_textarea(
+        sumo_pages.new_message_page.type_into_textarea_body(
             text=utilities.user_message_test_data["valid_user_message"]
             ["one_character_message"]
         )
@@ -316,7 +316,7 @@ def test_new_message_field_validation(page: Page, create_user_factory):
         ) in NewMessagePageMessages.NINE_CHARACTERS_REMAINING_MESSAGE
 
     with allure.step("Verifying that the characters remaining color is the expected one"):
-        expect(sumo_pages.new_message_page.get_characters_remaining_text_element()
+        expect(sumo_pages.new_message_page.get_characters_remaining_text_locator()
                ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
 
     # elif self.browser == "firefox":
@@ -329,14 +329,14 @@ def test_new_message_field_validation(page: Page, create_user_factory):
     #     )
 
     with allure.step("Adding 9 characters inside the textarea field"):
-        sumo_pages.new_message_page.type_into_new_message_body_textarea(
+        sumo_pages.new_message_page.type_into_textarea_body(
             text=utilities.user_message_test_data["valid_user_message"]
             ["9_characters_message"]
         )
 
     with allure.step("Verifying that the char remaining string is updated accordingly"):
         expect(
-            sumo_pages.new_message_page.get_characters_remaining_text_element()
+            sumo_pages.new_message_page.get_characters_remaining_text_locator()
         ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
 
     # elif self.browser == "firefox":
@@ -350,7 +350,7 @@ def test_new_message_field_validation(page: Page, create_user_factory):
 
     with allure.step("Verifying that the characters remaining color is the expected one"):
         expect(
-            sumo_pages.new_message_page.get_characters_remaining_text_element()
+            sumo_pages.new_message_page.get_characters_remaining_text_locator()
         ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
 
     # elif self.browser == "firefox":
@@ -388,7 +388,7 @@ def test_new_message_cancel_button(page: Page, create_user_factory):
 
     with allure.step("Clicking on the 'Cancel' button and verifying that the user is "
                      "redirected back to the inbox page"):
-        sumo_pages.new_message_page.click_on_new_message_cancel_button()
+        sumo_pages.new_message_page.click_cancel_button()
         expect(
             sumo_pages.mess_system_user_navbar.get_inbox_navbar_element()
         ).to_have_css("background-color", InboxPageMessages.NAVBAR_INBOX_SELECTED_BG_COLOR)
@@ -406,7 +406,7 @@ def test_new_message_cancel_button(page: Page, create_user_factory):
     with allure.step("Navigating to the receiver inbox and verifying that no message was "
                      "received"):
         sumo_pages.top_navbar.click_on_inbox_option()
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_hidden()
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)).to_be_hidden()
 
 
 # C2706741, C2706736, C2706740, C2706739, C2706735
@@ -462,8 +462,8 @@ def test_messaging_system_unread_notification_after_message_deletion(page: Page,
         assert sumo_pages.top_navbar.is_unread_message_notification_displayed()
 
     with allure.step("Marking the first received message as read"):
-        sumo_pages.inbox_page.check_a_particular_message(content_first_message)
-        sumo_pages.inbox_page.click_on_inbox_mark_selected_as_read_button()
+        sumo_pages.inbox_page.check_a_particular_message_based_on_excerpt(content_first_message)
+        sumo_pages.inbox_page.click_on_mark_selected_as_read_button()
 
     with allure.step("Verifying that the message is successfully marked as read"):
         assert content_first_message in sumo_pages.inbox_page.get_all_read_messages_excerpt()
@@ -491,8 +491,8 @@ def test_messaging_system_unread_notification_after_message_deletion(page: Page,
         assert sumo_pages.top_navbar.is_unread_message_notification_displayed()
 
     with allure.step("Marking the second received message as read"):
-        sumo_pages.inbox_page.check_a_particular_message(content_second_message)
-        sumo_pages.inbox_page.click_on_inbox_mark_selected_as_read_button()
+        sumo_pages.inbox_page.check_a_particular_message_based_on_excerpt(content_second_message)
+        sumo_pages.inbox_page.click_on_mark_selected_as_read_button()
 
     with allure.step("Verifying that the new message notification counter resembles the unread "
                      "inbox message count"):
@@ -547,17 +547,17 @@ def test_new_message_preview(page: Page, create_user_factory):
 
     with allure.step("Clicking on the 'Preview' button and verifying that the preview "
                      "section is successfully displayed"):
-        sumo_pages.new_message_page.click_on_new_message_preview_button()
-        expect(sumo_pages.new_message_page.message_preview_section_element()).to_be_visible()
+        sumo_pages.new_message_page.click_on_preview_button()
+        expect(sumo_pages.new_message_page.get_preview_section_locator()).to_be_visible()
 
     with allure.step("Verifying that all the preview items are displayed"):
-        assert sumo_pages.new_message_page.get_text_of_test_data_first_paragraph_text(
+        assert sumo_pages.new_message_page.get_text_of_previewed_data_first_paragraph(
         ) in NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_TEXT
 
-        assert sumo_pages.new_message_page.get_text_of_test_data_first_p_strong_text(
+        assert sumo_pages.new_message_page.get_text_of_previewed_data_first_p_strong(
         ) in NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_STRONG_TEXT
 
-        assert sumo_pages.new_message_page.get_text_of_test_data_first_p_italic_text(
+        assert sumo_pages.new_message_page.get_text_of_previewed_data_first_p_italic(
         ) in NewMessagePageMessages.PREVIEW_MESSAGE_CONTENT_FIRST_PARAGRAPH_ITALIC_TEXT
 
         numbered_list_items = [
@@ -572,16 +572,16 @@ def test_new_message_preview(page: Page, create_user_factory):
             NewMessagePageMessages.PREVIEW_MESSAGE_UL_LI_NUMBER_THREE,
         ]
 
-        assert sumo_pages.new_message_page.get_text_of_numbered_list_items(
+        assert sumo_pages.new_message_page.get_text_of_previewed_data_numbered_list_items(
         ) == numbered_list_items
 
-        assert sumo_pages.new_message_page.get_text_of_bulleted_list_items(
+        assert sumo_pages.new_message_page.get_text_of_previewed_data_bulleted_list_items(
         ) == bulleted_list_items
 
-        expect(sumo_pages.new_message_page.new_message_preview_external_link_test_data_element()
+        expect(sumo_pages.new_message_page.get_preview_external_link_test_data_locator()
                ).to_be_visible()
 
-        expect(sumo_pages.new_message_page.new_message_preview_internal_link_test_data_element()
+        expect(sumo_pages.new_message_page.get_preview_internal_link_test_data_locator()
                ).to_be_visible()
 
     with allure.step("Clicking on the internal link and verifying that the user is "
@@ -607,7 +607,7 @@ def test_new_message_preview(page: Page, create_user_factory):
                      "message were received"):
         utilities.start_existing_session(cookies=test_user_two)
         sumo_pages.top_navbar.click_on_inbox_option()
-        expect(sumo_pages.inbox_page.inbox_message(username=test_user["username"])
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_sender(username=test_user["username"])
                ).to_be_hidden()
 
 
@@ -638,10 +638,10 @@ def test_messages_can_be_selected_and_deleted(page: Page, create_user_factory):
 
     with allure.step("Clicking on the 'Delete Selected' button"):
         sumo_pages.sent_message_page.click_on_delete_selected_button(
-            expected_locator=sumo_pages.sent_message_page.sent_messages_page_message_banner_text)
+            expected_locator=sumo_pages.sent_message_page.banner_text)
 
     with check, allure.step("Verifying that the correct message is displayed"):
-        assert sumo_pages.sent_message_page.get_sent_messages_page_deleted_banner_text(
+        assert sumo_pages.sent_message_page.get_sent_message_deleted_banner_text(
         ) in SentMessagesPageMessages.NO_MESSAGES_SELECTED_BANNER_TEXT
 
     with allure.step("Verifying that the message is still listed inside the sent messages "
@@ -662,11 +662,11 @@ def test_messages_can_be_selected_and_deleted(page: Page, create_user_factory):
     with check, allure.step("Clicking on the 'delete selected' button while no messages is "
                             "selected and verifying that the correct banner is displayed"):
         sumo_pages.mess_system_user_navbar.click_on_messaging_system_navbar_inbox()
-        sumo_pages.inbox_page.click_on_inbox_delete_selected_button(
-            expected_locator=sumo_pages.inbox_page.inbox_page_message_action_banner)
-        assert sumo_pages.inbox_page.get_text_inbox_page_message_banner_text(
+        sumo_pages.inbox_page.click_on_delete_selected_button(
+            expected_locator=sumo_pages.inbox_page.message_action_banner)
+        assert sumo_pages.inbox_page.get_action_banner_text(
         ) in InboxPageMessages.NO_MESSAGES_SELECTED_BANNER_TEXT
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body).first
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body).first
                ).to_be_visible()
 
     with allure.step("Selecting the messages and deleting it via the delete selected button"):
@@ -674,8 +674,8 @@ def test_messages_can_be_selected_and_deleted(page: Page, create_user_factory):
             message_body, expected_url=InboxPageMessages.INBOX_PAGE_STAGE_URL)
 
     with allure.step("Verifying that the messages are no longer displayed"):
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_hidden()
-        assert sumo_pages.inbox_page.get_text_inbox_page_message_banner_text(
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)).to_be_hidden()
+        assert sumo_pages.inbox_page.get_action_banner_text(
         ) in InboxPageMessages.MULTIPLE_MESSAGES_DELETION_BANNER_TEXT
 
     with allure.step("Navigating to the sent messages section and clearing all messages via "
@@ -689,7 +689,7 @@ def test_messages_can_be_selected_and_deleted(page: Page, create_user_factory):
                ).to_be_hidden()
 
     with check, allure.step("Verifying that the correct banner is displayed"):
-        assert sumo_pages.sent_message_page.get_sent_messages_page_deleted_banner_text(
+        assert sumo_pages.sent_message_page.get_sent_message_deleted_banner_text(
         ) in SentMessagesPageMessages.MULTIPLE_MESSAGES_DELETION_BANNER_TEXT
 
     with allure.step("Signing in with the receiver account and navigating to the inbox"):
@@ -697,7 +697,7 @@ def test_messages_can_be_selected_and_deleted(page: Page, create_user_factory):
         sumo_pages.top_navbar.click_on_inbox_option()
 
     with allure.step("Verifying that the messages are displayed inside the inbox section"):
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_visible()
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)).to_be_visible()
 
     with allure.step("Deleting all messages from the inbox page via the delete selected "
                      "button'"):
@@ -706,8 +706,8 @@ def test_messages_can_be_selected_and_deleted(page: Page, create_user_factory):
 
     with allure.step("Verifying that the messages are no longer displayed inside the inbox"
                      " section and the correct banner is displayed"):
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_hidden()
-        assert sumo_pages.inbox_page.get_text_inbox_page_message_banner_text(
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)).to_be_hidden()
+        assert sumo_pages.inbox_page.get_action_banner_text(
         ) in InboxPageMessages.MESSAGE_DELETED_BANNER_TEXT
 
 
@@ -727,12 +727,12 @@ def test_group_messages_cannot_be_sent_by_non_staff_users(page: Page, create_use
         sumo_pages.mess_system_user_navbar.click_on_messaging_system_nav_new_message()
 
     with allure.step("Typing in a group name inside the To field"):
-        sumo_pages.new_message_page.type_into_new_message_to_input_field(
+        sumo_pages.new_message_page.type_into_to_input_field(
             utilities.user_message_test_data['test_groups'][0]
         )
 
     with allure.step("Verifying that no users are returned"):
-        expect(sumo_pages.new_message_page.get_no_user_to_locator()).to_be_visible(timeout=15000)
+        expect(sumo_pages.new_message_page.get_no_user_message_locator()).to_be_visible(timeout=15000)
 
     with allure.step("Navigating to the groups page"):
         utilities.navigate_to_link(utilities.general_test_data['groups'])
@@ -804,7 +804,7 @@ def test_staff_users_can_send_group_messages(page: Page, create_user_factory):
             utilities.start_existing_session(cookies=user)
 
             sumo_pages.top_navbar.click_on_inbox_option()
-            expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
+            expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)
                    ).to_be_visible()
             sumo_pages.inbox_page.delete_all_inbox_messages_via_delete_selected_button(
                 message_body, expected_url=InboxPageMessages.INBOX_PAGE_STAGE_URL)
@@ -815,7 +815,7 @@ def test_staff_users_can_send_group_messages(page: Page, create_user_factory):
             utilities.start_existing_session(cookies=user)
 
             sumo_pages.top_navbar.click_on_inbox_option()
-            expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
+            expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)
                    ).to_be_hidden()
 
 
@@ -864,7 +864,7 @@ def test_staff_users_can_send_messages_to_multiple_groups(page: Page, create_use
         for user in [test_user_two, test_user_three]:
             utilities.start_existing_session(user)
             sumo_pages.top_navbar.click_on_inbox_option()
-            expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
+            expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)
                    ).to_be_visible()
             sumo_pages.inbox_page.delete_all_inbox_messages_via_delete_selected_button(
                 message_body, expected_url=InboxPageMessages.INBOX_PAGE_STAGE_URL)
@@ -915,7 +915,7 @@ def test_staff_users_can_send_messages_to_both_groups_and_user(page: Page, creat
             utilities.start_existing_session(user)
 
             sumo_pages.top_navbar.click_on_inbox_option()
-            expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)
+            expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)
                    ).to_be_visible()
             sumo_pages.inbox_page.delete_all_inbox_messages_via_delete_selected_button(
                 message_body, expected_url=InboxPageMessages.INBOX_PAGE_STAGE_URL)
@@ -961,13 +961,13 @@ def test_removed_group_users_do_not_receive_group_messages(page: Page,
                      f"the group and verifying that the message was received"):
         utilities.start_existing_session(cookies=test_user_three)
         sumo_pages.top_navbar.click_on_inbox_option()
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_visible()
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)).to_be_visible()
         sumo_pages.inbox_page.delete_all_inbox_messages_via_delete_selected_button(
             message_body, expected_url=InboxPageMessages.INBOX_PAGE_STAGE_URL)
 
     with allure.step("Verifying that the removed user has not received the group message"):
         utilities.start_existing_session(cookies=test_user_two)
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_hidden()
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)).to_be_hidden()
 
 
 # C2584835
@@ -986,10 +986,10 @@ def test_unable_to_send_group_messages_to_profiless_groups(page: Page,
         sumo_pages.mess_system_user_navbar.click_on_messaging_system_nav_new_message()
 
     with allure.step("Typing in a profiless group name inside the To field"):
-        sumo_pages.new_message_page.type_into_new_message_to_input_field("kb-contributors")
+        sumo_pages.new_message_page.type_into_to_input_field("kb-contributors")
 
     with allure.step("Verifying that no users are returned"):
-        expect(sumo_pages.new_message_page.get_no_user_to_locator()).to_be_visible(timeout=15000)
+        expect(sumo_pages.new_message_page.get_no_user_message_locator()).to_be_visible(timeout=15000)
 
 
 # C2083482
@@ -1024,9 +1024,9 @@ def test_pm_group_member(page: Page, is_firefox, create_user_factory):
                      "field"):
         # Firefox GH runner fails here. We are running this assertion only in Chrome for now
         if not is_firefox:
-            assert sumo_pages.new_message_page.get_user_to_text() == test_user_two["username"], (
+            assert sumo_pages.new_message_page.get_to_user_text() == test_user_two["username"], (
                 f"Incorrect 'To' receiver. Expected: {test_user_two['username']}. "
-                f"Received: {sumo_pages.new_message_page.get_user_to_text()}"
+                f"Received: {sumo_pages.new_message_page.get_to_user_text()}"
             )
 
     with allure.step("Sending a message to the user"):
@@ -1034,7 +1034,7 @@ def test_pm_group_member(page: Page, is_firefox, create_user_factory):
             message_body=message_body)
 
     with check, allure.step("Verifying that the correct message sent banner is displayed"):
-        assert sumo_pages.inbox_page.get_text_inbox_page_message_banner_text(
+        assert sumo_pages.inbox_page.get_action_banner_text(
         ) == InboxPageMessages.MESSAGE_SENT_BANNER_TEXT
 
     with allure.step("Clicking on the 'Sent Messages option"):
@@ -1056,7 +1056,7 @@ def test_pm_group_member(page: Page, is_firefox, create_user_factory):
         sumo_pages.top_navbar.click_on_inbox_option()
 
     with allure.step("Verifying that the inbox contains the previously sent messages"):
-        expect(sumo_pages.inbox_page._inbox_message_based_on_excerpt(message_body)).to_be_visible()
+        expect(sumo_pages.inbox_page.get_inbox_message_locator_based_on_excerpt(message_body)).to_be_visible()
 
     with allure.step("Deleting the messages from the inbox section"):
         sumo_pages.messaging_system_flow.delete_message_flow(

--- a/playwright_tests/tests/user_deletion_tests/forums/test_user_deletion_in_community_forums.py
+++ b/playwright_tests/tests/user_deletion_tests/forums/test_user_deletion_in_community_forums.py
@@ -1,0 +1,437 @@
+import allure
+import pytest
+from playwright.sync_api import Page
+from pytest_check import check
+from playwright_tests.core.utilities import Utilities
+from playwright_tests.messages.contribute_messages.con_discussions.off_topic import \
+    OffTopicForumMessages
+from playwright_tests.pages.sumo_pages import SumoPages
+
+
+# C3132836
+@pytest.mark.userDeletion
+def test_thread_with_no_replies_is_not_assigned_to_system_user(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+
+    with allure.step("Signing in and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title="Test op deletion", thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Deleting the user"):
+        sumo_pages.edit_profile_flow.close_account()
+
+    with allure.step("Navigating back to the thread and verifying that 404 is returned"):
+        assert utilities.navigate_to_link(thread_url).status == 404
+
+
+# C2955157
+@pytest.mark.userDeletion
+def test_locked_thread_with_no_replies_is_not_assigned_to_system_user(page: Page,
+                                                                      create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(permissions=["lock_forum_thread"])
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title="Test op deletion", thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Locking the forum thread"):
+        sumo_pages.forum_thread_page.click_lock_this_thread_option()
+
+    with allure.step("Deleting the account and verifying that the contributor thread is deleted"):
+        sumo_pages.edit_profile_flow.close_account()
+        assert utilities.navigate_to_link(thread_url).status == 404
+
+
+#  C2955157
+@pytest.mark.userDeletion
+def test_sticky_thread_with_no_replies_is_not_assigned_to_system_user(page:Page,
+                                                                      create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(permissions=["sticky_forum_thread"])
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title="Test op deletion", thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Marking the thread as sticky"):
+        sumo_pages.forum_thread_page.click_sticky_this_thread_option()
+
+    with allure.step("Deleting the account and verifying that the contributor thread is deleted"):
+        sumo_pages.edit_profile_flow.close_account()
+        assert utilities.navigate_to_link(thread_url).status == 404
+
+
+# C2960034
+@pytest.mark.userDeletion
+def test_edited_thread_with_no_replies_is_not_assigned_to_system_user(page: Page,
+                                                                      create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(groups=["forum-contributors", "Forum Moderators"])
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        thread_id = sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title="Test op deletion", thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Editing the title and first post"):
+        new_thread_title = (utilities.discussion_thread_data['thread_title'] + utilities.
+                            generate_random_number(1, 1000))
+        sumo_pages.contributor_thread_flow.edit_thread_title(new_thread_title)
+        sumo_pages.contributor_thread_flow.edit_thread_post(thread_id, "Edited thread body")
+
+    with allure.step("Deleting the account and verifying that the contributor thread is deleted"):
+        sumo_pages.edit_profile_flow.close_account()
+        assert utilities.navigate_to_link(thread_url).status == 404
+
+
+# C2955157
+@pytest.mark.userDeletion
+def test_deleting_the_user_which_locked_the_thread(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory(groups=["forum-contributors", "Forum Moderators"])
+    test_user_three = create_user_factory(groups=["forum-contributors", "Forum Moderators"])
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        thread = sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title="Test op deletion", thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Locking the thread using a forum moderator account"):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.forum_thread_page.click_lock_this_thread_option()
+
+    with allure.step("Deleting the forum moderator account and verifying that the thread was "
+                     "not affected by this deletion"):
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+        assert "Locked" in sumo_pages.forum_thread_page.get_thread_meta_information()
+        assert sumo_pages.forum_thread_page.get_post_author(thread) == test_user["username"]
+
+    with allure.step("Unlocking the thread using a forum moderator account"):
+        utilities.start_existing_session(cookies=test_user_three)
+        sumo_pages.forum_thread_page.click_unlock_this_thread_option()
+
+    with allure.step("Deleting the forum moderator account and verifying that the thread was not "
+                     "affected by this deletion"):
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+        assert not "Locked" in sumo_pages.forum_thread_page.get_thread_meta_information()
+        assert sumo_pages.forum_thread_page.get_post_author(thread) == test_user["username"]
+
+
+# C2955157
+@pytest.mark.userDeletion
+def test_deleting_the_user_which_stickied_the_thread(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory(groups=["forum-contributors", "Forum Moderators"])
+    test_user_three = create_user_factory(groups=["forum-contributors", "Forum Moderators"])
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        thread = sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title="Test op deletion", thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Sticking the thread using a forum moderator account"):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.forum_thread_page.click_sticky_this_thread_option()
+
+    with allure.step("Deleting the forum moderator account and verifying that the thread was "
+                     "not affected by this deletion"):
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+        assert "Sticky" in sumo_pages.forum_thread_page.get_thread_meta_information()
+        assert sumo_pages.forum_thread_page.get_post_author(thread) == test_user["username"]
+
+    with allure.step("Unsticking the thread using a different forum moderator"):
+        utilities.start_existing_session(cookies=test_user_three)
+        sumo_pages.forum_thread_page.click_unsticky_this_thread_option()
+
+    with allure.step("Deleting the forum moderator account and verifying that the thread was not "
+                     "affected by this deletion"):
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+        assert not "Sticky" in sumo_pages.forum_thread_page.get_thread_meta_information()
+        assert sumo_pages.forum_thread_page.get_post_author(thread) == test_user["username"]
+
+
+# C2952067
+@pytest.mark.userDeletion
+def test_edited_threads_are_assigned_successfully_to_system_account(page: Page,
+                                                                    create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(groups=["forum-contributors", "Forum Moderators"])
+    test_user_two = create_user_factory()
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title="Test op deletion", thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+
+    with allure.step("Posting a new thread reply using a different account"):
+        utilities.start_existing_session(cookies=test_user_two)
+        thread_reply_id = sumo_pages.contributor_thread_flow.post_thread_reply("Test Reply")
+
+
+    with allure.step("Signing in back with the first user and editing the second thread post"):
+        utilities.start_existing_session(cookies=test_user)
+        new_thread_body = "Edited thread body"
+        sumo_pages.contributor_thread_flow.edit_thread_post(thread_reply_id, new_thread_body)
+
+    with check, allure.step("Deleting the second user and verifying that: "
+                            "1. The edited thread reply body is kept"
+                            "2. The edited thread reply is assigned to SuMo bot "
+                            "3. The editor is successfully displayed inside the 'Modified by "
+                            "section'"):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+
+        assert sumo_pages.forum_thread_page.get_post_content(thread_reply_id) == new_thread_body
+        assert (sumo_pages.forum_thread_page.get_post_author(thread_reply_id) == utilities.
+                general_test_data["system_account_name"])
+        assert (test_user["username"] in sumo_pages.forum_thread_page.
+                get_modified_by_text(thread_reply_id))
+
+
+# C2952066
+@pytest.mark.userDeletion
+def test_deleting_the_user_which_edited_a_thread(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory(groups=["forum-contributors", "Forum Moderators"])
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        thread_id = sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title="Test op deletion", thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Signing in with a forum moderator and editing the title and the body of the"
+                     " forum post"):
+        utilities.start_existing_session(cookies=test_user_two)
+        new_thread_title = (utilities.discussion_thread_data['thread_title'] + utilities.
+                            generate_random_number(1, 1000))
+        new_thread_body = "Edited thread body"
+        sumo_pages.contributor_thread_flow.edit_thread_title(new_thread_title)
+        sumo_pages.contributor_thread_flow.edit_thread_post(
+            thread_id, new_thread_body)
+
+    with check, allure.step("Deleting the forum moderator and verifying that: "
+                            "1. The thread title edit is kept. "
+                            "2. The thread body edit is kept. "
+                            "3. The modified by section is removed."):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+
+        assert sumo_pages.forum_thread_page.get_forum_thread_title() == new_thread_title
+        assert sumo_pages.forum_thread_page.get_post_content(thread_id) == new_thread_body
+        assert not sumo_pages.forum_thread_page.is_modified_by_section_displayed(thread_id)
+
+
+# C2939461
+@pytest.mark.userDeletion
+def test_threads_are_assigned_to_system_account_if_contains_additional_posts(page: Page,
+                                                                             create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory()
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        thread = sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title="Test op deletion", thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Posting a new thread reply using a different account"):
+        utilities.start_existing_session(cookies=test_user_two)
+        thread_reply_id = sumo_pages.contributor_thread_flow.post_thread_reply("Test Reply")
+
+    with check, allure.step("Deleting the OP of the forum post and verifying that: "
+                            "1. The first forum post is assigned to Sumo Bot "
+                            "2. The second forum post remains assigned to the second user"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+
+        assert (sumo_pages.forum_thread_page.get_post_author(thread) == utilities.
+                general_test_data["system_account_name"])
+        assert (sumo_pages.forum_thread_page.
+                get_post_author(thread_reply_id) == test_user_two["username"])
+
+        with allure.step("Deleting the thread"):
+            utilities.start_existing_session(session_file_name=staff_user)
+            sumo_pages.contributor_thread_flow.delete_thread()
+
+
+# C2939461
+@pytest.mark.userDeletion
+def test_thread_replies_are_assigned_to_system_account(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory()
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+    thread_title = "Test thread " + utilities.generate_random_number(1, 1000)
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        thread = sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title=thread_title, thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Posting a new thread reply using a different account"):
+        utilities.start_existing_session(cookies=test_user_two)
+        thread_reply_id = sumo_pages.contributor_thread_flow.post_thread_reply("Test Reply")
+
+    with check, allure.step("Deleting the second user and verifying that: "
+                            "1. The first forum post remains assigned to the first user, "
+                            "2. The second forum post is assigned to SumoBot."
+                            "3. Verifying that the 'Last Post' from the targeted forum/thread "
+                            "shows SumoBot."):
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+
+        assert (sumo_pages.forum_thread_page.
+                get_post_author(thread) == test_user["username"])
+        assert (sumo_pages.forum_thread_page.get_post_author(thread_reply_id) == utilities.
+                general_test_data["system_account_name"])
+
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        assert (sumo_pages.forum_discussions_page.get_last_post_by_text(thread_title) == utilities.
+                general_test_data["system_account_name"])
+
+        with allure.step("Deleting the thread"):
+            utilities.start_existing_session(session_file_name=staff_user)
+            utilities.navigate_to_link(thread_url)
+            sumo_pages.contributor_thread_flow.delete_thread()
+
+
+# C2947499
+@pytest.mark.userDeletion
+def test_quoted_first_post_is_moved_to_system_account(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory()
+    thread_title = "Test thread " + utilities.generate_random_number(1, 1000)
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        thread = sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title=thread_title, thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Posting a new thread reply with a different user by quoting the original "
+                     "post."):
+        utilities.start_existing_session(cookies=test_user_two)
+        thread_reply_id = sumo_pages.contributor_thread_flow.quote_thread_post(thread)
+
+    with check, allure.step("Deleting the second user and verifying that: "
+                            "1. The first forum post remains assigned to the first user, "
+                            "2. The second forum post is assigned to SumoBot."
+                            "3. The user one is displayed inside the quoted field"):
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+
+        assert (sumo_pages.forum_thread_page.
+                get_post_author(thread) == test_user["username"])
+        assert (sumo_pages.forum_thread_page.get_post_author(thread_reply_id) == utilities.
+                general_test_data["system_account_name"])
+        assert (test_user["username"] in sumo_pages.forum_thread_page.
+                get_thread_post_mention_text(thread_reply_id))
+
+    with allure.step("Deleting the thread"):
+        utilities.start_existing_session(session_file_name=staff_user)
+        sumo_pages.contributor_thread_flow.delete_thread()
+
+
+# C2952021
+@pytest.mark.userDeletion
+def test_quoted_replies_are_moved_to_system_account(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory()
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+    thread_title = "Test thread " + utilities.generate_random_number(1, 1000)
+
+    with allure.step("Signing in to SUMO and posting a new contributor forum thread"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(OffTopicForumMessages.PAGE_URL)
+        thread = sumo_pages.contributor_thread_flow.post_a_new_thread(
+            thread_title=thread_title, thread_body="Test op deletion thread body")
+        thread_url = utilities.get_page_url()
+
+    with allure.step("Posting a new thread reply with a different user"):
+        utilities.start_existing_session(cookies=test_user_two)
+        second_thread_reply = sumo_pages.contributor_thread_flow.post_thread_reply("Just a reply")
+
+    with allure.step("Signing back with the first user and leaving a new thread reply by quoting "
+                     "the thread reply posted by the second user"):
+        utilities.start_existing_session(cookies=test_user)
+        third_thread_reply = sumo_pages.contributor_thread_flow.quote_thread_post(
+            second_thread_reply)
+
+    with check, allure.step("Deleting the second user and verifying that: "
+                            "1. The first forum post remains assigned to the first user, "
+                            "2. The second forum post is assigned to SumoBot."
+                            "3. The reply which quotes the second reply belongs to the first user "
+                            "4. The reply which quotes the second reply contains the username of  "
+                            "the deleted user inside the mention section"):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.navigate_to_link(thread_url)
+
+        assert (sumo_pages.forum_thread_page.
+                get_post_author(thread) == test_user["username"])
+        assert (sumo_pages.forum_thread_page.get_post_author(second_thread_reply) == utilities.
+                general_test_data["system_account_name"])
+        assert (sumo_pages.forum_thread_page.
+                get_post_author(third_thread_reply) == test_user["username"])
+
+        # Currently we are showing the username of the deleted user. This might change in the
+        # future.
+        assert (test_user_two["username"] in sumo_pages.forum_thread_page.
+                get_thread_post_mention_text(third_thread_reply))
+
+    with allure.step("Deleting the thread"):
+        utilities.start_existing_session(session_file_name=staff_user)
+        sumo_pages.contributor_thread_flow.delete_thread()

--- a/playwright_tests/tests/user_deletion_tests/kb/test_user_deletion_and_article_contributions.py
+++ b/playwright_tests/tests/user_deletion_tests/kb/test_user_deletion_and_article_contributions.py
@@ -1,0 +1,204 @@
+import allure
+import pytest
+from playwright.sync_api import Page, expect
+from pytest_check import check
+from playwright_tests.core.utilities import Utilities
+from playwright_tests.pages.sumo_pages import SumoPages
+from playwright_tests.tests.conftest import create_user_factory
+
+
+# C2952002, C2952017
+@pytest.mark.userDeletion
+def test_reviewed_revisions_assignment_to_system_account(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
+    test_user_two = create_user_factory()
+    staff = utilities.username_extraction_from_email(utilities.staff_user)
+
+    with allure.step("Signing in with the first test user and creating a new kb article"):
+        utilities.start_existing_session(cookies=test_user)
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page, approve_revision=True)
+
+    with allure.step("Signing in with the second account and creating a new revision"):
+        utilities.start_existing_session(cookies=test_user_two)
+        second_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
+
+    with allure.step("Signing in with the first test user, creating a new revision and approving "
+                     "it"):
+        utilities.start_existing_session(cookies=test_user)
+        third_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision(
+            approve_revision= True)
+
+    with allure.step("Signing in with the second user and deleting the account via the edit my "
+                     "profile page"):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.edit_profile_flow.close_account()
+
+    with check, allure.step("Navigating back to the article's show history page and verifying "
+                            "that the second revision was deleted since it was not approved"):
+        utilities.navigate_to_link(article_details["article_url"] + "/history")
+        utilities.start_existing_session(session_file_name=staff)
+
+        assert not sumo_pages.kb_article_show_history_page.is_revision_displayed(
+            second_revision["revision_id"])
+
+    with check, allure.step("Verifying that the other revisions are belonging to the user which "
+                            "was not deleted"):
+        assert sumo_pages.kb_article_show_history_page.get_revision_creator(
+            article_details["first_revision_id"]) == test_user["username"]
+        assert sumo_pages.kb_article_show_history_page.get_revision_creator(
+            third_revision["revision_id"]) == test_user["username"]
+
+    with allure.step("Signing in with the first user and deleting the account"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.edit_profile_flow.close_account()
+
+    with allure.step("Navigating back to the article and verifying that all revisions belong "
+                     "to SuMo Bot"):
+        utilities.navigate_to_link(article_details["article_url"] + "/history")
+        utilities.start_existing_session(session_file_name=staff)
+
+        assert (sumo_pages.kb_article_show_history_page.get_revision_creator(
+            article_details["first_revision_id"]
+        ) == utilities.general_test_data["system_account_name"])
+        assert (sumo_pages.kb_article_show_history_page.get_revision_creator(
+            third_revision["revision_id"]) == utilities.general_test_data["system_account_name"])
+
+    with allure.step("Deleting the test article"):
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()
+
+
+# C2952003, C2952016
+@pytest.mark.userDeletion
+def test_unreviewed_revisions_are_not_assigned_to_system_account(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    staff = utilities.username_extraction_from_email(utilities.staff_user)
+
+    with allure.step("Signing in with the first test user and creating a new kb article"):
+        utilities.start_existing_session(cookies=test_user)
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(page=page)
+        sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
+
+    with allure.step("Navigating to the 'Edit profile' and delete the account via the "
+                     "'Close account and delete all profile information' option"):
+        sumo_pages.edit_profile_flow.close_account()
+
+    with allure.step("Signing in with a staff account, navigating to the article page and "
+                     "verifying that 404 is returned"):
+        utilities.start_existing_session(session_file_name=staff)
+        assert utilities.navigate_to_link(article_details["article_url"]).status == 404
+
+
+# C2952004
+@pytest.mark.userDeletion
+def test_deferred_revisions_are_not_assigned_to_system_account(page:Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory(groups=["Knowledge Base Reviewers"])
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+
+    with allure.step("Creating a new article and approving it's first revision"):
+        utilities.start_existing_session(cookies=test_user_two)
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page, approve_revision=True)
+
+    with allure.step("Signing in with a different user and submitting a new article revision "
+                     "without approving it"):
+        utilities.start_existing_session(cookies=test_user)
+        second_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
+
+    with allure.step("Signing in back with the KB reviewer and deferring the second revision"):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.submit_kb_article_flow.defer_revision(second_revision["revision_id"])
+
+    with allure.step("Deleting the first user and verifying that the revision was deleted"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.edit_profile_flow.close_account()
+        utilities.start_existing_session(cookies=test_user_two)
+        utilities.navigate_to_link(article_details["article_url"] + "/history")
+        assert not sumo_pages.kb_article_show_history_page.is_revision_displayed(
+            second_revision["revision_id"])
+
+    with allure.step("Deleting the article"):
+        utilities.start_existing_session(session_file_name=staff_user)
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()
+
+
+#  C2979501, C2979502
+@pytest.mark.userDeletion
+def test_localization_revisions_are_assigned_to_system_account(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
+    staff = utilities.username_extraction_from_email(utilities.staff_user)
+
+    with allure.step("Signing in with the KB reviewer and creating a new kb article, approving "
+                     "it's first revision and markit it as ready for localization"):
+        utilities.start_existing_session(cookies=test_user)
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(
+            page=page, approve_revision=True, ready_for_l10n=True)
+
+    with allure.step("Deleting the user"):
+        sumo_pages.edit_profile_flow.close_account()
+
+    with allure.step("Signing in with the staff user and verifying that the ready for localization"
+                     " status is kept"):
+        utilities.start_existing_session(session_file_name=staff)
+        utilities.navigate_to_link(article_details["article_url"] + "/history")
+        expect(sumo_pages.kb_article_show_history_page.get_ready_for_localization_status(
+            article_details["first_revision_id"])).to_be_visible()
+
+    with allure.step("Deleting the article"):
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()
+
+
+# C2979502
+@pytest.mark.userDeletion
+def test_reviewed_by_assignment_to_system_account(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory(groups=["Knowledge Base Reviewers"])
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+
+    with allure.step("Signing in and creating a new kb article"):
+        utilities.start_existing_session(cookies=test_user)
+        article_details = sumo_pages.submit_kb_article_flow.kb_article_creation_via_api(page=page)
+
+    with allure.step("Signing in with a KB reviewer and approving the revision"):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.submit_kb_article_flow.approve_kb_revision(
+            revision_id=article_details["first_revision_id"])
+
+    with allure.step("Signing in back with the first user and creating a new article revision"):
+        utilities.start_existing_session(cookies=test_user)
+        second_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
+
+    with allure.step("Signing in with a KB reviewer and deferring the revision"):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.submit_kb_article_flow.defer_revision(
+            revision_id=second_revision["revision_id"])
+
+    with allure.step("Deleting the user"):
+        sumo_pages.edit_profile_flow.close_account()
+
+    with allure.step("Navigating back to the show history page and verifying that the reviewer of "
+                     "both revisions is Sumo Bot"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(article_details["article_url"] + "/history")
+        sumo_pages.kb_article_show_history_page.click_on_a_revision_date(
+            article_details["first_revision_id"])
+        assert sumo_pages.kb_article_preview_revision_page.get_reviewed_by_text() == "SumoBot"
+        utilities.navigate_back()
+        sumo_pages.kb_article_show_history_page.click_on_a_revision_date(
+            second_revision["revision_id"])
+        assert sumo_pages.kb_article_preview_revision_page.get_reviewed_by_text() == "SumoBot"
+
+    with allure.step("Deleting the revision"):
+        utilities.start_existing_session(session_file_name=staff_user)
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()

--- a/playwright_tests/tests/user_deletion_tests/messaging_system/test_user_deletion_in_messaging_system.py
+++ b/playwright_tests/tests/user_deletion_tests/messaging_system/test_user_deletion_in_messaging_system.py
@@ -1,0 +1,91 @@
+import allure
+import pytest
+from playwright.sync_api import Page, expect
+from pytest_check import check
+from playwright_tests.core.utilities import Utilities
+from playwright_tests.messages.mess_system_pages_messages.read_message_page_messages import \
+    ReadMessagePageMessages
+from playwright_tests.pages.sumo_pages import SumoPages
+
+
+# C2939485
+@pytest.mark.userDeletion
+def test_deleted_user_is_displayed_in_both_inbox_and_outbox(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory()
+    deleted_user_username = "deleted user"
+    first_message_body = "Test " + utilities.generate_random_number(1, 1000)
+    second_message_body = "Test " + utilities.generate_random_number(1, 1000)
+
+    with allure.step("Signing in with the first test user and sending a message to the second "
+                     "user"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.top_navbar.click_on_inbox_option()
+        sumo_pages.inbox_page.click_on_new_message_button()
+        sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
+            recipient_username=test_user_two["username"], message_body=first_message_body)
+
+    with allure.step("Signing in with the second user and sending a message to the first user"):
+        utilities.start_existing_session(cookies=test_user_two)
+        sumo_pages.top_navbar.click_on_inbox_option()
+        sumo_pages.mess_system_user_navbar.click_on_messaging_system_nav_new_message()
+        sumo_pages.messaging_system_flow.complete_send_message_form_with_data(
+            recipient_username=test_user["username"], message_body=second_message_body)
+
+    with allure.step("Deleting the second user account"):
+        sumo_pages.edit_profile_flow.close_account()
+
+    with allure.step("Signing in with the first user and navigating to the inbox page"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.top_navbar.click_on_inbox_option()
+
+    with check, allure.step("Verifying that sender of the message is the 'delete user'"):
+        assert (sumo_pages.inbox_page.
+                get_sender_by_excerpt(second_message_body) == deleted_user_username)
+
+    with check, allure.step("Clicking on the message excerpt and verifying that the 'delete user "
+                            "is successfully displayed as the message sender'"):
+        sumo_pages.inbox_page.click_on_message_by_excerpt(second_message_body)
+        assert (deleted_user_username in sumo_pages.inbox_page.
+                get_the_deleted_user_message_sender_text())
+
+    with check, allure.step("Verifying that the deleted user information text is successfully "
+                            "displayed"):
+        assert (sumo_pages.inbox_page.
+                get_the_deleted_user_information_text() == ReadMessagePageMessages.
+                DELETED_USER_INFO)
+
+    with check, allure.step("Navigating to the outbox and verifying that the 'delete user' is the "
+                            "recipient of the sent message"):
+        utilities.wait_for_dom_to_load()
+        sumo_pages.mess_system_user_navbar.click_on_messaging_system_nav_sent_messages()
+        assert (sumo_pages.sent_message_page.
+                get_deleted_user_recipient_based_on_excerpt(first_message_body
+                                                            ) == deleted_user_username)
+
+    with check, allure.step("Clicking on the message subject and verifying that the 'delete user'"
+                            " is successfully displayed inside the TO field"):
+        sumo_pages.sent_message_page.click_on_sent_message_subject(first_message_body)
+        assert deleted_user_username in sumo_pages.sent_message_page.get_deleted_user()
+
+
+# C2939485
+@pytest.mark.userDeletion
+def test_messages_cannot_be_sent_to_system_user(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    user = create_user_factory()
+
+    with allure.step("Signing in with the test account and navigating to the new message page"):
+        utilities.start_existing_session(cookies=user)
+        sumo_pages.top_navbar.click_on_inbox_option()
+        sumo_pages.mess_system_user_navbar.click_on_messaging_system_nav_new_message()
+
+    with allure.step("Adding the system user inside the TO: field and verifying that the system "
+                     "user is not returned"):
+        sumo_pages.new_message_page.type_into_to_input_field(
+            utilities.general_test_data["system_account_name"])
+        expect(sumo_pages.new_message_page.get_no_user_message_locator()).to_be_visible(
+            timeout=15000)

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -287,7 +287,7 @@ def test_number_of_posted_articles_is_successfully_displayed(page: Page,
                 get_text_of_document_links())
 
     with allure.step("Navigating to the article and changing the title"):
-        new_article_title = "Updated title test v1"
+        new_article_title = "Updated title test " + utilities.generate_random_number(1, 1000)
         sumo_pages.my_documents_page.click_on_a_particular_document(
             article_details['article_title'])
         sumo_pages.edit_article_metadata_flow.edit_article_metadata(title=new_article_title)


### PR DESCRIPTION
This PR covers the following:
* Adding the userDeletion test suite to the playwright.yml workflow file.
* Increasing the stability of the tests by increasing the timeout when checking for "domcontentloaded" or "load" checks.
* Refactored the messaging system page object classes.
* Added the following coverage for the userDeletion test suite:
1. Verifying that threads with no replies are not assigned to the system account.
2. Verifying that the locked, sticky and edited threads with no replies are not assigned to system account.
3. Verifying that the deletion of the contributor user which locked, stickied or edited a thread does not affect the thread.
4. Verifying that threads are assigned to the system account if contains additional posts and the thread owner was deleted.
5. Verifying that thread replies are assigned to the system account if the owner of the replies is deleted.
6. Verifying that quoted replies are assigned to the system account if the onwer of the replies is deleted.
7. Verifying that reviewed kb article revisions are assigned to the system account if the revision owner is deleted.
8. Verifying that unreviewed kb article revisions are not assigned to the system account if the revision owner is deleted.
9. Verifying that deferred revisions are not assigned to the system account if the revision owner is deleted.
10. Verifying that approved revisions for kb article translations are assigned to the system account if the revision owner is deleted.
11. Verifying that the reviewer is assigned to the system account if the reviewer user account was deleted.
12. Verifying that private messages cannot be sent to the system account.
13. Verifying that the appropriate "deleted user" is displayed in both inbox and outbox if the sender or recipient user was deleted.