### PR TITLE
Update show-fx-download CTA macro URLs

### DIFF
--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -906,14 +906,14 @@
 <div class="firefox-download-button hidden">
   <div class="download-buttons">
     <div class="download-firefox">
-      <a href="https://www.mozilla.org/firefox/new/?utm_source=support.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=non-fx-button&amp;utm_content=body-download-button"
+      <a href="https://www.firefox.com/?utm_source=support.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=non-fx-button&amp;utm_content=body-download-button"
         class="download-button sumo-button primary-button button-lg">
         {{ _('Download Firefox') }}
       </a>
       <ul class="download-info text-body-xs">
-        <li><a href="https://www.mozilla.org/firefox/all/">{{ _('Systems and Languages') }}</a></li>
-        <li><a href="https://www.mozilla.org/firefox/notes">{{ _("What's New") }}</a></li>
-        <li><a href="https://www.mozilla.org/legal/privacy/firefox">{{ _('Privacy') }}</a></li>
+        <li><a href="https://www.firefox.com/download/all/">{{ _('Systems and Languages') }}</a></li>
+        <li><a href="https://www.firefox.com/firefox/notes/">{{ _("What's New") }}</a></li>
+        <li><a href="https://www.mozilla.org/privacy/firefox/">{{ _('Privacy') }}</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
https://github.com/mozilla/sumo/issues/2622

Current links to avoid additional redirections.