### PR TITLE
make the support switcher a banner

### DIFF
--- a/kitsune/questions/jinja2/questions/new_question.html
+++ b/kitsune/questions/jinja2/questions/new_question.html
@@ -38,24 +38,24 @@
       {{ _('Ask your question') }}
     {% endif %}
   </h2>
-
   {% if can_switch %}
-    <div class="support-type-switcher">
-      <p>
+    <div class="sumo-banner sumo-banner-no-close">
+      <div class="content">
         {% if current_support_type == SUPPORT_TYPE_ZENDESK %}
-          {{ _('You\'re contacting Mozilla Support directly.') }}
-          <a href="{{ url('questions.aaq_step3', product_slug=current_product.slug) }}?support_type={{ SUPPORT_TYPE_FORUM }}">
+          <span class="heading">{{ _('You\'re contacting Mozilla Support directly.') }}</span>
+          <a class="sumo-button sumo-button-wide primary-button button-lg" href="{{ url('questions.aaq_step3', product_slug=current_product.slug) }}?support_type={{ SUPPORT_TYPE_FORUM }}">
             {{ _('Ask the community instead') }}
           </a>
         {% else %}
-          {{ _('You\'re posting to the community forum.') }}
-          <a href="{{ url('questions.aaq_step3', product_slug=current_product.slug) }}?support_type={{ SUPPORT_TYPE_ZENDESK }}">
+          <span class="heading">{{ _('You\'re posting to the community forum.') }}</span>
+          <a class="sumo-button sumo-button-wide primary-button button-lg" href="{{ url('questions.aaq_step3', product_slug=current_product.slug) }}?support_type={{ SUPPORT_TYPE_ZENDESK }}">
             {{ _('Contact Mozilla Support instead') }}
           </a>
         {% endif %}
-      </p>
+      </div>
     </div>
   {% endif %}
+
 {% endblock %}
 
 {% block submit_button_value %}

--- a/kitsune/sumo/static/sumo/scss/components/_banner.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_banner.scss
@@ -84,7 +84,9 @@
     .sumo-button {
       margin-bottom: p.$spacing-lg;
       margin-left: 0;
-      max-width: 20%;
+      &:not(.sumo-button-wide) {
+        max-width: 20%;
+      }
     }
 
     .sumo-close-button {


### PR DESCRIPTION
mozilla/sumo#2720

I don't know if this is what we want, but it's an option.

<img width="1477" height="715" alt="image" src="https://github.com/user-attachments/assets/93034e82-6723-43fe-85c5-061b8d7b3252" />

<img width="1463" height="846" alt="image" src="https://github.com/user-attachments/assets/6b15913d-8727-4c32-bcb2-f99e0a9d6698" />

<img width="915" height="843" alt="image" src="https://github.com/user-attachments/assets/7a1e762e-02c6-4731-8679-758642c0bfa1" />

<img width="883" height="867" alt="image" src="https://github.com/user-attachments/assets/f4f5dffa-65ed-44a5-9a55-4d5504069083" />
