### PR TITLE
Add the Mastodon link to the readonly announcement

### DIFF
--- a/kitsune/sumo/jinja2/includes/readonly_annoucement.html
+++ b/kitsune/sumo/jinja2/includes/readonly_annoucement.html
@@ -1,9 +1,9 @@
 {% trans 
-    reddit="http://reddit.com/r/firefox", 
-    twitter="https://twitter.com/FirefoxSupport" %} 
+    reddit="https://reddit.com/r/firefox", 
+    mastodon="https://mastodon.social/@mozilla_support" %}
   This site will have limited
   functionality while we undergo maintenance to improve your experience. If an
-  article doesn't solve your issue and you want to ask a question, we have our
-  support community waiting to help you at
-  <a href="{{ reddit }}">/r/firefox</a> on Reddit. 
+  article doesn't solve your issue and you want to ask a question, you may reach
+  out to us on <a href="{{ mastodon }}">Mastodon</a>, or ask the
+  <a href="{{ reddit }}">Firefox community on Reddit</a>.
 {% endtrans %}


### PR DESCRIPTION
Add the Mastodon link to the readonly announcement and update the wording according to Kiki's suggestion in [#6977](https://github.com/mozilla/kitsune/issues/6977)