### PR TITLE
Rework Share data fallback message formatting

### DIFF
--- a/kitsune/questions/jinja2/questions/includes/aaq_macros.html
+++ b/kitsune/questions/jinja2/questions/includes/aaq_macros.html
@@ -197,9 +197,16 @@
         </button>
       </div>
       <p id="troubleshooting-manual" class="hide-until-expanded">
-        {% trans %}
-          We can't automatically get your browser's troubleshooting data, please
-          <a href="https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox">try these manual steps</a>.
+        {# L10n: Deprecated #}
+        {% set deprecated_share_data_fallback %}
+          {% trans %}
+            We can't automatically get your browser's troubleshooting data, please
+            <a href="https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox">try these manual steps</a>.
+          {% endtrans %}
+        {% endset %}
+        {# L10n: Try these manual steps refers to https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox #}
+        {% trans a_open='<a href="https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox" target="_blank">'|safe, a_close='</a>'|safe %}
+          We can't automatically get your browser's troubleshooting data, please {{ a_open }}try these manual steps{{ a_close }}.
         {% endtrans %}
       </p>
       <div id="troubleshooting-field" class="hide-until-expanded field full-width">


### PR DESCRIPTION
- Move the tags from the Share data fallback message to the trans block
- Add target="_blank" to the link in the Share data fallback message

Resolves #6881.

The old string is kept as deprecated to preserve existing translations and give localizers time to transfer them. We'll remove that string later.