### PR TITLE
fix duplicate emails from event unions

### DIFF
--- a/kitsune/questions/tests/test_notifications.py
+++ b/kitsune/questions/tests/test_notifications.py
@@ -153,7 +153,7 @@ class NotificationsTests(TestCase):
         # TODO: Too monolithic. Split this test into several.
         get_current.return_value.domain = "testserver"
 
-        u = UserFactory()
+        u = UserFactory(email="alan@example.com")
         q = self._toggle_watch_question("solution", u, turn_on=True)
         QuestionSolvedEvent.notify("anon@ymous.com", q)
 

--- a/kitsune/tidings/tests/test_events.py
+++ b/kitsune/tidings/tests/test_events.py
@@ -1,0 +1,43 @@
+from kitsune.sumo.tests import TestCase
+from kitsune.tidings.events import unique_by_email
+from kitsune.tidings.tests import WatchFactory
+from kitsune.users.tests import UserFactory
+
+
+class UniqueByEmailTests(TestCase):
+    def test_unique_by_email(self):
+        u1 = UserFactory(email="Alice@example.com")
+        u2 = UserFactory(email="sally@example.com")
+        u3 = UserFactory(email="")
+        u4 = UserFactory(email="")
+
+        w1 = WatchFactory(user=u1, event_type="thread reply")
+        w2 = WatchFactory(user=u1, event_type="forum thread")
+        w3 = WatchFactory(user=u2, event_type="thread reply")
+        w4 = WatchFactory(user=u2, event_type="forum thread")
+        w5 = WatchFactory(email="alice@example.com")
+        w6 = WatchFactory(email="ringo@example.com")
+
+        results = list(
+            unique_by_email(
+                [(u1, [w1]), (u2, [w3])], [(u3, [w5]), (u1, [w2]), (u2, [w4]), (u4, [w6])]
+            )
+        )
+
+        self.assertEqual(len(results), 3)
+        user, watches = results[0]
+        self.assertTrue(user.is_authenticated)
+        self.assertEqual(user.email, "sally@example.com")
+        self.assertEqual(len(watches), 2)
+        self.assertEqual({w.event_type for w in watches}, {w3.event_type, w4.event_type})
+        user, watches = results[1]
+        self.assertFalse(user.is_authenticated)
+        self.assertEqual(user.email, "ringo@example.com")
+        self.assertEqual(watches, [w6])
+        user, watches = results[2]
+        self.assertTrue(user.is_authenticated)
+        self.assertEqual(user.email, "Alice@example.com")
+        self.assertEqual(len(watches), 3)
+        self.assertEqual(
+            {w.event_type for w in watches}, {w1.event_type, w2.event_type, w5.event_type}
+        )

--- a/kitsune/tidings/utils.py
+++ b/kitsune/tidings/utils.py
@@ -7,42 +7,6 @@ from django.urls import reverse as django_reverse
 from django.utils.module_loading import import_string
 
 
-def collate(*iterables, **kwargs):
-    """Return an iterable ordered collation of the already-sorted items
-    from each of ``iterables``, compared by kwarg ``key``.
-
-    If ``reverse=True`` is passed, iterables must return their results in
-    descending order rather than ascending.
-
-    """
-    key = kwargs.pop("key", lambda a: a)
-    reverse = kwargs.pop("reverse", False)
-    min_or_max = max if reverse else min
-
-    rows = [iter(iterable) for iterable in iterables if iterable]
-    next_values = {}
-    by_key = []
-
-    def gather_next_value(row, index):
-        try:
-            next_value = next(row)
-        except StopIteration:
-            pass
-        else:
-            next_values[index] = next_value
-            by_key.append((key(next_value), index))
-
-    for index, row in enumerate(rows):
-        gather_next_value(row, index)
-
-    while by_key:
-        key_value, index = min_or_max(by_key)
-        by_key.remove((key_value, index))
-        next_value = next_values.pop(index)
-        yield next_value
-        gather_next_value(rows[index], index)
-
-
 def hash_to_unsigned(data):
     """If ``data`` is a string or unicode string, return an unsigned 4-byte int
     hash of it. If ``data`` is already an int that fits those parameters,


### PR DESCRIPTION
mozilla/sumo#2563

The current implementation of `_unique_by_email()` depends on the proper ordering of its `users_and_watches` argument in order to remove duplicates (the duplicates must be adjacent). When using the `EventUnion` class, the `collate` function is used to merge two different iterables of user/watches pairs. The `collate` function, however, doesn't guarantee duplicates are adjacent in all cases (for some as yet unidentified reason), and in some production cases, this caused duplicate emails to be sent.

The PR resolves the problem by replacing the `_unique_by_email()` function with a new `unique_by_email()` function that can merge multiple iterables of user/watches pairs into a single iterable free of duplicates without depending on any specific ordering of the input iterables. This also removes the need for the `collate` function.

The ordering of the user/watches returned by `unique_by_email()` matches the ordering of the original `_unique_by_email()` function. 