### PR TITLE
Playwright: Update the test report generation flow & fxa verification code fetching

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,8 +1,5 @@
 name: Playwright Tests
 on:
-    schedule:
-        # Playwright tests are running automatically in Firefox on each Monday & in Chromium on each Friday.
-        - cron: '0 5 * * 1,5'
     workflow_dispatch:
         inputs:
             Browsers:
@@ -77,18 +74,8 @@ jobs:
         run: |
           source .venv/bin/activate && python -m nltk.downloader wordnet omw-1.4
       - name: Set up browsers env
-        if: "github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'"
         run: |
-            if [ "${{ github.event_name }}" == 'schedule' ]; then
-                current_day=$(date +\%u)
-                if [ $current_day -eq 1 ]; then
-                    echo "BROWSER=firefox" >> $GITHUB_ENV
-                elif [ $current_day -eq 5 ]; then
-                    echo "BROWSER=chromium" >> $GITHUB_ENV
-                fi
-            elif [ "${{ github.event_name }}" == 'workflow_dispatch' ]; then
-                echo "BROWSER=${{inputs.Browsers}}" >> $GITHUB_ENV
-            fi
+            echo "BROWSER=${{inputs.Browsers}}" >> $GITHUB_ENV
       - name: Ensure Playwright browsers are installed
         run: |
             source .venv/bin/activate && playwright install ${{ env.BROWSER }}
@@ -104,7 +91,7 @@ jobs:
             source ../.venv/bin/activate
             declare dispatch_test_suite="${{inputs.TestSuite}}"
             declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productSupportPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics" "searchTests" "contributorForumSearch" "userGroupsTests" "antiSpamTests" "contributorDiscussions" "contributorDiscussionsThreads" "userDeletion")
-            if [ "$dispatch_test_suite" == "All" ] || [ "${{ github.event_name}}" == "schedule" ] ; then
+            if [ "$dispatch_test_suite" == "All" ] ; then
                 for test in "${all_test_suites[@]}"; do
                     if ! pytest -m ${test} --numprocesses 6 --browser ${{ env.BROWSER }} --reruns 2 -v; then
                         any_failures=true
@@ -138,21 +125,45 @@ jobs:
                 fi
             fi
             echo "TESTS_FAILED=$any_failures" >> $GITHUB_ENV
-      - name: Generating Allure Report
-        working-directory: playwright_tests
-        if: success() || failure()
-        run: |
-            curl -o allure-2.32.0.tgz -L https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.32.0/allure-commandline-2.32.0.tgz
-            tar -zxvf allure-2.32.0.tgz
-            export PATH=$PATH:$PWD/allure-2.32.0/bin
-            allure generate --single-file reports/allure_reports
-      - name: Upload the combined test report as artifact
-        if: success() || failure()
+
+      - name: Upload raw test results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Playwright test report
-          path: |
-            playwright_tests/allure-report
+            name: raw-allure-results
+            path: playwright_tests/reports/allure_reports
+
       - name: Playwright Test Status
         if: env.TESTS_FAILED == 'true'
         run: exit 1
+
+  generating_allure_report:
+      runs-on: ubuntu-latest
+      needs: playwright_tests
+      if: always()
+      steps:
+          - uses: actions/checkout@v3
+          - name: Download test results
+            uses: actions/download-artifact@v4
+            with:
+                name: raw-allure-results
+                path: allure-results
+          - name: Install Allure CLI
+            run: |
+                curl -o allure-2.32.0.tgz -L https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.32.0/allure-commandline-2.32.0.tgz
+                tar -zxvf allure-2.32.0.tgz
+                echo "$PWD/allure-2.32.0/bin" >> $GITHUB_PATH
+          - name: Generate Allure Report
+            run: |
+                allure generate --single-file allure-results -o allure-report
+          - name: Upload the combined test report as artifact
+            uses: actions/upload-artifact@v4
+            with:
+                name: Final Allure Report
+                path: allure-report
+          - name: Delete raw allure results
+            if: success()
+            uses: geekyeggo/delete-artifact@v5
+            with:
+                name: raw-allure-results
+

--- a/playwright_tests/core/utilities.py
+++ b/playwright_tests/core/utilities.py
@@ -93,16 +93,16 @@ class Utilities:
         for attempt in range(max_attempts):
             try:
                 # Steps:
-                # 1. Clearing the inbox for the given fxa username.
-                # 2. Parsing the inbox json encoded response for the x-signing-verify-code.
-                # 3. Clearing the inbox for the given fxa username if the verification code was
+                # 1. Parsing the inbox json encoded response for the subject.
+                # 2. Clearing the inbox for the given fxa username if the verification code was
                 # fetched.
