### PR TITLE
handle nullified profile on account events

### DIFF
--- a/kitsune/users/tasks.py
+++ b/kitsune/users/tasks.py
@@ -22,6 +22,15 @@ shared_task_with_retry = shared_task(
 log = logging.getLogger("k.task")
 
 
+def ignore_if_missing_profile(event: AccountEvent) -> bool:
+    """Checks if an event has an associated profile and, if not, marks it as ignored."""
+    if event.profile is None:
+        event.status = AccountEvent.IGNORED
+        event.save(update_fields=["status"])
+        return True
+    return False
+
+
 @shared_task_with_retry
 @transaction.atomic
 def process_event_delete_user(event_id):
@@ -30,9 +39,7 @@ def process_event_delete_user(event_id):
     except AccountEvent.DoesNotExist:
         return
 
-    if event.profile is None:
-        event.status = AccountEvent.IGNORED
-        event.save(update_fields=["status"])
+    if ignore_if_missing_profile(event):
         return
 
     user = event.profile.user
@@ -56,9 +63,7 @@ def process_event_subscription_state_change(event_id):
     except AccountEvent.DoesNotExist:
         return
 
-    if event.profile is None:
-        event.status = AccountEvent.IGNORED
-        event.save(update_fields=["status"])
+    if ignore_if_missing_profile(event):
         return
 
     body = json.loads(event.body)
@@ -92,9 +97,7 @@ def process_event_password_change(event_id):
     except AccountEvent.DoesNotExist:
         return
 
-    if event.profile is None:
-        event.status = AccountEvent.IGNORED
-        event.save(update_fields=["status"])
+    if ignore_if_missing_profile(event):
         return
 
     body = json.loads(event.body)
@@ -120,9 +123,7 @@ def process_event_profile_change(event_id):
     except AccountEvent.DoesNotExist:
         return
 
-    if event.profile is None:
-        event.status = AccountEvent.IGNORED
-        event.save(update_fields=["status"])
+    if ignore_if_missing_profile(event):
         return
 
     refresh_token = event.profile.fxa_refresh_token

--- a/kitsune/users/tests/test_tasks.py
+++ b/kitsune/users/tests/test_tasks.py
@@ -268,7 +268,7 @@ class AccountEventsTasksTestCase(TestCase):
         self.assertIs(profile.fxa_password_change, None)
         self.assertEqual(account_event.status, AccountEvent.UNPROCESSED)
 
-    def test_process_delete_user_with_none_profile(self):
+    def test_process_delete_user_without_profile(self):
         account_event = AccountEventFactory(
             body=json.dumps({}),
             event_type=AccountEvent.DELETE_USER,
@@ -281,7 +281,7 @@ class AccountEventsTasksTestCase(TestCase):
 
         self.assertEqual(account_event.status, AccountEvent.IGNORED)
 
-    def test_process_subscription_state_change_with_none_profile(self):
+    def test_process_subscription_state_change_without_profile(self):
         account_event = AccountEventFactory(
             body=json.dumps({"capabilities": ["capability_1"], "isActive": True, "changeTime": 1}),
             event_type=AccountEvent.SUBSCRIPTION_STATE_CHANGE,
@@ -294,7 +294,7 @@ class AccountEventsTasksTestCase(TestCase):
 
         self.assertEqual(account_event.status, AccountEvent.IGNORED)
 
-    def test_process_password_change_with_none_profile(self):
+    def test_process_password_change_without_profile(self):
         account_event = AccountEventFactory(
             body=json.dumps({"changeTime": 2000}),
             event_type=AccountEvent.PASSWORD_CHANGE,
@@ -307,7 +307,7 @@ class AccountEventsTasksTestCase(TestCase):
 
         self.assertEqual(account_event.status, AccountEvent.IGNORED)
 
-    def test_process_profile_change_with_none_profile(self):
+    def test_process_profile_change_without_profile(self):
         account_event = AccountEventFactory(
             body=json.dumps({}),
             event_type=AccountEvent.PROFILE_CHANGE,

--- a/kitsune/users/views.py
+++ b/kitsune/users/views.py
@@ -586,15 +586,33 @@ class WebhookView(View):
         for long_id, event in events.items():
             short_id = long_id.replace(SET_ID_PREFIX, "")
 
-            account_event = AccountEvent.objects.create(
-                issued_at=payload["iat"],
-                jwt_id=payload["jti"],
-                fxa_uid=fxa_uid,
-                status=AccountEvent.UNPROCESSED if profile_obj else AccountEvent.IGNORED,
-                body=json.dumps(event),
-                event_type=short_id,
-                profile=profile_obj,
-            )
+            if profile_obj and (short_id == AccountEvent.DELETE_USER):
+                # Avoid duplicate unprocessed delete-user events for the same profile.
+                account_event, created = AccountEvent.objects.get_or_create(
+                    profile=profile_obj,
+                    event_type=short_id,
+                    status=AccountEvent.UNPROCESSED,
+                    defaults={
+                        "fxa_uid": fxa_uid,
+                        "jwt_id": payload["jti"],
+                        "body": json.dumps(event),
+                        "issued_at": payload["iat"],
+                    },
+                )
+                if not created:
+                    # An unprocessed delete-user event for the same user already exists, and
+                    # has already been queued for processing, so no need to queue it again.
+                    continue
+            else:
+                account_event = AccountEvent.objects.create(
+                    issued_at=payload["iat"],
+                    jwt_id=payload["jti"],
+                    fxa_uid=fxa_uid,
+                    status=AccountEvent.UNPROCESSED if profile_obj else AccountEvent.IGNORED,
+                    body=json.dumps(event),
+                    event_type=short_id,
+                    profile=profile_obj,
+                )
 
             if profile_obj:
                 match short_id:


### PR DESCRIPTION
mozilla/sumo#2816

I was able to confirm the root cause of these errors. It's due to duplicate Mozilla Account events. For example, I can see two `delete-user` account events for a specific `fxa_uid` created within a second of each other. They both initially have profiles, but when the first is processed, the user deletion cascades such that the profile of the second is set to `None`, so when the second is processed, it fails when trying to get the user via its profile.

This PR doesn't attempt to de-duplicate account events. It only takes the defensive approach, detecting account events that have had their profiles nullified, and changing their status to `IGNORED`. We could, I think, de-duplicate events as well, if desired, with something like the following in the loop within `WebhookView.process_events`:

```python
for long_id, event in events.items():
    short_id = ...
    # Ignore duplicate events.
    if AccountEvent.objects.filter(fxa_uid=fxa_uid, event_type=short_id, status=AccountEvent.UNPROCESSED).exists():
        continue
    ...
```

By **not** doing that, we do gain a record of **all** incoming events, so I've opted for that approach (at least for now).
