### PR TITLE
Display spam questions for moderators in the user view

### DIFF
--- a/kitsune/sumo/jinja2/sumo/includes/question_entry.html
+++ b/kitsune/sumo/jinja2/sumo/includes/question_entry.html
@@ -101,6 +101,7 @@
     {% if question.channel == "direct_support" %}
       <span class="my-questions--channel-badge my-questions--channel-badge--direct-support"
             title="{{ _('This question was submitted via Direct Support') }}">
+        {# L10n: A label/tab for questions that are Premium support tickets handled by paid support agents. #}
         {{ _("Direct Support") }}
       </span>
       {% if question.zd_status == question.ZD_STATUS_SOLVED %}

--- a/kitsune/users/jinja2/users/questions_contributed.html
+++ b/kitsune/users/jinja2/users/questions_contributed.html
@@ -10,6 +10,7 @@
       {% if is_owner %}
         {{ _("My Questions") }}
       {% else %}
+        {# L10n: This is a title for user questions pages (like https://support.mozilla.org/user/kelimuttu/questions), displayed when a page is viewed by someone other than the profile owner. The page lists questions authored by the user. #}
         {{ _("Questions Asked") }}
       {% endif %}
     </h2>
@@ -21,10 +22,29 @@
           <a href="?" {% if not channel %}class="selected"{% endif %}><span>{{ _("All") }}</span></a>
         </li>
         <li class="tabs--item">
+          {# L10n: Displayed for users viewing their own questions. This is a label for a tab that lists community forum questions authored by the user. #}
           <a href="?channel=forum" {% if channel == "forum" %}class="selected"{% endif %}><span>{{ _("Forum") }}</span></a>
         </li>
         <li class="tabs--item">
+          {# L10n: A label/tab for questions that are Premium support tickets handled by paid support agents. #}
           <a href="?channel=direct_support" {% if channel == "direct_support" %}class="selected"{% endif %}><span>{{ _("Direct Support") }}</span></a>
+        </li>
+      </ul>
+    </nav>
+    {% endif %}
+
+    {% if is_moderator and (user_has_spam_questions or show) and not is_owner %}
+    <nav class="tabs">
+      <ul class="tabs--list">
+        <li class="tabs--item">
+          <a href="?" {% if not show %}class="selected"{% endif %}><span>{{ _("All") }}</span></a>
+        </li>
+        <li class="tabs--item">
+          {# L10n: Displayed for moderators only on user questions pages (like https://support.mozilla.org/user/kelimuttu/questions). This is a label for a tab that lists all non-spam forum questions authored by the user. #}
+          <a href="?show=valid" {% if show == "valid" %}class="selected"{% endif %}><span>{{ _("Valid") }}</span></a>
+        </li>
+        <li class="tabs--item">
+          <a href="?show=spam" {% if show == "spam" %}class="selected"{% endif %}><span>{{ _("Spam") }}</span></a>
         </li>
       </ul>
     </nav>

--- a/kitsune/users/views.py
+++ b/kitsune/users/views.py
@@ -223,6 +223,7 @@ def questions_contributed(request, username):
     profile = get_object_or_404(Profile, user__username=username, user__is_active=True)
 
     channel = request.GET.get("channel")
+    show = request.GET.get("show")
     product_slug = request.GET.get("product")
     topic_slug = request.GET.get("topic")
 
@@ -230,9 +231,13 @@ def questions_contributed(request, username):
     if not is_owner and channel == "direct_support":
         raise Http404()
 
+    is_moderator = request.user.has_perm("flagit.can_moderate")
+    if not is_moderator and show == "spam":
+        raise Http404()
+
     if channel != "direct_support":
         forum_questions = (
-            profile.user.questions.filter(is_spam=False)
+            profile.user.questions
             .select_related("solution", "product", "topic", "last_answer", "last_answer__creator")
             .order_by("-created")
         )
@@ -240,8 +245,14 @@ def questions_contributed(request, username):
             forum_questions = forum_questions.filter(product__slug=product_slug)
         if topic_slug:
             forum_questions = forum_questions.filter(topic__slug=topic_slug)
+        user_has_spam_questions = forum_questions.filter(is_spam=True).exists()
+        if is_moderator and show == "spam":
+            forum_questions = forum_questions.filter(is_spam=True)
+        elif not is_moderator or show == "valid":
+            forum_questions = forum_questions.filter(is_spam=False)
     else:
         forum_questions = profile.user.questions.none()
+        user_has_spam_questions = False
 
     support_tickets = (
         SupportTicket.objects.filter(
@@ -272,8 +283,11 @@ def questions_contributed(request, username):
             "profile": profile,
             "questions": questions,
             "channel": channel,
+            "show": show,
             "product_slug": product_slug,
             "topic_slug": topic_slug,
+            "is_moderator": is_moderator,
+            "user_has_spam_questions": user_has_spam_questions,
         },
     )
 


### PR DESCRIPTION
Resolves [#2961](https://github.com/mozilla/sumo/issues/2961).

Restore displaying of spam questions to moderators on the Questions Asked pages, and introduce a moderator-specific view consisting of 3 tabs:
- **All** (default), listing all the questions, including spam ones
- **Valid**, listing only questions not marked as spam
- **Spam**, listing only questions marked as spam

The tabs will be hidden when there are no spam questions (so that it's easy to see if there are any) and when viewing your own profile. The tabs will _not_ be hidden if you have legitimately opened one, even if there are no spam questions at the moment (so that you can always navigate back).

<img width="2526" height="1352" alt="image" src="https://github.com/user-attachments/assets/98ff6c0b-d6df-44ee-a9e4-1aa887d12be3" />

<img width="2526" height="1034" alt="image" src="https://github.com/user-attachments/assets/ecd53128-e85e-4a00-b243-53bcf41a07c3" />

<img width="2526" height="1034" alt="image" src="https://github.com/user-attachments/assets/ef63f615-df8c-421d-aba8-73958da94e11" />