-                # 4. Returning the fxa verification code for furthe usage.
+                # 3. Returning the fxa verification code for further usage.
                 cleared_username = self.username_extraction_from_email(fxa_username)
                 response = requests.get(f"https://restmail.net/mail/{cleared_username}")
                 response.raise_for_status()
                 json_response = response.json()
-                fxa_verification_code = json_response[0]['headers']['x-signin-verify-code']
+                fxa_verification_code = str(self.number_extraction_from_string(
+                    json_response[0]['subject']))
                 self.clear_fxa_email(cleared_username)
                 return fxa_verification_code
             except HTTPError as htt_err:

--- a/playwright_tests/flows/auth_flows/auth_flow.py
+++ b/playwright_tests/flows/auth_flows/auth_flow.py
@@ -65,6 +65,8 @@ class AuthFlowPage:
 
         if self.auth_page.is_enter_otp_code_input_field_displayed():
             """If the OTP code input field is displayed, provide the OTP code."""
+            self.utilities.clear_fxa_email(self.utilities.staff_user)
+            self.auth_page.click_on_email_new_code_button()
             self.__provide_otp_code(self.utilities.get_fxa_verification_code(
                 fxa_username=username))
         self.utilities.wait_for_dom_to_load()

--- a/playwright_tests/pages/auth_page.py
+++ b/playwright_tests/pages/auth_page.py
@@ -24,8 +24,10 @@ class AuthPage(BasePage):
         self.enter_your_password_input_field = page.locator("input[type='password']")
         self.enter_your_password_submit_button = page.get_by_role(
             "button", name="Sign in", exact=True)
-        self.enter_otp_code_input_field = page.locator("input#otp-code")
-        self.enter_otp_code_confirm_button = page.locator("button#submit-btn")
+        self.enter_otp_code_input_field = page.locator(
+            "//input[@data-testid='signin-token-code-input-field']")
+        self.enter_otp_code_confirm_button = page.locator("//button[@type='submit']")
+        self.email_new_code = page.locator("//button[text()='Email new code.']")
 
     def click_on_cant_sign_in_to_my_mozilla_account_link(self):
         """Click on 'Can't sign in to my Mozilla account' link"""
@@ -55,6 +57,10 @@ class AuthPage(BasePage):
         """Click on 'Submit' OTP code button"""
         self._click(self.enter_otp_code_confirm_button)
 
+    def click_on_email_new_code_button(self):
+        """Click on Email new code. button"""
+        self._click(self.email_new_code)
+
     def add_data_to_email_input_field(self, text: str):
         """Add data to 'Enter your email' input field"""
         self._fill(self.enter_your_email_input_field, text)
@@ -65,7 +71,7 @@ class AuthPage(BasePage):
 
     def add_data_to_otp_code_input_field(self, text: str):
         """Add data to 'Enter OTP code' input field"""
-        self._fill(self.enter_otp_code_input_field, text)
+        self._type(self.enter_otp_code_input_field, text, 100)
 
     def clear_email_input_field(self):
         """Clear 'Enter your email' input field"""

--- a/playwright_tests/tests/test_prerequisites_login.py
+++ b/playwright_tests/tests/test_prerequisites_login.py
@@ -20,5 +20,7 @@ def test_create_user_sessions_for_test_accounts(page: Page):
         account_password=utilities.user_secrets_pass
     )
     utilities.wait_for_given_timeout(3500)
+    assert (sumo_pages.top_navbar.get_text_of_logged_in_username() == utilities
+            .username_extraction_from_email(utilities.staff_user))
     username = utilities.username_extraction_from_email(utilities.staff_user)
     utilities.store_session_cookies(username)

