### PR TITLE
update stylelint and related packages

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,10 +1,12 @@
 {
   "extends": "stylelint-config-recommended-scss",
   "plugins": [
-    "stylelint-order"
+    "stylelint-order",
+    "@stylistic/stylelint-plugin"
   ],
   "defaultSeverity": "warning",
   "rules": {
+    "@stylistic/indentation": 2,
     "no-descending-specificity": null,
     "no-empty-source": null,
     "font-family-no-duplicate-names": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@babel/plugin-transform-runtime": "^7.19.6",
         "@babel/preset-env": "^7.20.2",
         "@mozilla-protocol/core": "16.1.0",
+        "@stylistic/stylelint-plugin": "^4.0.0",
         "@types/underscore": "^1.13.0",
         "autoprefixer": "^10.4.13",
         "babel-loader": "^9.1.2",
@@ -2905,6 +2906,97 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
+    },
+    "node_modules/@stylistic/stylelint-plugin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-4.0.0.tgz",
+      "integrity": "sha512-CFwt3K4Y/7bygNCLCQ8Sy4Hzgbhxq3BsNW0FIuYxl17HD3ywptm54ocyeiLVRrk5jtz1Zwks7Xr9eiZt8SWHAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3",
+        "postcss": "^8.5.6",
+        "postcss-selector-parser": "^7.1.0",
+        "postcss-value-parser": "^4.2.0",
+        "style-search": "^0.1.0"
+      },
+      "engines": {
+        "node": "^18.12 || >=20.9"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.22.0"
+      }
+    },
+    "node_modules/@stylistic/stylelint-plugin/node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@stylistic/stylelint-plugin/node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@stylistic/stylelint-plugin/node_modules/@csstools/media-query-list-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+      "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
     },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
@@ -12506,6 +12598,13 @@
       "peerDependencies": {
         "webpack": "^5.0.0"
       }
+    },
+    "node_modules/style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/stylehacks": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "sinon": "^21.0.1",
     "sinon-chai": "^3.7.0",
     "source-map-support": "^0.5.21",
+    "@stylistic/stylelint-plugin": "^4.0.0",
     "style-loader": "^3.3.1",
     "stylelint": "^16.26.1",
     "stylelint-config-recommended-scss": "^16.0.2",


### PR DESCRIPTION
This updates `stylelint` and its related packages, and also removes the indentation rule, which is no longer supported. If we'd prefer to keep the indentation rule, we can add the `@stylistic/stylelint-plugin`, which provides it.

The `npm run stylelint` command runs without error, but there are plenty of warnings, mostly about empty comments and ordering. This PR doesn't address the warnings, which we can add to this PR or take care of in another PR if desired.