### PR TITLE
better featured articles but with the same performance

### DIFF
--- a/kitsune/wiki/tests/test_utils.py
+++ b/kitsune/wiki/tests/test_utils.py
@@ -3,9 +3,7 @@ import time
 from datetime import date, timedelta
 from unittest import mock
 
-from django.conf import settings
 from django.contrib.sessions.backends.base import SessionBase
-from django.db.models import Q
 from django.http import Http404
 from django.test.utils import override_settings
 from requests.exceptions import HTTPError
@@ -31,7 +29,6 @@ from kitsune.wiki.utils import (
     get_featured_articles,
     get_kb_visited,
     get_pinned_articles,
-    get_q_object_for_parent,
     get_visible_document_or_404,
     has_visited_kb,
     num_active_contributors,
@@ -1272,90 +1269,3 @@ class GetPinnedArticlesTests(TestCase):
         RedirectRevisionFactory(document=valid_doc)
         result = get_pinned_articles(user=self.user, product=self.product1)
         self.assertEqual(result.count(), 0)
-
-
-class GetQObjectForParentTests(TestCase):
-    """
-    Test suite for the "get_q_object_for_parent" utility function.
-    """
-
-    def test_default_locale_single_kwarg(self):
-        """
-        Tests the simple path when the locale is the default.
-        It should return a single Q object with no 'parent__' prefix.
-        """
-        result = get_q_object_for_parent(
-            locale=settings.WIKI_DEFAULT_LANGUAGE,
-            is_archived=False,
-        )
-        self.assertEqual(result, Q(is_archived=False))
-
-    def test_non_default_locale_single_kwarg(self):
-        """
-        Tests the complex path for non-default locales.
-        It should return the combined OR query.
-        """
-        result = get_q_object_for_parent(locale="es", is_archived=False)
-
-        parent_q = Q(is_archived=False)
-        child_q = Q(parent__is_archived=False)
-        expected = (Q(parent__isnull=True) & parent_q) | (Q(parent__isnull=False) & child_q)
-
-        self.assertEqual(result, expected)
-
-    def test_none_locale_follows_non_default_path(self):
-        """
-        Tests that when locale is None (the default), the complex path is used.
-        """
-        result = get_q_object_for_parent(is_archived=False)
-
-        parent_q = Q(is_archived=False)
-        child_q = Q(parent__is_archived=False)
-        expected = (Q(parent__isnull=True) & parent_q) | (Q(parent__isnull=False) & child_q)
-
-        self.assertEqual(result, expected)
-
-    def test_default_locale_multiple_kwargs(self):
-        """
-        Tests the simple path with multiple keyword arguments.
-        """
-        result = get_q_object_for_parent(
-            locale=settings.WIKI_DEFAULT_LANGUAGE,
-            is_archived=False,
-            category=5,
-        )
-        self.assertEqual(result, Q(is_archived=False, category=5))
-
-    def test_non_default_locale_multiple_kwargs(self):
-        """
-        Tests the complex path with multiple keyword arguments.
-        """
-        result = get_q_object_for_parent(locale="it", is_archived=False, category=5)
-
-        parent_q = Q(is_archived=False, category=5)
-        child_q = Q(parent__is_archived=False, parent__category=5)
-        expected = (Q(parent__isnull=True) & parent_q) | (Q(parent__isnull=False) & child_q)
-
-        self.assertEqual(result, expected)
-
-    def test_default_locale_no_kwargs(self):
-        """
-        Tests the simple path with no keyword arguments.
-        Should return an empty, non-filtering Q object.
-        """
-        result = get_q_object_for_parent(locale=settings.WIKI_DEFAULT_LANGUAGE)
-        self.assertEqual(result, Q())
-
-    def test_non_default_locale_no_kwargs(self):
-        """
-        Tests the complex path with no keyword arguments.
-        The result should be a Q object that matches all rows
-        (i.e., parent is null OR parent is not null).
-        """
-        result = get_q_object_for_parent(locale="fr")
-        expected = Q(parent__isnull=True) | Q(parent__isnull=False)
-        self.assertEqual(result, expected)
-
-        # Test the None locale case as well
-        result = get_q_object_for_parent()
-        self.assertEqual(result, expected)


### PR DESCRIPTION
## Notes
- Expands the functionality of `get_featured_articles()`:
    - **Visibility**. Restricted articles can now be included in the featured articles depending on the permissions of the viewer.
    - **No longer excludes featured articles from the `Firefox Focus`, `Thunderbird`, and `Thunderbird for Android` product landing pages**.
    - **Excludes non-default category articles**.
    - **Non-English parent articles**. Non-English parent articles, although rare, can now be included in the featured articles for their specific locale.
- **The performance is the same as the original**, even with the extra pinned-article handling. Tested in production during full load:
```
>>> import random
>>> from typing import Any
>>> from django.conf import settings
>>> from django.db.models import Q
>>> from django.db.models.query import QuerySet
>>> from kitsune.dashboards import LAST_7_DAYS
>>> from kitsune.wiki.config import REDIRECT_HTML
>>> from kitsune.wiki.models import Document, PinnedArticleConfig
>>> 
l>>> PINNED_ARTICLE_LIMIT_Q = Q(
...     parent__isnull=True,
...     is_template=False,
...     is_archived=False,
...     category__in=settings.IA_DEFAULT_CATEGORIES,
... ) & ~Q(html__startswith=REDIRECT_HTML)
>>> 
>>> def get_q_object_for_parent(locale: str | None = None, **kwargs: dict[str, Any]) -> Q:
...     """
...     Returns a Django Q object that ensures that each of the provided keyword...     arguments is applied only on the parent. Provide the "locale" argument only
...     if already filtering for that locale.
...     """
...     parent_q = Q(**kwargs)
...     if locale == settings.WIKI_DEFAULT_LANGUAGE:
...         return parent_q
...     # Non-English documents can be parents too.
...     child_q = Q(**{f"parent__{k}": v for k, v in kwargs.items()})
...     return (Q(parent__isnull=True) & parent_q) | (Q(parent__isnull=False) & child_q)
... 
>>> def get_pinned_articles(
...     user=None, product=None, locale=settings.WIKI_DEFAULT_LANGUAGE, fetch_for_aaq=False
... ) -> QuerySet[Document]:
...     """
...     Given the product, locale, and whether or not we're getting pinned articles for the
...     AAQ, returns a queryset of the pinned articles that are visible to the given user.
...     """
...     qs = PinnedArticleConfig.objects
...     if fetch_for_aaq:
...         qs = qs.filter(aaq_configs__product=product, aaq_configs__is_active=True)
...     elif product:
...         qs = qs.filter(products=product)
...     else:
...         qs = qs.filter(use_for_home_page=True)
...     if not (config := qs.first()):
...         return Document.objects.none()
...     pinned_articles = config.pinned_articles.filter(PINNED_ARTICLE_LIMIT_Q)
...     condition = Q(id__in=pinned_articles)
...     if locale != settings.WIKI_DEFAULT_LANGUAGE:
...         condition = condition | Q(parent__in=pinned_articles)
...     return (
...         Document.objects.visible(user, locale=locale)
...         .filter(condition)
...         .select_related("current_revision")
...     )
... 
>>> def gf2(
...     user=None,
...     product=None,
...     topics=None,
...     locale=settings.WIKI_DEFAULT_LANGUAGE,
...     fetch_for_aaq=False,
...     limit=4,
... ):
...     """Returns up to 4 random articles from the most visited.
...     Args:
...         user: Optional user for visibility
...         product: Optional product to filter by
...         topics: Optional iterable of topics to filter by
...         locale: Locale to get articles for, defaults to WIKI_DEFAULT_LANGUAGE
...         fetch_for_aaq: Optional boolean (currently ignored)
...         limit: Optional integer to limit the number of articles
...     """
...     pinned_articles = list(
...         get_pinned_articles(
...             user=user,
...             product=product,
...             locale=locale,
...             fetch_for_aaq=fetch_for_aaq,
...         )
...     )
...     if (num_pinned_articles := len(pinned_articles)) >= limit:
...         if num_pinned_articles > limit:
...             pinned_articles = random.sample(pinned_articles, limit)
...         return pinned_articles
...     filter_kwargs = {"category__in": settings.IA_DEFAULT_CATEGORIES}
...     if product:
...         filter_kwargs.update(products=product)
...     if topics:
...         filter_kwargs.update(topics__in=topics)
...     qs = Document.objects.visible(
...         user,
...         locale=locale,
...         is_template=False,
...         is_archived=False,
...         current_revision__isnull=False,
...     ).filter(get_q_object_for_parent(locale=locale, **filter_kwargs))
...     if (not product) and (excluded_slugs := settings.EXCLUDE_PRODUCT_SLUGS_FEATURED_ARTICLES):
...         # If we're not filtering by a specific product, exclude the products...         # that have been configured for exclusion from featured articles.
...         qs = qs.exclude(
...             get_q_object_for_parent(
...                 locale=locale,
...                 products__slug__in=excluded_slugs,
...             )
...         )
...     qs = (
...         qs.filter(visits__period=LAST_7_DAYS)
...         .exclude(html__startswith=REDIRECT_HTML)
...         .select_related("current_revision")
...         .order_by("-visits__visits")
...     )
...     if topics:
...         # Documents that match multiple topics will be repeated,
...         # so remove any duplicates when we're matching by topics.
...         qs = qs.distinct()
...     # Only include the "limit * 2" most visited articles for sampling.
...     docs = list(qs[: limit * 2])
...     remaining_limit = limit - len(pinned_articles)
...     if len(docs) > remaining_limit:
...         docs = random.sample(docs, remaining_limit)
...     return pinned_articles + docs
... 
>>> timeit("gf2()", globals=globals(), number=100)
5.793605691025732
>>> product = Product.objects.get(slug="firefox")
>>> product
<Product: Firefox>
>>> timeit("gf2(product=product)", globals=globals(), number=100)
3.727559871011181
>>> timeit(setup="from kitsune.wiki.utils import get_featured_articles", stmt="get_featured_articles()", number=100)
6.661416374990949
>>> timeit(setup="from kitsune.wiki.utils import get_featured_articles", stmt="get_featured_articles(product=product)", globals=globals(), number=100)
3.410288790008053
```