### PR TITLE
Playwright test and framework improvements v1

### DIFF
--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -17,13 +17,6 @@ class BasePage:
             self.wait_for_dom_to_load()
         return self.page.locator(xpath)
 
-    def _get_elements_locators(self, xpath: str) -> list[Locator]:
-        """
-        This helper function returns a list of element locators from a given xpath.
-        """
-        self.wait_for_dom_to_load()
-        return self.page.locator(xpath).all()
-
     def _get_current_page_url(self) -> str:
         """
         This helper function returns the current page URL.
@@ -56,12 +49,6 @@ class BasePage:
         This helper function returns the inner text of a given locator.
         """
         self.wait_for_dom_to_load()
-        return locator.inner_text()
-
-    def _get_text_of_locator(self, locator: Locator) -> str:
-        """
-        This helper function returns the inner text of a given locator.
-        """
         return locator.inner_text()
 
     def _is_element_empty(self, locator: Locator) -> bool:
@@ -105,12 +92,6 @@ class BasePage:
         This helper function returns the input value of a given element locator.
         """
         return locator.input_value()
-
-    def _get_element_inner_text_from_page(self, locator: Locator) -> str:
-        """
-        This helper function returns the inner text of a given locator via the page instance.
-        """
-        return locator.inner_text()
 
     def _get_element_text_content(self, locator: Locator) -> str:
         """
@@ -284,12 +265,6 @@ class BasePage:
         else:
             return False
 
-    def _is_locator_visible(self, locator: Locator) -> bool:
-        """
-        This helper function checks if the given locator is visible.
-        """
-        return locator.is_visible()
-
     def _is_checkbox_checked(self, locator: Locator) -> bool:
         """
         This helper function checks if a given element locator is checked.
@@ -341,15 +316,6 @@ class BasePage:
         y (int): The y-coordinate.
         """
         self.page.mouse.move(x, y)
-
-    def wait_for_page_to_load(self):
-        """
-        This helper function awaits for the load event to be fired.
-        """
-        try:
-            self.page.wait_for_load_state("load")
-        except PlaywrightTimeoutError:
-            print("Load event was not fired. Continuing...")
 
     def eval_on_selector_for_last_child_text(self, element: str) -> str:
         """

--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_article_flow.py
@@ -229,6 +229,7 @@ class AddKbArticleFlow:
             significance_options[significance_type]()
 
         self.kb_article_review_revision_page.click_accept_revision_accept_button()
+        self.kb_article_show_history_page.is_revision_current(revision_id)
 
     @retry_on_502
     def submit_new_kb_revision(self, keywords=None, search_result_summary=None, content=None,

--- a/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/edit_article_meta_flow.py
@@ -92,6 +92,7 @@ class EditArticleMetaFlow:
                 self.kb_article_edit_metadata_page.add_related_documents(document)
 
         self.kb_article_edit_metadata_page.click_on_save_changes_button()
+        self.utilities.wait_for_page_to_load()
 
     @retry_on_502
     def remove_a_restricted_visibility_group(self, groups:[str, list[str]]):
@@ -102,3 +103,4 @@ class EditArticleMetaFlow:
             self.edit_kb_article_page.click_on_edit_anyway_option()
         self.kb_article_edit_metadata_page.delete_a_restricted_visibility_group_metadata(groups)
         self.kb_article_edit_metadata_page.click_on_save_changes_button()
+        self.utilities.wait_for_page_to_load()

--- a/playwright_tests/messages/contribute_messages/con_tools/kb_dashboard_messages.py
+++ b/playwright_tests/messages/contribute_messages/con_tools/kb_dashboard_messages.py
@@ -3,5 +3,6 @@ class KBDashboardPageMessages:
     GENERAL_NEGATIVE_STATUS = "No"
     GENERAL_POSITIVE_STATUS = "Yes"
 
-    def get_kb_not_live_status(self, revision_note: str) -> str:
+    @staticmethod
+    def get_kb_not_live_status(revision_note: str) -> str:
         return f"Review Needed: {revision_note}"

--- a/playwright_tests/messages/my_profile_pages_messages/my_profile_page_messages.py
+++ b/playwright_tests/messages/my_profile_pages_messages/my_profile_page_messages.py
@@ -4,5 +4,6 @@ class MyProfileMessages:
     COMMUNITY_PORTAL_LINK = "https://community.mozilla.org"
     PEOPLE_DIRECTORY_LINK = "https://people.mozilla.org"
 
-    def get_my_profile_stage_url(self: str) -> str:
-        return f"https://support.allizom.org/en-US/user/{self}/"
+    @staticmethod
+    def get_my_profile_stage_url(username: str) -> str:
+        return f"https://support.allizom.org/en-US/user/{username}/"

--- a/playwright_tests/messages/user_groups_messages.py
+++ b/playwright_tests/messages/user_groups_messages.py
@@ -4,73 +4,39 @@ class UserGroupMessages:
                                "replace the current one.")
     GROUP_INFORMATION_UPDATE_NOTIFICATION = "Group information updated successfully!"
 
-    def get_user_added_success_message(self: str, to_leaders=False) -> str:
-        """Get the user added success message.
-
-        Args:
-            username (str): The username of the user added to the group
-            to_leaders (bool, optional): If True, the user was added to the leaders. Defaults to
-            False.
-        """
+    @staticmethod
+    def get_user_added_success_message(username: str, to_leaders=False) -> str:
         if to_leaders:
-            return f"{self} added to the group leaders successfully!"
+            return f"{username} added to the group leaders successfully!"
         else:
-            return f"{self} added to the group successfully!"
+            return f"{username} added to the group successfully!"
 
-    def get_user_removed_success_message(self: str, from_leaders=False) -> str:
-        """Get the user removed success message.
-
-        Args:
-            username (str): The username of the user removed from the group
-            from_leaders (bool, optional): If True, the user was removed from the leaders. Defaults
-            to False.
-        """
+    @staticmethod
+    def get_user_removed_success_message(username: str, from_leaders=False) -> str:
         if from_leaders:
-            return f"{self} removed from the group leaders successfully!"
+            return f"{username} removed from the group leaders successfully!"
         else:
-            return f"{self} removed from the group successfully!"
+            return f"{username} removed from the group successfully!"
 
-    def get_change_avatar_page_header(self: str) -> str:
-        """Get the change avatar page header.
+    @staticmethod
+    def get_change_avatar_page_header(group_name: str) -> str:
+        return f"Change {group_name} group avatar"
 
-        Args:
-            user_group (str): The group name.
-        """
-        return f"Change {self} group avatar"
+    @staticmethod
+    def get_change_uploaded_avatar_page_header(group_name: str) -> str:
+        return f"Change {group_name} group avatar"
 
-    def get_change_uploaded_avatar_page_header(self: str) -> str:
-        """Get the change uploaded avatar page header.
+    @staticmethod
+    def get_delete_uploaded_avatar_page_header(group_name: str) -> str:
+        return f"Are you sure you want to delete the {group_name} group avatar?"
 
