### PR TITLE
Playwright: Fix search and localization dashboard test failures 

### DIFF
--- a/playwright_tests/messages/explore_help_articles/kb_article_revision_page_messages.py
+++ b/playwright_tests/messages/explore_help_articles/kb_article_revision_page_messages.py
@@ -5,7 +5,7 @@ class KBArticleRevision:
     KB_ARTICLE_REVISION_KEYWORD_HEADER = "Keywords:"
     KB_ARTICLE_REVISION_NO_STATUS = "No"
     KB_ARTICLE_REVISION_YES_STATUS = "Yes"
-    KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER = ("Unable to delete only revision of the "
+    KB_REVISION_CANNOT_DELETE_ONLY_REVISION_HEADER = ("Unable to delete the only revision of the "
                                                       "document")
     KB_REVISION_CANNOT_DELETE_ONLY_REVISION_SUBHEADER = ("To delete the document, please notify "
                                                          "an admin.")

--- a/playwright_tests/pages/search/search_page.py
+++ b/playwright_tests/pages/search/search_page.py
@@ -176,6 +176,7 @@ class SearchPage(BasePage):
             is_aaq (bool): Whether the search bar is on the AAQ flow pages
             is_sidebar (bool): Whether the search bar is on the sidebar
         """
+        self.wait_for_dom_to_load()
         if is_aaq:
             self.clear_the_searchbar(is_aaq=True)
             self._fill(self.searchbar_aaq, text)

--- a/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
@@ -78,10 +78,12 @@ def test_aaq_redirect(page: Page):
                                     f" {product_topic} is displayed"):
                 if product_topic in utilities.general_test_data["premium_products"]:
                     assert sumo_pages.common_web_elements.get_aaq_widget_text(
-                    ) == AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
+                    ) == AAQWidgetMessages.PREMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT, (
+                        f"Incorrect AAQ widget text displayed for the {product_topic} product")
                 else:
                     assert sumo_pages.common_web_elements.get_aaq_widget_text(
-                    ) == AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT
+                    ) == AAQWidgetMessages.FREEMIUM_AAQ_SUBHEADING_TEXT_SIGNED_OUT, (
+                        f"Incorrect AAQ widget text displayed for the {product_topic} product")
 
             with allure.step("Clicking on the AAQ button"):
                 sumo_pages.common_web_elements.click_on_aaq_button()

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_show_history.py
@@ -169,7 +169,7 @@ def test_kb_article_removal(page: Page, create_user_factory):
 def test_kb_article_category_link_and_header(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    test_user = create_user_factory()
+    test_user = create_user_factory(permissions=["delete_revision", "delete_document"])
 
     utilities.start_existing_session(cookies=test_user)
     for category in utilities.general_test_data["kb_article_categories"]:
@@ -205,6 +205,10 @@ def test_kb_article_category_link_and_header(page: Page, create_user_factory):
             expect(
                 page
             ).to_have_url(utilities.different_endpoints['kb_categories_links'][category])
+
+        with allure.step("Deleting the document"):
+            utilities.navigate_to_link(article_info["article_show_history_url"])
+            sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
 # C2101637, C2489543, C2102169, C2489542
@@ -383,9 +387,9 @@ def test_contributors_can_be_manually_added(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     kb_show_history_page_messages = KBArticleShowHistoryPageMessages()
-    test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
+    test_user = create_user_factory(groups=["Knowledge Base Reviewers"],
+                                    permissions=["delete_revision", "delete_document"])
     test_user_two = create_user_factory()
-
     utilities.start_existing_session(cookies=test_user)
 
     with allure.step("Clicking on the 'Edit Contributors' option, adding and selecting the "
@@ -414,6 +418,9 @@ def test_contributors_can_be_manually_added(page: Page, create_user_factory):
         sumo_pages.kb_article_page.click_on_article_option()
         assert (test_user_two["username"] in sumo_pages.kb_article_page.
                 get_list_of_kb_article_contributors())
+
+    with allure.step("Deleting the document"):
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
 # C2101634, C2489553, C2102186

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_article_translation.py
@@ -111,6 +111,7 @@ def test_not_ready_for_localization_articles_dashboard_status(page: Page, create
 
     with allure.step("Navigating to the parent article and marking it as ready for l10n"):
         utilities.navigate_to_link(article_details['article_url'])
+        sumo_pages.kb_article_page.click_on_show_history_option()
         sumo_pages.kb_article_show_history_page.click_on_ready_for_l10n_option(
             article_details['first_revision_id']
         )

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
@@ -78,7 +78,8 @@ def test_non_admin_users_kb_article_submission(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
     test_user = create_user_factory()
-    test_user_two = create_user_factory(groups=["Knowledge Base Reviewers"])
+    test_user_two = create_user_factory(groups=["Knowledge Base Reviewers"],
+                                        permissions=["delete_revision", "delete_document"])
     with allure.step(f"Signing in with {test_user['username']} user account"):
         utilities.start_existing_session(cookies=test_user)
 
@@ -122,6 +123,8 @@ def test_non_admin_users_kb_article_submission(page: Page, create_user_factory):
                 article_details['first_revision_id']))
         assert KBArticlePageMessages.REVIEW_REVISION_STATUS == status
 
+    with allure.step("Deleting the test article"):
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 # C2081446, C2081447, C2490049,  C2490051
 @pytest.mark.smokeTest
@@ -428,7 +431,8 @@ def test_articles_discussions_not_allowed(page: Page, create_user_factory):
 def test_kb_article_title_and_slug_validations(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
+    test_user = create_user_factory(groups=["Knowledge Base Reviewers"],
+                                    permissions=["delete_revision", "delete_document"])
 
     with allure.step(f"Signing in with {test_user['username']} user account"):
         utilities.start_existing_session(cookies=test_user)
@@ -551,6 +555,10 @@ def test_kb_article_title_and_slug_validations(page: Page, create_user_factory):
         sumo_pages.kb_submit_kb_article_form_page.click_on_changes_submit_button()
         assert sumo_pages.kb_submit_kb_article_form_page.get_all_kb_errors(
         )[0] == KBArticlePageMessages.KB_ARTICLE_SUBMISSION_TITLE_ERRORS[1]
+
+    with allure.step("Deleting the test article"):
+        utilities.navigate_to_link(article_details["article_show_history_url"])
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
 @pytest.mark.kbArticleCreationAndAccess
@@ -686,7 +694,7 @@ def test_kb_article_keywords_and_summary(page: Page, user_type, create_user_fact
 def test_edit_non_approved_articles(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    test_user = create_user_factory()
+    test_user = create_user_factory(permissions=["delete_revision", "delete_document"])
 
     with allure.step(f"Signing in with a {test_user['username']} user account"):
         utilities.start_existing_session(cookies=test_user)
@@ -704,6 +712,9 @@ def test_edit_non_approved_articles(page: Page, create_user_factory):
         expect(
             sumo_pages.kb_article_show_history_page.revision(second_revision['revision_id'])
         ).to_be_visible()
+
+    with allure.step("Deleting the test article"):
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 
 # C966833, C2102177, C2091592

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_product_support_page.py
@@ -228,21 +228,24 @@ def test_still_need_help_button_redirect(page: Page, create_user_factory):
                     with check, allure.step("Verifying that the correct still need help title is "
                                             "displayed"):
                         assert (sumo_pages.product_support_page.get_still_need_help_widget_title()
-                                ) == ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_TITLE
+                                ) == ProductSupportPageMessages.STILL_NEED_HELP_WIDGET_TITLE, (
+                            f"Incorrect widget title displayed for the {card} product")
                     if card in utilities.general_test_data['premium_products']:
                         with check, allure.step("Verifying that the correct still need help "
                                                 "content is displayed"):
                             assert (sumo_pages.product_support_page
                                     .get_still_need_help_widget_content()
                                     ) == (ProductSupportPageMessages
-                                          .STILL_NEED_HELP_WIDGET_CONTENT_PREMIUM)
+                                          .STILL_NEED_HELP_WIDGET_CONTENT_PREMIUM), (
+                                f"Incorrect widget content displayed for the {card} product")
 
                         with check, allure.step("Verifying that the correct still need help "
                                                 "button text is displayed"):
                             assert (sumo_pages.product_support_page
                                     .get_still_need_help_widget_button_text()
                                     ) == (ProductSupportPageMessages
-                                          .STILL_NEED_HELP_WIDGET_BUTTON_TEXT_PREMIUM)
+                                          .STILL_NEED_HELP_WIDGET_BUTTON_TEXT_PREMIUM), (
+                                f"Incorrect widget button displayed for the {card} product")
                         with allure.step("Clicking on the still need help widget button"):
                             sumo_pages.product_support_page.click_still_need_help_widget_button()
                     else:
@@ -251,7 +254,8 @@ def test_still_need_help_button_redirect(page: Page, create_user_factory):
                             assert (sumo_pages.product_support_page
                                     .get_still_need_help_widget_content()
                                     ) == (ProductSupportPageMessages
-                                          .STILL_NEED_HELP_WIDGET_CONTENT_FREEMIUM)
+                                          .STILL_NEED_HELP_WIDGET_CONTENT_FREEMIUM), (
+                                f"Incorrect widget content displayed for the {card} product")
 
                         with check, allure.step("Verifying that the correct still need help "
                                                 "button text is displayed"):

--- a/playwright_tests/tests/search_tests/test_main_searchbar.py
+++ b/playwright_tests/tests/search_tests/test_main_searchbar.py
@@ -10,16 +10,18 @@ from playwright_tests.messages.ask_a_question_messages.AAQ_messages.question_pag
 from playwright_tests.messages.homepage_messages import HomepageMessages
 from playwright_tests.messages.search_page_messages import SearchPageMessage
 from playwright_tests.pages.sumo_pages import SumoPages
+from playwright_tests.tests.conftest import create_user_factory
 
 
 # C890369
 @pytest.mark.smokeTest
 @pytest.mark.searchTests
-def test_searchbar_functionality_product_solutions_page(page: Page):
+def test_searchbar_functionality_product_solutions_page(page: Page, create_user_factory):
     sumo_pages = SumoPages(page)
     utilities = Utilities(page)
     test_article_name = "DoNotDelete"
-    test_question_name = "NVDA fails to load"
+    test_user = create_user_factory()
+    question = _create_test_question(page, test_user)
 
     with allure.step("Navigating to the Firefox product solutions page and using the searchbar to "
                      "search for a particular kb Article"):
@@ -33,10 +35,11 @@ def test_searchbar_functionality_product_solutions_page(page: Page):
         assert sumo_pages.search_page.get_the_highlighted_side_nav_item() == "Firefox"
 
     with allure.step("Using the searchbar to search for a particular question"):
-        sumo_pages.search_page.fill_into_searchbar(text=test_question_name, is_aaq=True)
+        sumo_pages.search_page.fill_into_searchbar(text=question["aaq_subject"], is_aaq=True)
 
     with allure.step("Verifying that the question is successfully returned"):
-        assert test_question_name in sumo_pages.search_page.get_all_search_results_article_titles()
+        assert (question["aaq_subject"] in sumo_pages.search_page.
+                get_all_search_results_article_titles())
 
     with allure.step("Verifying that the filter by product is applied to the correct product"):
         assert sumo_pages.search_page.get_the_highlighted_side_nav_item() == "Firefox"
@@ -44,11 +47,12 @@ def test_searchbar_functionality_product_solutions_page(page: Page):
 
 @pytest.mark.smokeTest
 @pytest.mark.searchTests
-def test_searchbar_functionality_product_support_page(page: Page):
+def test_searchbar_functionality_product_support_page(page: Page, create_user_factory):
     sumo_pages = SumoPages(page)
     utilities = Utilities(page)
     test_article_name = "DoNotDelete"
-    test_question_name = "NVDA fails to load"
+    test_user = create_user_factory()
+    question = _create_test_question(page, test_user)
 
     with allure.step("Navigating to the Firefox product support page and using the searchbar to "
                      "search for a particular kb Article"):
@@ -62,10 +66,11 @@ def test_searchbar_functionality_product_support_page(page: Page):
         assert sumo_pages.search_page.get_the_highlighted_side_nav_item() == "Firefox"
 
     with allure.step("Using the searchbar to search for a particular question"):
-        sumo_pages.search_page.fill_into_searchbar(test_question_name)
+        sumo_pages.search_page.fill_into_searchbar(question["aaq_subject"])
 
     with allure.step("Verifying that the question is successfully returned"):
-        assert test_question_name in sumo_pages.search_page.get_all_search_results_article_titles()
+        assert (question["aaq_subject"] in sumo_pages.search_page.
+                get_all_search_results_article_titles())
 
     with allure.step("Verifying that the filter by product is applied to the correct product"):
         assert sumo_pages.search_page.get_the_highlighted_side_nav_item() == "Firefox"
@@ -73,11 +78,12 @@ def test_searchbar_functionality_product_support_page(page: Page):
 
 @pytest.mark.smokeTest
 @pytest.mark.searchTests
-def test_searchbar_functionality_explore_by_topic_page(page: Page):
+def test_searchbar_functionality_explore_by_topic_page(page: Page, create_user_factory):
     sumo_pages = SumoPages(page)
     utilities = Utilities(page)
     test_article_name = "DoNotDelete"
-    test_question_name = "NVDA fails to load"
+    test_user = create_user_factory()
+    question = _create_test_question(page, test_user)
 
     with allure.step("Navigating to the 'Browse' explore by topic page and using the searchbar to "
                      "search for a particular kb Article"):
@@ -92,10 +98,11 @@ def test_searchbar_functionality_explore_by_topic_page(page: Page):
 
     with allure.step("Using the searchbar to search for a particular question"):
         sumo_pages.search_page.clear_the_searchbar(is_sidebar=True)
-        sumo_pages.search_page.fill_into_searchbar(test_question_name, is_sidebar=True)
+        sumo_pages.search_page.fill_into_searchbar(question['aaq_subject'], is_sidebar=True)
 
     with allure.step("Verifying that the question is successfully returned"):
-        assert test_question_name in sumo_pages.search_page.get_all_search_results_article_titles()
+        assert (question['aaq_subject'] in sumo_pages.search_page.
+                get_all_search_results_article_titles())
 
     with allure.step("Verifying that the filter by product is applied to the correct product"):
         assert sumo_pages.search_page.get_the_highlighted_side_nav_item() == "All Products"
@@ -104,11 +111,12 @@ def test_searchbar_functionality_explore_by_topic_page(page: Page):
 # C891284
 @pytest.mark.smokeTest
 @pytest.mark.searchTests
-def test_searchbar_functionality_product_community_forum_page(page: Page):
+def test_searchbar_functionality_product_community_forum_page(page: Page, create_user_factory):
     sumo_pages = SumoPages(page)
     utilities = Utilities(page)
     test_article_name = "DoNotDelete"
-    test_question_name = "NVDA fails to load"
+    test_user = create_user_factory()
+    question = _create_test_question(page, test_user)
 
     with allure.step("Navigating to the Firefox community forum page and using the searchbar to "
                      "search for a particular kb Article"):
@@ -123,10 +131,11 @@ def test_searchbar_functionality_product_community_forum_page(page: Page):
 
     with allure.step("Using the searchbar to search for a particular question"):
         sumo_pages.search_page.clear_the_searchbar(is_sidebar=True)
-        sumo_pages.search_page.fill_into_searchbar(test_question_name, is_sidebar=True)
+        sumo_pages.search_page.fill_into_searchbar(question['aaq_subject'], is_sidebar=True)
 
     with allure.step("Verifying that the question is successfully returned"):
-        assert test_question_name in sumo_pages.search_page.get_all_search_results_article_titles()
+        assert (question['aaq_subject'] in sumo_pages.search_page.
+                get_all_search_results_article_titles())
 
     with allure.step("Verifying that the filter by product is applied to the correct product"):
         assert sumo_pages.search_page.get_the_highlighted_side_nav_item() == "All Products"
@@ -134,11 +143,13 @@ def test_searchbar_functionality_product_community_forum_page(page: Page):
 
 @pytest.mark.smokeTest
 @pytest.mark.searchTests
-def test_searchbar_functionality_browse_all_forum_threads_by_topic_page(page: Page):
+def test_searchbar_functionality_browse_all_forum_threads_by_topic_page(page: Page,
+                                                                        create_user_factory):
     sumo_pages = SumoPages(page)
     utilities = Utilities(page)
     test_article_name = "DoNotDelete"
-    test_question_name = "NVDA fails to load"
+    test_user = create_user_factory()
+    question = _create_test_question(page, test_user)
 
     with allure.step("Navigating to the 'Settings' browse all forum threads by topic page and "
                      "using the searchbar to search for a particular kb Article"):
@@ -153,10 +164,11 @@ def test_searchbar_functionality_browse_all_forum_threads_by_topic_page(page: Pa
 
     with allure.step("Using the searchbar to search for a particular question"):
         sumo_pages.search_page.clear_the_searchbar(is_sidebar=True)
-        sumo_pages.search_page.fill_into_searchbar(test_question_name, is_sidebar=True)
+        sumo_pages.search_page.fill_into_searchbar(question['aaq_subject'], is_sidebar=True)
 
     with allure.step("Verifying that the question is successfully returned"):
-        assert test_question_name in sumo_pages.search_page.get_all_search_results_article_titles()
+        assert (question['aaq_subject'] in sumo_pages.search_page.
+                get_all_search_results_article_titles())
 
     with allure.step("Verifying that the filter by product is applied to the correct product"):
         assert sumo_pages.search_page.get_the_highlighted_side_nav_item() == "All Products"
@@ -297,13 +309,13 @@ def test_searchbar_functionality_on_article_page(page: Page, create_user_factory
     sumo_pages = SumoPages(page)
     utilities = Utilities(page)
     test_article_name = "DoNotDelete"
-    test_question_name = "NVDA fails to load"
-    test_user = create_user_factory(groups=["kb-contributors"])
+    test_user = create_user_factory(groups=["kb-contributors"],
+                                    permissions=["delete_revision", "delete_document"])
+    question = _create_test_question(page,test_user,sign_out=False)
 
     with allure.step("Submitting a new KB article against the Firefox product and using the "
                      "searchbar to search for a particular kb Article"):
-        utilities.start_existing_session(cookies=test_user)
-        sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
+        article = sumo_pages.submit_kb_article_flow.submit_simple_kb_article()
         sumo_pages.kb_article_page.click_on_article_option()
         utilities.wait_for_given_timeout(2000)
         sumo_pages.search_page.fill_into_searchbar(test_article_name, is_sidebar=True)
@@ -316,14 +328,18 @@ def test_searchbar_functionality_on_article_page(page: Page, create_user_factory
 
     with allure.step("Using the searchbar to search for a particular question"):
         sumo_pages.search_page.clear_the_searchbar(is_sidebar=True)
-        sumo_pages.search_page.fill_into_searchbar(test_question_name, is_sidebar=True)
+        sumo_pages.search_page.fill_into_searchbar(question['aaq_subject'], is_sidebar=True)
 
     with allure.step("Verifying that the question is successfully returned"):
-        assert test_question_name in sumo_pages.search_page.get_all_search_results_article_titles()
+        assert (question['aaq_subject'] in sumo_pages.search_page.
+                get_all_search_results_article_titles())
 
     with allure.step("Verifying that the filter by product is applied to the correct product"):
         assert sumo_pages.search_page.get_the_highlighted_side_nav_item() == "Firefox"
 
+    with allure.step("Deleting the test article"):
+        utilities.navigate_to_link(article['article_show_history_url'])
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()
 
 # C1329220
 @pytest.mark.searchTests
@@ -1328,3 +1344,31 @@ def _verify_search_results(page: Page, search_term: str, locale: str, search_res
             in_content = True
             break
     return in_title or in_content
+
+def _create_test_question(page: Page, user, sign_out=True):
+    sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
+
+    utilities.start_existing_session(cookies=user)
+    with allure.step("Navigating to the AAQ form and posting a new AAQ question"):
+        utilities.navigate_to_link(utilities.aaq_question_test_data["products_aaq_url"]["Firefox"])
+
+    question = sumo_pages.aaq_flow.submit_an_aaq_question(
+        subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
+        topic_name=utilities.aaq_question_test_data["valid_firefox_question"]["topic_value"],
+        body=utilities.aaq_question_test_data["valid_firefox_question"]["question_body"],
+        expected_locator=sumo_pages.question_page.questions_header
+    )
+
+    with allure.step("Leaving a reply to the question so it appears on search results"):
+        sumo_pages.aaq_flow.post_question_reply_flow(
+            repliant_username=user["username"],
+            reply=utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
+        )
+
+    with allure.step("Waiting until the test question is returned in search results"):
+        utilities.wait_for_given_timeout(65000)
+        if sign_out:
+            utilities.delete_cookies()
+
+    return question


### PR DESCRIPTION
- Added article deletion flow in some tests for which the test kb article was not deleted automatically after the revision owner/s test accounts deletion step.
- Isolated some search tests by creating test questions for each test instead of using an existing one.
- Updated the expected error message when attempting to delete the only kb article revision.
- Fixed some flaky tests.