### PR TITLE
Differentiate the Updated strings by changing one of them

### DIFF
--- a/kitsune/dashboards/readouts.py
+++ b/kitsune/dashboards/readouts.py
@@ -45,7 +45,7 @@ MOST_VIEWED = 1
 MOST_RECENT = 2
 REVIEW_STATUSES = {
     1: (_lazy("Review Needed"), "wiki.document_revisions", "review"),
-    0: (_lazy("Updated"), "", "ok"),
+    0: (_lazy("Up to Date"), "", "ok"),
 }
 SIGNIFICANCE_STATUSES = {
     MEDIUM_SIGNIFICANCE: (_lazy("Update Needed"), "wiki.edit_document", "update"),

--- a/kitsune/dashboards/tests/test_readouts.py
+++ b/kitsune/dashboards/tests/test_readouts.py
@@ -648,7 +648,7 @@ class TemplateTests(ReadoutTestCase):
 
         self.assertEqual(1, len(self.rows(locale=locale, product=p)))
         self.assertEqual(t.title, self.row(locale=locale, product=p)["title"])
-        self.assertEqual("Updated", self.row(locale=locale, product=p)["status"])
+        self.assertEqual("Up to Date", self.row(locale=locale, product=p)["status"])
 
     def test_needs_changes(self):
         """Test status for article that needs changes"""
@@ -704,7 +704,7 @@ class HowToContributeTests(ReadoutTestCase):
 
         self.assertEqual(1, len(self.rows(locale=locale, product=p)))
         self.assertEqual(d2.title, self.row(locale=locale, product=p)["title"])
-        self.assertEqual("Updated", self.row(locale=locale, product=p)["status"])
+        self.assertEqual("Up to Date", self.row(locale=locale, product=p)["status"])
 
 
 class AdministrationTests(ReadoutTestCase):
@@ -723,7 +723,7 @@ class AdministrationTests(ReadoutTestCase):
 
         self.assertEqual(1, len(self.rows(locale=locale, product=p)))
         self.assertEqual(d2.title, self.row(locale=locale, product=p)["title"])
-        self.assertEqual("Updated", self.row(locale=locale, product=p)["status"])
+        self.assertEqual("Up to Date", self.row(locale=locale, product=p)["status"])
 
 
 class MostVisitedTranslationsTests(ReadoutTestCase):
@@ -795,7 +795,7 @@ class MostVisitedTranslationsTests(ReadoutTestCase):
         translation = TranslatedRevisionFactory(document__locale="de", is_approved=True)
         row = self.row()
         self.assertEqual(row["title"], translation.document.title)
-        self.assertEqual(str(row["status"]), "Updated")
+        self.assertEqual(str(row["status"]), "Up to Date")
         self.assertEqual(row["status_class"], "ok")
 
     def test_one_rejected_revision(self):

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -126,13 +126,13 @@ FILTER_GROUPS = {
 
 ORDER_BY = OrderedDict(
     [
-        # L10n: This is a question order option. It is a part of a drop-down menu with no heading.
+        # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
         ("updated", ("updated", _lazy("Updated"))),
-        # L10n: This is a question order option. It is a part of a drop-down menu with no heading.
+        # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
         ("views", ("questionvisits__visits", _lazy("Views"))),
-        # L10n: This is a question order option. It is a part of a drop-down menu with no heading.
+        # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
         ("votes", ("num_votes_past_week", _lazy("Votes"))),
-        # L10n: This is a question order option. It is a part of a drop-down menu with no heading.
+        # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
         ("replies", ("num_answers", _lazy("Replies"))),
     ]
 )


### PR DESCRIPTION
- Differentiate the "Updated" strings from the l10n dashboard and the Forum sorting dropdown by changing the one from the dashboard.
- Update the corresponding tests.
- Replace "order" with "sort" in l10n comments for better clarity.

Fully resolves [#2630](https://github.com/mozilla/sumo/issues/2630)