### PR TITLE
switch to workload identity for the GA client

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -952,11 +952,6 @@ TIDINGS_REVERSE = "kitsune.sumo.urlresolvers.reverse"
 
 
 # Google Analytics settings.
-# GA_KEY is expected b64 encoded.
-GA_KEY = config("GA_KEY", default=None)  # Google API client key
-GA_ACCOUNT = config(
-    "GA_ACCOUNT", "something@developer.gserviceaccount.com"
-)  # Google API Service Account email address
 GA_PROPERTY_ID = config("GA_PROPERTY_ID", default="123456789")
 GTM_CONTAINER_ID = config("GTM_CONTAINER_ID", default="")  # Google container ID
 GA_DEBUG_MODE = config("GA_DEBUG_MODE", default=False, cast=bool)


### PR DESCRIPTION
mozilla/sumo#2607

IMPORTANT: Merge https://github.com/mozilla/webservices-infra/pull/8131 prior to merging this PR.

## Notes
This has already been successfully tested locally with both the stage and production settings. 🚀 

### Impersonating the `stage` settings locally
- Impersonate the GKE stage service account
- Set the `GOOGLE_APPLICATION_CREDENTIALS` to a local directory that stores the impersonated creds and that is within reach of the `docker-compose` containers. 
- Set the `GA_PROPERTY_ID` setting to the ID of the SUMO stage GA4 property
- Set `GOOGLE_CLOUD_PROJECT=moz-fx-sumo-nonprod`

### Impersonating the `prod` settings locally
- Impersonate the GKE prod service account
- Set the `GOOGLE_APPLICATION_CREDENTIALS` to a local directory that stores the impersonated creds and that is within reach of the `docker-compose` containers. 
- Set the `GA_PROPERTY_ID` setting to the ID of the SUMO prod GA4 property
- Set `GOOGLE_CLOUD_PROJECT=moz-fx-sumo-prod`
