### PR TITLE
Add SUMO rules mentions & Improve AAQ step 3

### DIFF
--- a/kitsune/flagit/jinja2/flagit/content_moderation.html
+++ b/kitsune/flagit/jinja2/flagit/content_moderation.html
@@ -45,6 +45,7 @@
                 hx-swap="delete">
             {% csrf_token %}
             <select name="status">
+              {# L10n: A default option for dropdown menus (displayed when none of the actual options is selected). #}
               <option value="">{{ _('Please select...') }}</option>
               <option value="1">{{ _('Content categorization is updated.') }}</option>
               <option value="2">{{ _('Content is appropriately categorized.') }}</option>

--- a/kitsune/flagit/jinja2/flagit/queue.html
+++ b/kitsune/flagit/jinja2/flagit/queue.html
@@ -21,6 +21,7 @@
           <form class="update inline-form" action="{{ object.form_action }}" method="post">
             {% csrf_token %}
             <select name="status">
+              {# L10n: A default option for dropdown menus (displayed when none of the actual options is selected). #}
               <option value="">{{ _('Please select...') }}</option>
               {% if object.reason == "spam" %}
                 <option value="1">{{ _('Removed spam content.') }}</option>

--- a/kitsune/flagit/jinja2/flagit/zendesk_spam.html
+++ b/kitsune/flagit/jinja2/flagit/zendesk_spam.html
@@ -26,6 +26,7 @@
           <form class="update inline-form" action="{{ object.form_action }}" method="post">
             {% csrf_token %}
             <select name="status">
+              {# L10n: A default option for dropdown menus (displayed when none of the actual options is selected). #}
               <option value="">{{ _('Please select...') }}</option>
               <option value="1">{{ _('Removed spam content.') }}</option>
               <option value="2">{{ _('No spam found.') }}</option>

--- a/kitsune/forums/jinja2/forums/edit_post.html
+++ b/kitsune/forums/jinja2/forums/edit_post.html
@@ -21,7 +21,7 @@
       <div class="form-widget{% if form.content.errors %} invalid{% endif %}">
         {{ form.content.label_tag()|safe }}
         <div class="content-box">
-          {{ content_editor(form.content) }}
+          {{ content_editor(form.content, mention_rules=true) }}
         </div>
       </div>
 

--- a/kitsune/forums/jinja2/forums/new_thread.html
+++ b/kitsune/forums/jinja2/forums/new_thread.html
@@ -28,7 +28,7 @@
           {{ field.label_tag()|safe }}
           {% if field.name == 'content' %}
             <div class="content-box">
-              {{ content_editor(field) }}
+              {{ content_editor(field, mention_rules=true) }}
             </div>
           {% else %}
             {{ field|safe }}

--- a/kitsune/forums/jinja2/forums/posts.html
+++ b/kitsune/forums/jinja2/forums/posts.html
@@ -68,7 +68,7 @@
         {% endif %}
 
         <div id="thread-reply">
-          {{ content_editor(form.content) }}
+          {{ content_editor(form.content, mention_rules=true) }}
         </div>
         <div class="editor-actions sumo-button-wrap reverse-on-desktop align-end">
           <button type="submit" class="sumo-button primary-button">{{ _('Post Reply') }}</button>

--- a/kitsune/kbforums/jinja2/kbforums/edit_post.html
+++ b/kitsune/kbforums/jinja2/kbforums/edit_post.html
@@ -22,7 +22,7 @@
       <div class="form-widget{% if form.content.errors %} invalid{% endif %}">
         {{ form.content.label_tag()|safe }}
         <div class="content-box">
-          {{ content_editor(form.content) }}
+          {{ content_editor(form.content, mention_rules=true) }}
         </div>
       </div>
 

--- a/kitsune/kbforums/jinja2/kbforums/new_thread.html
+++ b/kitsune/kbforums/jinja2/kbforums/new_thread.html
@@ -30,7 +30,7 @@
           {{ field.label_tag()|safe }}
           {% if field.name == 'content' %}
             <div class="content-box">
-              {{ content_editor(field) }}
+              {{ content_editor(field, mention_rules=true) }}
             </div>
           {% else %}
             {{ field|safe }}

--- a/kitsune/kbforums/jinja2/kbforums/posts.html
+++ b/kitsune/kbforums/jinja2/kbforums/posts.html
@@ -92,7 +92,7 @@
           {% endif %}
 
           <div id="thread-reply">
-            {{ content_editor(form.content) }}
+            {{ content_editor(form.content, mention_rules=true) }}
           </div>
 
           <div class="editor-actions sumo-button-wrap reverse-on-desktop align-end">

--- a/kitsune/questions/forms.py
+++ b/kitsune/questions/forms.py
@@ -14,55 +14,75 @@ from kitsune.questions.utils import remove_pii
 from kitsune.sumo.forms import KitsuneBaseForumForm
 from kitsune.upload.models import ImageAttachment
 
-# labels and help text
+# unused labels and help text
+# L10n: Unused. A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
 SITE_AFFECTED_LABEL = _lazy("URL of affected site")
+# L10n: Unused. A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
 CRASH_ID_LABEL = _lazy("Crash ID(s)")
-CRASH_ID_HELP = _lazy(
-    "If you submit information to Mozilla when you crash, "
-    "you'll be given a crash ID which uniquely identifies "
-    "your crash and lets us look at details that may help "
-    "identify the cause. To find your recently submitted "
-    "crash IDs, go to <strong>about:crashes</strong> in "
-    "your location bar. <a href='https://support.mozilla."
-    "com/en-US/kb/Firefox+crashes#Getting_the_most_"
-    "accurate_help_with_your_Firefox_crash' "
-    "target='_blank'>Click for detailed instructions</a>."
-)
-TROUBLESHOOTING_LABEL = _lazy("Troubleshooting Information")
-TROUBLESHOOTING_HELP = _lazy(
-    "This information gives details about the "
-    "internal workings of your browser that will "
-    "help in answering your question."
-)
+# if you want to use the following string, update it to remove "en-US" from the link first
+# when updating, don't remove the original string, just mark it as deprecated and create a new one
+# L10n: Unused. A description of the "Crash ID(s)" field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
+CRASH_ID_HELP = _lazy("If you submit information to Mozilla when you crash, you'll be given a crash ID which uniquely identifies your crash and lets us look at details that may help identify the cause. To find your recently submitted crash IDs, go to <strong>about:crashes</strong> in your location bar. <a href='https://support.mozilla.com/en-US/kb/Firefox+crashes#Getting_the_most_accurate_help_with_your_Firefox_crash' target='_blank'>Click for detailed instructions</a>.")
+# L10n: Unused. A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
 FREQUENCY_LABEL = _lazy("This happens")
 FREQUENCY_CHOICES = [
     ("", ""),
+    # L10n: Unused. An option for the "This happens" field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
     ("NOT_SURE", _lazy("Not sure how often")),
+    # L10n: Unused. An option for the "This happens" field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
     ("ONCE_OR_TWICE", _lazy("Just once or twice")),
+    # L10n: Unused. An option for the "This happens" field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
     ("FEW_TIMES_WEEK", _lazy("A few times a week")),
+    # L10n: Unused. An option for the "This happens" field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
     ("EVERY_TIME", _lazy("Every time Firefox opened")),
 ]
+# L10n: Unused. A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
 STARTED_LABEL = _lazy("This started when...")
-TITLE_LABEL = _lazy("Subject")
-CONTENT_LABEL = _lazy("How can we help?")
-FF_VERSION_LABEL = _lazy("Firefox version")
-OS_LABEL = _lazy("Operating system")
+# L10n: Unused. A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
 PLUGINS_LABEL = _lazy("Installed plugins")
+# L10n: Unused. A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
 ADDON_LABEL = _lazy("Extension/plugin you are having trouble with")
+# L10n: Unused. A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
 DEVICE_LABEL = _lazy("Mobile device")
+
+# unused labels and help text
+# L10n: A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
+TROUBLESHOOTING_LABEL = _lazy("Troubleshooting Information")
+# L10n: A description of the "Troubleshooting Information" field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
+TROUBLESHOOTING_HELP = _lazy("This information gives details about the internal workings of your browser that will help in answering your question.")
+# L10n: A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
+TITLE_LABEL = _lazy("Summarize your question")
+# L10n: A description of the "Summarize your question" field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
+TITLE_HELP_TEXT = _lazy("Please summarize your question in one sentence:")
+# L10n: A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
+CONTENT_LABEL = _lazy("How can we help?")
+# L10n: A description of the "How can we help?" field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
+CONTENT_HELP_TEXT = _lazy('Please include as much detail as possible. Also, remember to follow our <a href="https://support.mozilla.org/kb/mozilla-support-rules-guidelines" target="_blank">rules and guidelines</a>.')
+# L10n: A label for a field, displayed when filing a Firefox-related question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
+FF_VERSION_LABEL = _lazy("Firefox version")
+# L10n: A label for a field, displayed when filing a Thunderbird-related question form (e.g., on https://support.mozilla.org/questions/new/thunderbird/form).
+TB_VERSION_LABEL = _lazy("Thunderbird version")
+# L10n: A placeholder for the "Thunderbird version" field, displayed when filing a Thunderbird-related question form (e.g., on https://support.mozilla.org/questions/new/thunderbird/form).
+TB_VERSION_PLACEHOLDER = _lazy("e.g., 140.5.0esr, 146.1.0 release or 147.0b4")
+# L10n: A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
+OS_LABEL = _lazy("Operating system")
+# L10n: A label for a field, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
 CATEGORY_LABEL = _lazy("Which topic best describes your question?")
+# L10n: A label for a checkbox, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form).
 NOTIFICATIONS_LABEL = _lazy("Email me when someone answers the thread")
 
+# L10n: A placeholder for the "Post a Reply" editor.
 REPLY_PLACEHOLDER = _lazy("Enter your reply here.")
+# L10n: A placeholder for the email field, displayed when subscribing to a question while not signed in.
 EMAIL_PLACEHOLDER = _lazy("Enter your email address here.")
 
 
 class EditQuestionForm(forms.ModelForm):
     """Form to edit an existing question"""
 
-    title = forms.CharField(label=TITLE_LABEL, min_length=5)
+    title = forms.CharField(label=TITLE_LABEL, help_text=TITLE_HELP_TEXT, min_length=5)
 
-    content = forms.CharField(label=CONTENT_LABEL, min_length=5, widget=forms.Textarea())
+    content = forms.CharField(label=CONTENT_LABEL, help_text=CONTENT_HELP_TEXT, min_length=5, widget=forms.Textarea())
 
     class Meta:
         model = Question
@@ -75,6 +95,7 @@ class EditQuestionForm(forms.ModelForm):
         form fields to include depend on the selected product/category.
         """
         super().__init__(*args, **kwargs)
+        self.label_suffix = None
 
         #  Extra fields required by product/category selected
         extra_fields = []
@@ -87,6 +108,13 @@ class EditQuestionForm(forms.ModelForm):
             self.fields["ff_version"] = forms.CharField(
                 label=FF_VERSION_LABEL,
                 required=False,
+            )
+
+        if "tb_version" in extra_fields:
+            self.fields["tb_version"] = forms.CharField(
+                label=TB_VERSION_LABEL,
+                required=False,
+                widget=forms.TextInput(attrs={"placeholder": TB_VERSION_PLACEHOLDER}),
             )
 
         if "os" in extra_fields:
@@ -108,7 +136,17 @@ class EditQuestionForm(forms.ModelForm):
 
         for field in self.fields.values():
             if not field.required:
+                # L10n: A label suffix for optional fields, displayed when filing a question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). The leading space must be preserved.
                 field.label_suffix = _lazy(" (optional):")
+
+        for name, field in self.fields.items():
+            if field.help_text:
+                bound = self[name]
+                bound.help_id = f"{bound.id_for_label}_help"
+                if field.widget.attrs.get("aria-describedby"):
+                    field.widget.attrs["aria-describedby"] += " " + bound.help_id
+                else:
+                    field.widget.attrs["aria-describedby"] = bound.help_id
 
     def clean_content(self):
         """Validate that content field contains actual text, not just HTML markup."""
@@ -117,6 +155,7 @@ class EditQuestionForm(forms.ModelForm):
         text_only = html.unescape(text_only).strip()
 
         if len(text_only) < 5:
+            # L10n: An error message displayed under the "How can we help?" field when filing a question form if the submitted value contains too few non-HTML symbols.
             raise forms.ValidationError(_("Question content cannot be empty."))
         return content
 
@@ -177,7 +216,8 @@ class NewQuestionForm(EditQuestionForm):
     category = forms.ModelChoiceField(
         label=CATEGORY_LABEL,
         queryset=Topic.objects.none(),
-        empty_label="Please select",
+        # L10n: A default option for dropdown menus (displayed when none of the actual options is selected).
+        empty_label=_lazy("Please select..."),
         required=True,
     )
 
@@ -275,6 +315,3 @@ class WatchQuestionForm(forms.Form):
             return self.cleaned_data["email"]
         # Clear out the email for logged in users, we don't want to use it.
         return None
-
-
-bucket_choices = [(1, "1 day"), (7, "1 week"), (30, "1 month")]

--- a/kitsune/questions/jinja2/questions/edit_answer.html
+++ b/kitsune/questions/jinja2/questions/edit_answer.html
@@ -49,7 +49,7 @@
           {{ errorlist(form) }}
 
           <div class="form-widget{% if form.content.errors %} invalid{% endif %}">
-            {{ content_editor(form.content) }}
+            {{ content_editor(form.content, mention_rules=true) }}
           </div>
 
           {{ attachments_form('questions.Answer', answer.pk, answer.images.all(), settings, request.user) }}

--- a/kitsune/questions/jinja2/questions/edit_question.html
+++ b/kitsune/questions/jinja2/questions/edit_question.html
@@ -22,6 +22,7 @@
   <p>{{ _('When editing a question, uploading new images or deleting existing ones will happen instantly.') }}</p>
 {% endblock %}
 
+{# L10n: A button displayed when editing an existing question. #}
 {% block submit_button_value %}{{ _('Save Question') }}{% endblock %}
 
 {% block more_submit_buttons %}

--- a/kitsune/questions/jinja2/questions/includes/aaq_macros.html
+++ b/kitsune/questions/jinja2/questions/includes/aaq_macros.html
@@ -2,7 +2,9 @@
 {% from 'includes/common_macros.html' import featured_articles, scam_banner %}
 
 {% macro select_product(products) -%}
+  {# L10n: A header, displayed when asking a new question (on https://support.mozilla.org/questions/new and in Premium product question forms). #}
   <h1 class="sumo-page-heading">{{ _('Contact Support') }}</h1>
+  {# L10n: A subheader, displayed when asking a new question (on https://support.mozilla.org/questions/new). #}
   <h2 class="sumo-page-subheading">{{ _('Which product do you need help with?') }}</h2>
   <div class="sumo-page-section--inner">
     <div id="product-picker" class="sumo-card-grid stack-on-mobile">
@@ -30,6 +32,7 @@
           </div>
         {% endfor %}
         <div class="card card--centered-button">
+          {# L10n: A button, displayed when asking a new question (on https://support.mozilla.org/questions/new). #}
           <a class="sumo-button primary-button button-lg" href="{{ url('questions.home') }}">{{ _('Browse All Product Forums')}}</a>
         </div>
       </div>
@@ -49,8 +52,10 @@
         <span class="progress--link-inner">
           <span class="progress--dot"></span>
           {% if step > 1 and step < 4 %}
+            {# L10n: A label, displayed in a progress bar when asking a new question (when a product is selected, e.g., on https://support.mozilla.org/questions/new/firefox). #}
             <span class="progress--label">{{ _('Change Product') }}</span>
           {% else %}
+            {# L10n: A label, displayed in a progress bar when asking a new question (on https://support.mozilla.org/questions/new/). #}
             <span class="progress--label">{{ _('Select Product') }}</span>
           {% endif %}
         </span>
@@ -65,6 +70,7 @@
         {% endif %}>
         <span class="progress--link-inner">
           <span class="progress--dot"></span>
+          {# L10n: A label, displayed in a progress bar when asking a new question (e.g., on https://support.mozilla.org/questions/new/). #}
           <span class="progress--label">{{ _('Explore Solutions') }}</span>
         </span>
       </a>
@@ -104,18 +110,23 @@
     {% if aaq_context %}
       {% if request.user.is_authenticated %}
         {% if is_ticketed %}
+          {# L10n: Text for the Ask a Question CTA widget (case: Premium products; the user is signed in). #}
           <p>{{ _('Still need help? Continue to contact our support team.') }}</p>
         {% else %}
+          {# L10n: Text for the Ask a Question CTA widget (case: Freemium products; the user is signed in). #}
           <p>{{ _('Still need help? Continue to ask your question on our forums.') }}</p>
         {% endif %}
      {% else %}
         {% if is_ticketed %}
+          {# L10n: Text for the Ask a Question CTA widget (case: Premium products; the user is not signed in). #}
           <p>{{ _('Still need help? Sign in to contact our support team.') }}</p>
         {% else %}
+          {# L10n: Text for the Ask a Question CTA widget (case: Freemium products; the user is not signed in). #}
           <p>{{ _('Still need help? Sign in to ask your question on our forums.') }}</p>
         {% endif %}
       {% endif %}
     {% else %}
+      {# L10n: Text for the Ask a Question CTA widget (case: Ask-a-question workflow is not configured). #}
       <p>{{ _('Still need help? Continue to ask your question and get help.') }}</p>
     {% endif %}
 
@@ -135,6 +146,7 @@
         "link_name": "{{ link_name }}",
         "link_detail": "{{ link_detail }}"
       }'>
+      {# L10n: A button. #}
       {{ _('Continue')}}
     </a>
     </div>
@@ -153,13 +165,16 @@
 
     <div class="sumo-l-two-col sidebar-on-right align-center cols-on-medium">
       <div class="sumo-l-two-col--main home-search-section--content">
-        <img class="page-heading--logo" src="{{ product.image_alternate_url }}" alt="{{ product.title }} logo">
+        {# L10n: Alt text for a product logo. #}
+        <img class="page-heading--logo" src="{{ product.image_alternate_url }}" alt="{{ _('{product} logo')|f(product=product.title) }}">
         <h1 class="sumo-page-heading ">
-          <span class="product-title-text">{{ product.title }} {{ _('Solutions') }}</span>
+          {# L10n: A header, displayed when asking a new question with a product selected (e.g., on https://support.mozilla.org/questions/new/firefox). #}
+          <span class="product-title-text">{{ _('{product} Solutions')|f(product=product.title) }}</span>
         </h1>
         {{ search_box(settings, id='question-search-masthead', params=search_params) }}
 
         <p class="page-heading--intro-text">
+            {# L10n: Introduction, displayed when asking a new question with a product selected (e.g., on https://support.mozilla.org/questions/new/firefox). #}
             {{ _('Browse our self-help options first or continue to ask your question and get help.') }}
         </p>
       </div>
@@ -191,31 +206,50 @@
 
 {% macro troubleshooting_instructions(field) %}
   <div>
-    <div id="api-section">
-      <div id="troubleshooting-button" class="sumo-button-wrap">
-        <button class="sumo-button" id="share-data" type="button">
-          {{ _('Share Data') }}
-        </button>
-      </div>
-      <p id="troubleshooting-manual" class="hide-until-expanded">
-        {# L10n: Deprecated #}
-        {% set deprecated_share_data_fallback %}
-          {% trans %}
-            We can't automatically get your browser's troubleshooting data, please
-            <a href="https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox">try these manual steps</a>.
-          {% endtrans %}
-        {% endset %}
-        {# L10n: Try these manual steps refers to https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox #}
+    <div id="troubleshooting-button" class="sumo-button-wrap">
+      <button class="sumo-button" id="share-data" type="button" aria-describedby="{{ field.help_id }}">
+        {# L10n: A button for sharing troubleshooting data when asking a new question (displayed, e,g., on https://support.mozilla.org/questions/new/firefox/form). #}
+        {{ _('Share Data') }}
+      </button>
+    </div>
+    <div id="troubleshooting-manual" class="hide-until-expanded" class="field-help-text">
+      {# L10n: Deprecated #}
+      {% set deprecated_share_data_fallback %}
+        {% trans %}
+          We can't automatically get your browser's troubleshooting data, please
+          <a href="https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox">try these manual steps</a>.
+        {% endtrans %}
+      {% endset %}
+      {# L10n: Deprecated. Try these manual steps refers to https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox #}
+      {% set deprecated_share_data_fallback_2 %}
         {% trans a_open='<a href="https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox" target="_blank">'|safe, a_close='</a>'|safe %}
           We can't automatically get your browser's troubleshooting data, please {{ a_open }}try these manual steps{{ a_close }}.
         {% endtrans %}
-      </p>
-      <div id="troubleshooting-field" class="hide-until-expanded field full-width">
-        {{ field }}
-      </div>
-      <p>
-        {{ _('This information gives details about the internal workings of your browser that will help in answering your question.') }}
-      </p>
+      {% endset %}
+      {# L10n: Try these manual steps refers to https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox #}
+      {% trans a_open='<a href="https://support.mozilla.org/kb/use-troubleshooting-information-page-fix-firefox" target="_blank">'|safe, a_close='</a>'|safe %}
+        We’re unable to pull your browser’s troubleshooting data – please {{ a_open }}try these manual steps{{ a_close }}.
+      {% endtrans %}
+    </div>
+    <div id="troubleshooting-field" class="hide-until-expanded field full-width">
+      {{ field }}
     </div>
   </div>
+{% endmacro %}
+
+{% macro helpful_tip() %}
+  <h3 class="sumo-card-heading">
+    {# L10n: Alt text for the helpful tip icon displayed when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). Source: https://assets-prod.sumo.prod.webservices.mozgcp.net/static/highlight.975d9eebb1f0b621.svg #}
+    <img class="card--icon-sm" src="{{ webpack_static('protocol/img/icons/highlight.svg') }}" alt="{{ _('Helpful Tip icon') }}" />
+    {# L10n: A header for the Helpful Tip card displayed when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). #}
+    {{ _('Helpful Tip!')}}
+  </h3>
+  {# L10n: Text for the Helpful Tip card displayed when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). #}
+  <p>
+    {% trans %}
+      Follow through. Sometimes, our volunteers would ask you for
+      more information or to test out certain scenarios. The sooner
+      you can do this, the sooner they would know how to fix it.
+    {% endtrans %}
+  </p>
 {% endmacro %}

--- a/kitsune/questions/jinja2/questions/includes/question_editing_frame.html
+++ b/kitsune/questions/jinja2/questions/includes/question_editing_frame.html
@@ -8,7 +8,7 @@ behaviors like editing them can be provided by overriding blocks.
 {% extends "questions/base.html" %}
 {% from "layout/errorlist.html" import errorlist %}
 {% from "includes/common_macros.html" import search_box, scam_banner, content_editor with context %}
-{% from "questions/includes/aaq_macros.html" import progress_bar %}
+{% from "questions/includes/aaq_macros.html" import helpful_tip, progress_bar %}
 {% from "questions/includes/aaq_macros.html" import troubleshooting_instructions with context %}
 {% from "upload/attachments.html" import attachments_form %}
 {% set scripts = ('questions', 'questions.geo',) %}
@@ -27,7 +27,8 @@ behaviors like editing them can be provided by overriding blocks.
     {% endif %}
 
     {% block formwrap %}
-    <img class="page-heading--logo" src="{{ current_product.image_alternate_url }}" alt="{{ current_product.title }} logo" />
+    {# L10n: Alt text for a product logo. #}
+    <img class="page-heading--logo" src="{{ current_product.image_alternate_url }}" alt="{{ _('{product} logo')|f(product=current_product.title) }}" />
 
     {# TODO: hook this up to the backend when subproducts are in.
     <div class="mzp-c-menu-list subheading-dropdown">
@@ -48,20 +49,19 @@ behaviors like editing them can be provided by overriding blocks.
       <aside class="sumo-l-two-col--sidebar">
         {% if form and current_support_type != SUPPORT_TYPE_ZENDESK %}
           <div class="card has-moz-headings is-in-sidebar is-callout-bg text-center large-only">
-              <img class="card--img" src="{{ webpack_static('sumo/img/Mozilla-Heads-Keith-Negley-180628__400.png') }}" alt="Illustration of community" />
+              {# L10n: Alt text for the illustration of community displayed when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). Source: https://assets-prod.sumo.prod.webservices.mozgcp.net/static/Mozilla-Heads-Keith-Negley-180628__400.99f12ceb616ae784.png #}
+              <img class="card--img" src="{{ webpack_static('sumo/img/Mozilla-Heads-Keith-Negley-180628__400.png') }}" alt="{{ _('Illustration of community') }}" />
               <div class="card--details">
+                {# L10n: A header for the Community card displayed when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). #}
                 <h3 class="card--title">{{ _('Our Community is here to help') }}</h3>
+                {# L10n: Text for the Community card displayed when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). #}
                 <p class="card--desc">{{ _('Kindness is at the heart of our community. Our volunteers are happy to share their time and Firefox knowledge with you.') }}</p>
                 <p><strong><a href="{{ url('landings.contribute') }}">{{ _('Learn More') }}</a></strong></p>
               </div>
           </div>
 
           <div class="large-only">
-            <h3 class="sumo-card-heading">
-              <img class="card--icon-sm" src="{{ webpack_static('protocol/img/icons/highlight.svg') }}" alt="Helpful Tip icon" />
-              {{ _('Helpful Tip!')}}
-            </h3>
-            <p>{{ _('Follow through. Sometimes, our volunteers would ask you for more information or to test out certain scenarios. The sooner you can do this, the sooner they would know how to fix it.')}}
+            {{ helpful_tip() }}
           </div>
         {% endif %}
       </aside>
@@ -79,6 +79,7 @@ behaviors like editing them can be provided by overriding blocks.
 
               {% if current_support_type != SUPPORT_TYPE_ZENDESK %}
                 <p class="sumo-page-intro">
+                  {# L10n: An introduction, displayed when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). #}
                   {% trans %}
                     Be nice. Our volunteers are Mozilla users just like you,
                     who take the time out of their day to help.
@@ -88,12 +89,14 @@ behaviors like editing them can be provided by overriding blocks.
 
               <div class="info card shade-bg highlight mb">
               {% if is_loginless and not user.is_authenticated %}
+                {# L10n: An introduction, displayed when filing a new question form regarding sign-in troubles. To access it, try asking a question about any product while being not signed in and then click "I can't sign in to my Mozilla account". #}
                 {% trans %}
                   Can't sign in to your account and need help?
                   You've found the right place. Complete the form below
                   to contact our support staff.
                 {% endtrans %}
               {% else %}
+                {# L10n: An advice, displayed when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). #}
                 {% trans %}
                   Be descriptive.
                   Saying “playing video on YouTube is always choppy”
@@ -114,8 +117,11 @@ behaviors like editing them can be provided by overriding blocks.
                     {% if field.name == 'ff_version' %}
                       <li class="system-details-info show">
                         <p>
+                          {# L10n: Text introducing the Firefox version and the Operating system fields when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). #}
                           {{ _("We've made some educated guesses about your current browser and operating system.") }}
+                          {# L10n: A link that shows the Firefox version and the Operating system fields when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). #}
                           <a href="#show-details" class="show">{{ _('Show details &raquo;')|safe }}</a>
+                          {# L10n: A link that hides the Firefox version and the Operating system fields when filing a new question form (e.g., on https://support.mozilla.org/questions/new/firefox/form). #}
                           <a href="#hide-details" class="hide hide-until-expanded">{{ _('Hide details &raquo;')|safe }}</a>
                         </p>
                       </li>
@@ -127,13 +133,18 @@ behaviors like editing them can be provided by overriding blocks.
 
                   <li class="{{ li_class }} {% if field.errors %}has-error invalid{% endif %} cf">
                     {{ field.label_tag()|safe }}
+                    {% if field.help_text and field.name != 'troubleshooting' %}
+                      <div id="{{ field.help_id }}" class="field-help-text">{{ field.help_text|safe }}</div>
+                    {% endif %}
                     {% if field.name == 'content' %}
                       {{ content_editor(field) }}
                     {% elif field.name == 'troubleshooting' %}
+                      <div id="{{ field.help_id }}">{{ field.help_text|safe }}</div>
                       {{ troubleshooting_instructions(field) }}
                     {% elif field.name == 'description' and is_loginless %}
                       <label for="{{ field.id_for_label }}">
                         <span class="fieldnote">
+                          {# L10n: Description for the Tell Us More field, displayed when filing a new question form regarding sign-in troubles. To access it, try asking a question about any product while being not signed in and then click "I can't sign in to my Mozilla account". #}
                           {{ _(
                           "Include details such as your account e-mail or specifics about"
                           " your sign-in issue to help us get you back into your account quicker."
@@ -146,10 +157,6 @@ behaviors like editing them can be provided by overriding blocks.
                       {{ field.as_widget(attrs=category_field_attrs)|safe }}
                     {% else %}
                       {{ field|safe }}
-                    {% endif %}
-
-                    {% if field.help_text and field.name != 'troubleshooting' %}
-                      <p>{{ field.help_text|safe }}</p>
                     {% endif %}
 
                     {% if field.name != 'content' %}
@@ -174,21 +181,12 @@ behaviors like editing them can be provided by overriding blocks.
               </ul>
 
               <div class="hide-on-large field">
-                <h3 class="sumo-card-heading">
-                  <img class="card--icon-sm" src="{{ webpack_static('protocol/img/icons/highlight.svg') }}" alt="Helpful Tip icon" />
-                  {{ _('Helpful Tip!')}}
-                </h3>
-                <p>
-                {% trans %}
-                  Follow through. Sometimes, our volunteers would ask you for
-                  more information or to test out certain scenarios. The sooner
-                  you can do this, the sooner they would know how to fix it.
-                {% endtrans %}
-                </p>
+                {{ helpful_tip() }}
               </div>
 
               <div class="sumo-button-wrap aaq-form-buttons reverse-on-desktop align-right">
-                <button type="submit" class="sumo-button primary-button" {% block submit_button_attrs %}{% endblock %}>{% block submit_button_value %}Save Question{% endblock %}</button>
+                {# L10n: A button displayed when editing an existing question. #}
+                <button type="submit" class="sumo-button primary-button" {% block submit_button_attrs %}{% endblock %}>{% block submit_button_value %}{{ _('Save Question') }}{% endblock %}</button>
                 {% block more_submit_buttons %}
                 <a class="sumo-button secondary-button push-right" href="{{ cancel_url }}" class="cancel">{{ _('Cancel') }}</a>
                 {% endblock %}

--- a/kitsune/questions/jinja2/questions/new_question.html
+++ b/kitsune/questions/jinja2/questions/new_question.html
@@ -33,6 +33,7 @@
 {% block major_detail_instructions %}
   <h2 class="sumo-page-heading">
     {% if current_support_type == SUPPORT_TYPE_ZENDESK %}
+      {# L10n: A header, displayed when asking a new question (on https://support.mozilla.org/questions/new and in Premium product question forms). #}
       {{ _('Contact Support') }}
     {% else %}
       {{ _('Ask your question') }}

--- a/kitsune/questions/jinja2/questions/question_details.html
+++ b/kitsune/questions/jinja2/questions/question_details.html
@@ -262,7 +262,7 @@
           {{ errorlist(form) }}
 
           <div class="main-content">
-            {{ content_editor(form.content) }}
+            {{ content_editor(form.content, mention_rules=true) }}
             {% if question.needs_info %}
             <div class="field checkbox">
               <input id="id_info_provided" type="checkbox" name="clear_needsinfo" {% if user == question.creator %}checked="checked"{% endif %}>
@@ -509,19 +509,19 @@
                 <section id="more-system-details" class="mzp-u-modal-content text-body-md" title="{{ _('Additional System Details') }}" data-target="#show-more-details">
                   <h2 class="sumo-page-subheading">{{ _('Additional System Details') }}</h2>
                   {% if question.metadata.crash_id %}
-                  <h3 class="sumo-card-heading">{{ _('Crash ID') }}</h3>
+                  <h3 class="sumo-card-heading">{{ crash_id_label }}</h3>
                   <p>{{ question.metadata.crash_id }}</p>
                   {% endif %}
                   {% if question.metadata.frequency %}
-                  <h3 class="sumo-card-heading">{{ _('This happened') }}</h3>
+                  <h3 class="sumo-card-heading">{{ frequency_label }}</h3>
                   <p>{{ frequencies[question.metadata.frequency] }}</p>
                   {% endif %}
                   {% if question.metadata.started %}
-                  <h3 class="sumo-card-heading">{{ _('This started when...') }}</h3>
+                  <h3 class="sumo-card-heading">{{ started_label }}</h3>
                   <p>{{ question.metadata.started }}</p>
                   {% endif %}
                   {% if question.metadata.plugins %}
-                  <h3 class="sumo-card-heading">{{ _('Installed Plug-ins') }}</h3>
+                  <h3 class="sumo-card-heading">{{ plugins_label }}</h3>
                   <p><span class="plugins">
                     {{ question.metadata.plugins|wiki_to_html }}
                   </span></p>

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -41,7 +41,11 @@ from kitsune.questions import config
 from kitsune.questions.events import QuestionReplyEvent, QuestionSolvedEvent
 from kitsune.questions.feeds import AnswersFeed, QuestionsFeed, TaggedQuestionsFeed
 from kitsune.questions.forms import (
+    CRASH_ID_LABEL,
     FREQUENCY_CHOICES,
+    FREQUENCY_LABEL,
+    PLUGINS_LABEL,
+    STARTED_LABEL,
     AnswerForm,
     EditQuestionForm,
     NewQuestionForm,
@@ -1596,6 +1600,7 @@ def _answers_data(request, question_id, form=None, watch_form=None, answer_previ
             AnswersFeed().title(question),
         ),
     )
+
     frequencies = dict(FREQUENCY_CHOICES)
 
     is_watching_question = request.user.is_authenticated and (
@@ -1616,7 +1621,11 @@ def _answers_data(request, question_id, form=None, watch_form=None, answer_previ
         "answer_preview": answer_preview,
         "watch_form": watch_form or _init_watch_form(request, "reply"),
         "feeds": feed_urls,
+        "crash_id_label": CRASH_ID_LABEL,
+        "frequency_label": FREQUENCY_LABEL,
         "frequencies": frequencies,
+        "started_label": STARTED_LABEL,
+        "plugins_label": PLUGINS_LABEL,
         "is_watching_question": is_watching_question,
         "tags": tags,
         "tag_ids": {t.id for t in tags},

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -671,7 +671,13 @@
 </li>
 {% endmacro %}
 
-{% macro content_editor(field) %}
+{% macro content_editor(field, mention_rules=false) %}
+{% if mention_rules %}
+  {# L10n: Text displayed above the content editor (particularly, when posting a question or a reply). Rules and guidelines refer to https://support.mozilla.org/kb/mozilla-support-rules-guidelines #}
+  <div class="field-help-text">{% trans a_open='<a href="https://support.mozilla.org/kb/mozilla-support-rules-guidelines" target="_blank">'|safe, a_close='</a>'|safe %}
+    Remember to follow our {{ a_open }}rules and guidelines{{ a_close }}.
+  {% endtrans %}</div>
+{% endif %}
 <div class="field has-large-textarea editor{% if field.errors %} invalid{% endif %}"
   data-media-search-url="{{ url('gallery.async') }}" data-media-gallery-url="{{ url('gallery.home') }}">
   <div class="editor-tools"></div>

--- a/kitsune/sumo/static/sumo/js/aaq.js
+++ b/kitsune/sumo/static/sumo/js/aaq.js
@@ -7,7 +7,7 @@ import RemoteTroubleshooting from "./remote";
 
 export default class AAQSystemInfo {
   static slugs = {
-    desktop: ["/firefox/", "/firefox-enterprise/"],
+    desktop: ["/firefox/", "/firefox-enterprise/", "/thunderbird/"],
     mobile: ["/mobile/", "/ios/", "/focus-firefox/", "/thunderbird-android/"],
   };
 
@@ -15,7 +15,10 @@ export default class AAQSystemInfo {
     this.form = form;
 
     // Autofill the user agent
-    form.querySelector('input[name="useragent"]').value = navigator.userAgent;
+    let userAgentInput = form.querySelector('input[name="useragent"]');
+    if (userAgentInput) {
+      userAgentInput.value = navigator.userAgent;
+    }
 
     this.setupTroubleshootingInfo();
   }
@@ -36,10 +39,13 @@ export default class AAQSystemInfo {
 
     this.form.querySelector('input[name="os"]').value = platform.toString();
 
-    const browser = await detect.getBrowser();
-    if (browser.mozilla) {
-      this.form.querySelector('input[name="ff_version"]').value =
-        browser.version.toString();
+    let ffVersionField = this.form.querySelector('input[name="ff_version"]');
+    if (ffVersionField) {
+      const browser = await detect.getBrowser();
+      if (browser.mozilla) {
+        ffVersionField.value =
+          browser.version.toString();
+      }
     }
   }
 
@@ -66,6 +72,13 @@ export default class AAQSystemInfo {
             "none";
           this.form.querySelector("#troubleshooting-manual").style.display =
             "block";
+          let widget = this.form.querySelector("#id_troubleshooting");
+          const widget_ariaDescribedby = widget.getAttribute("aria-describedby");
+          if (widget_ariaDescribedby) {
+            widget.setAttribute("aria-describedby", widget_ariaDescribedby + " troubleshooting-manual");
+          } else {
+            widget.setAttribute("aria-describedby", "troubleshooting-manual");
+          }
         }
         this.form.querySelector("#troubleshooting-field").style.display =
           "block";

--- a/kitsune/sumo/static/sumo/js/browserdetect.js
+++ b/kitsune/sumo/static/sumo/js/browserdetect.js
@@ -69,7 +69,7 @@ class OS {
       "nt 6.2": "8",
       "nt 6.3": "8.1",
       "nt 6.4": "10",
-      "nt 10.0": "10",
+      "nt 10.0": "10/11",
     },
   };
 }
@@ -234,6 +234,10 @@ export class TroubleshootingDetector extends GenericDetector {
       os.name = "Windows";
       os.version = "11";
     }
+    else if (osVersion?.includes("Windows_NT 10.0")) {
+      os.name = "Windows";
+      os.version = "10";
+    }
     return os;
   }
 
@@ -260,7 +264,7 @@ export default class BrowserDetect {
 
   async getOS() {
     let os = await this.uaDetector.os();
-    if (os.name === "Windows" && os.version === "10") {
+    if (os.name === "Windows" && os.version === "10/11") {
       // could be windows 11
       let browser = await this.uaDetector.browser();
       if (browser.mozilla && !os.mobile) {

--- a/kitsune/sumo/static/sumo/js/form-wizard-configure-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-configure-step.js
@@ -7,6 +7,8 @@ import configureStepStylesURL from "../scss/form-wizard-configure-step.styles.sc
 
 export class ConfigureStep extends BaseFormStep {
   get template() {
+    // L10n: A button.
+    const continueString = gettext("Continue");
     return `
       <template>
         <div class="configure-step-wrapper">
@@ -43,7 +45,7 @@ export class ConfigureStep extends BaseFormStep {
           </p>
 
           <p id="buttons">
-            <button id="next" class="mzp-c-button mzp-t-product" data-event-name="dmw_click" data-event-parameters='{"dmw_click_target": "configuration-next"}'>${gettext("Continue")}</button>
+            <button id="next" class="mzp-c-button mzp-t-product" data-event-name="dmw_click" data-event-parameters='{"dmw_click_target": "configuration-next"}'>${continueString}</button>
           </p>
         </div>
       </template>

--- a/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
+++ b/kitsune/sumo/static/sumo/js/form-wizard-sign-in-step.js
@@ -8,6 +8,8 @@ export class SignInStep extends BaseFormStep {
   #emailErrorEl = null;
 
   get template() {
+    // L10n: A button.
+    const continueString = gettext("Continue");
     return `
       <template>
         <div id="sign-in-step-root">
@@ -39,7 +41,7 @@ export class SignInStep extends BaseFormStep {
               <input id="email" name="email" type="email" required="true" placeholder="${gettext("user@example.com")}" pending-autofocus="" />
             </div>
 
-            <button id="continue" class="mzp-c-button mzp-t-product" type="submit" data-event-name="dmw_click">${gettext("Continue")}</button>
+            <button id="continue" class="mzp-c-button mzp-t-product" type="submit" data-event-name="dmw_click">${continueString}</button>
           </form>
 
           <p class="for-sign-up form-footer">

--- a/kitsune/sumo/static/sumo/js/questions.js
+++ b/kitsune/sumo/static/sumo/js/questions.js
@@ -86,7 +86,7 @@ function init() {
     new AjaxPreview($('#preview'));
   }
 
-  Marky.createSimpleToolbar('.editor-tools', '#reply-content, #id_content', {cannedResponses: !$body.is('.new-question')});
+  Marky.createSimpleToolbar('.editor-tools', '#reply-content, #id_content', {cannedResponses: !$body.is('.new-question') && !$body.is('.edit-question')});
 
   // product selector page reloading
   $('#product-selector select').on('change', function() {
@@ -114,10 +114,11 @@ function init() {
 function initQuestion(action) {
   const questionForm = document.querySelector('#question-form');
   if (!questionForm) return;
+  let aaq = new AAQSystemInfo(questionForm);
   if (action === "editing") {
     questionForm.querySelector("#troubleshooting-field").style.display = "block";
   } else {
-    new AAQSystemInfo(questionForm).fillDetails();
+    aaq.fillDetails();
     hideDetails(questionForm);
   }
 }

--- a/kitsune/sumo/static/sumo/js/tests/browserdetecttests.js
+++ b/kitsune/sumo/static/sumo/js/tests/browserdetecttests.js
@@ -42,7 +42,7 @@ describe("BrowserDetect", () => {
       },
       os: {
         name: "Windows",
-        version: "10",
+        version: "10/11",
       },
     },
     {
@@ -264,7 +264,7 @@ describe("BrowserDetect", () => {
       },
       os: {
         name: "Windows",
-        version: "10",
+        version: "10/11",
       },
     },
     {

--- a/kitsune/sumo/static/sumo/scss/components/_field-help-text.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_field-help-text.scss
@@ -1,0 +1,5 @@
+@use 'protocol/css/includes/lib' as p;
+
+.field-help-text {
+  margin-bottom: p.$spacing-sm;
+}

--- a/kitsune/sumo/static/sumo/scss/components/_index.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_index.scss
@@ -21,6 +21,7 @@
 @forward 'progress-bar';
 @forward 'dashboards';
 @forward 'flaggit';
+@forward 'field-help-text';
 
 // for https://support.mozilla.org/en-US/kb/dashboard/metrics/aggregated
 @forward 'jqueryui';

--- a/kitsune/users/jinja2/users/auth.html
+++ b/kitsune/users/jinja2/users/auth.html
@@ -34,6 +34,7 @@
                 </p>
                 <div class="center-on-mobile">
                   <p class="login-button-wrap">
+                    {# L10n: A button. #}
                     <a rel="nofollow" href="{{ url('users.fxa_authentication_init') }}?next={{ next_url }}"
                       class="sumo-button primary-button button-lg button-full-width">{{ _('Continue') }}</a>
                   </p>

--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -477,7 +477,8 @@
             "link_name": "in-article-aaq-banner.aaq-step-3",
             "link_detail": "{{ product_slug }}"
           }'>
-            {{ _('Contact Support') }}
+            {# L10n: A button in a CTA displayed at the end of some Mozilla accounts articles. #}
+            {{ pgettext('CTA button', 'Contact Support') }}
         </a>
       </div>
     </div>


### PR DESCRIPTION
Rebased [#7114](https://github.com/mozilla/kitsune/pull/7114).

### Changes
- Add SUMO rules mentions when creating/editing a question, an answer, a forum thread, a forum post, a KB forum thread or a KB forum post ([#2196](https://github.com/mozilla/sumo/issues/2196)).
- In AAQ step 3, replace "Subject:" with "Summarize your question" and add help text for this field.
- In AAQ step 3, display the Troubleshooting Info help text above the Share Data button, right after the field name.
- In AAQ step 3, add the "tb_version" extra field ([#2536](https://github.com/mozilla/sumo/issues/2536)).
- In AAQ step 3, autofill the OS version field for Thunderbird.
- Fix the issue with the Share Data button not working when editing a question ([#1642](https://github.com/mozilla/sumo/issues/1642)).
- Do not display the Common responses button when editing a question.
- Improve accessibility.
- Use "Windows 10/11" when there is not enough info to identify the exact Windows NT 10.0 version ([#2700](https://github.com/mozilla/sumo/issues/2700)).
- Add l10n comments.
- Improve i18n, internationalize some alt strings
- Move repeated Helpful Tip code to a macro
- Remove an unused variable from forms.py

Resolves [#2196](https://github.com/mozilla/sumo/issues/2196), [#2536](https://github.com/mozilla/sumo/issues/2536), [#1642](https://github.com/mozilla/sumo/issues/1642), [#2700](https://github.com/mozilla/sumo/issues/2700).

### Screenshots

<details>
<summary>AAQ step 3 (Firefox): [click to expand]</summary>
<img width="2526" height="4784" alt="image_2025-12-08_17-48-27" src="https://github.com/user-attachments/assets/5032f512-31b5-4032-82af-39333cc5f4d9" />
</details>

<details>
<summary>AAQ step 3 (Firefox) after clicking the Share Data button, in case we failed to pull the data: [click to expand]</summary>
<img width="2526" height="4928" alt="image_2025-12-08_17-50-11" src="https://github.com/user-attachments/assets/468d963a-a446-479f-a1b8-76429750dc9f" />
</details>

<details>
<summary>AAQ step 3 (Thunderbird): [click to expand]</summary>
<img width="2526" height="4816" alt="image_2025-12-08_17-52-38" src="https://github.com/user-attachments/assets/b955c8cb-4d35-4bc2-af92-e0a2fd78b7bd" />
</details>

<details>
<summary>An example of how the editor looks on the updated surfaces (except for questions): [click to expand]</summary>
<img width="2526" height="3828" alt="image_2025-12-08_17-58-57" src="https://github.com/user-attachments/assets/efc114f9-6364-429f-99cc-cc0c1e548cfc" />
</details>

_Note: Some icons in the screenshots may be missing because they were taken on a test setup._

### TODO [admin]
Once this PR is merged, the following changes have to be made via the admin console:
- "tb_version" needs to be added to the Thunderbird & Thunderbird for Android AAQ Configurations' extra fields (for the "Thunderbird version" field to be displayed).
- (optional, but recommended) The "Windows 10/11" tag needs to be created (for it to be applied when we can't determine whether a user is on Windows 10 or Windows 11).