### PR TITLE
improve support configuration

### DIFF
--- a/kitsune/community/views.py
+++ b/kitsune/community/views.py
@@ -11,8 +11,7 @@ from kitsune.community.utils import (
     top_contributors_questions,
 )
 from kitsune.forums.models import Thread
-from kitsune.products.models import Product
-from kitsune.questions.models import AAQConfig
+from kitsune.products.models import Product, ProductSupportConfig
 from kitsune.search.base import SumoSearchPaginator
 from kitsune.search.search import ProfileSearch
 from kitsune.sumo.parser import get_object_fallback
@@ -59,7 +58,7 @@ def home(request):
 
         # If the locale is enabled for the Support Forum, show the top
         # contributors for that locale
-        if locale in AAQConfig.objects.locales_list():
+        if locale in ProductSupportConfig.objects.locales_list():
             data["top_contributors_questions"], _ = top_contributors_questions(
                 locale=locale, product=product
             )
@@ -117,7 +116,7 @@ def top_contributors(request, area):
             results, total = top_contributors_questions(
                 locale=locale, product=product, count=page_size, page=page
             )
-            locales = AAQConfig.objects.locales_list()
+            locales = ProductSupportConfig.objects.locales_list()
         case "kb":
             results, total = top_contributors_kb(product=product, count=page_size, page=page)
             locales = None

--- a/kitsune/dashboards/readouts.py
+++ b/kitsune/dashboards/readouts.py
@@ -22,7 +22,7 @@ from markupsafe import Markup
 
 from kitsune.dashboards import LAST_30_DAYS, PERIODS
 from kitsune.dashboards.models import WikiDocumentVisits
-from kitsune.questions.models import AAQConfig
+from kitsune.products.models import ProductSupportConfig
 from kitsune.sumo.redis_utils import RedisError, redis_client
 from kitsune.sumo.templatetags.jinja_helpers import urlparams
 from kitsune.sumo.urlresolvers import reverse
@@ -400,7 +400,10 @@ def l10n_overview_rows(locale, product=None, user=None):
             "percent": percent_or_100(top_20_translated, 20 if total_docs > 20 else total_docs),
             # L10n: This is an entry description for the Overview table, displayed on
             # https://support.mozilla.org/localization (for non-en-US locales).
-            "description": _("These are the top 20 most visited articles in the last 30 days, which account for over 50% of the traffic to the Knowledge Base."),
+            "description": _(
+                "These are the top 20 most visited articles in the last 30 days, which "
+                "account for over 50% of the traffic to the Knowledge Base."
+            ),
         },
         "top-50": {
             # L10n: This is an entry header for the Overview table, displayed on
@@ -411,7 +414,7 @@ def l10n_overview_rows(locale, product=None, user=None):
             "percent": percent_or_100(top_50_translated, 50 if total_docs > 50 else total_docs),
             # L10n: This is an entry description for the Overview table, displayed on
             # https://support.mozilla.org/localization (for non-en-US locales).
-            "description": _("These are the top 50 most visited articles " "in the last 30 days."),
+            "description": _("These are the top 50 most visited articles in the last 30 days."),
         },
         "top-100": {
             # L10n: This is an entry header for the Overview table, displayed on
@@ -422,7 +425,10 @@ def l10n_overview_rows(locale, product=None, user=None):
             "percent": percent_or_100(top_100_translated, 100 if total_docs > 100 else total_docs),
             # L10n: This is an entry description for the Overview table, displayed on
             # https://support.mozilla.org/localization (for non-en-US locales).
-            "description": _("These are the top 100 most visited articles in the last 30 days, which account for over 99% of the traffic to the Knowledge Base."),
+            "description": _(
+                "These are the top 100 most visited articles in the last 30 days, "
+                "which account for over 99% of the traffic to the Knowledge Base."
+            ),
         },
         "templates": {
             # This string is reused in different contexts, so we should avoid providing an l10n comment.
@@ -433,7 +439,11 @@ def l10n_overview_rows(locale, product=None, user=None):
             "percent": percent_or_100(translated_templates, total_templates),
             # L10n: This is an entry description for the Overview table, displayed on
             # https://support.mozilla.org/localization (for non-en-US locales).
-            "description": _("Templates are a way of reusing pieces of content across KB articles. You can create and update a set of instructions in one place, and then refer to it in other pages."),
+            "description": _(
+                "Templates are a way of reusing pieces of content across KB articles. "
+                "You can create and update a set of instructions in one place, and then "
+                "refer to it in other pages."
+            ),
         },
         "all": {
             # L10n: This is an entry header for the Overview table, displayed on
@@ -444,7 +454,9 @@ def l10n_overview_rows(locale, product=None, user=None):
             "percent": percent_or_100(translated_docs, total_docs),
             # L10n: This is an entry description for the Overview table, displayed on
             # https://support.mozilla.org/localization (for non-en-US locales).
-            "description": _("This is the number of all Knowledge Base articles that are ready to be localized."),
+            "description": _(
+                "This is the number of all Knowledge Base articles that are ready to be localized."
+            ),
         },
     }
 
