### PR TITLE
Do not render 404 on support widgets

### DIFF
--- a/kitsune/products/jinja2/products/includes/topic_macros.html
+++ b/kitsune/products/jinja2/products/includes/topic_macros.html
@@ -42,7 +42,7 @@
 
 
 {% macro topic_metadata(topics, product=None) %}
-{% if product and has_aaq_config and not settings.READ_ONLY %}
+{% if product and has_support_config and not settings.READ_ONLY %}
   <section class="support-callouts mzp-l-content sumo-page-section--inner">
     <div class="card card--ribbon is-inverse heading-is-one-line">
       <div class="card--details">

--- a/kitsune/products/views.py
+++ b/kitsune/products/views.py
@@ -9,7 +9,7 @@ from product_details import product_details
 from kitsune.flagit.views import get_hierarchical_topics
 from kitsune.products import get_product_redirect_response
 from kitsune.products.models import Product, Topic, TopicSlugHistory
-from kitsune.sumo.utils import has_aaq_config, set_aaq_context
+from kitsune.sumo.utils import has_support_config, set_aaq_context
 from kitsune.wiki.decorators import check_simple_wiki_locale
 from kitsune.wiki.facets import documents_for, topics_for
 from kitsune.wiki.models import Document, Revision
@@ -69,7 +69,7 @@ def product_landing(request: HttpRequest, slug: str) -> HttpResponse:
             "search_params": {"product": slug},
             "latest_version": latest_version,
             "featured": get_featured_articles(product=product, locale=request.LANGUAGE_CODE),
-            "has_aaq_config": has_aaq_config(product),
+            "has_support_config": has_support_config(product),
         },
     )
 

--- a/kitsune/questions/jinja2/questions/question_list.html
+++ b/kitsune/questions/jinja2/questions/question_list.html
@@ -102,7 +102,7 @@
         {% endif %}
       </div>
       <div class="sumo-l-two-col--sidebar forum--masthead-cta">
-      {% if product_slug and has_aaq_config %}
+      {% if product_slug and has_support_config %}
         {% set aaq_url = url('questions.aaq_step2', product_slug=product_slug) %}
       {% else %}
         {% set aaq_url = url('questions.aaq_step1') %}

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -65,7 +65,7 @@ from kitsune.sumo.urlresolvers import reverse
 from kitsune.sumo.utils import (
     build_paged_url,
     get_next_url,
-    has_aaq_config,
+    has_support_config,
     is_ratelimited,
     paginate,
     set_aaq_context,
@@ -201,7 +201,7 @@ def question_list(request, product_slug=None, topic_slug=None):
     multiple = (len(products) > 1) or ("all" in product_slugs)
     product_with_aaq = False
     if products and not multiple:
-        product_with_aaq = has_aaq_config(products[0])
+        product_with_aaq = has_support_config(products[0])
 
     topics = []
 
@@ -406,7 +406,7 @@ def question_list(request, product_slug=None, topic_slug=None):
         "selected_topic_slug": topics[0].slug if topics else None,
         "product_slug": product_slug,
         "topic_navigation": topic_navigation,
-        "has_aaq_config": product_with_aaq,
+        "has_support_config": product_with_aaq,
     }
 
     if products:
@@ -604,9 +604,7 @@ def aaq(request, product_slug=None, step=1, is_loginless=False):
 
     # Return 404 if the products does not have an AAQ form or if it is archived
     product = None
-    products_with_support = Product.active.filter(
-        support_configs__is_active=True
-    ).filter(
+    products_with_support = Product.active.filter(support_configs__is_active=True).filter(
         Q(support_configs__forum_config__isnull=False)
         | Q(support_configs__zendesk_config__isnull=False)
     )

--- a/kitsune/sumo/templatetags/jinja_helpers.py
+++ b/kitsune/sumo/templatetags/jinja_helpers.py
@@ -27,7 +27,7 @@ from markupsafe import Markup, escape
 
 from kitsune.sumo import parser
 from kitsune.sumo.urlresolvers import reverse
-from kitsune.sumo.utils import has_aaq_config, in_staff_group, is_trusted_user, webpack_static
+from kitsune.sumo.utils import has_support_config, in_staff_group, is_trusted_user, webpack_static
 from kitsune.users.models import Profile
 from kitsune.wiki.showfor import showfor_data as _showfor_data
 
@@ -47,7 +47,7 @@ class DateTimeFormatError(Exception):
 library.global_function(webpack_static)
 library.global_function(is_trusted_user)
 library.global_function(in_staff_group)
-library.global_function(has_aaq_config)
+library.global_function(has_support_config)
 
 
 @library.filter


### PR DESCRIPTION
This fix does not fallback to the first available support option if one is disabled. For example if there's a hybrid flow and the AAQ config gets deactivated, it does not fall back to ZD. Handling of inactive sub-configs will be fixed in https://github.com/mozilla/sumo/issues/2721