### PR TITLE
Introduce search reindex api for playwright usage

### DIFF
--- a/kitsune/search/api.py
+++ b/kitsune/search/api.py
@@ -1,0 +1,75 @@
+import json
+
+from django.conf import settings
+from django.http import Http404, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+from kitsune.access.decorators import group_required
+from kitsune.search.es_utils import get_doc_types
+
+
+@group_required("Staff")
+@require_POST
+@csrf_exempt
+def reindex_document(request):
+    """
+    Force-reindex a specific document in Elasticsearch and refresh the index
+    so it becomes immediately searchable.
+
+    Testing-only endpoint, gated behind DEV + ENABLE_TESTING_ENDPOINTS.
+
+    Expects JSON body:
+        {
+            "doc_type": "WikiDocument",  # required
+            "obj_id": 12345              # required
+        }
+    """
+    if not (settings.DEV and settings.ENABLE_TESTING_ENDPOINTS):
+        raise Http404
+
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({"message": "Invalid JSON payload."}, status=400)
+
+    doc_type_name = data.get("doc_type")
+    obj_id = data.get("obj_id")
+
+    if not (doc_type_name and obj_id):
+        return JsonResponse(
+            {"message": 'Invalid JSON payload (missing "doc_type" or "obj_id").'},
+            status=400,
+        )
+
+    # Validate doc_type is a known document type.
+    valid_doc_types = {cls.__name__: cls for cls in get_doc_types()}
+    doc_type = valid_doc_types.get(doc_type_name)
+    if doc_type is None:
+        return JsonResponse(
+            {
+                "message": f'Unknown doc_type "{doc_type_name}". '
+                f"Valid types: {', '.join(sorted(valid_doc_types.keys()))}."
+            },
+            status=400,
+        )
+
+    # Look up the ORM object.
+    model = doc_type.get_model()
+    try:
+        obj = model.objects.get(pk=obj_id)
+    except model.DoesNotExist:
+        return JsonResponse(
+            {"message": f"{doc_type_name} with id {obj_id} does not exist."},
+            status=404,
+        )
+
+    # Index the document synchronously with refresh=True so it's immediately searchable.
+    if doc_type.update_document:
+        doc_type.prepare(obj).to_action("update", doc_as_upsert=True, refresh=True)
+    else:
+        doc_type.prepare(obj).to_action("index", refresh=True)
+
+    return JsonResponse(
+        {"message": f"{doc_type_name} {obj_id} has been indexed and refreshed."}
+    )

--- a/kitsune/search/urls.py
+++ b/kitsune/search/urls.py
@@ -1,8 +1,18 @@
+from django.conf import settings
 from django.urls import re_path
 
-from kitsune.search import views
+from kitsune.search import api, views
 
 urlpatterns = [
     re_path(r"^$", views.simple_search, name="search"),
     re_path(r"^xml$", views.opensearch_plugin, name="search.plugin"),
 ]
+
+if settings.ENABLE_TESTING_ENDPOINTS:
+    urlpatterns += [
+        re_path(
+            r"^api/reindex-document$",
+            api.reindex_document,
+            name="search.api.reindex_document",
+        ),
+    ]

--- a/playwright_tests/tests/search_tests/test_main_searchbar.py
+++ b/playwright_tests/tests/search_tests/test_main_searchbar.py
@@ -202,7 +202,9 @@ def test_searchbar_functionality_and_search_filters(page: Page, create_user_fact
             repliant_username=test_user["username"],
             reply=utilities.aaq_question_test_data['valid_firefox_question']['question_reply']
         )
-        utilities.wait_for_given_timeout(65000)
+        question_id = utilities.number_extraction_from_string(
+            question_info["question_id"])
+        utilities.reindex_document("QuestionDocument", question_id)
         sumo_pages.search_page.fill_into_searchbar(test_article_name, is_sidebar=True)
 
     product_filter = sumo_pages.search_page.get_the_highlighted_side_nav_item()


### PR DESCRIPTION
Search related playwright tests are slow due to the need of waiting for the default reindex to kick in. 

This PR tries to solve that issue by creating a secured endpoint which should trigger a reindex when called (only against a given obj_id)