### PR TITLE
Switch from naturaltime to timesince

### DIFF
--- a/kitsune/sumo/templatetags/jinja_helpers.py
+++ b/kitsune/sumo/templatetags/jinja_helpers.py
@@ -11,7 +11,6 @@ import wikimarkup.parser
 from babel.dates import format_date, format_datetime, format_time
 from babel.numbers import format_decimal
 from django.conf import settings
-from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.db.models.fields.files import FieldFile
 from django.http import QueryDict
 from django.template.loader import render_to_string
@@ -241,7 +240,7 @@ def _contextual_locale(context):
 
 @jinja2.pass_context
 @library.global_function
-def datetimeformat(context, value, format="shortdatetime", use_naturaltime=False):
+def datetimeformat(context, value, format="shortdatetime", use_timesince=False):
     """
     Returns a formatted date/time using Babel's locale settings. Uses the
     timezone from settings.py, if the user has not been authenticated.
@@ -276,8 +275,8 @@ def datetimeformat(context, value, format="shortdatetime", use_naturaltime=False
     convert_value = new_value.astimezone(convert_tzinfo)
     locale = _babel_locale(_contextual_locale(context))
 
-    if use_naturaltime and (django_now().astimezone(convert_tzinfo) - convert_value).days < 30:
-        return naturaltime(convert_value)
+    if use_timesince and (django_now().astimezone(convert_tzinfo) - convert_value).days < 30:
+        return timesince(convert_value)
 
     if format == "shortdatetime" or format == "shortdate":
         # Check if the date is today

--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -24,7 +24,7 @@
        <img class="pencil" src="{{ webpack_static('sumo/img/pencil.svg') }}" />
        <strong>{% if is_first_revision %}{{ _("Created") }}{% else %}{{ _("Last updated") }}{% endif %}:</strong>
         <span class="time">
-          {{ datetimeformat(created_date, format="shortdate", use_naturaltime=True) }}
+          {{ datetimeformat(created_date, format="shortdate", use_timesince=True) }}
         </span>
       </span>
     {% endif %}


### PR DESCRIPTION
- Switch from `naturaltime` to `timesince` in `datetimeformat`, as `naturaltime` breaks l10n
- Rename `datetimeformat`'s `use_naturaltime` argument to `use_timesince`

Hopefully resolves [#1978](https://github.com/mozilla/sumo/issues/1978)