### PR TITLE
Playwright: Fix allure report generation error

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -126,44 +126,22 @@ jobs:
             fi
             echo "TESTS_FAILED=$any_failures" >> $GITHUB_ENV
 
-      - name: Upload raw test results
+      - name: Generating Allure Report
+        working-directory: playwright_tests
+        if: always()
+        run: |
+            curl -o allure-2.32.0.tgz -L https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.32.0/allure-commandline-2.32.0.tgz
+            tar -zxvf allure-2.32.0.tgz
+            export PATH=$PATH:$PWD/allure-2.32.0/bin
+            allure generate --single-file reports/allure_reports
+
+      - name: Upload the combined test report as artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-            name: raw-allure-results
-            path: playwright_tests/reports/allure_reports
+            name: Playwright test report
+            path: playwright_tests/allure-report
 
       - name: Playwright Test Status
         if: env.TESTS_FAILED == 'true'
         run: exit 1
-
-  generating_allure_report:
-      runs-on: ubuntu-latest
-      needs: playwright_tests
-      if: always()
-      steps:
-          - uses: actions/checkout@v3
-          - name: Download test results
-            uses: actions/download-artifact@v4
-            with:
-                name: raw-allure-results
-                path: allure-results
-          - name: Install Allure CLI
-            run: |
-                curl -o allure-2.32.0.tgz -L https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.32.0/allure-commandline-2.32.0.tgz
-                tar -zxvf allure-2.32.0.tgz
-                echo "$PWD/allure-2.32.0/bin" >> $GITHUB_PATH
-          - name: Generate Allure Report
-            run: |
-                allure generate --single-file allure-results -o allure-report
-          - name: Upload the combined test report as artifact
-            uses: actions/upload-artifact@v4
-            with:
-                name: Final Allure Report
-                path: allure-report
-          - name: Delete raw allure results
-            if: success()
-            uses: geekyeggo/delete-artifact@v5
-            with:
-                name: raw-allure-results
-

--- a/playwright_tests/core/utilities.py
+++ b/playwright_tests/core/utilities.py
@@ -93,7 +93,7 @@ class Utilities:
         for attempt in range(max_attempts):
             try:
                 # Steps:
-                # 1. Parsing the inbox json encoded response for the subject.
+                # 1. Parsing the inbox json encoded response for the x-signing-verify-code.
                 # 2. Clearing the inbox for the given fxa username if the verification code was
                 # fetched.
                 # 3. Returning the fxa verification code for further usage.
@@ -101,8 +101,7 @@ class Utilities:
                 response = requests.get(f"https://restmail.net/mail/{cleared_username}")
                 response.raise_for_status()
                 json_response = response.json()
-                fxa_verification_code = str(self.number_extraction_from_string(
-                    json_response[0]['subject']))
+                fxa_verification_code = json_response[0]['headers']['x-signin-verify-code']
                 self.clear_fxa_email(cleared_username)
                 return fxa_verification_code
             except HTTPError as htt_err:


### PR DESCRIPTION
* Probably due to some recent FxA changes the confirmation code started showing again inside the x-signing-verify-code header. Updated the flow to fetch it from there.
* Updated the playwright.yml file since I've hit the `The action geekyeggo/delete-artifact@v5 is not allowed in mozilla/kitsune because all actions must be from a repository owned by your enterprise` during execution. 