### PR TITLE
prefer fastly-client-ip for remote-addr

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -24,6 +24,8 @@ LOG_LEVEL = config("LOG_LEVEL", default=logging.INFO)
 # Set to 'json' for MozLog format (https://wiki.mozilla.org/Firefox/Services/Logging)
 LOG_FORMAT = config("LOG_FORMAT", default="")
 
+ENABLE_REMOTE_ADDR_LOGGING = config("ENABLE_REMOTE_ADDR_LOGGING", default=False, cast=bool)
+
 SYSLOG_TAG = "http_sumo_app"
 
 # Repository directory.
@@ -392,7 +394,7 @@ STORAGES = {
 # of the proxies is assumed to append its IP to the "X-Forwarded-For" HTTP header
 # after the real client IP. The real client IP can be preceded by untrusted IPs,
 # so "X-Forwarded-For: untrusted-client-ip, ..., real-client-ip, proxy-ip, ...".
-TRUSTED_PROXY_COUNT = config("TRUSTED_PROXY_COUNT", cast=int, default=1)
+TRUSTED_PROXY_COUNT = config("TRUSTED_PROXY_COUNT", cast=int, default=2)
 
 
 def immutable_file_test(path, url):
@@ -474,7 +476,7 @@ MIDDLEWARE: tuple[str, ...] = (
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
-    "kitsune.sumo.middleware.SetRemoteAddrFromForwardedFor",
+    "kitsune.sumo.middleware.SetRemoteAddr",
     "kitsune.sumo.middleware.EnforceHostIPMiddleware",
     # VaryNoCacheMiddleware must be above LocaleMiddleware
     # so that it can see the response has a vary on accept-language.


### PR DESCRIPTION
mozilla/sumo#2653

## Notes
- The Fastly WAF provides the `Fastly-Client-IP` header, which is a reliable (cannot be spoofed) source for the client's IP address.
- This PR adjusts our middleware that sets the `REMOTE_ADDR` header for incoming requests to prefer the `Fastly-Client-IP` header, and fallback to the `X-Forwarded-For` header if the `Fastly-Client-IP` header is not present.
- This PR also changes the `TRUSTED_PROXY_COUNT` setting from 1 to 2, which accounts for the presence of the Fastly WAF.
- This PR also provides logging (for confirmation purposes only), if enabled via the new setting `ENABLE_REMOTE_ADDR_LOGGING`.