-        Args:
-            user_group (str): The group name.
-        """
-        return f"Change {self} group avatar"
-
-    def get_delete_uploaded_avatar_page_header(self: str) -> str:
-        """Get the delete uploaded avatar page header.
-
-        Args:
-            user_group (str): The group name.
-        """
-        return f"Are you sure you want to delete the {self} group avatar?"
-
-    def get_delete_user_header(self: str, group: str, delete_leader=False) -> str:
-        """Get the delete user page header.
-
-        Args:
-            username (str): The username of the user to delete.
-            group (str): The group name.
-            delete_leader (bool, optional): If True, the user is a leader. Defaults to False.
-        """
+    @staticmethod
+    def get_delete_user_header(username: str, group: str, delete_leader=False) -> str:
         if delete_leader:
-            return f"Are you sure you want to remove {self} from {group} leaders?"
+            return f"Are you sure you want to remove {username} from {group} leaders?"
         else:
-            return f"Are you sure you want to remove {self} from {group}?"
+            return f"Are you sure you want to remove {username} from {group}?"
 
-    def get_edit_profile_information_page_header(self: str) -> str:
-        """Get the edit profile information page header.
-
-        Args:
-            group_name (str): The group name.
-        """
-        return f"Edit {self} profile information"
+    @staticmethod
+    def get_edit_profile_information_page_header(group_name: str) -> str:
+        return f"Edit {group_name} profile information"

--- a/playwright_tests/pages/auth_page.py
+++ b/playwright_tests/pages/auth_page.py
@@ -112,7 +112,7 @@ class AuthPage(BasePage):
         """Check if 'Enter OTP code' input field is displayed"""
         self._wait_for_locator(self.continue_with_firefox_accounts_button)
         return (
-            self._is_element_visible(self.enter_otp_code_input_field) or self._is_locator_visible(
+            self._is_element_visible(self.enter_otp_code_input_field) or self._is_element_visible(
             self.enter_otp_new_account_code_input_field)
         )
 

--- a/playwright_tests/pages/common_elements/common_web_elements.py
+++ b/playwright_tests/pages/common_elements/common_web_elements.py
@@ -51,6 +51,7 @@ class CommonWebElements(BasePage):
             f"[normalize-space(text())='{card_title}']/../../following-sibling::a")
 
         """Locators belonging to the pagination elements."""
+        self.pagination_items = page.locator("//ol[@class='pagination']//a")
         self.pagination_item = lambda pagination_item: page.locator(
             f"//ol[@class='pagination']//a[text()={pagination_item}]")
         self.selected_pagination_item = page.locator(
@@ -176,6 +177,10 @@ class CommonWebElements(BasePage):
     def click_on_next_pagination_item(self):
         """Clicking on the next pagination item."""
         self._click(self.next_pagination_item)
+
+    def click_on_last_pagination_item(self):
+        """Clicking on the last pagination item."""
+        self._click(self.pagination_items.last)
 
     def is_next_pagination_item_visible(self) -> bool:
         """Return if the next pagination item is visible or not."""

--- a/playwright_tests/pages/contribute/contributor_tools_pages/recent_revisions_page.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/recent_revisions_page.py
@@ -57,6 +57,7 @@ class RecentRevisions(BasePage):
         self.revision_diff_section = page.locator("div[class='revision-diff']")
 
     """Actions against the right-side menu locators."""
+
     def click_on_kb_dashboard_option(self):
         self._click(self.kb_dashboard_option)
 
@@ -73,10 +74,11 @@ class RecentRevisions(BasePage):
         self._click(self.aggregated_metrics)
 
     """Actions against the recent revisions table locators."""
+
     def get_all_revision_dates(self) -> list[str]:
         return self._get_text_of_elements(self.all_dates)
 
-    def get_list_of_all_locale_tage(self) -> list[str]:
+    def get_list_of_all_locale_tags(self) -> list[str]:
         return self._get_text_of_elements(self.locale_tag)
 
     def get_list_of_all_editors(self) -> list[str]:
@@ -124,5 +126,4 @@ class RecentRevisions(BasePage):
         self._click(self.revision_date(article_title, username))
 
     def get_revision_comment(self, article_title: str, username: str) -> str:
-        return self._get_element_inner_text_from_page(
-            self.revision_comment(article_title, username))
+        return self._get_text_of_element(self.revision_comment(article_title, username))

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_page.py
@@ -145,6 +145,9 @@ class KBArticlePage(BasePage):
     def is_helpfulness_widget_displayed(self) -> bool:
         return self._is_element_visible(self.helpfulness_widget)
 
+    def wait_for_helpfulness_widget_to_be_hidden(self, timeout=7000):
+        self._wait_for_locator_to_be_hidden(self.helpfulness_widget, timeout=timeout)
+
     def click_on_helpful_button(self):
         self._click(self.helpful_button)
 

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_show_history_page.py
@@ -206,4 +206,4 @@ class KBArticleShowHistoryPage(BasePage):
 
     def get_revision_creator(self, revision_id: str) -> str:
         """Get the revision creator based on the revision id."""
-        return self._get_element_inner_text_from_page(self.revision_creator(revision_id))
+        return self._get_text_of_element(self.revision_creator(revision_id))

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
@@ -133,4 +133,3 @@ class KBArticleEditMetadata(BasePage):
 
     def click_on_save_changes_button(self):
         self._click(self.save_changes_button)
-        self.wait_for_page_to_load()

--- a/playwright_tests/pages/homepage.py
+++ b/playwright_tests/pages/homepage.py
@@ -32,7 +32,7 @@ class Homepage(BasePage):
         """Returns the link text of the user notification links."""
         text = []
         for element in self.user_notification_links:
-            text.append(self._get_text_of_locator(element))
+            text.append(self._get_text_of_element(element))
         return text
 
     def click_on_a_certain_notification_link(self, link_text: str):

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from playwright.sync_api import Page
 
 from playwright_tests.flows.ask_a_question_flows.aaq_flows.aaq_flow import AAQFlow
@@ -145,145 +147,317 @@ from playwright_tests.pages.user_pages.my_profile_user_navbar import UserNavbar
 
 class SumoPages:
     def __init__(self, page: Page):
-        # Auth Page.
-        self.auth_page = AuthPage(page)
+        self._page = page
 
-        # Search Page.
-        self.search_page = SearchPage(page)
+    # Auth Page.
+    @cached_property
+    def auth_page(self):
+        return AuthPage(self._page)
 
-        # Homepage.
-        self.homepage = Homepage(page)
+    # Search Page.
+    @cached_property
+    def search_page(self):
+        return SearchPage(self._page)
 
-        # Ways to contribute_messages pages.
-        self.ways_to_contribute_pages = WaysToContributePages(page)
+    # Homepage.
+    @cached_property
+    def homepage(self):
+        return Homepage(self._page)
 
-        # Footer.
-        self.footer_section = FooterSection(page)
+    # Ways to contribute_messages pages.
+    @cached_property
+    def ways_to_contribute_pages(self):
+        return WaysToContributePages(self._page)
 
-        # top-navbar.
-        self.top_navbar = TopNavbar(page)
+    # Footer.
+    @cached_property
+    def footer_section(self):
+        return FooterSection(self._page)
 
-        # Profile pages.
-        self.my_profile_page = MyProfilePage(page)
-        self.my_answers_page = MyProfileAnswersPage(page)
-        self.my_questions_page = MyProfileMyQuestionsPage(page)
-        self.question_page = QuestionPage(page)
-        self.my_documents_page = MyProfileDocumentsPage(page)
-        self.edit_my_profile_page = MyProfileEdit(page)
-        self.edit_my_profile_settings_page = MyProfileEditSettingsPage(page)
-        self.edit_my_profile_con_areas_page = MyProfileEditContributionAreasPage(page)
-        self.user_navbar = UserNavbar(page)
+    # top-navbar.
+    @cached_property
+    def top_navbar(self):
+        return TopNavbar(self._page)
 
-        # Messaging System.
-        self.sent_message_page = SentMessagePage(page)
-        self.new_message_page = NewMessagePage(page)
-        self.inbox_page = InboxPage(page)
-        self.mess_system_user_navbar = MessagingSystemUserNavbar(page)
+    # Profile pages.
+    @cached_property
+    def my_profile_page(self):
+        return MyProfilePage(self._page)
 
-        # Contribute page.
-        self.contribute_page = ContributePage(page)
+    @cached_property
+    def my_answers_page(self):
+        return MyProfileAnswersPage(self._page)
 
-        # Community hub page.
-        self.community_hub_page = CommunityHubPage(page)
+    @cached_property
+    def my_questions_page(self):
+        return MyProfileMyQuestionsPage(self._page)
 
-        # AAQ Pages
-        self.aaq_form_page = AAQFormPage(page)
+    @cached_property
+    def question_page(self):
+        return QuestionPage(self._page)
 
-        # Explore our help articles products page.
-        self.products_page = ProductsPage(page)
-        self.explore_by_topic_page = ExploreByTopicPage(page)
+    @cached_property
+    def my_documents_page(self):
+        return MyProfileDocumentsPage(self._page)
 
-        # KB Articles.
-        self.kb_submit_kb_article_form_page = SubmitKBArticlePage(page)
-        self.kb_article_page = KBArticlePage(page)
-        self.kb_edit_article_page = EditKBArticlePage(page)
-        self.kb_article_discussion_page = KBArticleDiscussionPage(page)
-        self.kb_article_show_history_page = KBArticleShowHistoryPage(page)
-        self.kb_article_review_revision_page = KBArticleReviewRevisionPage(page)
-        self.kb_article_preview_revision_page = KBArticleRevisionsPreviewPage(page)
-        self.kb_article_edit_article_metadata_page = KBArticleEditMetadata(page)
-        self.kb_what_links_here_page = WhatLinksHerePage(page)
-        self.kb_category_page = KBCategoryPage(page)
-        self.translate_article_page = TranslateArticlePage(page)
+    @cached_property
+    def edit_my_profile_page(self):
+        return MyProfileEdit(self._page)
 
-        # Product Topics page
-        self.product_topics_page = ProductTopicPage(page)
+    @cached_property
+    def edit_my_profile_settings_page(self):
+        return MyProfileEditSettingsPage(self._page)
 
-        # Product Solutions page.
-        self.product_solutions_page = ProductSolutionsPage(page)
+    @cached_property
+    def edit_my_profile_con_areas_page(self):
+        return MyProfileEditContributionAreasPage(self._page)
 
-        # Product Support page.
-        self.product_support_page = ProductSupportPage(page)
+    @cached_property
+    def user_navbar(self):
+        return UserNavbar(self._page)
 
-        # Contact Support page.
-        self.contact_support_page = ContactSupportPage(page)
+    # Messaging System.
+    @cached_property
+    def sent_message_page(self):
+        return SentMessagePage(self._page)
 
-        # Forums
-        self.all_community_forums_page = SupportForumsPage(page)
-        self.product_support_forum = ProductSupportForum(page)
+    @cached_property
+    def new_message_page(self):
+        return NewMessagePage(self._page)
 
-        # User Groups
-        self.user_groups = GroupsPage(page)
+    @cached_property
+    def inbox_page(self):
+        return InboxPage(self._page)
 
-        # Article Discussions page.
-        self.article_discussions_page = ArticleDiscussionsPage(page)
+    @cached_property
+    def mess_system_user_navbar(self):
+        return MessagingSystemUserNavbar(self._page)
 
-        # Dashboard pages.
-        self.kb_dashboard_page = KBDashboard(page)
-        self.recent_revisions_page = RecentRevisions(page)
-        self.localization_unreviewed_page = UnreviewedLocalizationPage(page)
-        self.most_visited_translations_page = MostVisitedTranslations(page)
+    # Contribute page.
+    @cached_property
+    def contribute_page(self):
+        return ContributePage(self._page)
 
-        # Media Gallery page.
-        self.media_gallery = MediaGallery(page)
+    # Community hub page.
+    @cached_property
+    def community_hub_page(self):
+        return CommunityHubPage(self._page)
 
-        # Moderate Forum Page
-        self.moderate_forum_content_page = ModerateForumContent(page)
+    # AAQ Pages
+    @cached_property
+    def aaq_form_page(self):
+        return AAQFormPage(self._page)
 
-        # Discussions pages
-        self.contributor_discussions_page = ContributorDiscussionPage(page)
-        self.forum_discussions_page = ForumDiscussionsPage(page)
-        self.new_thread_page = NewThreadPage(page)
-        self.edit_thread_title_page = EditThreadTitle(page)
-        self.edit_post_thread_page = EditThreadPostPage(page)
-        self.delete_thread_post_page = DeleteThreadPostPage(page)
-        self.forum_thread_page = ForumThreadPage(page)
+    # Explore our help articles products page.
+    @cached_property
+    def products_page(self):
+        return ProductsPage(self._page)
 
-        # Discussion Threads flow.
-        self.contributor_thread_flow = ContributorThreadFlow(page)
+    @cached_property
+    def explore_by_topic_page(self):
+        return ExploreByTopicPage(self._page)
 
-        # Auth flow Page.
-        self.auth_flow_page = AuthFlowPage(page)
+    # KB Articles.
+    @cached_property
+    def kb_submit_kb_article_form_page(self):
+        return SubmitKBArticlePage(self._page)
 
-        # AAQ Flow.
-        self.aaq_flow = AAQFlow(page)
+    @cached_property
+    def kb_article_page(self):
+        return KBArticlePage(self._page)
 
-        # Messaging System Flows.
-        self.messaging_system_flow = MessagingSystemFlows(page)
+    @cached_property
+    def kb_edit_article_page(self):
+        return EditKBArticlePage(self._page)
 
-        # Edit profile flow
-        self.edit_profile_flow = EditProfileDataFlow(page)
+    @cached_property
+    def kb_article_discussion_page(self):
+        return KBArticleDiscussionPage(self._page)
 
-        # KB article Flow
-        self.submit_kb_article_flow = AddKbArticleFlow(page)
+    @cached_property
+    def kb_article_show_history_page(self):
+        return KBArticleShowHistoryPage(self._page)
 
-        # KB article translation Flow
-        self.submit_kb_translation_flow = KbArticleTranslationFlow(page)
+    @cached_property
+    def kb_article_review_revision_page(self):
+        return KBArticleReviewRevisionPage(self._page)
 
-        # KB article deletion Flow
-        self.kb_article_deletion_flow = DeleteKbArticleFlow(page)
+    @cached_property
+    def kb_article_preview_revision_page(self):
+        return KBArticleRevisionsPreviewPage(self._page)
 
-        # KB article edit metadata Flow
-        self.edit_article_metadata_flow = EditArticleMetaFlow(page)
+    @cached_property
+    def kb_article_edit_article_metadata_page(self):
+        return KBArticleEditMetadata(self._page)
 
-        # KB add article media Flow
-        self.add_kb_media_flow = AddKbMediaFlow(page)
+    @cached_property
+    def kb_what_links_here_page(self):
+        return WhatLinksHerePage(self._page)
 
-        # User Group Flow
-        self.user_group_flow = UserGroupFlow(page)
+    @cached_property
+    def kb_category_page(self):
+        return KBCategoryPage(self._page)
 
-        # KB article threads Flow
-        self.kb_article_thread_flow = KbThreads(page)
+    @cached_property
+    def translate_article_page(self):
+        return TranslateArticlePage(self._page)
 
-        # Common Web Elements
-        self.common_web_elements = CommonWebElements(page)
+    # Product Topics page
+    @cached_property
+    def product_topics_page(self):
+        return ProductTopicPage(self._page)
+
+    # Product Solutions page.
+    @cached_property
+    def product_solutions_page(self):
+        return ProductSolutionsPage(self._page)
+
+    # Product Support page.
+    @cached_property
+    def product_support_page(self):
+        return ProductSupportPage(self._page)
+
+    # Contact Support page.
+    @cached_property
+    def contact_support_page(self):
+        return ContactSupportPage(self._page)
+
+    # Forums
+    @cached_property
+    def all_community_forums_page(self):
+        return SupportForumsPage(self._page)
+
+    @cached_property
+    def product_support_forum(self):
+        return ProductSupportForum(self._page)
+
+    # User Groups
+    @cached_property
+    def user_groups(self):
+        return GroupsPage(self._page)
+
+    # Article Discussions page.
+    @cached_property
+    def article_discussions_page(self):
+        return ArticleDiscussionsPage(self._page)
+
+    # Dashboard pages.
+    @cached_property
+    def kb_dashboard_page(self):
+        return KBDashboard(self._page)
+
+    @cached_property
+    def recent_revisions_page(self):
+        return RecentRevisions(self._page)
+
+    @cached_property
+    def localization_unreviewed_page(self):
+        return UnreviewedLocalizationPage(self._page)
+
+    @cached_property
+    def most_visited_translations_page(self):
+        return MostVisitedTranslations(self._page)
+
+    # Media Gallery page.
+    @cached_property
+    def media_gallery(self):
+        return MediaGallery(self._page)
+
+    # Moderate Forum Page
+    @cached_property
+    def moderate_forum_content_page(self):
+        return ModerateForumContent(self._page)
+
+    # Discussions pages
+    @cached_property
+    def contributor_discussions_page(self):
+        return ContributorDiscussionPage(self._page)
+
+    @cached_property
+    def forum_discussions_page(self):
+        return ForumDiscussionsPage(self._page)
+
+    @cached_property
+    def new_thread_page(self):
+        return NewThreadPage(self._page)
+
+    @cached_property
+    def edit_thread_title_page(self):
+        return EditThreadTitle(self._page)
+
+    @cached_property
+    def edit_post_thread_page(self):
+        return EditThreadPostPage(self._page)
+
+    @cached_property
+    def delete_thread_post_page(self):
+        return DeleteThreadPostPage(self._page)
+
+    @cached_property
+    def forum_thread_page(self):
+        return ForumThreadPage(self._page)
+
+    # Discussion Threads flow.
+    @cached_property
+    def contributor_thread_flow(self):
+        return ContributorThreadFlow(self._page)
+
+    # Auth flow Page.
+    @cached_property
+    def auth_flow_page(self):
+        return AuthFlowPage(self._page)
+
+    # AAQ Flow.
+    @cached_property
+    def aaq_flow(self):
+        return AAQFlow(self._page)
+
+    # Messaging System Flows.
+    @cached_property
+    def messaging_system_flow(self):
+        return MessagingSystemFlows(self._page)
+
+    # Edit profile flow
+    @cached_property
+    def edit_profile_flow(self):
+        return EditProfileDataFlow(self._page)
+
+    # KB article Flow
+    @cached_property
+    def submit_kb_article_flow(self):
+        return AddKbArticleFlow(self._page)
+
+    # KB article translation Flow
+    @cached_property
+    def submit_kb_translation_flow(self):
+        return KbArticleTranslationFlow(self._page)
+
+    # KB article deletion Flow
+    @cached_property
+    def kb_article_deletion_flow(self):
+        return DeleteKbArticleFlow(self._page)
+
+    # KB article edit metadata Flow
+    @cached_property
+    def edit_article_metadata_flow(self):
+        return EditArticleMetaFlow(self._page)
+
+    # KB add article media Flow
+    @cached_property
+    def add_kb_media_flow(self):
+        return AddKbMediaFlow(self._page)
+
+    # User Group Flow
+    @cached_property
+    def user_group_flow(self):
+        return UserGroupFlow(self._page)
+
+    # KB article threads Flow
+    @cached_property
+    def kb_article_thread_flow(self):
+        return KbThreads(self._page)
+
+    # Common Web Elements
+    @cached_property
+    def common_web_elements(self):
+        return CommonWebElements(self._page)

--- a/playwright_tests/pages/top_navbar.py
+++ b/playwright_tests/pages/top_navbar.py
@@ -1,3 +1,4 @@
+import re
 from playwright.sync_api import ElementHandle, Locator, Page
 from playwright_tests.core.basepage import BasePage
 from playwright_tests.pages.contribute.contributor_tools_pages.recent_revisions_page import \
@@ -112,6 +113,27 @@ class TopNavbar(BasePage):
     def click_on_sumo_nav_logo(self):
         """Click on the sumo nav logo"""
         self._click(self.sumo_nav_logo)
+
+    def get_text_of_option_and_click(self, option: Locator, hover_menu, is_first: bool) -> str:
+        """Get the text of a navbar dropdown option and click it, hovering if needed.
+
+        Args:
+            option: The locator of the option to click.
+            hover_menu: A callable that hovers over the parent menu to reveal the dropdown.
+            is_first: Whether this is the first option (skips initial hover).
+
+        Returns:
+            The normalized text of the option.
+        """
+        if not is_first:
+            hover_menu()
+        option_text = re.sub(r'\s+', ' ', self._get_text_of_element(option)).strip()
+        if self._is_element_visible(option):
+            self._click(option)
+        else:
+            hover_menu()
+            self._click(option)
+        return option_text
 
     """Actions against the 'Explore Help Articles' top-navbar section."""
     def hover_over_explore_by_product_top_navbar_option(self):

--- a/playwright_tests/pages/user_pages/my_profile_edit.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit.py
@@ -74,11 +74,11 @@ class MyProfileEdit(BasePage):
 
     def get_timezone_select_value(self) -> str:
         """Return the selected value of the timezone dropdown"""
-        return self._get_element_inner_text_from_page(self.selected_timezone)
+        return self._get_text_of_element(self.selected_timezone)
 
     def get_preferred_locale_select_value(self) -> str:
         """Return the selected value of the preferred locale dropdown"""
-        return self._get_element_inner_text_from_page(self.selected_locale)
+        return self._get_text_of_element(self.selected_locale)
 
     def get_involved_with_mozilla_month_select_value(self) -> str:
         """Return the selected value of the involved with mozilla month dropdown"""

--- a/playwright_tests/pages/user_pages/my_profile_my_questions_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_my_questions_page.py
@@ -35,7 +35,7 @@ class MyProfileMyQuestionsPage(BasePage):
 
     def get_text_of_listed_question_by_index(self, index: int) -> str:
         """Returns the text of the first listed question."""
-        return self._get_element_inner_text_from_page(self.questions_by_index(index))
+        return self._get_text_of_element(self.questions_by_index(index))
 
 
     def get_all_my_posted_questions(self) -> list[str]:

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -20,15 +20,11 @@ markers =
     productSupportPage: Tests belonging to the product support page.
     kbArticleCreationAndAccess: Tests belonging to the kb article creation and access.
     articleThreads: Tests belonging to the kb article threads.
-    beforeThreadTests: Article threads tests prerequisites.
-    afterThreadTests: Article threads tests teardown.
     kbArticleShowHistory: Tests belonging to the kb article show history section.
     recentRevisionsDashboard: Tests belonging to the recent revisions dashboard.
     kbDashboard: Tests belonging to the KB dashboard.
     kbRestrictedVisibility: Tests belonging to the KB article restriction functionality.
     kbArticleTranslation: Tests belonging to kb article translation.
-    deleteAllRestrictedTestArticles: Deleting all restricted test articles.
-    create_delete_article: Fixture used for creating and deleting test articles.
     exploreByTopics: Tests belonging to the explore help articles by topics page.
     searchTests: Tests belonging to the search functionality.
     contributorForumSearch: Tests belonging to the contributor forums search functionality.

--- a/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
@@ -20,7 +20,6 @@ def test_popular_topics_navbar(page: Page):
     with allure.step("Navigating to product topics pages"):
         for product_topic in utilities.general_test_data["product_topics"]:
             topic_url = utilities.general_test_data["product_topics"][product_topic]
-            page.wait_for_timeout(400)
             utilities.navigate_to_link(topic_url)
             utilities.wait_for_url_to_be(topic_url)
 

--- a/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
+++ b/playwright_tests/tests/contribute_tests/dashboards_tests/test_kb_dashboard.py
@@ -14,7 +14,7 @@ from playwright_tests.pages.sumo_pages import SumoPages
 def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["forum-contributors"])
     test_user_two = create_user_factory(groups=["forum-contributors"])
     test_user_three = create_user_factory(groups=["Knowledge Base Reviewers"])
@@ -36,7 +36,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page, create_user_
     with check, allure.step("Verifying that the correct live status is displayed"):
         assert sumo_pages.kb_dashboard_page.get_a_particular_article_status(
             article_details['article_title']
-        ).strip() == kb_dashboard_page_messages.get_kb_not_live_status(
+        ).strip() == KBDashboardPageMessages.get_kb_not_live_status(
             revision_note=article_details['article_review_description']
         )
 
@@ -77,7 +77,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page, create_user_
                             "correct live status is displayed"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_a_particular_article_status(
-            article_details['article_title']).strip() == kb_dashboard_page_messages.KB_LIVE_STATUS
+            article_details['article_title']).strip() == KBDashboardPageMessages.KB_LIVE_STATUS
 
     with allure.step("Signing out and verifying that the article is visible"):
         utilities.delete_cookies()
@@ -103,7 +103,7 @@ def test_unreviewed_articles_visibility_in_kb_dashboard(page: Page, create_user_
 def test_kb_dashboard_articles_status(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with a Knowledge Base Reviewer account"):
@@ -122,7 +122,7 @@ def test_kb_dashboard_articles_status(page: Page, create_user_factory):
             utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_a_particular_article_status(
             article_details['article_title']
-        ).strip() == kb_dashboard_page_messages.get_kb_not_live_status(
+        ).strip() == KBDashboardPageMessages.get_kb_not_live_status(
             revision_note=second_revision['changes_description']
         )
 
@@ -137,7 +137,7 @@ def test_kb_dashboard_articles_status(page: Page, create_user_factory):
                             "status is displayed"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_a_particular_article_status(
-            article_details['article_title']).strip() == kb_dashboard_page_messages.KB_LIVE_STATUS
+            article_details['article_title']).strip() == KBDashboardPageMessages.KB_LIVE_STATUS
 
 
 # C2496647
@@ -145,7 +145,7 @@ def test_kb_dashboard_articles_status(page: Page, create_user_factory):
 def test_kb_dashboard_revision_deferred_status(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with a Knowledge Base Reviewer account"):
@@ -165,7 +165,7 @@ def test_kb_dashboard_revision_deferred_status(page: Page, create_user_factory):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_a_particular_article_status(
             article_details['article_title']
-        ) == kb_dashboard_page_messages.get_kb_not_live_status(
+        ) == KBDashboardPageMessages.get_kb_not_live_status(
             second_revision['changes_description'])
 
     with allure.step("Navigating back to the article history page and deferring the revision"):
@@ -180,7 +180,7 @@ def test_kb_dashboard_revision_deferred_status(page: Page, create_user_factory):
                             "correct status is displayed"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_a_particular_article_status(
-            article_details['article_title']) == kb_dashboard_page_messages.KB_LIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.KB_LIVE_STATUS
 
 
 # C2496646
@@ -197,7 +197,7 @@ def test_kb_dashboard_needs_update_when_reviewing_a_revision(page: Page, create_
         article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
             approve_first_revision=True)
 
-    with allure.step("Creating an new article revision for the document"):
+    with allure.step("Creating a new article revision for the document"):
         second_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
         sumo_pages.submit_kb_article_flow.approve_kb_revision(
             revision_id=second_revision['revision_id'], revision_needs_change=True
@@ -216,7 +216,7 @@ def test_kb_dashboard_needs_update_when_reviewing_a_revision(page: Page, create_
 def test_kb_dashboard_needs_update_edit_metadata(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with Knowledge Base Reviewer account"):
@@ -249,7 +249,7 @@ def test_kb_dashboard_needs_update_edit_metadata(page: Page, create_user_factory
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_needs_update_status(
             article_details['article_title']
-        ).strip() == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+        ).strip() == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
     with allure.step("Navigating back to the article's 'Edit Article Metadata' page and "
                      "removing the needs change updates"):
@@ -268,7 +268,7 @@ def test_kb_dashboard_needs_update_edit_metadata(page: Page, create_user_factory
 def test_ready_for_l10n_kb_dashboard_revision_approval(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with a Knowledge Base Reviewer account"):
@@ -287,7 +287,7 @@ def test_ready_for_l10n_kb_dashboard_revision_approval(page: Page, create_user_f
                             "the correct l10n status is displayed"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
 
 # C2266378
@@ -296,7 +296,7 @@ def test_ready_for_l10n_kb_dashboard_revision_approval(page: Page, create_user_f
 def test_ready_for_l10n_kb_dashboard_revision_l10n_status(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with a Knowledge Base Reviewer account"):
@@ -310,7 +310,7 @@ def test_ready_for_l10n_kb_dashboard_revision_l10n_status(page: Page, create_use
                             "the correct l10n status is displayed"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Navigating back to the article page and marking the revision as ready "
                      "for l10n"):
@@ -325,7 +325,7 @@ def test_ready_for_l10n_kb_dashboard_revision_l10n_status(page: Page, create_use
                      "correct l10n status is displayed"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
 
 # C2875533
@@ -334,7 +334,7 @@ def test_ready_for_l10n_kb_dashboard_revision_l10n_status(page: Page, create_use
 def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with a Knowledge Base Reviewer account"):
@@ -349,7 +349,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
                             "(No)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with check, allure.step("Approving the KB article without marking it as ready for l10n and "
                             "verifying that the correct l10N status is displayed inside the KB "
@@ -359,7 +359,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
             revision_id=article_details["first_revision_id"])
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Creating a new revision and approve it as minor significance"):
         utilities.navigate_to_link(article_details["article_url"])
@@ -370,7 +370,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
                             "(No)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Creating a new revision and approving it as normal significance and ready "
                      "for localization"):
@@ -383,7 +383,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
                             "(Yes)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
     with allure.step("Creating a new revision and approving it as normal significance and not "
                      "ready for localization"):
@@ -396,7 +396,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
                             "dashboard (No)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Creating a new minor revision and approving it"):
         utilities.navigate_to_link(article_details["article_url"])
@@ -408,7 +408,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
                             "dashboard (No)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Creating a new major revision and not marking it as ready for localization"):
         utilities.navigate_to_link(article_details["article_url"])
@@ -420,7 +420,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
                             "dashboard (No)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Creating a new minor revision and approving it"):
         utilities.navigate_to_link(article_details["article_url"])
@@ -432,7 +432,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
                             "dashboard (No)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Creating a new major revision and marking it as ready for localization"):
         utilities.navigate_to_link(article_details["article_url"])
@@ -444,7 +444,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
                             "dashboard (Yes)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
 
 # C2875537
@@ -453,7 +453,7 @@ def test_ready_for_l10n_kb_dashboard_status_update(page: Page, create_user_facto
 def test_ready_for_l10n_status_update_via_history_page(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with a Knowledge Base Reviewer account"):
@@ -474,7 +474,7 @@ def test_ready_for_l10n_status_update_via_history_page(page: Page, create_user_f
                             "displayed inside the KB dashboard (No)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Marking the newly submitted revision as ready for localization via the"
                      " /history page"):
@@ -488,9 +488,9 @@ def test_ready_for_l10n_status_update_via_history_page(page: Page, create_user_f
                             "inside the KB dashboard (Yes)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
-    with check, allure.step("Creating a new minor revision"):
+    with allure.step("Creating a new minor revision"):
         utilities.navigate_to_link(article_details["article_show_history_url"])
         sumo_pages.submit_kb_article_flow.submit_new_kb_revision(
             approve_revision=True, significance_type='minor'
@@ -500,7 +500,7 @@ def test_ready_for_l10n_status_update_via_history_page(page: Page, create_user_f
                             " inside the KB dashboard (Yes)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
     with allure.step("Creating a new major significance revision"):
         utilities.navigate_to_link(article_details["article_show_history_url"])
@@ -512,7 +512,7 @@ def test_ready_for_l10n_status_update_via_history_page(page: Page, create_user_f
                             " inside the KB dashboard (No)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Marking the newly submitted revision as ready for localization via the"
                      " /history page"):
@@ -526,7 +526,7 @@ def test_ready_for_l10n_status_update_via_history_page(page: Page, create_user_f
                             " inside the KB dashboard (Yes)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
 
 # C2875536
@@ -535,7 +535,7 @@ def test_deferring_revision_does_not_impact_l10n_kb_dashboard_status(page: Page,
                                                                      create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with a Knowledge Base Reviewer account"):
@@ -554,7 +554,7 @@ def test_deferring_revision_does_not_impact_l10n_kb_dashboard_status(page: Page,
                             " inside the KB dashboard (No)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
     with allure.step("Creating a new revision of normal significance and approving it by marking"
                      "it as ready for localization"):
@@ -567,18 +567,18 @@ def test_deferring_revision_does_not_impact_l10n_kb_dashboard_status(page: Page,
                             " inside the KB dashboard (Yes)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
     with allure.step("Creating a new revision and deferring it instead of approving"):
         utilities.navigate_to_link(article_details["article_show_history_url"])
-        forth_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
-        sumo_pages.submit_kb_article_flow.defer_revision(forth_revision['revision_id'])
+        fourth_revision = sumo_pages.submit_kb_article_flow.submit_new_kb_revision()
+        sumo_pages.submit_kb_article_flow.defer_revision(fourth_revision['revision_id'])
 
     with check, allure.step("Verifying that the correct ready for localization status is displayed"
                             " inside the KB dashboard (Yes)"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
 
 
 # C2266378
@@ -586,7 +586,7 @@ def test_deferring_revision_does_not_impact_l10n_kb_dashboard_status(page: Page,
 def test_article_translation_not_allowed_kb_dashboard(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with a Knowledge Base Reviewer account"):
@@ -601,7 +601,7 @@ def test_article_translation_not_allowed_kb_dashboard(page: Page, create_user_fa
                      "correct l10n status is displayed"):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_ready_for_l10n_status(
-            article_details['article_title']) == kb_dashboard_page_messages.GENERAL_NEGATIVE_STATUS
+            article_details['article_title']) == KBDashboardPageMessages.GENERAL_NEGATIVE_STATUS
 
 
 # C2266379, C2266380
@@ -609,7 +609,7 @@ def test_article_translation_not_allowed_kb_dashboard(page: Page, create_user_fa
 def test_article_stale_kb_dashboard(page: Page, create_user_factory):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    kb_dashboard_page_messages = KBDashboardPageMessages()
+
     test_user = create_user_factory(groups=["Knowledge Base Reviewers"])
 
     with allure.step("Signing in with a Knowledge Base Reviewer account"):
@@ -628,7 +628,7 @@ def test_article_stale_kb_dashboard(page: Page, create_user_factory):
         utilities.navigate_to_link(utilities.general_test_data['dashboard_links']['kb_overview'])
         assert sumo_pages.kb_dashboard_page.get_stale_status(
             article_details['article_title']
-        ) == kb_dashboard_page_messages.GENERAL_POSITIVE_STATUS
+        ) == KBDashboardPageMessages.GENERAL_POSITIVE_STATUS
         assert sumo_pages.kb_dashboard_page.get_existing_expiry_date(
             article_details['article_title']
         ) == utilities.convert_string_to_datetime(

--- a/playwright_tests/tests/contribute_tests/test_groups.py
+++ b/playwright_tests/tests/contribute_tests/test_groups.py
@@ -95,7 +95,7 @@ def test_group_edit_buttons_visibility(page: Page, create_user_factory):
 
 
 # C2783730, C2715807
-@pytest.mark.skip
+@pytest.mark.skip(reason="Visual comparison test - requires baseline images")
 @pytest.mark.userGroupsTests
 def test_change_group_avatar(page: Page, create_user_factory):
     utilities = Utilities(page)

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_article_creation_and_access.py
@@ -1540,9 +1540,8 @@ def test_article_helpfulness_votes(page: Page, vote_type, create_user_factory):
                 KB_SURVEY_FEEDBACK
             )
 
-        with check, allure.step("Waiting for 6 seconds and verifying that the widget is no longer"
-                                " displayed"):
-            utilities.wait_for_given_timeout(6000)
+        with check, allure.step("Verifying that the helpfulness widget is no longer displayed"):
+            sumo_pages.kb_article_page.wait_for_helpfulness_widget_to_be_hidden()
             assert not sumo_pages.kb_article_page.is_helpfulness_widget_displayed()
 
         with check, allure.step("Refreshing the page and verifying that the widget is no longer "
@@ -1596,9 +1595,8 @@ def test_article_helpfulness_cancel_vote(page: Page, vote_type, create_user_fact
             assert (sumo_pages.kb_article_page.get_survey_message_text() == KBArticlePageMessages.
                     KB_SURVEY_FEEDBACK_NO_ADDITIONAL_DETAILS)
 
-        with check, allure.step("Waiting for 6 seconds and verifying that the widget is no longer"
-                                " displayed"):
-            utilities.wait_for_given_timeout(6000)
+        with check, allure.step("Verifying that the helpfulness widget is no longer displayed"):
+            sumo_pages.kb_article_page.wait_for_helpfulness_widget_to_be_hidden()
             assert not sumo_pages.kb_article_page.is_helpfulness_widget_displayed()
 
         with check, allure.step("Refreshing the page and verifying that the widget is no longer "
@@ -1658,9 +1656,8 @@ def test_article_unhelpfulness_votes(page: Page, vote_type, create_user_factory)
         assert (sumo_pages.kb_article_page.get_survey_message_text() == KBArticlePageMessages.
                 KB_SURVEY_FEEDBACK)
 
-    with check, allure.step("Waiting for 6 seconds and verifying that the widget is no longer"
-                            " displayed"):
-        utilities.wait_for_given_timeout(6000)
+    with check, allure.step("Verifying that the helpfulness widget is no longer displayed"):
+        sumo_pages.kb_article_page.wait_for_helpfulness_widget_to_be_hidden()
         assert not sumo_pages.kb_article_page.is_helpfulness_widget_displayed()
 
     with check, allure.step("Refreshing the page and verifying that the widget is no longer "
@@ -1715,9 +1712,8 @@ def test_article_unhelpfulness_cancel_vote(page: Page, vote_type, create_user_fa
         assert (sumo_pages.kb_article_page.get_survey_message_text() == KBArticlePageMessages.
                 KB_SURVEY_FEEDBACK_NO_ADDITIONAL_DETAILS)
 
-    with check, allure.step("Waiting for 6 seconds and verifying that the widget is no longer"
-                            " displayed"):
-        utilities.wait_for_given_timeout(6000)
+    with check, allure.step("Verifying that the helpfulness widget is no longer displayed"):
+        sumo_pages.kb_article_page.wait_for_helpfulness_widget_to_be_hidden()
         assert not sumo_pages.kb_article_page.is_helpfulness_widget_displayed()
 
     with check, allure.step("Refreshing the page and verifying that the widget is no longer "
@@ -1806,7 +1802,7 @@ def test_voting_the_same_article_twice_is_not_possible(page: Page, context: Brow
 
     with check, allure.step("Verifying that the helpfulness widget is no longer displayed inside"
                             " first browser window"):
-        utilities.wait_for_given_timeout(1000)
+        sumo_pages.kb_article_page.wait_for_helpfulness_widget_to_be_hidden()
         assert not sumo_pages.kb_article_page.is_helpfulness_widget_displayed()
 
 
@@ -1857,6 +1853,7 @@ def test_adding_and_removing_related_documents(page: Page, create_user_factory):
         sumo_pages.kb_article_edit_article_metadata_page.remove_related_document(
             test_article_titles[1])
         sumo_pages.kb_article_edit_article_metadata_page.click_on_save_changes_button()
+        utilities.wait_for_page_to_load()
 
     with allure.step(f"Verifying that the f{test_article_titles[1]} is no longer listed inside "
                      "'Related Articles' section"):

--- a/playwright_tests/tests/footer_tests/test_footer.py
+++ b/playwright_tests/tests/footer_tests/test_footer.py
@@ -29,7 +29,7 @@ def test_all_footer_links_are_working(page: Page):
         # Some links are returning status code 429.
         # We are currently treating them as pass cases.
         with allure.step(f"Verifying that {url} is not broken"):
-            assert response.status in set(range(400)) | {403, 429}
+            assert response.status < 400 or response.status in (403, 429)
 
 
 # C2316348
@@ -40,6 +40,4 @@ def test_locale_selector(page: Page):
                      "correct page locale"):
         for locale in sumo_pages.footer_section.get_all_footer_locales():
             sumo_pages.footer_section.switch_to_a_locale(locale)
-            expect(
-                page
-            ).to_have_url(re.compile(f".*{locale}"))
+            expect(page).to_have_url(re.compile(f".*/{re.escape(locale)}(/|$)"))

--- a/playwright_tests/tests/homepage_tests/test_homepage.py
+++ b/playwright_tests/tests/homepage_tests/test_homepage.py
@@ -28,14 +28,16 @@ def test_join_our_community_card_learn_more_redirects_to_contribute_page(page: P
 @pytest.mark.homePageTests
 def test_join_our_community_card_has_the_correct_content(page: Page):
     sumo_pages = SumoPages(page)
-    with allure.step( "Verifying that the 'Join Our Community' card has the correct strings"
-                      " applied"):
+    with allure.step("Verifying that the 'Join Our Community' card has the correct strings"
+                     " applied"):
         assert (
             sumo_pages.common_web_elements.get_volunteer_learn_more_card_header()
             == HomepageMessages.JOIN_OUR_COMMUNITY_CARD_TITLE
-            and sumo_pages.common_web_elements.get_volunteer_learn_more_card_text()
+        ), "Incorrect card header is displayed"
+        assert (
+            sumo_pages.common_web_elements.get_volunteer_learn_more_card_text()
             == HomepageMessages.JOIN_OUR_COMMUNITY_CARD_DESCRIPTION
-        ), "Incorrect strings are displayed"
+        ), "Incorrect card description is displayed"
 
 
 # C876541
@@ -47,23 +49,23 @@ def test_homepage_feature_articles_are_available_and_interactable(page: Page):
     with allure.step("Verifying if the correct number of featured articles are present on the"
                      " homepage"):
         assert sumo_pages.homepage.get_number_of_featured_articles(
-        ) is HomepageMessages.EXPECTED_FEATURED_ARTICLES_COUNT
+        ) == HomepageMessages.EXPECTED_FEATURED_ARTICLES_COUNT
 
-    with allure.step("Clicking on each featured article card and verifying that the user is"
+    with allure.step("Clicking on each featured article card and verifying that the user is "
                      "redirected to the correct article page."):
-        counter = 0
-        for featured_article in sumo_pages.homepage.get_featured_articles_titles():
+        count = sumo_pages.homepage.get_number_of_featured_articles()
+        for counter in range(count):
             articles_names = sumo_pages.homepage.get_featured_articles_titles()
             sumo_pages.homepage.click_on_a_featured_card(counter)
             assert (
                 sumo_pages.kb_article_page.get_text_of_article_title().strip()
                 == articles_names[counter].strip()
-            ), (f"Incorrect featured article displayed. Expected: {featured_article} "
+            ), (f"Incorrect featured article displayed. "
+                f"Expected: {articles_names[counter]} "
                 f"Received: {sumo_pages.kb_article_page.get_text_of_article_title()}")
 
             with allure.step("Navigating back to the previous page"):
                 utilities.navigate_back()
-                counter += 1
 
 
 # C873774
@@ -74,9 +76,8 @@ def test_product_cards_are_functional_and_redirect_to_the_proper_support_page(pa
     utilities = Utilities(page)
     with allure.step("Verifying that the product cards redirect to the correct support page"):
         card_titles = sumo_pages.homepage.get_text_of_product_card_titles()
-        counter = 0
-        for product_card in card_titles:
-            expected_product_title = card_titles[counter] + SupportPageMessages.TITLE_CONTAINS
+        for counter, product_card in enumerate(card_titles):
+            expected_product_title = product_card + SupportPageMessages.TITLE_CONTAINS
             sumo_pages.homepage.click_on_product_card(counter)
             assert (
                 expected_product_title
@@ -88,4 +89,3 @@ def test_product_cards_are_functional_and_redirect_to_the_proper_support_page(pa
 
             with allure.step("Navigating back to the previous page"):
                 utilities.navigate_back()
-                counter += 1

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -271,15 +271,6 @@ def test_new_message_field_validation(page: Page, create_user_factory):
         expect(sumo_pages.new_message_page.textarea_remaining_characters_message
                ).to_have_css("color", NewMessagePageMessages.ENOUGH_CHARACTERS_REMAINING_COLOR)
 
-    # elif self.browser == "firefox":
-    #     check.equal(
-    #         self.pages.new_message_page.get_characters_remaining_text_color(),
-    #         NewMessagePageMessages.ENOUGH_CHARACTERS_REMAINING_COLOR_FIREFOX,
-    #         f"Incorrect color displayed. "
-    #         f"Expected: {NewMessagePageMessages.ENOUGH_CHARACTERS_REMAINING_COLOR_FIREFOX} "
-    #         f"Received: {self.pages.new_message_page.get_characters_remaining_text_color()}",
-    #     )
-
     with allure.step("Adding one character inside the textarea field"):
         sumo_pages.new_message_page.type_into_textarea_body(
             text=utilities.user_message_test_data["valid_user_message"]
@@ -294,15 +285,6 @@ def test_new_message_field_validation(page: Page, create_user_factory):
         expect(sumo_pages.new_message_page.textarea_remaining_characters_message
                ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
 
-    # elif self.browser == "firefox":
-    #     check.equal(
-    #         self.pages.new_message_page.get_characters_remaining_text_color(),
-    #         NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR_FIREFOX,
-    #         f"Incorrect color displayed. "
-    #         f"Expected: {NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR_FIREFOX} "
-    #         f"Received: {self.pages.new_message_page.get_characters_remaining_text_color()}",
-    #     )
-
     with allure.step("Adding 9 characters inside the textarea field"):
         sumo_pages.new_message_page.type_into_textarea_body(
             text=utilities.user_message_test_data["valid_user_message"]
@@ -314,28 +296,10 @@ def test_new_message_field_validation(page: Page, create_user_factory):
             sumo_pages.new_message_page.textarea_remaining_characters_message
         ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
 
-    # elif self.browser == "firefox":
-    #     check.equal(
-    #         self.pages.new_message_page.get_characters_remaining_text_color(),
-    #         NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR_FIREFOX,
-    #         f"Incorrect color displayed. "
-    #         f"Expected: {NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR_FIREFOX} "
-    #         f"Received: {self.pages.new_message_page.get_characters_remaining_text_color()}",
-    #     )
-
     with allure.step("Verifying that the characters remaining color is the expected one"):
         expect(
             sumo_pages.new_message_page.textarea_remaining_characters_message
         ).to_have_css("color", NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR)
-
-    # elif self.browser == "firefox":
-    #     check.equal(
-    #         self.pages.new_message_page.get_characters_remaining_text_color(),
-    #         NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR_FIREFOX,
-    #         f"Incorrect color displayed. "
-    #         f"Expected: {NewMessagePageMessages.NO_CHARACTERS_REMAINING_COLOR_FIREFOX} "
-    #         f"Received: {self.pages.new_message_page.get_characters_remaining_text_color()}",
-    #     )
 
 
 # C891417
@@ -416,6 +380,18 @@ def test_messaging_system_unread_notification_after_message_deletion(page: Page,
             expected_url=SentMessagesPageMessages.SENT_MESSAGES_PAGE_URL
         )
 
+    def assert_unread_notification_matches_inbox():
+        """Verify the navbar unread counter matches the actual unread inbox count."""
+        unread_count = len(sumo_pages.inbox_page.all_unread_messages.all())
+        sumo_pages.top_navbar.mouse_over_profile_avatar()
+        if unread_count == 0:
+            assert sumo_pages.top_navbar.unread_message_count.is_hidden()
+            assert sumo_pages.top_navbar.unread_message_profile_notification.is_hidden()
+        else:
+            assert (sumo_pages.top_navbar
+                    .get_unread_message_notification_counter_value() == unread_count)
+            assert sumo_pages.top_navbar.unread_message_profile_notification.is_visible()
+
     with allure.step("Signing in with the recipient"):
         utilities.start_existing_session(cookies=test_user_two)
 
@@ -424,11 +400,7 @@ def test_messaging_system_unread_notification_after_message_deletion(page: Page,
 
     with allure.step("Verifying that the avatar notification and the new message counter is "
                      "correct"):
-        inbox_messages_count = len(sumo_pages.inbox_page.all_unread_messages.all())
-        sumo_pages.top_navbar.mouse_over_profile_avatar()
-        assert (sumo_pages.top_navbar
-                .get_unread_message_notification_counter_value() == inbox_messages_count)
-        assert sumo_pages.top_navbar.unread_message_profile_notification.is_visible()
+        assert_unread_notification_matches_inbox()
 
     with allure.step("Marking the first received message as read"):
         sumo_pages.inbox_page.check_a_particular_message_based_on_excerpt(content_first_message)
@@ -439,11 +411,7 @@ def test_messaging_system_unread_notification_after_message_deletion(page: Page,
 
     with allure.step("Verifying that the new message notification counter resembles the unread "
                      "inbox message count"):
-        inbox_messages_count = len(sumo_pages.inbox_page.all_unread_messages.all())
-        sumo_pages.top_navbar.mouse_over_profile_avatar()
-        assert (sumo_pages.top_navbar
-                .get_unread_message_notification_counter_value() == inbox_messages_count)
-        assert sumo_pages.top_navbar.unread_message_profile_notification.is_visible()
+        assert_unread_notification_matches_inbox()
 
     with allure.step("Deleting the first message"):
         sumo_pages.messaging_system_flow.delete_message_flow(
@@ -453,11 +421,7 @@ def test_messaging_system_unread_notification_after_message_deletion(page: Page,
 
     with allure.step("Verifying that the new message notification counter resembles the unread "
                      "inbox message count"):
-        inbox_messages_count = len(sumo_pages.inbox_page.all_unread_messages.all())
-        sumo_pages.top_navbar.mouse_over_profile_avatar()
-        assert (sumo_pages.top_navbar
-                .get_unread_message_notification_counter_value() == inbox_messages_count)
-        assert sumo_pages.top_navbar.unread_message_profile_notification.is_visible()
+        assert_unread_notification_matches_inbox()
 
     with allure.step("Marking the second received message as read"):
         sumo_pages.inbox_page.check_a_particular_message_based_on_excerpt(content_second_message)
@@ -465,15 +429,7 @@ def test_messaging_system_unread_notification_after_message_deletion(page: Page,
 
     with allure.step("Verifying that the new message notification counter resembles the unread "
                      "inbox message count"):
-        inbox_messages_count = len(sumo_pages.inbox_page.all_unread_messages.all())
-        sumo_pages.top_navbar.mouse_over_profile_avatar()
-        if inbox_messages_count == 0:
-            assert sumo_pages.top_navbar.unread_message_count.is_hidden()
-            assert sumo_pages.top_navbar.unread_message_profile_notification.is_hidden()
-        else:
-            assert (sumo_pages.top_navbar
-                    .get_unread_message_notification_counter_value() == inbox_messages_count)
-            assert sumo_pages.top_navbar.unread_message_profile_notification.is_visible()
+        assert_unread_notification_matches_inbox()
 
     with allure.step("Deleting the second received message"):
         sumo_pages.messaging_system_flow.delete_message_flow(
@@ -483,13 +439,7 @@ def test_messaging_system_unread_notification_after_message_deletion(page: Page,
 
     with allure.step("Verifying that the new message notification counter resembles the unread "
                      "inbox message count"):
-        inbox_messages_count = len(sumo_pages.inbox_page.all_unread_messages.all())
-        sumo_pages.top_navbar.mouse_over_profile_avatar()
-        if inbox_messages_count == 0:
-            assert sumo_pages.top_navbar.unread_message_count.is_hidden()
-        else:
-            assert (sumo_pages.top_navbar
-                    .get_unread_message_notification_counter_value() == inbox_messages_count)
+        assert_unread_notification_matches_inbox()
 
 
 # C891418

--- a/playwright_tests/tests/search_tests/test_main_searchbar.py
+++ b/playwright_tests/tests/search_tests/test_main_searchbar.py
@@ -1118,11 +1118,14 @@ def test_aaq_question_id_and_is_archived_fields_search(page:Page, create_user_fa
         assert sumo_pages.question_page.get_thread_locked_text(
         ) == QuestionPageMessages.ARCHIVED_THREAD_BANNER
 
-    with check, allure.step("Navigating back and searching for the question_is_archived:false"
+    with check, allure.step("Navigating back and searching for the question_is_archived:false "
                             "and verifying that the returned search results are only unarchived "
                             "questions"):
         sumo_pages.top_navbar.click_on_sumo_nav_logo()
         sumo_pages.search_page.fill_into_searchbar("field:question_is_archived:false")
+        utilities.wait_for_given_timeout(2000)
+        sumo_pages.common_web_elements.click_on_last_pagination_item()
+        utilities.wait_for_given_timeout(2000)
         results = sumo_pages.search_page.get_all_search_results_handles()
         random.choice(results).click()
         if sumo_pages.question_page.is_thread_locked_banner_displayed():

--- a/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
+++ b/playwright_tests/tests/top_navbar_section_tests/test_top_navbar.py
@@ -1,9 +1,7 @@
-import re
 import allure
 import pytest
 from playwright.sync_api import Page
 from pytest_check import check
-import requests
 from playwright_tests.core.utilities import Utilities
 from playwright_tests.messages.ask_a_question_messages.contact_support_messages import \
     ContactSupportMessages
@@ -19,12 +17,13 @@ from playwright_tests.pages.sumo_pages import SumoPages
 @pytest.mark.topNavbarTests
 def test_number_of_options_not_signed_in(page: Page):
     sumo_pages = SumoPages(page)
+    utilities = Utilities(page)
 
     with check, allure.step("Verifying that the SUMO logo is successfully displayed"):
         image = sumo_pages.top_navbar.get_sumo_nav_logo()
         image_link = image.get_attribute("src")
-        response = requests.get(image_link, stream=True)
-        assert response.status_code < 400
+        response = utilities.get_api_response(page, image_link)
+        assert response.status < 400
 
     with allure.step("Verifying that the top-navbar for signed in users contains: Explore "
                      "Help Articles, Community Forums, Ask a Question and Contribute"):
@@ -47,14 +46,14 @@ def test_number_of_options_signed_in(page: Page, create_user_factory):
     with check, allure.step("Verifying that the SUMO logo is successfully displayed"):
         image = sumo_pages.top_navbar.get_sumo_nav_logo()
         image_link = image.get_attribute("src")
-        response = requests.get(image_link, stream=True)
-        assert response.status_code < 400
+        response = utilities.get_api_response(page, image_link)
+        assert response.status < 400
 
     with allure.step("Verifying that the top-navbar contains: Explore Help Articles, "
                      "Community Forums, Ask a Question, Contribute"):
         top_navbar_items = sumo_pages.top_navbar.get_available_menu_titles()
         assert top_navbar_items == TopNavbarMessages.TOP_NAVBAR_OPTIONS, (
-            "Incorrect elements displayed in top-navbar for " "signed-in state"
+            "Incorrect elements displayed in top-navbar for signed-in state"
         )
 
 
@@ -69,15 +68,11 @@ def test_explore_by_product_redirects(page: Page):
                      "redirect"):
         for index, option in enumerate(
             sumo_pages.top_navbar.get_all_explore_by_product_options_locators()):
-            if index > 0:
-                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option()
-            current_option = re.sub(
-                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
-            if sumo_pages.top_navbar._is_locator_visible(option):
-                sumo_pages.top_navbar._click(option)
-            else:
-                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option()
-                sumo_pages.top_navbar._click(option)
+            current_option = sumo_pages.top_navbar.get_text_of_option_and_click(
+                option,
+                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option,
+                is_first=index == 0,
+            )
 
             if current_option == "Firefox desktop":
                 current_option = utilities.remove_character_from_string(current_option, 'desktop')
@@ -99,15 +94,11 @@ def test_explore_by_topic_redirects(page: Page):
     with allure.step("Clicking on all options from the 'Explore by topic' and verifying the "
                      "redirect"):
         for index, option in enumerate(sumo_pages.top_navbar.get_all_explore_by_topic_locators()):
-            if index > 0:
-                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option()
-            current_option = re.sub(
-                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
-            if sumo_pages.top_navbar._is_locator_visible(option):
-                sumo_pages.top_navbar._click(option)
-            else:
-                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option()
-                sumo_pages.top_navbar._click(option)
+            current_option = sumo_pages.top_navbar.get_text_of_option_and_click(
+                option,
+                sumo_pages.top_navbar.hover_over_explore_by_product_top_navbar_option,
+                is_first=index == 0,
+            )
 
             assert (current_option == sumo_pages.explore_by_topic_page
                     .get_explore_by_topic_page_header())
@@ -136,15 +127,11 @@ def test_browse_by_product_community_forum_redirect(page: Page, create_user_fact
                      "redirect"):
         for index, option in enumerate(
             sumo_pages.top_navbar.get_all_browse_by_product_options_locators()):
-            if index > 0:
-                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option()
-            current_option = re.sub(
-                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
-            if sumo_pages.top_navbar._is_locator_visible(option):
-                sumo_pages.top_navbar._click(option)
-            else:
-                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option()
-                sumo_pages.top_navbar._click(option)
+            current_option = sumo_pages.top_navbar.get_text_of_option_and_click(
+                option,
+                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option,
+                is_first=index == 0,
+            )
 
             if current_option == "Firefox desktop":
                 current_option = utilities.remove_character_from_string(
@@ -170,15 +157,11 @@ def test_browse_all_forum_threads_by_topic_redirect(page: Page, create_user_fact
                      "verifying the redirect"):
         for index, option in enumerate(
             sumo_pages.top_navbar.get_all_browse_all_forum_threads_by_topic_locators()):
-            if index > 0:
-                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option()
-            current_option = re.sub(
-                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
-            if sumo_pages.top_navbar._is_locator_visible(option):
-                sumo_pages.top_navbar._click(option)
-            else:
-                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option()
-                sumo_pages.top_navbar._click(option)
+            current_option = sumo_pages.top_navbar.get_text_of_option_and_click(
+                option,
+                sumo_pages.top_navbar.hover_over_community_forums_top_navbar_option,
+                is_first=index == 0,
+            )
 
             assert (sumo_pages.product_support_page.get_product_support_title_text()
                     == "All Products Community Forum")
@@ -198,15 +181,11 @@ def test_ask_a_question_top_navbar_redirect(page: Page):
     with allure.step("Clicking on all options from the 'Ask a Question' and verifying the "
                      "redirect"):
         for index, option in enumerate(sumo_pages.top_navbar.get_all_ask_a_question_locators()):
-            if index > 0:
-                sumo_pages.top_navbar.hover_over_ask_a_question_top_navbar()
-            current_option = re.sub(
-                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
-            if sumo_pages.top_navbar._is_locator_visible(option):
-                sumo_pages.top_navbar._click(option)
-            else:
-                sumo_pages.top_navbar.hover_over_ask_a_question_top_navbar()
-                sumo_pages.top_navbar._click(option)
+            current_option = sumo_pages.top_navbar.get_text_of_option_and_click(
+                option,
+                sumo_pages.top_navbar.hover_over_ask_a_question_top_navbar,
+                is_first=index == 0,
+            )
 
             if current_option == "Firefox desktop":
                 current_option = utilities.remove_character_from_string(
@@ -240,15 +219,11 @@ def test_contribute_top_navbar_redirects(page: Page, create_user_factory):
                      "the redirects"):
         for index, option in enumerate(sumo_pages.top_navbar
                                        .get_all_contributor_discussions_locators()):
-            if index > 0:
-                sumo_pages.top_navbar.hover_over_contribute_top_navbar()
-            current_option = re.sub(
-                r'\s+', ' ', sumo_pages.top_navbar._get_text_of_locator(option)).strip()
-            if sumo_pages.top_navbar._is_locator_visible(option):
-                sumo_pages.top_navbar._click(option)
-            else:
-                sumo_pages.top_navbar.hover_over_contribute_top_navbar()
-                sumo_pages.top_navbar._click(option)
+            current_option = sumo_pages.top_navbar.get_text_of_option_and_click(
+                option,
+                sumo_pages.top_navbar.hover_over_contribute_top_navbar,
+                is_first=index == 0,
+            )
 
             if current_option == "Article discussions":
                 assert (sumo_pages.forum_discussions_page.get_forum_discussions_page_title()

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -1,3 +1,5 @@
+import random
+import string
 import allure
 import pytest
 from pytest_check import check
@@ -13,6 +15,18 @@ from playwright_tests.messages.my_profile_pages_messages.my_profile_page_message
 from playwright_tests.messages.my_profile_pages_messages.user_profile_navbar_messages import (
     UserProfileNavbarMessages)
 from playwright_tests.pages.sumo_pages import SumoPages
+
+
+def _submit_firefox_question(utilities: Utilities, sumo_pages: SumoPages) -> dict:
+    """Navigate to the Firefox AAQ form and submit a standard question."""
+    firefox_data = utilities.aaq_question_test_data["valid_firefox_question"]
+    utilities.navigate_to_link(utilities.aaq_question_test_data["products_aaq_url"]["Firefox"])
+    return sumo_pages.aaq_flow.submit_an_aaq_question(
+        subject=firefox_data["subject"],
+        topic_name=firefox_data["topic_value"],
+        body=firefox_data["question_body"],
+        expected_locator=sumo_pages.question_page.questions_header
+    )
 
 
 # C891409
@@ -76,16 +90,7 @@ def test_provided_solutions_number_is_successfully_displayed(page: Page, create_
 
     with allure.step("Navigating to the Firefox AAQ form and posting a new AAQ question for "
                      "the Firefox product"):
-        utilities.navigate_to_link(utilities.aaq_question_test_data["products_aaq_url"]["Firefox"])
-        question_info = (
-            sumo_pages.aaq_flow.submit_an_aaq_question(
-                subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=utilities.
-                aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=utilities.aaq_question_test_data["valid_firefox_question"]["question_body"],
-                expected_locator=sumo_pages.question_page.questions_header
-            )
-        )
+        question_info = _submit_firefox_question(utilities, sumo_pages)
 
     with allure.step("Posting a reply to the question"):
         utilities.start_existing_session(cookies=second_user)
@@ -160,18 +165,7 @@ def test_number_of_my_profile_answers_is_successfully_displayed(page: Page, crea
         utilities.start_existing_session(cookies=test_user)
 
     with allure.step("Navigating to the Firefox AAQ form and posting a new AAQ question"):
-        utilities.navigate_to_link(
-            utilities.aaq_question_test_data["products_aaq_url"]["Firefox"]
-        )
-        question_info = (
-            sumo_pages.aaq_flow.submit_an_aaq_question(
-                subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=utilities.
-                aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=utilities.aaq_question_test_data["valid_firefox_question"]["question_body"],
-                expected_locator=sumo_pages.question_page.questions_header
-            )
-        )
+        question_info = _submit_firefox_question(utilities, sumo_pages)
 
     with allure.step("Posting a reply for the question"):
         reply_text = utilities.question_test_data["non_solution_reply"]
@@ -193,8 +187,9 @@ def test_number_of_my_profile_answers_is_successfully_displayed(page: Page, crea
 
     with allure.step("Updating the question title and question reply"):
         sumo_pages.my_answers_page.click_on_specific_answer(answer_id)
-        updated_title_text = ("Updated Question Title " + utilities.
-                              generate_random_number(1,1000))
+        updated_title_text = (
+            "Updated Question Title ".join(random.choice(string.ascii_lowercase + string.digits
+                                                         ) for _ in range(10)))
         updated_reply_text = "Updated reply"
         sumo_pages.aaq_flow.editing_question_flow(subject=updated_title_text, submit_edit=True)
         sumo_pages.aaq_flow.editing_reply_flow(
@@ -255,7 +250,8 @@ def test_number_of_posted_articles_is_successfully_displayed(page: Page, create_
                 get_text_of_document_links())
 
     with allure.step("Navigating to the article and changing the title"):
-        new_article_title = "Updated title test " + utilities.generate_random_number(1, 1000)
+        new_article_title = "Updated ".join(random.choice(string.ascii_lowercase + string.digits
+                                                          ) for _ in range(10))
         sumo_pages.my_documents_page.click_on_a_particular_document(
             article_details['article_title'])
         sumo_pages.edit_article_metadata_flow.edit_article_metadata(title=new_article_title)

--- a/playwright_tests/tests/user_page_tests/test_my_questions.py
+++ b/playwright_tests/tests/user_page_tests/test_my_questions.py
@@ -8,6 +8,18 @@ from playwright_tests.messages.my_profile_pages_messages.my_questions_page_messa
 from playwright_tests.pages.sumo_pages import SumoPages
 
 
+def _submit_firefox_question(utilities: Utilities, sumo_pages: SumoPages) -> dict:
+    """Navigate to the Firefox AAQ form and submit a standard question."""
+    firefox_data = utilities.aaq_question_test_data["valid_firefox_question"]
+    utilities.navigate_to_link(utilities.aaq_question_test_data["products_aaq_url"]["Firefox"])
+    return sumo_pages.aaq_flow.submit_an_aaq_question(
+        subject=firefox_data["subject"],
+        topic_name=firefox_data["topic_value"],
+        body=firefox_data["question_body"],
+        expected_locator=sumo_pages.question_page.questions_header
+    )
+
+
 #  C2094280,  C890790
 @pytest.mark.userQuestions
 def test_number_of_questions_is_incremented_when_posting_a_question(page: Page,
@@ -20,14 +32,7 @@ def test_number_of_questions_is_incremented_when_posting_a_question(page: Page,
         utilities.start_existing_session(cookies=test_user)
 
     with allure.step("Navigating to the AAQ form and posting a new AAQ question"):
-        utilities.navigate_to_link(utilities.aaq_question_test_data["products_aaq_url"]["Firefox"])
-
-        sumo_pages.aaq_flow.submit_an_aaq_question(
-            subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-            topic_name=utilities.aaq_question_test_data["valid_firefox_question"]["topic_value"],
-            body=utilities.aaq_question_test_data["valid_firefox_question"]["question_body"],
-            expected_locator=sumo_pages.question_page.questions_header
-        )
+        _submit_firefox_question(utilities, sumo_pages)
 
     with allure.step("Navigating back to the profile page and verifying that the number of "
                      "questions has incremented"):
@@ -48,19 +53,8 @@ def test_my_contributions_questions_reflects_my_questions_page_numbers(page: Pag
         utilities.start_existing_session(cookies=test_user)
 
     with allure.step("Submitting two new questions"):
-        counter = 0
-        while counter < 2:
-            utilities.navigate_to_link(
-                utilities.aaq_question_test_data["products_aaq_url"]["Firefox"]
-            )
-            sumo_pages.aaq_flow.submit_an_aaq_question(
-                subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=utilities.
-                aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=utilities.aaq_question_test_data["valid_firefox_question"]["question_body"],
-                expected_locator=sumo_pages.question_page.questions_header
-            )
-            counter += 1
+        for _ in range(2):
+            _submit_firefox_question(utilities, sumo_pages)
 
     with allure.step("Accessing the 'My profile' and extracting the number of questions "
                      "listed inside the my profile page"):
@@ -100,16 +94,7 @@ def test_correct_messages_is_displayed_if_user_has_no_posted_questions(page: Pag
 
     with allure.step("Navigating to the Firefox AAQ form and posting a new AAQ question for "
                      "the Firefox product"):
-        utilities.navigate_to_link(utilities.aaq_question_test_data["products_aaq_url"]["Firefox"])
-        question_info = (
-            sumo_pages.aaq_flow.submit_an_aaq_question(
-                subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=utilities
-                .aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=utilities.aaq_question_test_data["valid_firefox_question"]["question_body"],
-                expected_locator=sumo_pages.question_page.questions_header
-            )
-        )
+        question_info = _submit_firefox_question(utilities, sumo_pages)
 
     with check, allure.step("Accessing the my questions page and verifying that the no question"
                             " message is no longer displayed"):
@@ -142,26 +127,8 @@ def test_question_page_reflects_posted_questions_and_redirects_to_question(page:
         utilities.start_existing_session(cookies=test_user)
 
     with allure.step("Navigating to the Firefox AAQ form and posting a new AAQ question"):
-        utilities.navigate_to_link(utilities.aaq_question_test_data["products_aaq_url"]["Firefox"])
-        first_question = (
-            sumo_pages.aaq_flow.submit_an_aaq_question(
-                subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=utilities.
-                aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=utilities.aaq_question_test_data["valid_firefox_question"]["question_body"],
-                expected_locator=sumo_pages.question_page.questions_header
-            )
-        )
-        utilities.navigate_to_link(utilities.aaq_question_test_data["products_aaq_url"]["Firefox"])
-        second_question = (
-            sumo_pages.aaq_flow.submit_an_aaq_question(
-                subject=utilities.aaq_question_test_data["valid_firefox_question"]["subject"],
-                topic_name=utilities.
-                aaq_question_test_data["valid_firefox_question"]["topic_value"],
-                body=utilities.aaq_question_test_data["valid_firefox_question"]["question_body"],
-                expected_locator=sumo_pages.question_page.questions_header
-            )
-        )
+        first_question = _submit_firefox_question(utilities, sumo_pages)
+        second_question = _submit_firefox_question(utilities, sumo_pages)
 
     with check, allure.step("Navigating to my questions profile page and verifying that the first "
                             "element from the My Questions page is the recently posted question"):
@@ -181,4 +148,3 @@ def test_question_page_reflects_posted_questions_and_redirects_to_question(page:
         utilities.navigate_back()
         sumo_pages.my_questions_page.click_on_a_question_by_index(2)
         expect(page).to_have_url(first_question["question_page_url"])
-


### PR DESCRIPTION
- Use `@cached_property` for sumo_pages to achieve lazy instantiation & instance reuse.
- Convert all UserGroupMessages methods to `@staticmethod` with descriptive parameter names (username, group_name)
- Convert MyProfileMessages.get_my_profile_stage_url to `@staticmethod`
- Convert KBDashboardPageMessages.get_kb_not_live_status to `@staticmethod` and remove unnecessary class instantiation from all test functions
- Fix method name typo: get_list_of_all_locale_tage -> get_list_of_all_locale_tags
- Add skip reason to bare `@pytest.mark.skip` decorator
- Add missing soft-assert (with check) wrappers in test_add_new_group_leader
- Remove incorrect soft-assert wrapper from non-assertion action step
- Simplify date filter logic with list comprehension and named variables
- Replace hardcoded date strings with existing variables
- Refactor basepage, sumo_pages, top_navbar, and various page objects
- Update test files to use refactored page utilities