### PR TITLE
map tier1 topic tag to legacy tag for ZD

### DIFF
--- a/kitsune/customercare/__init__.py
+++ b/kitsune/customercare/__init__.py
@@ -229,3 +229,24 @@ ZENDESK_CATEGORIES_LOGINLESS = {
         },
     ]
 }
+
+
+ZENDESK_LEGACY_MAPPING: dict[str, set] = {
+    "accounts": {
+        "t1-accounts",
+        "t1-passwords-and-sign-in",
+    },
+    "technical": {
+        "t1-accessibility",
+        "t1-backup-recovery-and-sync",
+        "t1-browse",
+        "t1-download-and-save",
+        "t1-email-and-messaging",
+        "t1-installation-and-updates",
+        "t1-performance-and-connectivity",
+        "t1-privacy-and-security",
+        "t1-search-tag-and-share",
+        "t1-settings",
+    },
+    "payment": {"t1-billing-and-subscriptions"},
+}

--- a/kitsune/customercare/tests/test_utils.py
+++ b/kitsune/customercare/tests/test_utils.py
@@ -79,7 +79,7 @@ class GenerateClassificationTagsTests(TestCase):
 
         tags = generate_classification_tags(submission, result)
 
-        self.assertEqual(tags, ["t1-settings"])
+        self.assertEqual(tags, ["t1-settings", "technical"])
 
     def test_two_tier_topic(self):
         """Test generating tags for a tier 2 topic."""
@@ -93,7 +93,7 @@ class GenerateClassificationTagsTests(TestCase):
 
         tags = generate_classification_tags(submission, result)
 
-        self.assertEqual(tags, ["t1-settings", "t2-notifications"])
+        self.assertEqual(tags, ["t1-settings", "t2-notifications", "technical"])
 
     def test_three_tier_topic(self):
         """Test generating tags for a tier 3 topic."""
@@ -111,7 +111,9 @@ class GenerateClassificationTagsTests(TestCase):
 
         tags = generate_classification_tags(submission, result)
 
-        self.assertEqual(tags, ["t1-settings", "t2-addons-extensions-and-themes", "t3-extensions"])
+        self.assertEqual(
+            tags, ["t1-settings", "t2-addons-extensions-and-themes", "t3-extensions", "technical"]
+        )
 
     @patch("kitsune.customercare.utils.ZENDESK_CATEGORIES")
     def test_automation_tag_included_when_matched(self, mock_categories):
@@ -139,6 +141,7 @@ class GenerateClassificationTagsTests(TestCase):
         self.assertIn("ssa-sign-in-failure-automation", tags)
         self.assertIn("t1-passwords-and-sign-in", tags)
         self.assertIn("t2-sign-in", tags)
+        self.assertIn("accounts", tags)
 
     @patch("kitsune.customercare.utils.ZENDESK_CATEGORIES")
     def test_no_automation_tag_when_not_matched(self, mock_categories):
@@ -153,15 +156,15 @@ class GenerateClassificationTagsTests(TestCase):
             }
         ]
 
-        tier1 = TopicFactory(title="Settings", parent=None, is_archived=False)
+        tier1 = TopicFactory(title="Billing and subscriptions", parent=None, is_archived=False)
         tier1.products.add(self.product)
 
         submission = Mock(product=self.product)
-        result = {"topic_result": {"topic": "Settings"}}
+        result = {"topic_result": {"topic": "Billing and subscriptions"}}
 
         tags = generate_classification_tags(submission, result)
 
-        self.assertEqual(tags, ["t1-settings"])
+        self.assertEqual(tags, ["t1-billing-and-subscriptions", "payment"])
         self.assertNotIn("some-automation", tags)
 
     def test_product_reassignment_includes_other_tag(self):
@@ -179,6 +182,7 @@ class GenerateClassificationTagsTests(TestCase):
 
         self.assertIn("other", tags)
         self.assertIn("t1-settings", tags)
+        self.assertIn("technical", tags)
 
     def test_archived_topic_returns_undefined(self):
         """Test that archived topics are not found and return ['undefined']."""


### PR DESCRIPTION
mozilla/sumo#2668

NOTE: This PR **restores the equality matching of the tier tags when finding a matching automation tag**, because many of the `ZENDESK_CATEGORIES` share common tier1 tags but differ in their tier2 or tier3 tags, so we'd end up matching the wrong category and therefore assign the wrong automation tag.

## Question
Do we want to add the fallback `general` legacy tag to all of the "failure" return paths within `generate_classification_tags()`, for example when the topic title is "Undefined" or when the topic title can't be found? I didn't do that, but it seems possible that we should.