@@ -512,7 +524,7 @@ class Readout:
             visits = r["visits"]
             r["percent"] = (
                 0
-                if visits is None or not max_visits
+                if (visits is None or not max_visits)
                 else round(visits / float(max_visits) * 100)
             )
 
@@ -1121,7 +1133,9 @@ class UnhelpfulReadout(Readout):
                 return None
 
         helpfulness = Markup(
-            '<span title="{:+.1f}%">{:.1f}%</span>'.format(float(result[3]) * 100, float(result[2]) * 100)
+            '<span title="{:+.1f}%">{:.1f}%</span>'.format(
+                float(result[3]) * 100, float(result[2]) * 100
+            )
         )
         return {
             "title": str(result[6]),
@@ -1140,7 +1154,9 @@ class UnreadyForLocalizationReadout(Readout):
     title = _lazy("Changes Not Ready For Localization")
     # L10n: Unused. This is a description for the Changes Not Ready For Localization table,
     # displayed on https://support.mozilla.org/contributors/unready.
-    description = _lazy("Articles which have approved revisions newer than the latest ready-for-localization one")
+    description = _lazy(
+        "Articles which have approved revisions newer than the latest ready-for-localization one"
+    )
     # No short_title; the Contributors dash lacks an Overview readout
     # L10n: Unused. This is a link to be displayed under the Changes Not Ready For Localization overview table,
     # which redirects users to the full Changes Not Ready For Localization table (https://support.mozilla.org/contributors/unready).
@@ -1274,7 +1290,7 @@ class CannedResponsesReadout(Readout):
 
     @classmethod
     def should_show_to(cls, request):
-        return request.LANGUAGE_CODE in AAQConfig.objects.locales_list()
+        return request.LANGUAGE_CODE in ProductSupportConfig.objects.locales_list()
 
     def get_queryset(self, max=None):
         qs = (
@@ -1366,7 +1382,8 @@ READOUTS = L10N_READOUTS.copy()
 READOUTS.update(CONTRIBUTOR_READOUTS)
 
 GROUP_L10N_READOUTS = OrderedDict(
-    (t.slug, t) for t in [MostVisitedTranslationsReadout, UnreviewedReadout]  # type: ignore
+    (t.slug, t)  # type: ignore
+    for t in [MostVisitedTranslationsReadout, UnreviewedReadout]
 )
 # English group locale is the same as l10n dashboard.
 GROUP_CONTRIBUTOR_READOUTS = CONTRIBUTOR_READOUTS

--- a/kitsune/flagit/views.py
+++ b/kitsune/flagit/views.py
@@ -320,7 +320,11 @@ def moderate_content(request):
             "objects": objects,
             "locale": request.LANGUAGE_CODE,
             "products": [
-                (p.slug, p.title) for p in Product.active.filter(aaq_configs__is_active=True)
+                (p.slug, p.title)
+                for p in Product.active.filter(
+                    support_configs__is_active=True,
+                    support_configs__forum_config__enabled_locales__isnull=False,
+                ).distinct()
             ],
             "selected_product": product_slug,
             "assignees": sorted(

--- a/kitsune/products/admin.py
+++ b/kitsune/products/admin.py
@@ -181,6 +181,7 @@ class ZendeskTopicConfigurationInline(admin.TabularInline):
     Inline editor for topic-to-config associations.
     Shows which topics are included in this config with their settings.
     """
+
     model = ZendeskTopicConfiguration
     extra = 1
     autocomplete_fields = ("zendesk_topic",)
@@ -200,7 +201,13 @@ class ZendeskTopicAdmin(admin.ModelAdmin):
 
 
 class ZendeskConfigAdmin(admin.ModelAdmin):
-    list_display = ("name", "ticket_form_id", "enable_os_field", "skip_spam_moderation", "topic_count")
+    list_display = (
+        "name",
+        "ticket_form_id",
+        "enable_os_field",
+        "skip_spam_moderation",
+        "topic_count",
+    )
     list_display_links = ("name",)
     list_editable = ("enable_os_field", "skip_spam_moderation")
     list_filter = ("enable_os_field", "skip_spam_moderation")
@@ -309,19 +316,27 @@ class ProductSupportConfigAdmin(admin.ModelAdmin):
         if not obj.zendesk_config:
             return "—"
 
-        topic_configs = obj.zendesk_config.topic_configurations.all().select_related("zendesk_topic")
+        topic_configs = obj.zendesk_config.topic_configurations.all().select_related(
+            "zendesk_topic"
+        )
         if not topic_configs:
             return format_html("<em>No topics configured</em>")
 
         topic_items = []
         for topic_config in topic_configs:
             topic = topic_config.zendesk_topic
-            loginless_badge = " <span style='color: #666;'>(loginless only)</span>" if topic_config.loginless_only else ""
+            loginless_badge = (
+                " <span style='color: #666;'>(loginless only)</span>"
+                if topic_config.loginless_only
+                else ""
+            )
             topic_items.append(
                 f"<li><strong>{topic.slug}</strong>: {topic.topic}{loginless_badge}</li>"
             )
 
-        return format_html("<ul style='margin: 0; padding-left: 20px;'>{}</ul>", "".join(topic_items))
+        return format_html(
+            "<ul style='margin: 0; padding-left: 20px;'>{}</ul>", "".join(topic_items)
+        )
 
 
 class ZendeskTopicConfigurationAdmin(admin.ModelAdmin):

--- a/kitsune/products/managers.py
+++ b/kitsune/products/managers.py
@@ -13,7 +13,7 @@ class ProductManager(NonArchivedManager):
     def with_question_forums(self, language_code: str = ""):
         q_kwargs: dict[str, Any] = {
             "support_configs__is_active": True,
-            "support_configs__forum_config__is_active": True,
+            "support_configs__forum_config__enabled_locales__isnull": False,
         }
 
         if language_code:

--- a/kitsune/products/tests/test_support_routing.py
+++ b/kitsune/products/tests/test_support_routing.py
@@ -33,7 +33,7 @@ class SupportRoutingTests(TestCase):
 
     def test_forum_only_routing(self):
         """Forum-only product returns (SUPPORT_TYPE_FORUM, False)."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         ProductSupportConfigFactory(
             product=self.product,
             forum_config=aaq_config,
@@ -73,7 +73,7 @@ class SupportRoutingTests(TestCase):
 
     def test_hybrid_no_groups_default_forum(self):
         """Hybrid product with no groups defaults to forum, allows switching."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         zendesk_config = ZendeskConfigFactory()
         ProductSupportConfigFactory(
             product=self.product,
@@ -95,7 +95,7 @@ class SupportRoutingTests(TestCase):
 
     def test_hybrid_no_groups_default_zendesk(self):
         """Hybrid product with no groups defaults to Zendesk, allows switching."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         zendesk_config = ZendeskConfigFactory()
         ProductSupportConfigFactory(
             product=self.product,
@@ -117,7 +117,7 @@ class SupportRoutingTests(TestCase):
 
     def test_hybrid_no_groups_honors_requested_type(self):
         """Hybrid product with no groups honors requested_type query param."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         zendesk_config = ZendeskConfigFactory()
         ProductSupportConfigFactory(
             product=self.product,
@@ -139,7 +139,7 @@ class SupportRoutingTests(TestCase):
 
     def test_hybrid_with_groups_user_not_in_group(self):
         """Hybrid with groups: user NOT in group is locked to default."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         zendesk_config = ZendeskConfigFactory()
         group = GroupFactory(name="beta-testers")
         config = ProductSupportConfigFactory(
@@ -163,7 +163,7 @@ class SupportRoutingTests(TestCase):
 
     def test_hybrid_with_groups_user_in_group_can_switch(self):
         """Hybrid with groups: user IN group can switch."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         zendesk_config = ZendeskConfigFactory()
         group = GroupFactory(name="beta-testers")
         config = ProductSupportConfigFactory(
@@ -190,7 +190,7 @@ class SupportRoutingTests(TestCase):
 
     def test_hybrid_group_default_override(self):
         """Hybrid with groups: group_default_support_type overrides default."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         zendesk_config = ZendeskConfigFactory()
         group = GroupFactory(name="beta-testers")
         config = ProductSupportConfigFactory(
@@ -219,7 +219,7 @@ class SupportRoutingTests(TestCase):
 
     def test_invalid_requested_type_ignored(self):
         """Invalid requested_type query param is ignored."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         zendesk_config = ZendeskConfigFactory()
         ProductSupportConfigFactory(
             product=self.product,
@@ -242,7 +242,7 @@ class SupportRoutingTests(TestCase):
 
     def test_anonymous_user_hybrid_no_groups(self):
         """Anonymous user on hybrid product with no groups can switch."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         zendesk_config = ZendeskConfigFactory()
         ProductSupportConfigFactory(
             product=self.product,
@@ -264,7 +264,7 @@ class SupportRoutingTests(TestCase):
 
     def test_anonymous_user_hybrid_with_groups(self):
         """Anonymous user on hybrid with groups is locked to default."""
-        aaq_config = AAQConfigFactory(product=self.product)
+        aaq_config = AAQConfigFactory()
         zendesk_config = ZendeskConfigFactory()
         group = GroupFactory(name="beta-testers")
         config = ProductSupportConfigFactory(

--- a/kitsune/questions/migrations/0024_remove_aaqconfig_unique_active_config_and_more.py
+++ b/kitsune/questions/migrations/0024_remove_aaqconfig_unique_active_config_and_more.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("questions", "0023_alter_answer_created_alter_answer_updated_and_more"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="aaqconfig",
+            name="unique_active_config",
+        ),
+        migrations.RemoveField(
+            model_name="aaqconfig",
+            name="product",
+        ),
+        migrations.RemoveField(
+            model_name="aaqconfig",
+            name="is_active",
+        ),
+    ]

--- a/kitsune/questions/tests/__init__.py
+++ b/kitsune/questions/tests/__init__.py
@@ -1,7 +1,6 @@
 import factory
 from django.utils import timezone
 
-from kitsune.products.tests import ProductFactory
 from kitsune.questions.models import (
     AAQConfig,
     Answer,
@@ -66,8 +65,6 @@ class AAQConfigFactory(factory.django.DjangoModelFactory):
         model = AAQConfig
 
     title = FuzzyUnicode()
-    product = factory.SubFactory(ProductFactory)
-    is_active = True
 
     @factory.post_generation
     def enabled_locales(self, create, extracted, **kwargs):

--- a/kitsune/questions/tests/test_api.py
+++ b/kitsune/questions/tests/test_api.py
@@ -8,7 +8,8 @@ from django.utils import timezone
 from rest_framework.exceptions import APIException
 from rest_framework.test import APIClient
 
-from kitsune.products.tests import ProductFactory, TopicFactory
+from kitsune.products.models import ProductSupportConfig
+from kitsune.products.tests import ProductFactory, ProductSupportConfigFactory, TopicFactory
 from kitsune.questions import api
 from kitsune.questions.models import Answer, Question
 from kitsune.questions.tests import (
@@ -521,7 +522,13 @@ class TestQuestionViewSet(TestCase):
         """Test that questions created via the API are auto-tagged."""
         tag = TagFactory(name="desktop")
         product = ProductFactory()
-        AAQConfigFactory(product=product, is_active=True, associated_tags=[tag])
+        aaq_config = AAQConfigFactory(associated_tags=[tag])
+        ProductSupportConfigFactory(
+            product=product,
+            forum_config=aaq_config,
+            is_active=True,
+            default_support_type=ProductSupportConfig.SUPPORT_TYPE_FORUM,
+        )
 
         q = QuestionFactory(product=product)
         self.client.force_authenticate(user=q.creator)

--- a/kitsune/questions/tests/test_forms.py
+++ b/kitsune/questions/tests/test_forms.py
@@ -3,7 +3,8 @@ import json
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 
-from kitsune.products.tests import ProductFactory, TopicFactory
+from kitsune.products.models import ProductSupportConfig
+from kitsune.products.tests import ProductFactory, ProductSupportConfigFactory, TopicFactory
 from kitsune.questions.forms import NewQuestionForm, WatchQuestionForm
 from kitsune.questions.tests import AAQConfigFactory, QuestionLocaleFactory
 from kitsune.sumo.tests import TestCase
@@ -43,10 +44,14 @@ class TestNewQuestionForm(TestCase):
         self.locale = QuestionLocaleFactory(locale=settings.LANGUAGE_CODE)
         self.product = ProductFactory(slug="firefox")
         self.aaq_config = AAQConfigFactory(
-            product=self.product,
             enabled_locales=[self.locale],
-            is_active=True,
             extra_fields=["troubleshooting", "ff_version", "os"],
+        )
+        ProductSupportConfigFactory(
+            product=self.product,
+            forum_config=self.aaq_config,
+            is_active=True,
+            default_support_type=ProductSupportConfig.SUPPORT_TYPE_FORUM,
         )
 
     def test_metadata_keys(self):

--- a/kitsune/questions/tests/test_templates.py
+++ b/kitsune/questions/tests/test_templates.py
@@ -1235,7 +1235,13 @@ class QuestionEditingTests(TestCase):
         """The edit-question form should show appropriate metadata fields."""
         product = ProductFactory()
         question_id = QuestionFactory(product=product).id
-        AAQConfigFactory(product=product)
+        aaq_config = AAQConfigFactory()
+        ProductSupportConfigFactory(
+            product=product,
+            forum_config=aaq_config,
+            is_active=True,
+            default_support_type=ProductSupportConfig.SUPPORT_TYPE_FORUM,
+        )
         response = get(self.client, "questions.edit_question", kwargs={"question_id": question_id})
         self.assertEqual(response.status_code, 200)
 
@@ -1262,7 +1268,13 @@ class QuestionEditingTests(TestCase):
         """Posting a valid edit form should save the question."""
         p = ProductFactory(slug="firefox")
         q = QuestionFactory(product=p)
-        AAQConfigFactory(product=p)
+        aaq_config = AAQConfigFactory()
+        ProductSupportConfigFactory(
+            product=p,
+            forum_config=aaq_config,
+            is_active=True,
+            default_support_type=ProductSupportConfig.SUPPORT_TYPE_FORUM,
+        )
         response = post(
             self.client,
             "questions.edit_question",
@@ -1325,7 +1337,7 @@ class AAQTemplateTestCase(TestCase):
 
         self.user = UserFactory()
         self.product = ProductFactory(title="Firefox", slug="firefox")
-        self.aaq_config = AAQConfigFactory(product=self.product, is_active=True)
+        self.aaq_config = AAQConfigFactory()
         # Create ProductSupportConfig for routing
         ProductSupportConfigFactory(
             product=self.product,
@@ -1420,12 +1432,8 @@ class ProductForumTemplateTestCase(TestCase):
         mza = ProductFactory(title="Mozilla Account", slug="mozilla-account")
 
         lcl, _ = QuestionLocale.objects.get_or_create(locale=settings.LANGUAGE_CODE)
-        firefox_forum_config = AAQConfigFactory(
-            product=firefox, is_active=True, enabled_locales=[lcl]
-        )
-        android_forum_config = AAQConfigFactory(
-            product=android, is_active=True, enabled_locales=[lcl]
-        )
+        firefox_forum_config = AAQConfigFactory(enabled_locales=[lcl])
+        android_forum_config = AAQConfigFactory(enabled_locales=[lcl])
 
         ProductSupportConfigFactory(product=firefox, forum_config=firefox_forum_config)
         ProductSupportConfigFactory(product=android, forum_config=android_forum_config)

--- a/kitsune/sumo/context_processors.py
+++ b/kitsune/sumo/context_processors.py
@@ -1,8 +1,7 @@
-
 from django.conf import settings
 from django.utils import timezone, translation
 
-from kitsune.questions.models import AAQConfig
+from kitsune.products.models import ProductSupportConfig
 
 
 def global_settings(request):
@@ -21,7 +20,7 @@ def i18n(request):
 
 def aaq_languages(request):
     """Adds the list of AAQ languages to the context."""
-    return {"AAQ_LANGUAGES": AAQConfig.objects.locales_list()}
+    return {"AAQ_LANGUAGES": ProductSupportConfig.objects.locales_list()}
 
 
 def current_year(request):

--- a/kitsune/sumo/tests/test_utils.py
+++ b/kitsune/sumo/tests/test_utils.py
@@ -340,20 +340,21 @@ class WebpackStaticTests(TestCase):
 class HasSupportConfigTests(TestCase):
     def test_product_support_config_inactive(self):
         from kitsune.products.tests import ProductFactory, ProductSupportConfigFactory
-        from kitsune.questions.tests import AAQConfigFactory
+        from kitsune.questions.tests import AAQConfigFactory, QuestionLocaleFactory
 
         product = ProductFactory()
-        aaq_config = AAQConfigFactory(product=product, is_active=True)
+        locale = QuestionLocaleFactory(locale="en-US")
+        aaq_config = AAQConfigFactory(enabled_locales=[locale])
         ProductSupportConfigFactory(product=product, forum_config=aaq_config, is_active=False)
 
         self.assertFalse(has_support_config(product))
 
-    def test_aaq_config_inactive(self):
+    def test_forum_config_no_locales(self):
         from kitsune.products.tests import ProductFactory, ProductSupportConfigFactory
         from kitsune.questions.tests import AAQConfigFactory
 
         product = ProductFactory()
-        aaq_config = AAQConfigFactory(product=product, is_active=False)
+        aaq_config = AAQConfigFactory()
         ProductSupportConfigFactory(product=product, forum_config=aaq_config, is_active=True)
 
         self.assertFalse(has_support_config(product))
@@ -373,10 +374,11 @@ class HasSupportConfigTests(TestCase):
 
     def test_forum_support_active(self):
         from kitsune.products.tests import ProductFactory, ProductSupportConfigFactory
-        from kitsune.questions.tests import AAQConfigFactory
+        from kitsune.questions.tests import AAQConfigFactory, QuestionLocaleFactory
 
         product = ProductFactory()
-        aaq_config = AAQConfigFactory(product=product, is_active=True)
+        locale = QuestionLocaleFactory(locale="en-US")
+        aaq_config = AAQConfigFactory(enabled_locales=[locale])
         ProductSupportConfigFactory(product=product, forum_config=aaq_config, is_active=True)
 
         self.assertTrue(has_support_config(product))

--- a/kitsune/sumo/utils.py
+++ b/kitsune/sumo/utils.py
@@ -406,15 +406,15 @@ def has_support_config(product=None):
         except Product.DoesNotExist:
             return False
 
-    # Check ProductSupportConfig with either:
-    # 1. Active forum support (AAQConfig.is_active=True), OR
+    # Check for the existence of a ProductSupportConfig with either:
+    # 1. Forum support with at least one enabled locale, OR
     # 2. Zendesk support configured
     return (
         ProductSupportConfig.objects.filter(
             product=product,
             is_active=True,
         )
-        .filter(Q(forum_config__is_active=True) | Q(zendesk_config__isnull=False))
+        .filter(Q(forum_config__enabled_locales__isnull=False) | Q(zendesk_config__isnull=False))
         .exists()
     )
 

--- a/kitsune/wiki/tests/test_utils.py
+++ b/kitsune/wiki/tests/test_utils.py
@@ -10,7 +10,8 @@ from requests.exceptions import HTTPError
 
 from kitsune.dashboards import LAST_7_DAYS
 from kitsune.dashboards.models import WikiDocumentVisits
-from kitsune.products.tests import ProductFactory, TopicFactory
+from kitsune.products.models import ProductSupportConfig
+from kitsune.products.tests import ProductFactory, ProductSupportConfigFactory, TopicFactory
 from kitsune.questions.tests import AAQConfigFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.users.tests import GroupFactory, UserFactory
@@ -999,8 +1000,20 @@ class GetPinnedArticlesTests(TestCase):
         self.user_g1 = UserFactory(groups=[group1])
         self.product1 = ProductFactory(slug="firefox")
         self.product2 = ProductFactory(slug="mobile")
-        self.aaq_config1 = AAQConfigFactory(product=self.product1)
-        self.aaq_config2 = AAQConfigFactory(product=self.product2)
+        self.aaq_config1 = AAQConfigFactory()
+        self.aaq_config2 = AAQConfigFactory()
+        ProductSupportConfigFactory(
+            product=self.product1,
+            forum_config=self.aaq_config1,
+            is_active=True,
+            default_support_type=ProductSupportConfig.SUPPORT_TYPE_FORUM,
+        )
+        ProductSupportConfigFactory(
+            product=self.product2,
+            forum_config=self.aaq_config2,
+            is_active=True,
+            default_support_type=ProductSupportConfig.SUPPORT_TYPE_FORUM,
+        )
 
         self.en_doc = ApprovedRevisionFactory(
             document__locale="en-US",

--- a/kitsune/wiki/utils.py
+++ b/kitsune/wiki/utils.py
@@ -122,7 +122,10 @@ def get_pinned_articles(
     qs = PinnedArticleConfig.objects
 
     if fetch_for_aaq:
-        qs = qs.filter(aaq_configs__product=product, aaq_configs__is_active=True)
+        qs = qs.filter(
+            aaq_configs__support_configs__product=product,
+            aaq_configs__support_configs__is_active=True,
+        )
     elif product:
         qs = qs.filter(products=product)
     else:


### PR DESCRIPTION
mozilla/sumo#2721

## Highlights
- The `ProductSupportConfig` is now the sole source of **product** support information. It's the only support-related config that can be associated with a product and activated/deactivated.
- The `AAQConfig` is no longer activated/deactivated and no longer directly associated with a product. It's associated with a product only by associating it with a `ProductSupportConfig` instance. A single `AAQConfig` may be used within any number of `ProductSupportConfig` instances.
- A `ProductSupportConfig` instance cannot be activated unless it has at least one support channel (Zendesk or forum), and also, if it has a forum support channel, that forum config must have at least one enabled locale.
- Assumes that `ProductSupportConfig` instances are created only via the admin console (not programmatically), so enforces validation only during `clean`, not `save`.