### PR TITLE
Playwright add restmail test accounts

### DIFF
--- a/playwright_tests/flows/auth_flows/auth_flow.py
+++ b/playwright_tests/flows/auth_flows/auth_flow.py
@@ -1,39 +1,50 @@
 from playwright.sync_api import Page
-
 from playwright_tests.core.utilities import Utilities
 from playwright_tests.pages.auth_page import AuthPage
+from playwright_tests.pages.top_navbar import TopNavbar
 
 
 class AuthFlowPage:
 
     def __init__(self, page: Page):
+        self.page = page
         self.utilities = Utilities(page)
         self.auth_page = AuthPage(page)
+        self.top_navbar = TopNavbar(page)
 
     # Providing OTP code to FxA auth.
-    def __provide_otp_code(self, otp_code: str):
+    def __provide_otp_code(self, otp_code: str, new_account: bool = False):
         """Add data to 'Enter your OTP code' input field and click on 'Submit' button
 
         Args:
             otp_code (str): OTP code to be added to the input field.
+            new_account (str): If the user is a new fxa account.
         """
-        self.auth_page.add_data_to_otp_code_input_field(otp_code)
+        if new_account:
+            self.auth_page.add_data_to_new_account_otp_code_input_field(otp_code)
+        else:
+            self.auth_page.add_data_to_otp_code_input_field(otp_code)
         self.auth_page.click_on_otp_code_confirm_button()
 
     # Providing the needed login credentials to FxA auth.
-    def __provide_login_credentials_and_submit(self, username: str, password: str):
+    def __provide_login_credentials_and_submit(self, username: str, password: str,
+                                               new_account: bool = False):
         """Provide login credentials to FxA auth and submit them.
 
         Args:
             username (str): Username to be added to the input field.
-            password (str): Password to be added to the input field
+            password (str): Password to be added to the input field.
+            new_account (bool): If we are creating a new fxa test account.
         """
         self.auth_page.add_data_to_email_input_field(username)
         self.auth_page.click_on_enter_your_email_submit_button()
 
         self.auth_page.add_data_to_password_input_field(password)
         with self.utilities.page.expect_navigation():
-            self.auth_page.click_on_enter_your_password_submit_button()
+            if new_account:
+                self.auth_page.click_on_create_account_button()
+            else:
+                self.auth_page.click_on_enter_your_password_submit_button()
 
     def login_with_existing_session(self):
         """Login with an existing session."""
@@ -43,15 +54,22 @@ class AuthFlowPage:
         self.auth_page.click_on_user_logged_in_sign_in_button()
 
     # Sign in flow.
-    def sign_in_flow(self, username: str, account_password: str) -> str:
+    def sign_in_flow(self, username: str, account_password: str, via_top_navbar: bool = False,
+                     is_restmail: bool = False, new_account: bool = False) -> [str, str]:
         """Sign in flow.
 
         Args:
             username (str): Username to be used for sign in.
             account_password (str): Password to be used for sign in.
+            via_top_navbar (bool): If the login should be initiated via the top-navbar.
+            is_restmail (bool): If restmail test user.
+            new_account (bool): If creating a new test user fxa account.
         """
-        # Forcing an email clearance
-        self.utilities.clear_email()
+        if via_top_navbar:
+            self.top_navbar.click_on_signin_signup_button()
+            # Also acts as a wait. Introduced in order to avoid flakiness which occurred on some
+            # GH runs.
+            self.auth_page.continue_with_firefox_accounts_button.wait_for(timeout=5000)
 
         if self.auth_page.is_continue_with_firefox_button_displayed():
             """If the 'Continue with Firefox Accounts' button is displayed, click on it."""
@@ -61,12 +79,12 @@ class AuthFlowPage:
             """If the 'Use a different account' button is displayed, click on it."""
             self.auth_page.click_on_use_a_different_account_button()
 
-        self.__provide_login_credentials_and_submit(username, account_password)
-
+        self.__provide_login_credentials_and_submit(username, account_password, new_account)
         if self.auth_page.is_enter_otp_code_input_field_displayed():
             """If the OTP code input field is displayed, provide the OTP code."""
-            self.utilities.clear_email()
-            self.auth_page.click_on_email_new_code_button()
-            self.__provide_otp_code(self.utilities.get_fxa_verification_code())
+            self.__provide_otp_code(self.utilities.get_fxa_verification_code(
+                restmail_username=username if is_restmail else None, new_account=new_account
+            ), new_account=new_account
+            )
         self.utilities.wait_for_dom_to_load()
-        return username
+        return username, account_password

--- a/playwright_tests/messages/homepage_messages.py
+++ b/playwright_tests/messages/homepage_messages.py
@@ -7,3 +7,6 @@ class HomepageMessages:
         "our knowledge base."
     )
     EXPECTED_FEATURED_ARTICLES_COUNT = 4
