### PR TITLE
determine when to show AAQ CTA widget

### DIFF
--- a/kitsune/products/jinja2/products/documents.html
+++ b/kitsune/products/jinja2/products/documents.html
@@ -46,7 +46,7 @@
   {{ topic_sidebar(topics[:10], subtopics, product, topic, subtopic) }}
 {% endif %}
 
-{{ aaq_widget(request, topic=topic) }}
+{{ aaq_widget(request, product=product, topic=topic) }}
 
 {% endblock %}
 

--- a/kitsune/questions/jinja2/questions/includes/aaq_macros.html
+++ b/kitsune/questions/jinja2/questions/includes/aaq_macros.html
@@ -80,9 +80,15 @@
   </ul>
 {%- endmacro %}
 
-{% macro aaq_widget(request, location="aaq", topic=None) %}
+{% macro aaq_widget(request, product=None, topic=None) %}
   {% set aaq_context = request.session.get("aaq_context") %}
-  {% if aaq_context and (aaq_context.has_public_forum or aaq_context.has_ticketing_support) %}
+  {% set current_support = aaq_context.current_support_type if aaq_context else None %}
+  {% set has_forum = aaq_context.has_public_forum if aaq_context else False %}
+  {% set has_default_forum = aaq_context.has_default_public_forum if aaq_context else False %}
+  {% set multiple_products = aaq_context.multiple_products if aaq_context else False %}
+  {% set is_ticketed = (current_support == 'zendesk') if current_support else False %}
+
+  {% if (not product) or has_forum or is_ticketed or has_default_forum %}
   <div class="aaq-widget card is-inverse elevation-01 text-center radius-md">
     <h2 class="card--title has-bottom-margin">
       <svg class="card--icon-sm" width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -96,12 +102,6 @@
 
       {{ _('Ask a Question') }}
     </h2>
-    {% set link_detail = aaq_context.product_slug if aaq_context else topic %}
-    {% set current_support = aaq_context.current_support_type if aaq_context else None %}
-    {% set has_forum = aaq_context.has_public_forum if aaq_context else False %}
-    {% set multiple_products = aaq_context.multiple_products if aaq_context else False %}
-    {% set is_ticketed = (current_support == 'zendesk') if current_support else False %}
-
     {% if aaq_context %}
       {% if request.user.is_authenticated %}
         {% if is_ticketed %}
@@ -128,6 +128,8 @@
                        else url('questions.aaq_step3', product_slug=aaq_context.product_slug)
                        if aaq_context and not multiple_products
                        else url('questions.aaq_step1') %}
+
+    {% set link_detail = aaq_context.product_slug if aaq_context else topic %}
 
     <a class="sumo-button primary-button feature-box"
       href="{{ next_step }}"
@@ -166,7 +168,7 @@
         </p>
       </div>
       <div class="sumo-l-two-col--sidebar">
-        {{ aaq_widget(request) }}
+        {{ aaq_widget(request, product=product) }}
       </div>
     </div>
   </div>

--- a/kitsune/questions/jinja2/questions/question_details.html
+++ b/kitsune/questions/jinja2/questions/question_details.html
@@ -325,7 +325,7 @@
   {{ search_box(settings, id='support-search-sidebar', params=search_params, placeholder=_('Search Support')) }}
 </div>
 
-{{ aaq_widget(request) }}
+{{ aaq_widget(request, product=product) }}
 
 <div class="questions-sidebar">
   <nav class="sidebar-nav is-action-list" id="question-tools">

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -441,6 +441,11 @@ def set_aaq_context(request, product, multiple_products=False):
             "can_switch": can_switch,
         }
 
+        if request.LANGUAGE_CODE != settings.WIKI_DEFAULT_LANGUAGE:
+            aaq_context["has_default_public_forum"] = product.questions_enabled(
+                locale=settings.WIKI_DEFAULT_LANGUAGE
+            )
+
     # Update the session with the AAQ context.
     request.session["aaq_context"] = aaq_context
 

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -58,7 +58,7 @@
   </div>
 
   {% if show_aaq_widget %}
-    {{ aaq_widget(request) }}
+    {{ aaq_widget(request, product=product) }}
   {% endif %}
 
   {% if fallback_reason == 'no_translation' %}


### PR DESCRIPTION
mozilla/sumo#2762
mozilla/sumo#2767

This avoids any regressions while also not displaying the AAQ CTA widget when it doesn't make sense.

It was really tricky to think through all of the cases. Thanks to @emilghittasv for the discussion!