### PR TITLE
safe question/answer image when file non-existent

### DIFF
--- a/kitsune/sumo/templatetags/jinja_helpers.py
+++ b/kitsune/sumo/templatetags/jinja_helpers.py
@@ -12,6 +12,7 @@ from babel.dates import format_date, format_datetime, format_time
 from babel.numbers import format_decimal
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
+from django.db.models.fields.files import FieldFile
 from django.http import QueryDict
 from django.template.loader import render_to_string
 from django.templatetags.static import static as django_static
@@ -553,3 +554,17 @@ def slug_to_title(slug):
     Convert a slug to a title.
     """
     return slug.replace("-", " ").capitalize()
+
+
+@library.global_function
+def safe_file_url(file: FieldFile) -> str | None:
+    """
+    Returns the URL of the given file field or None if its underlying file does not exist.
+    """
+    if not file:
+        return None
+
+    try:
+        return file.url
+    except (AttributeError, ValueError):
+        return None

--- a/kitsune/upload/jinja2/upload/attachments.html
+++ b/kitsune/upload/jinja2/upload/attachments.html
@@ -22,8 +22,8 @@
 
       {% endif %}
     {% endif %}
-    <a class="image" href="{{ image.file.url }}">
-      <img src="{{ image.thumbnail_if_set().url }}"/>
+    <a class="image" href="{{ safe_file_url(image.file) }}">
+      <img src="{{ safe_file_url(image.thumbnail_if_set()) }}"/>
     </a>
   </div>
 {%- endmacro %}


### PR DESCRIPTION
mozilla/sumo#2603

This PR simply prevents a 500 error when displaying questions/answers with attached images that are somehow missing their underlying file. It does not investigate the cause of the missing files.