### PR TITLE
remove clear-all button

### DIFF
--- a/kitsune/sumo/static/sumo/js/wiki.editor.js
+++ b/kitsune/sumo/static/sumo/js/wiki.editor.js
@@ -196,9 +196,6 @@ document.addEventListener("DOMContentLoaded", function () {
   new TomSelect("select[id='id_restrict_to_groups']", {
     closeAfterSelect: true,
     plugins: {
-      clear_button: {
-        title: "Clear All",
-      },
       remove_button: {
         title: "Remove Item"
       },

--- a/kitsune/sumo/static/sumo/js/wiki_search.js
+++ b/kitsune/sumo/static/sumo/js/wiki_search.js
@@ -34,9 +34,6 @@ document.addEventListener("DOMContentLoaded", function() {
     closeAfterSelect: true,
     maxItems: null, // Allow multiple selections
     plugins: {
-      clear_button: {
-        title: "Clear All",
-      },
       remove_button: {
         title: 'Remove this document'
       }

--- a/kitsune/sumo/static/sumo/scss/components/_wiki.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_wiki.scss
@@ -1318,23 +1318,3 @@ article {
     transform: rotate(0);
   }
 }
-
-// Styling for the tom-select clear_button plugin.
-.ts-wrapper.multi.plugin-clear_button .ts-control > .clear-button {
-  opacity: 100%;
-  width: 1rem;
-  height: 1rem;
-  font-size: 1rem;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  padding-bottom: 8px;
-  text-shadow: 0 1px 0 rgba(0, 51, 83, 30%);
-  border-radius: 3px;
-  background-image: linear-gradient(to bottom, #1da7ee, #178ee9) !important;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 20%),inset 0 1px rgba(255, 255, 255, 3%);
-
-  &:hover {
-    background-image: linear-gradient(to bottom, #008fd8, #0075cf) !important;
-  }
-}


### PR DESCRIPTION
mozilla/sumo#2565

I originally thought that the `Clear All` `TomSelect` button would be a nice convenience, but in the end it causes more problems than it's worth. Removing it.