--- a/playwright_tests/tests/user_deletion_tests/forums/community_forums/test_user_deletion_in_community_forums.py
+++ b/playwright_tests/tests/user_deletion_tests/forums/community_forums/test_user_deletion_in_community_forums.py
@@ -226,6 +226,7 @@ def test_user_deletion_on_question_with_spam_replies(page: Page, create_user_fac
 
 
 # C2807314
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 @pytest.mark.parametrize("question_type", ["archived", "non-archived"])
 def test_user_deletion_on_question_with_replies_from_other_user(page: Page,
@@ -325,6 +326,7 @@ def test_user_deletion_on_question_with_replies_from_same_user(page: Page,
 
 
 # C2807314
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 @pytest.mark.parametrize("question_type", ["archived", "non-archived"])
 def test_user_deletion_on_question_with_solution(page: Page, question_type, create_user_factory):
@@ -418,6 +420,7 @@ def test_user_deletion_on_voted_question(page: Page, question_type, create_user_
 
 
 # C2807938, C2807940, C2926133, C2807890, C2807892, C2807893
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 @pytest.mark.parametrize("answer_type", ["simple", "solution", "voted"])
 @pytest.mark.parametrize("question_type", ["archived", "non-archived"])

--- a/playwright_tests/tests/user_deletion_tests/forums/contributor_forums/test_user_deletion_in_contributor_forums.py
+++ b/playwright_tests/tests/user_deletion_tests/forums/contributor_forums/test_user_deletion_in_contributor_forums.py
@@ -9,6 +9,7 @@ from playwright_tests.pages.sumo_pages import SumoPages
 
 
 # C3132836
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 def test_thread_with_no_replies_is_not_assigned_to_system_user(page: Page, create_user_factory):
     utilities = Utilities(page)
@@ -261,6 +262,7 @@ def test_deleting_the_user_which_edited_a_thread(page: Page, create_user_factory
 
 
 # C2939461
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 def test_threads_are_assigned_to_system_account_if_contains_additional_posts(page: Page,
                                                                              create_user_factory):
@@ -299,6 +301,7 @@ def test_threads_are_assigned_to_system_account_if_contains_additional_posts(pag
 
 
 # C2939461
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 def test_thread_replies_are_assigned_to_system_account(page: Page, create_user_factory):
     utilities = Utilities(page)

--- a/playwright_tests/tests/user_deletion_tests/groups/test_user_deletion_in_groups.py
+++ b/playwright_tests/tests/user_deletion_tests/groups/test_user_deletion_in_groups.py
@@ -5,7 +5,8 @@ from playwright_tests.core.utilities import Utilities
 from playwright_tests.pages.sumo_pages import SumoPages
 
 
-# C2939494 
+# C2939494
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 def test_deleted_user_is_removed_from_groups(page: Page, create_user_factory):
     utilities = Utilities(page)

--- a/playwright_tests/tests/user_deletion_tests/kb/test_user_deletion_and_article_contributions.py
+++ b/playwright_tests/tests/user_deletion_tests/kb/test_user_deletion_and_article_contributions.py
@@ -8,6 +8,7 @@ from playwright_tests.tests.conftest import create_user_factory
 
 
 # C2952002, C2952017
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 def test_reviewed_revisions_assignment_to_system_account(page: Page, create_user_factory):
     utilities = Utilities(page)
@@ -71,6 +72,7 @@ def test_reviewed_revisions_assignment_to_system_account(page: Page, create_user
 
 
 # C2952003, C2952016
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 def test_unreviewed_revisions_are_not_assigned_to_system_account(page: Page, create_user_factory):
     utilities = Utilities(page)
@@ -130,6 +132,7 @@ def test_deferred_revisions_are_not_assigned_to_system_account(page:Page, create
 
 
 #  C2979501, C2979502
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 def test_localization_revisions_are_assigned_to_system_account(page: Page, create_user_factory):
     utilities = Utilities(page)

--- a/playwright_tests/tests/user_deletion_tests/media_gallery/test_user_deletion_in_media_gallery.py
+++ b/playwright_tests/tests/user_deletion_tests/media_gallery/test_user_deletion_in_media_gallery.py
@@ -8,6 +8,7 @@ from playwright_tests.pages.sumo_pages import SumoPages
 
 
 # C2939491
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 def test_media_file_ownership_reassignment_to_system_account(page: Page, create_user_factory):
     utilities = Utilities(page)

--- a/playwright_tests/tests/user_deletion_tests/messaging_system/test_user_deletion_in_messaging_system.py
+++ b/playwright_tests/tests/user_deletion_tests/messaging_system/test_user_deletion_in_messaging_system.py
@@ -9,6 +9,7 @@ from playwright_tests.pages.sumo_pages import SumoPages
 
 
 # C2939485
+@pytest.mark.smokeTest
 @pytest.mark.userDeletion
 def test_deleted_user_is_displayed_in_both_inbox_and_outbox(page: Page, create_user_factory):
     utilities = Utilities(page)


### PR DESCRIPTION
playwright.yml updates:
* Removed the test run on a scheduled (cron) basis (rely only on workflow_dispatch for now).
* Generating a raw test report at the end of the test execution step (even if the workflow run was manually canceled)
* Extract the Allure report generation step into a separate job which is going to generate the final single-file allure report based on the generated raw report. Once the single-file allure report generation is complete, the raw test report artifact is going to be deleted.

Other updates:
* Updated the fxa verification code fetching flows.
* Included a couple of the newly added tests to the smokeTest suite.