### PR TITLE
properly handle redirects in context of l10n

### DIFF
--- a/kitsune/wiki/models.py
+++ b/kitsune/wiki/models.py
@@ -439,6 +439,10 @@ class Document(NotificationsMixin, ModelBase, DocumentPermissionMixin):
             or self.category in (ADMINISTRATION_CATEGORY, CANNED_RESPONSES_CATEGORY)
         )
 
+    @property
+    def is_redirect(self):
+        return self.html.startswith(REDIRECT_HTML)
+
     def get_absolute_url(self):
         return reverse("wiki.document", locale=self.locale, args=[self.slug])
 
@@ -486,7 +490,7 @@ class Document(NotificationsMixin, ModelBase, DocumentPermissionMixin):
         # If a document starts with REDIRECT_HTML and contains any <a> tags
         # with hrefs, return the href of the first one. This trick saves us
         # from having to parse the HTML every time.
-        if self.html.startswith(REDIRECT_HTML):
+        if self.is_redirect:
             anchors = PyQuery(self.html)("a[href]")
             if anchors:
                 # Articles with a redirect have a link that has the locale

--- a/kitsune/wiki/services.py
+++ b/kitsune/wiki/services.py
@@ -59,6 +59,7 @@ class StaleTranslationService:
                 locale__in=target_locales,
                 current_revision__isnull=False,
             )
+            .exclude(parent__html__startswith=REDIRECT_HTML)
             .select_related("parent", "parent__latest_localizable_revision", "current_revision")
             .filter(
                 # Parent has been updated since this translation
@@ -144,9 +145,7 @@ class HybridTranslationService:
                 "document__parent__latest_localizable_revision_id"
             )
         )
-        translations_discontinued = Q(document__parent__is_archived=True) | Q(
-            document__parent__html__startswith=REDIRECT_HTML
-        )
+        translations_discontinued = Q(document__parent__html__startswith=REDIRECT_HTML)
 
         # Unreviewed machine translations that are no longer useful.
         self._qs_obsolete = unreviewed_translations.filter(

--- a/kitsune/wiki/strategies.py
+++ b/kitsune/wiki/strategies.py
@@ -120,6 +120,7 @@ class TranslationStrategy(AbstractTranslationStrategy):
             [
                 document.is_localizable,
                 document.locale == settings.WIKI_DEFAULT_LANGUAGE,
+                not document.is_redirect,
                 revision.is_approved,
                 not revision.significance or revision.significance > TYPO_SIGNIFICANCE,
             ]

--- a/kitsune/wiki/tests/test_views.py
+++ b/kitsune/wiki/tests/test_views.py
@@ -1,4 +1,3 @@
-
 import json
 from unittest import mock
 
@@ -1439,6 +1438,19 @@ class RedirectTests(TestCase):
         redirect = rev.document
         response = self.client.get(redirect.get_absolute_url() + "?redirect=no", follow=True)
         self.assertContains(response, "REDIRECT ")
+
+    def test_translation_when_parent_is_redirect(self):
+        """If the translation's parent is a redirect, the translation should redirect."""
+        target = ApprovedRevisionFactory(document__locale="en-US").document
+        parent = RedirectRevisionFactory(
+            document__locale="en-US", is_approved=True, target=target
+        ).document
+        child = ApprovedRevisionFactory(document__parent=parent, document__locale="it").document
+        response = self.client.get(child.get_absolute_url())
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            response["location"].startswith(target.get_absolute_url().replace("/en-US/", "/it/"))
+        )
 
 
 class LocaleRedirectTests(TestCase):

--- a/kitsune/wiki/views.py
+++ b/kitsune/wiki/views.py
@@ -207,9 +207,10 @@ def document(request, document_slug, document=None):
             # We can't find any approved content to show.
             fallback_reason = "no_content"
 
-    any_localizable_revision = doc.revisions.filter(
-        is_approved=True, is_ready_for_localization=True
-    ).exists()
+    if doc.parent and doc.parent.is_redirect:
+        # If a translation's parent is a redirect, always use the parent instead.
+        doc = doc.parent
+
     # Obey explicit redirect pages:
     # Don't redirect on redirect=no (like Wikipedia), so we can link from a
     # redirected-to-page back to a "Redirected from..." link, so you can edit
@@ -334,7 +335,9 @@ def document(request, document_slug, document=None):
         "show_aaq_widget": show_aaq_widget,
         "breadcrumb_items": breadcrumbs,
         "document_css_class": document_css_class,
-        "any_localizable_revision": any_localizable_revision,
+        "any_localizable_revision": doc.revisions.filter(
+            is_approved=True, is_ready_for_localization=True
+        ).exists(),
         "full_locale_name": full_locale_name,
         "switching_devices_product": switching_devices_product,
         "switching_devices_topic": switching_devices_topic,


### PR DESCRIPTION
mozilla/sumo#2534

## Notes
- So far, this has been only partially tested locally.
- I initially inserted code to drop the "is ready for localization" checkbox when approving a redirect revision (because they're never translated), but then removed it thinking it might be best not to confuse localizers by its absence. I'm happy to reinsert that code if desired.
