### PR TITLE
improve performance of two product support methods

### DIFF
--- a/kitsune/products/models.py
+++ b/kitsune/products/models.py
@@ -97,25 +97,18 @@ class Product(BaseProductTopic):
     @property
     def has_ticketing_support(self):
         """Return boolean if a product has Zendesk ticketing support"""
-        try:
-            config = self.support_configs.get(is_active=True)
-        except ProductSupportConfig.DoesNotExist:
-            return False
-        else:
-            return config.enable_zendesk_support
+        return self.support_configs.filter(
+            is_active=True,
+            zendesk_config__isnull=False,
+        ).exists()
 
     def questions_enabled(self, locale):
         """Check if product has an active public forum in the given locale."""
-        try:
-            config = self.support_configs.get(is_active=True)
-        except ProductSupportConfig.DoesNotExist:
-            return False
-
-        return (
-            config.forum_config
-            and config.forum_config.is_active
-            and config.forum_config.enabled_locales.filter(locale=locale).exists()
-        )
+        return self.support_configs.filter(
+            is_active=True,
+            forum_config__is_active=True,
+            forum_config__enabled_locales__locale=locale,
+        ).exists()
 
     def get_absolute_url(self):
         return reverse("products.product", kwargs={"slug": self.slug})


### PR DESCRIPTION
While working on #7173, I noticed that we could reduce the query count of the `Product.has_ticketing_support` property and the `Product.questions_enabled()` method.