### PR TITLE
Extend JS avatar fallback to images inside .avatar

### DIFF
--- a/kitsune/sumo/static/sumo/js/profile-avatars.js
+++ b/kitsune/sumo/static/sumo/js/profile-avatars.js
@@ -1,6 +1,8 @@
 import avatar from "sumo/img/avatar.png";
 
-var imgs = document.querySelectorAll('img.avatar');
+const imgs = Array.from(new Set(
+  document.querySelectorAll('img.avatar, .avatar img')
+));
 
 if (imgs) {
   imgs.forEach(function(e) {


### PR DESCRIPTION
Resolves [#2783](https://github.com/mozilla/sumo/issues/2783).

Our [JS-level avatar fallback](https://github.com/mozilla/kitsune/blob/main/kitsune/sumo/static/sumo/js/profile-avatars.js) is limited to `img.avatar` (images with the "avatar" class applied). However, on question details pages (as well as some others), avatar images do not have the "avatar" class and are instead located inside other elements with the "avatar" class.

This patch extends the selector to child images of elements with the "avatar" class.