### PR TITLE
Add Forum moderator discussions to the top navbar

### DIFF
--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -747,6 +747,15 @@
     {{ _('Localization discussions') }}
   </a>
 </li>
+{% if user.has_perm('flagit.can_moderate') %}
+  <li>
+    <a href="{{ url('forums.threads', 'forum-moderators') }}" {% if active == "forum-moderators" %} class="selected" {% endif %}
+      data-event-name="link_click"
+      data-event-parameters='{"link_name": "{{ context + '.forum-moderator-discussions' }}"}'>
+      {{ _('Forum moderator discussions') }}
+    </a>
+  </li>
+{% endif %}
 {% if context == "main-menu" %}
   <li>
     <a class="color-link" href="{{ url('forums.forums') }}"
@@ -764,15 +773,6 @@
       {{ _('Knowledge base discussions') }}
     </a>
   </li>
-{% if user.has_perm('flagit.can_moderate') %}
-  <li>
-    <a href="{{ url('forums.threads', 'forum-moderators') }}" {% if active == "forum-moderators" %} class="selected" {% endif %}
-      data-event-name="link_click"
-      data-event-parameters='{"link_name": "{{ context + '.forum-moderator-discussions' }}"}'>
-      {{ _('Forum moderator discussions') }}
-    </a>
-  </li>
-{% endif %}
   <li>
     <a href="{{ url('forums.threads', 'off-topic') }}" {% if active == "off-topic" %} class="selected" {% endif %}
       data-event-name="link_click"

--- a/playwright_tests/tests/contribute_tests/contributor_discussions/test_contributor_discussions_page.py
+++ b/playwright_tests/tests/contribute_tests/contributor_discussions/test_contributor_discussions_page.py
@@ -108,8 +108,6 @@ def test_contributor_discussions_forums_title_redirect(page: Page, create_user_f
                 forum = "forum moderator discussions"
             elif forum == "Off Topic":
                 forum = forum + " discussions"
-            elif forum == "Mobile Support forum discussions":
-                forum = "Mobile support discussions"
             elif forum == "Lost Threads":
                 forum = "Lost thread discussions"
 


### PR DESCRIPTION
- Add _Forum moderator discussions_ to the top navbar
- Remove the _Mobile Support forum discussions_ mention from a test

Resolves [#2524](https://github.com/mozilla/sumo/issues/2524).