### PR TITLE
Display in-product link indicator to contributors

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
+++ b/kitsune/wiki/jinja2/wiki/includes/sidebar_modules.html
@@ -6,7 +6,7 @@
   {% endif %}
   <nav id="doc-tools">
     <ul class="sidebar-nav sidebar-folding">
-      {% if in_staff_group(user) and (document or parent).is_linked_in_product %}
+      {% if (is_contributor(user) or in_staff_group(user)) and (document or parent).is_linked_in_product %}
         <li>
           <figure class="linked-in-product">
             <img src="{{ webpack_static('sumo/img/info.svg') }}" alt="{{ _('Information icon') }}" />


### PR DESCRIPTION
Extend the in-product link indicator visibility to users registered as contributors.

Resolves [#2206](https://github.com/mozilla/sumo/issues/2206).