### PR TITLE
Add context to differentiate the Updated strings

### DIFF
--- a/kitsune/dashboards/readouts.py
+++ b/kitsune/dashboards/readouts.py
@@ -19,6 +19,7 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _lazy
 from django.utils.translation import pgettext_lazy
 from markupsafe import Markup
+from tower import ugettext_lazy
 
 from kitsune.dashboards import LAST_30_DAYS, PERIODS
 from kitsune.dashboards.models import WikiDocumentVisits
@@ -45,7 +46,7 @@ MOST_VIEWED = 1
 MOST_RECENT = 2
 REVIEW_STATUSES = {
     1: (_lazy("Review Needed"), "wiki.document_revisions", "review"),
-    0: (_lazy("Updated"), "", "ok"),
+    0: (ugettext_lazy("Updated", context="article l10n status"), "", "ok"),
 }
 SIGNIFICANCE_STATUSES = {
     MEDIUM_SIGNIFICANCE: (_lazy("Update Needed"), "wiki.edit_document", "update"),

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -31,6 +31,7 @@ from django.utils.translation import gettext_lazy as _lazy
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from django_user_agents.utils import get_user_agent
 from sentry_sdk import capture_exception
+from tower import ugettext_lazy
 from zenpy.lib.exception import APIException
 
 from kitsune.access.decorators import login_required, permission_required
@@ -126,13 +127,13 @@ FILTER_GROUPS = {
 
 ORDER_BY = OrderedDict(
     [
-        # L10n: This is a question order option. It is a part of a drop-down menu with no heading.
-        ("updated", ("updated", _lazy("Updated"))),
-        # L10n: This is a question order option. It is a part of a drop-down menu with no heading.
+        # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
+        ("updated", ("updated", ugettext_lazy("Updated", context="question sort option"))),
+        # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
         ("views", ("questionvisits__visits", _lazy("Views"))),
-        # L10n: This is a question order option. It is a part of a drop-down menu with no heading.
+        # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
         ("votes", ("num_votes_past_week", _lazy("Votes"))),
-        # L10n: This is a question order option. It is a part of a drop-down menu with no heading.
+        # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
         ("replies", ("num_answers", _lazy("Replies"))),
     ]
 )


### PR DESCRIPTION
Add context to differentiate the "Updated" strings from the l10n dashboard and the Forum sorting dropdown.
Replace "order" with "sort" in l10n comments for better clarity.

Fully resolves [#2630](https://github.com/mozilla/sumo/issues/2630)