+    NEW_USER_REGISTRATION_MESSAGE = (
+        "Welcome! You are now signed in using your Mozilla account. Edit your profile.\n"
+        "Already have a different Mozilla Support Account? Read more.")

--- a/playwright_tests/pages/homepage.py
+++ b/playwright_tests/pages/homepage.py
@@ -6,6 +6,12 @@ class Homepage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
 
+        """General page locators."""
+        self.user_notification = page.locator("//ul[@class='user-messages']//p")
+        self.user_notification_links = page.locator("//ul[@class='user-messages']//p/a").all()
+        self.user_notification_link_by_link_text = lambda link_name: page.locator(
+            f"//ul[@class='user-messages']//p/a[normalize-space(text())='{link_name}']")
+
         """Locators belonging to the product list section."""
         self.product_list = page.locator("div.card--product")
         self.product_card_titles = page.locator("div.card--product h3.card--title"
@@ -17,6 +23,21 @@ class Homepage(BasePage):
         self.featured_articles_list = page.locator("div.card--article")
         self.featured_articles_card_titles = page.locator("div.card--article").get_by_role("link")
 
+    """Actions against the general page locators."""
+    def get_user_notification(self) -> str:
+        """Returns the displayed user notification."""
+        return self._get_text_of_element(self.user_notification)
+
+    def get_user_notification_link_text(self) -> list[str]:
+        """Returns the link text of the user notification links."""
+        text = []
+        for element in self.user_notification_links:
+            text.append(self._get_text_of_locator(element))
+        return text
+
+    def click_on_a_certain_notification_link(self, link_text: str):
+        """Clicks on a link displayed inside the user notification by the link text."""
+        self._click(self.user_notification_link_by_link_text(link_text))
 
     """Actions against the product cards."""
     def get_text_of_product_card_titles(self) -> list[str]:

--- a/playwright_tests/test_data/different_endpoints.json
+++ b/playwright_tests/test_data/different_endpoints.json
@@ -8,5 +8,6 @@
             "Navigation": "https://support.allizom.org/en-US/kb/category/50",
             "Templates": "https://support.allizom.org/en-US/kb/category/60",
             "Canned Responses": "https://support.allizom.org/en-US/kb/category/70"
-          }
+          },
+  "fxa_stage": "https://accounts.stage.mozaws.net"
 }

--- a/playwright_tests/tests/test_prerequisites_login.py
+++ b/playwright_tests/tests/test_prerequisites_login.py
@@ -1,6 +1,12 @@
+import random
+import string
+
+import allure
 import pytest
 from playwright.sync_api import Page, expect
+from pytest_check import check
 from playwright_tests.core.utilities import Utilities
+from playwright_tests.messages.homepage_messages import HomepageMessages
 from playwright_tests.pages.sumo_pages import SumoPages
 
 
@@ -10,16 +16,26 @@ def test_create_user_sessions_for_test_accounts(page: Page):
     sumo_pages = SumoPages(page)
     staff_user = utilities.staff_user
 
-    sumo_pages.top_navbar.click_on_signin_signup_button()
-    # Also acts as a wait. Introduced in order to avoid flakiness which occurred on some
-    # GH runs.
-    expect(sumo_pages.auth_page.continue_with_firefox_accounts_button).to_be_visible()
-
     sumo_pages.auth_flow_page.sign_in_flow(
-        username=staff_user,
-        account_password=utilities.user_secrets_pass
+        username=staff_user, account_password=utilities.user_secrets_pass, via_top_navbar=True
     )
     expect(sumo_pages.top_navbar.signed_in_username).to_have_text(
         utilities.username_extraction_from_email(staff_user)
     )
     utilities.store_session_cookies(utilities.username_extraction_from_email(staff_user))
+
+@pytest.mark.loginSessions
+def test_new_account_creation(page: Page, restmail_test_account_creation):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    username, password = restmail_test_account_creation
+
+    with check, allure.step("Verifying that the correct username is displayed inside the"
+                            " top-navbar and the correct user message banner is displayed"):
+        utilities.wait_for_url_to_be(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US, 20000)
+
+        expect(sumo_pages.top_navbar.signed_in_username).to_have_text(
+            utilities.username_extraction_from_email(username)
+        )
+        assert (sumo_pages.homepage.get_user_notification() == HomepageMessages.
+                NEW_USER_REGISTRATION_MESSAGE)


### PR DESCRIPTION
- Add restmail account creation logic back and integrate it with the existing gmail one.
- Add fxa page specific locators & actions.
- Add homepage locators & actions related to the user notification banner.
- Add a fixture that creates a restmail test account and deletes it on teardown.
- Expand playwright loginSessions coverage by adding a test that verifies if new SuMo accounts can be successfully created.