### PR TITLE
improve the l10n llm response

### DIFF
--- a/kitsune/llm/l10n/prompt.py
+++ b/kitsune/llm/l10n/prompt.py
@@ -82,7 +82,7 @@ r"\\[((mailto:|git://|irc://|https?://|ftp://|/)[^<>\\]\\[\\x00-\\x20\\x7f]*)\\s
 4. For each part that is different, **freshly translate** that part. **Remember to obey the `Rules for translating special strings`**.
 5. **Combine** the copied parts and the freshly translated parts into a final translation.
 6. In your response, include your final translation and an explanation describing what you did for each step.
-7. **Format** your response by providing your final translation, followed by the delimiter `{{ delimiter }}`, followed by your explanation.
+7. **Format** your response by providing your final translation, followed by the delimiter `{{ delimiter }}`, followed by your explanation. Your final translation **must be provided without any added commentary, formatting, markdown fences, or extra text of any kind**.
 """
 
 SOURCE_ARTICLE = """


### PR DESCRIPTION
mozilla/sumo#2544

## Notes
Locally, I made over 40 runs using the new prompt, and none of the runs added any extra formatting (like a markdown fence) or text of any kind to the translation part of the LLM response. I think this will significantly reduce errors when parsing the L10N LLM response.