### PR TITLE
Switch avatar fallback to a capture-phase listener

### DIFF
--- a/kitsune/sumo/static/sumo/js/profile-avatars.js
+++ b/kitsune/sumo/static/sumo/js/profile-avatars.js
@@ -1,16 +1,31 @@
 import avatar from "sumo/img/avatar.png";
 
-const imgs = Array.from(new Set(
-  document.querySelectorAll('img.avatar, .avatar img')
-));
+const FALLBACK_URL = new URL(avatar, window.location.href).href;
+const AVATAR_SELECTOR = 'img.avatar, .avatar img';
 
+window.addEventListener(
+  'error',
+  (event) => {
+    const target = event.target;
+    if (isAvatar(target) && target.src != FALLBACK_URL) {
+      target.src = avatar;
+    }
+  },
+  true
+);
+
+// Apply the fallback to the images not caught by the above listener.
+const imgs = Array.from(new Set(
+  document.querySelectorAll(AVATAR_SELECTOR)
+));
 if (imgs) {
-  imgs.forEach(function(e) {
-    e.addEventListener('error', defaultAvatar);
+  imgs.forEach(function(img) {
+    if (img.complete && img.currentSrc && img.naturalWidth === 0) {
+      img.src = avatar;
+    }
   });
 }
 
-function defaultAvatar() {
-  this.onerror = null;
-  this.src = avatar;
+function isAvatar(target) {
+  return target instanceof HTMLImageElement && target.matches(AVATAR_SELECTOR);
 }


### PR DESCRIPTION
- Switch JS-level avatar fallback to a capture-phase listener, which ensures fallback for dynamically added elements.
- Ensure fallback for avatars that fail to load before the listener is even added.

Resolves [#2809](https://github.com/mozilla/sumo/issues/2809).