### PR TITLE
Remove the Solution provided filter option

### DIFF
--- a/kitsune/questions/managers.py
+++ b/kitsune/questions/managers.py
@@ -70,10 +70,6 @@ class QuestionManager(Manager):
         )
         return qs.exclude(last_answer__creator=F("creator"))
 
-    def solution_provided(self):
-        qs = self.filter(solution__isnull=True, is_locked=False)
-        return qs.exclude(last_answer__creator=F("creator"))
-
     def locked(self):
         return self.filter(is_locked=True)
 

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -106,8 +106,6 @@ FILTER_GROUPS = {
         [
             # L10n: This is a question filter option for the Responded tab.
             ("needsinfo", _lazy("Needs info")),
-            # L10n: This is a question filter option for the Responded tab.
-            ("solution-provided", _lazy("Solution provided")),
         ]
     ),
     "done": OrderedDict(
@@ -230,8 +228,6 @@ def question_list(request, product_slug=None, topic_slug=None):
             question_qs = question_qs.unhelpful_answers()
         case "needsinfo":
             question_qs = question_qs.needs_info()
-        case "solution-provided":
-            question_qs = question_qs.solution_provided()
         case "solved":
             question_qs = question_qs.solved()
         case "locked":


### PR DESCRIPTION
The "Solution provided" filter option for the Responded tab is redundant and makes no sense. Solved questions are excluded from the Responded tab by definition, and there's the "Solved" filter option in the Done tab. This PR removes the "Solution provided" filter.

Resolves [#814](https://github.com/mozilla/sumo/issues/814)