### PR TITLE
fix #5446: Add clarification about avatar sync for Sumo users

### DIFF
--- a/kitsune/users/jinja2/users/edit_profile.html
+++ b/kitsune/users/jinja2/users/edit_profile.html
@@ -30,6 +30,13 @@
       {% trans a_open='<a href="https://support.mozilla.org/en-US/kb/change-primary-email-address-firefox-accounts">'|safe, a_close='</a>'|safe %}
         To change your email or avatar, visit the Mozilla accounts page. {{ a_open }} Learn more. {{ a_close }}
       {% endtrans %}
+      <br>
+      <small>
+        {% trans %}
+          <strong>Note:</strong> After changing your avatar, you'll need to log out and log back in to support.mozilla.org
+          for the change to appear.
+        {% endtrans %}
+      </small>
     </p>
 
     <div>


### PR DESCRIPTION
# summary
 This PR adds clarification text for sumo users about the need after avatar changes on Firefox Account.

#Change Made
-Added a note in `kitsune/users/jinja2/users/edit-profile.html
-This note explains that users need to log out and log back in to support.mozilla.org for avatar change to appear
-Used proper `{% trans  %}`  tags for internationalization support


#Fixes     
closes #5446 

This is my first contribution to kitsune!