### PR TITLE
Add the Spam tab

### DIFF
--- a/kitsune/questions/jinja2/questions/question_list.html
+++ b/kitsune/questions/jinja2/questions/question_list.html
@@ -153,6 +153,13 @@
           <span>{{ _('Done') }}</span>
         </a>
       </li>
+      {% if request.user.has_perm("flagit.can_moderate") %}
+      <li class="tabs--item">
+        <a href="{{ questions_url(show='spam', filter=None, page=None) }}" {{ show|class_selected('spam') }}>
+          <span>{{ _('Spam') }}</span>
+        </a>
+      </li>
+      {% endif %}
     </ul>
   </nav>
 
@@ -281,6 +288,7 @@
 
 
 {% block side %}
+{% if show != "spam" %}
 <div class="forum--sidebar-sort large-only">
   <select data-sort-questions>
     {% for o, details in orders.items() %}
@@ -292,6 +300,7 @@
     {% endfor %}
   </select>
 </div>
+{% endif %}
 
 {% if request.user.is_authenticated %}
 <div class="questions-sidebar">
@@ -303,7 +312,7 @@
       {% for f, desc in filters.items() %}
       <li {{ filter|class_selected(f) }}><a href="{{ questions_url(filter=f, page=None) }}">{{ desc }}</a></li>
       {% endfor %}
-      {% if topic_list %}
+      {% if topic_list and show != "spam" %}
         <li class="sidebar-subheading sidebar-nav--heading-item">{{ _('Topic') }}</li>
         <li>
 
@@ -324,9 +333,11 @@
           </select>
         </li>
       {% endif %}
+      {% if show != "spam" %}
       <li class="sidebar-subheading sidebar-nav--heading-item">{{ _('Show me') }}</li>
       <li {{ owner|class_selected(None) }}><a href="{{ questions_url(owner='all', page=None) }}">{{ _('Posts from everyone') }}</a></li>
       <li {{ owner|class_selected('mine') }}><a href="{{ questions_url(owner='mine', page=None) }}">{{ _('My contributions') }}</a></li>
+      {% endif %}
     </ul>
   </nav>
 

--- a/kitsune/questions/managers.py
+++ b/kitsune/questions/managers.py
@@ -4,6 +4,7 @@ from django.db.models import F, Manager, Q
 from django.db.models.functions import Now
 
 from kitsune.questions import config
+from kitsune.users.models import Profile
 
 
 class QuestionManager(Manager):
@@ -71,6 +72,15 @@ class QuestionManager(Manager):
 
     def solved(self):
         return self.filter(solution__isnull=False)
+
+    def spam(self):
+        return self.filter(is_spam=True)
+
+    def detected_spam(self):
+        return self.filter(is_spam=True, marked_as_spam_by=Profile.get_sumo_bot().id)
+
+    def undetected_spam(self):
+        return self.filter(is_spam=True).exclude(marked_as_spam_by=Profile.get_sumo_bot().id)
 
 
 class AAQConfigManager(Manager):

--- a/kitsune/questions/tests/test_managers.py
+++ b/kitsune/questions/tests/test_managers.py
@@ -1,9 +1,20 @@
 from kitsune.questions.models import Answer, Question
 from kitsune.questions.tests import AnswerFactory, QuestionFactory
 from kitsune.sumo.tests import TestCase
+from kitsune.users.models import Profile
 
 
 class QuestionManagerTestCase(TestCase):
+    def test_spam(self):
+        """Verify the spam queryset."""
+        # Create a question, there shouldn't be any spam yet.
+        q = QuestionFactory()
+        self.assertEqual(0, Question.objects.spam().count())
+
+        # Mark the question as spam
+        q.mark_as_spam(Profile.get_sumo_bot())
+        self.assertEqual(1, Question.objects.spam().count())
+
     def test_done(self):
         """Verify the done queryset."""
         # Create a question, there shouldn't be any done yet.
@@ -54,7 +65,7 @@ class QuestionManagerTestCase(TestCase):
 
     def test_needs_attention(self):
         """Verify the needs_attention queryset."""
-        # Create a question, there shouldn't be one needs_attention.
+        # Create a question, there should be one needs_attention.
         q = QuestionFactory()
         self.assertEqual(1, Question.objects.needs_attention().count())
 


### PR DESCRIPTION
Resolve [#2494](https://github.com/mozilla/sumo/issues/2494)

- Remove questions marked as spam from all the current tabs (*All*, *Attention needed*, *Responded* and *Done*) for moderators.
- Create a new **Spam** tab, visible for moderators only:
  - The tab contains those and only those questions that were marked as spam (either automatically or manually).
  - The questions are sorted by last update (Updated) with no sorting options available.
  - Filters **All**, **Marked automatically** and **Marked manually** are available.
  - There is no sorting by topic.
  - There is no *Show me* option.
- Create a test for the new Spam tab.
- Fix a comment typo in QuestionManagerTestCase.test_needs_attention()