### PR TITLE
Remove placeholder for first author in extract.py

### DIFF
--- a/kitsune/sumo/management/commands/extract.py
+++ b/kitsune/sumo/management/commands/extract.py
@@ -133,7 +133,7 @@ def update_header_comments(filename):
         ),
         (
             re.compile(r"^# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.$", flags=re.MULTILINE),
-            f"# FIRST AUTHOR <EMAIL@ADDRESS>, {current_year}.",
+            "",
         ),
     ]
     pot_file = Path(filename)


### PR DESCRIPTION
Remove the `# FIRST AUTHOR <EMAIL@ADDRESS>, {current_year}.` line from the resource comment.

Resolves [#2616](https://github.com/mozilla/sumo/issues/2616)