### PR TITLE
Update readonly announcement to remove Twitter link

### DIFF
--- a/kitsune/sumo/jinja2/includes/readonly_annoucement.html
+++ b/kitsune/sumo/jinja2/includes/readonly_annoucement.html
@@ -5,6 +5,5 @@
   functionality while we undergo maintenance to improve your experience. If an
   article doesn't solve your issue and you want to ask a question, we have our
   support community waiting to help you at
-  <a href="{{ twitter }}">@FirefoxSupport</a> on Twitter and<a href="{{ reddit }}">/r/firefox</a>
-  on Reddit. 
+  <a href="{{ reddit }}">/r/firefox</a> on Reddit. 
 {% endtrans %}


### PR DESCRIPTION
Removes the Twitter support link from the announcement as the account is no longer maintained.

Resolves #6977 