### PR TITLE
improve question details/list

### DIFF
--- a/kitsune/questions/config.py
+++ b/kitsune/questions/config.py
@@ -9,7 +9,6 @@ HIGHEST_RANKING = 100
 
 # Special tag names:
 NEEDS_INFO_TAG_NAME = "needsinfo"
-OFFTOPIC_TAG_NAME = "offtopic"
 
 # How long until a question is automatically taken away from a user
 TAKE_TIMEOUT = 600

--- a/kitsune/questions/jinja2/questions/question_list.html
+++ b/kitsune/questions/jinja2/questions/question_list.html
@@ -223,9 +223,8 @@
               </ul>
               <div class="forum--content">
                 <aside class="forum--meta question-meta {% if not question.num_answers %}urgent{% endif %}">
-                  {% set tags = question.my_tags %}
                   <ul class="tag-list push-right">
-                  {% for tag in tags %}
+                  {% for tag in question.tags.all()|sort(attribute='name') %}
                     <li class="tag"><a class="tag-name" href="{{ questions_url(tagged=tag.slug) }}">{{ tag }}</a></li>
                   {% endfor %}
                   {% if question.is_spam %}

--- a/kitsune/questions/models.py
+++ b/kitsune/questions/models.py
@@ -383,7 +383,7 @@ class Question(AAQBase):
     def is_contributor(self, user):
         """Did the passed in user contribute to this question?"""
         if user.is_authenticated:
-            if hasattr(self, 'user_is_contributor'):
+            if hasattr(self, "user_is_contributor"):
                 return self.user_is_contributor
             return user.id in self.contributors
 
@@ -405,10 +405,6 @@ class Question(AAQBase):
     def is_solved(self):
         return self.solution_id is not None
 
-    @property
-    def is_offtopic(self):
-        return config.OFFTOPIC_TAG_NAME in [t.name for t in self.my_tags]
-
     @cached_property
     def created_after_failed_kb_deflection(self) -> bool:
         """
@@ -427,16 +423,6 @@ class Question(AAQBase):
         except QuestionMetaData.DoesNotExist:
             return []
         return json.loads(metadata.value)
-
-    @property
-    def my_tags(self):
-        """A caching wrapper around self.tags.all()."""
-        cache_key = self.tags_cache_key % self.id
-        tags = cache.get(cache_key)
-        if tags is None:
-            tags = list(self.tags.all().order_by("name"))
-            cache.add(cache_key, tags, settings.CACHE_MEDIUM_TIMEOUT)
-        return tags
 
     @classmethod
     def get_serializer(cls, serializer_type="full"):
@@ -515,7 +501,7 @@ class Question(AAQBase):
     def num_visits(self):
         """Get the number of visits for this question."""
         # Use annotation if it exists (from question_list view optimization)
-        if hasattr(self, 'visits_count'):
+        if hasattr(self, "visits_count"):
             return self.visits_count
 
         if not hasattr(self, "_num_visits"):

--- a/kitsune/questions/tests/test_utils.py
+++ b/kitsune/questions/tests/test_utils.py
@@ -292,7 +292,7 @@ class ProcessClassificationResultTests(TestCase):
             FlaggedObject.objects.filter(content_type=q_ct, object_id=question.id).exists()
         )
         self.assertEqual(question.topic, self.topic1)
-        self.assertEqual({tag.name for tag in question.my_tags}, {self.topic1.slug})
+        self.assertEqual({tag.name for tag in question.tags.all()}, {self.topic1.slug})
 
         process_classification_result(question, classification_result)
 
@@ -300,7 +300,7 @@ class ProcessClassificationResultTests(TestCase):
 
         self.assertFalse(question.is_spam)
         self.assertEqual(question.topic, self.topic2)
-        self.assertEqual({tag.name for tag in question.my_tags}, {self.topic2.slug})
+        self.assertEqual({tag.name for tag in question.tags.all()}, {self.topic2.slug})
         self.assertTrue(
             FlaggedObject.objects.filter(
                 content_type=q_ct,
@@ -329,7 +329,7 @@ class ProcessClassificationResultTests(TestCase):
             FlaggedObject.objects.filter(content_type=q_ct, object_id=question.id).exists()
         )
         self.assertIsNone(question.topic)
-        self.assertFalse(question.my_tags)
+        self.assertFalse(question.tags.count())
 
         process_classification_result(question, classification_result)
 
@@ -337,7 +337,7 @@ class ProcessClassificationResultTests(TestCase):
 
         self.assertFalse(question.is_spam)
         self.assertEqual(question.topic, self.topic2)
-        self.assertEqual({tag.name for tag in question.my_tags}, {self.topic2.slug})
+        self.assertEqual({tag.name for tag in question.tags.all()}, {self.topic2.slug})
         self.assertTrue(
             FlaggedObject.objects.filter(
                 content_type=q_ct,
@@ -366,7 +366,7 @@ class ProcessClassificationResultTests(TestCase):
             FlaggedObject.objects.filter(content_type=q_ct, object_id=question.id).exists()
         )
         self.assertEqual(question.topic, self.topic1)
-        self.assertEqual({tag.name for tag in question.my_tags}, {self.topic1.slug})
+        self.assertEqual({tag.name for tag in question.tags.all()}, {self.topic1.slug})
 
         process_classification_result(question, classification_result)
 
@@ -374,7 +374,7 @@ class ProcessClassificationResultTests(TestCase):
 
         self.assertFalse(question.is_spam)
         self.assertEqual(question.topic, self.topic1)
-        self.assertEqual({tag.name for tag in question.my_tags}, {self.topic1.slug})
+        self.assertEqual({tag.name for tag in question.tags.all()}, {self.topic1.slug})
         self.assertTrue(
             FlaggedObject.objects.filter(
                 content_type=q_ct,


### PR DESCRIPTION
mozilla/sumo#2664

## Notes
This PR improves the performance of the `questions.details` and `questions.list` endpoints:
- Eliminates the `Question.my_tags` property, which was only used for the `questions.details` and `questions.list` endpoints -- also eliminates the `Question.is_offtopic` property because it was unused.
- Replaces the `Question.my_tags` property with a prefetch of `tags` combined with the use of `.tags.all()`.
    - Eliminates the Redis calls.
    - Takes advantage of the prefetched tags, which the `Question.my_tags` property did not because its use of `order_by` in the `.tags.all().order_by("name")` call forced a new query. 
- For the `questions.details` endpoint, eliminates extra queries for attributes like `creator`, `updated_by`, and `last_answer` by adding those to the question query via `select_related`, and also eliminates the extra query for the `metadata_set` by prefetching that.