### PR TITLE
Add dark mode

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -3,8 +3,14 @@
 {% if request.LANGUAGE_CODE == 'xx' %}
   {% set meta = [('robots', 'noindex')] %}
 {% endif %}
+{# Read the theme cookie set by theme-toggle.js so we can pre-render the correct     #}
+{# data-theme and background inline — this eliminates a potential navigation flash entirely  #}
+{# because the HTML arrives from the server already styled, before any JS runs.      #}
+{% set _theme_cookie = request.COOKIES.get('sumo-theme', '') %}
+{% set _is_dark = _theme_cookie == 'dark' %}
 <!DOCTYPE html>
 <html class="no-js" lang="{{ request.LANGUAGE_CODE }}"
+  {% if _is_dark %}data-theme="dark" style="background-color:#1C1B22;color-scheme:dark"{% elif _theme_cookie == 'light' %}data-theme="light" style="color-scheme:light"{% endif %}
   {% if DIR %}dir="{{ DIR }}"{% endif %}
   {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %}
   {% if ga_content_group %}data-ga-content-group="{{ ga_content_group }}"{% endif %}
@@ -15,6 +21,28 @@
   {% if settings.GA_CONSOLE_LOGGING %}data-ga-console-logging="true"{% endif %}
   {% if settings.GA_DEBUG_MODE %}data-ga-debug-mode="true"{% endif %}>
 <head>
+  {# ============================================================ #}
+  {# Theme flash prevention                                       #}
+  {# Primary: data-theme + style are pre-rendered by Django from  #}
+  {# the sumo-theme cookie (set by theme-toggle.js on toggle).   #}
+  {# Fallback: inline style + script cover first-time visitors    #}
+  {# (no cookie yet) who rely on OS dark mode.                   #}
+  {# #1C1B22 = --color-dark-gray-09 = --page-bg in dark mode.    #}
+  {# ============================================================ #}
+  <style>
+    :root { color-scheme: light dark; }
+    @media (prefers-color-scheme: dark) {
+      html:not([data-theme="light"]),
+      html:not([data-theme="light"]) body { background-color: #1C1B22; color-scheme: dark; }
+    }
+    html[data-theme="dark"],
+    html[data-theme="dark"] body { background-color: #1C1B22; color-scheme: dark; }
+    html[data-theme="light"],
+    html[data-theme="light"] body { color-scheme: light; }
+  </style>
+  {# Fallback for first-time OS-dark visitors with no cookie yet. #}
+  <script>(function(){if(document.documentElement.getAttribute('data-theme'))return;var p=window.matchMedia('(prefers-color-scheme:dark)').matches;if(p){var e=document.documentElement;e.style.backgroundColor='#1C1B22';e.style.colorScheme='dark';}})();</script>
+
   {% include "includes/google-analytics.html" %}
 
   {% block head_top %}{% endblock %}
@@ -137,6 +165,19 @@
         {% endif %}
 
       </a>
+      <div class="sumo-nav--theme-toggle" x-data="themeToggle()">
+        <button
+          type="button"
+          class="sumo-nav--theme-toggle-button"
+          x-on:click="toggle()"
+          aria-label="{{ _('Toggle dark mode') }}">
+          {# Moon: shown in light mode — click to go dark #}
+          <svg class="theme-icon theme-icon--moon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          {# Sun: shown in dark mode — click to go light #}
+          <svg class="theme-icon theme-icon--sun" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        </button>
+      </div>
+
       <div class="mzp-c-navigation-items sumo-nav--list-wrap" id="main-navigation">
         <div class="mzp-c-navigation-menu">
           <nav class="mzp-c-menu mzp-is-basic">

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -155,7 +155,7 @@
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
           <div class="mzp-c-menu-item-head">
             <svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <g transform="translate(3 3)" stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd"
+              <g transform="translate(3 3)" stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd"
                 stroke-linecap="round">
                 <rect stroke-linejoin="round" width="18" height="18" rx="2" />
                 <path d="M4 5h10M4 9h10M4 13h4" />
@@ -228,7 +228,7 @@
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
             <div class="mzp-c-menu-item-head">
               <svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                <g transform="translate(3 3)" stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd"
+                <g transform="translate(3 3)" stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd"
                   stroke-linecap="round">
                   <rect stroke-linejoin="round" width="18" height="18" rx="2" />
                   <path d="M4 5h10M4 9h10M4 13h4" />
@@ -255,7 +255,7 @@
             <div class="mzp-c-menu-item-head">
               <svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24">
-                <g stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
+                <g stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
                   stroke-linejoin="round">
                   <path
                     d="M17 17l-1.051 3.154a1 1 0 01-1.898 0L13 17H5a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2h-2zM7 8h10M7 12h10" />
@@ -334,7 +334,7 @@
                 viewBox="0 0 24 24">
                 <path
                   d="M10.5 9.5L3 17c-1 1.667-1 3 0 4s2.333.833 4-.5l7.5-7.5c2.333 1.054 4.333.734 6-.96 1.667-1.693 1.833-3.707.5-6.04l-3 3-2.5-.5L15 6l3-3c-2.333-1.333-4.333-1.167-6 .5-1.667 1.667-2.167 3.667-1.5 6z"
-                  stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
+                  stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
                   stroke-linejoin="round" />
               </svg>
               <h4 class="mzp-c-menu-item-title">{{ _('Browse all forum threads by topic') }}</h4>
@@ -361,7 +361,7 @@
             <div class="mzp-c-menu-item-head">
               <svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24">
-                <g stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
+                <g stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
                   stroke-linejoin="round">
                   <path d="M11 3H4a2 2 0 00-2 2v12a2 2 0 002 2h9l2 4 2-4h2a2 2 0 002-2v-6" />
                   <path d="M17.5 2.5a2.121 2.121 0 013 3L13 13l-4 1 1-4 7.5-7.5z" />
@@ -521,7 +521,7 @@
                 data-event-parameters='{"link_name": "main-menu.contributor-discussions"}'>
                 <svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 24 24">
-                  <g stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
+                  <g stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
                     stroke-linejoin="round">
                     <path
                       d="M17 17l-1.051 3.154a1 1 0 01-1.898 0L13 17H5a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2h-2zM7 8h10M7 12h10" />
@@ -543,7 +543,7 @@
                   viewBox="0 0 24 24">
                   <path
                     d="M10.5 9.5L3 17c-1 1.667-1 3 0 4s2.333.833 4-.5l7.5-7.5c2.333 1.054 4.333.734 6-.96 1.667-1.693 1.833-3.707.5-6.04l-3 3-2.5-.5L15 6l3-3c-2.333-1.333-4.333-1.167-6 .5-1.667 1.667-2.167 3.667-1.5 6z"
-                    stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
+                    stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
                     stroke-linejoin="round" />
                 </svg>
                 <h4 class="mzp-c-menu-item-title">{{ _('Contributor tools') }}</h4>
@@ -595,7 +595,7 @@
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
             <a class="mzp-c-menu-item-link" rel="nofollow" href="{{ profile_url(user) }}">
               <svg class="mzp-c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                <g transform="translate(5 3)" stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd">
+                <g transform="translate(5 3)" stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd">
                   <path d="M0 18c1-4 3.333-6 7-6s6 2 7 6" stroke-linecap="round" />
                   <circle cx="7" cy="4" r="4" />
                 </g>
@@ -615,7 +615,7 @@
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
             <a class="mzp-c-menu-item-link" rel="nofollow" href="{{ url('users.edit_settings') }}">
               <svg class="mzp-c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                <g transform="translate(1 1)" stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd"
+                <g transform="translate(1 1)" stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd"
                   stroke-linecap="round" stroke-linejoin="round">
                   <circle cx="11" cy="11" r="3" />
                   <path
@@ -633,7 +633,7 @@
           <section class="mzp-c-menu-item mzp-has-icon sumo-nav--dropdown-item">
             <a class="mzp-c-menu-item-link" href="{{ url('messages.inbox') }}">
               <svg class="mzp-c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                <g stroke="#000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
+                <g stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"
                   stroke-linejoin="round">
                   <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
                   <path d="M22 6l-10 7L2 6" />

--- a/kitsune/sumo/static/sumo/js/alpine.js
+++ b/kitsune/sumo/static/sumo/js/alpine.js
@@ -2,9 +2,12 @@ import Alpine from "@alpinejs/csp";
 import trackEvent from "sumo/js/analytics";
 // we need to import surveyForm here so it's available to Alpine components
 import surveyForm from "sumo/js/survey_form";
+import { themeToggle } from "sumo/js/theme-toggle";
 
 window.Alpine = Alpine;
 // Add trackEvent to the window object so it's available to Alpine components
 window.trackEvent = trackEvent;
+
+Alpine.data('themeToggle', themeToggle);
 
 Alpine.start();

--- a/kitsune/sumo/static/sumo/js/messages.js
+++ b/kitsune/sumo/static/sumo/js/messages.js
@@ -46,7 +46,7 @@ $(function() {
     message = interpolate(gettext('%s characters remaining'), [delta]);
     $summaryCount.text(message);
     if (maxCount - currentCount >= 10) {
-      $summaryCount.css('color', 'black');
+      $summaryCount.css('color', '');
     } else {
       $summaryCount.css('color', 'red');
       if (currentCount >= maxCount) {

--- a/kitsune/sumo/static/sumo/js/theme-toggle.js
+++ b/kitsune/sumo/static/sumo/js/theme-toggle.js
@@ -1,0 +1,61 @@
+const STORAGE_KEY = 'sumo-theme';
+const COOKIE_NAME = 'sumo-theme';
+// 1 year in seconds
+const COOKIE_MAX_AGE = 31536000;
+
+function getSystemTheme() {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function getSavedTheme() {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  return (saved === 'dark' || saved === 'light') ? saved : null;
+}
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  // Persist as a cookie so Django can pre-render data-theme server-side,
+  // eliminating the navigation flash before any JS runs.
+  document.cookie = `${COOKIE_NAME}=${theme};path=/;max-age=${COOKIE_MAX_AGE};SameSite=Lax`;
+}
+
+/**
+ * Alpine component for the theme toggle button.
+ * Register via: Alpine.data('themeToggle', themeToggle)
+ */
+export function themeToggle() {
+  return {
+    theme: getSavedTheme() || getSystemTheme(),
+
+    get isDark() {
+      return this.theme === 'dark';
+    },
+
+    toggle() {
+      this.theme = this.isDark ? 'light' : 'dark';
+      localStorage.setItem(STORAGE_KEY, this.theme);
+      applyTheme(this.theme);
+    },
+
+    init() {
+      // Sync with what the server-rendered data-theme (from cookie) already set.
+      const htmlTheme = document.documentElement.getAttribute('data-theme');
+      if (htmlTheme === 'dark' || htmlTheme === 'light') {
+        this.theme = htmlTheme;
+      } else {
+        // No server-side cookie yet (e.g. first visit) — apply and set cookie now.
+        applyTheme(this.theme);
+      }
+
+      // Stay in sync when the user changes preference in another tab.
+      window.addEventListener('storage', (e) => {
+        if (e.key === STORAGE_KEY) {
+          this.theme = (e.newValue === 'dark' || e.newValue === 'light')
+            ? e.newValue
+            : getSystemTheme();
+          applyTheme(this.theme);
+        }
+      });
+    },
+  };
+}

--- a/kitsune/sumo/static/sumo/js/wiki.js
+++ b/kitsune/sumo/static/sumo/js/wiki.js
@@ -215,9 +215,9 @@ import collapsibleAccordionInit from "sumo/js/protocol-details-init";
         var currentCount = $summaryBox.val().length;
         $summaryCount.text(warningCount - currentCount);
         if (warningCount - currentCount >= 0) {
-          $summaryCount.css('color', 'black');
+          $summaryCount.css('color', '');
         } else {
-          $summaryCount.css('color', 'red');
+          $summaryCount.css('color', 'var(--color-error)');
           if (currentCount >= maxCount) {
             $summaryBox.val($summaryBox.val().substr(0, maxCount));
           }

--- a/kitsune/sumo/static/sumo/scss/base/_reset.scss
+++ b/kitsune/sumo/static/sumo/scss/base/_reset.scss
@@ -10,6 +10,7 @@ body {
   display: flex;
   flex-direction: column;
   height: auto;
+  background-color: var(--page-bg);
 }
 *, *:before, *:after {
   box-sizing: border-box;

--- a/kitsune/sumo/static/sumo/scss/base/_table.scss
+++ b/kitsune/sumo/static/sumo/scss/base/_table.scss
@@ -172,3 +172,39 @@ td.status,
 td.ready-for-l10n.yes {
   background: var(--color-green-03);
 }
+
+@media (prefers-color-scheme: dark) {
+  td.needs-update.yes,
+  td.stale.yes {
+    background: rgba(255, 213, 0, 0.15);
+  }
+
+  td.status,
+  td.ready-for-l10n.yes {
+    background: rgba(63, 180, 111, 0.15);
+  }
+}
+
+[data-theme="dark"] {
+  td.needs-update.yes,
+  td.stale.yes {
+    background: rgba(255, 213, 0, 0.15);
+  }
+
+  td.status,
+  td.ready-for-l10n.yes {
+    background: rgba(63, 180, 111, 0.15);
+  }
+}
+
+[data-theme="light"] {
+  td.needs-update.yes,
+  td.stale.yes {
+    background: var(--color-yellow-03);
+  }
+
+  td.status,
+  td.ready-for-l10n.yes {
+    background: var(--color-green-03);
+  }
+}

--- a/kitsune/sumo/static/sumo/scss/base/forms/_buttons.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_buttons.scss
@@ -258,6 +258,16 @@ input[type=submit]:focus {
   }
 }
 
+@media (prefers-color-scheme: dark) {
+  .is-details .icon-button button {
+    filter: invert(1);
+  }
+}
+
+[data-theme="dark"] .is-details .icon-button button {
+  filter: invert(1);
+}
+
 
 .sumo-close-button {
   appearance: none;

--- a/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_fields.scss
@@ -8,6 +8,31 @@
   --field-border-color-disabled: var(--color-marketing-gray-03);
   --field-background-color-disabled: var(--color-marketing-gray-01);
   --field-color-disabled: var(--color-marketing-gray-03);
+  --field-bg: var(--color-white);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --field-border-color-default: var(--color-border);
+    --field-border-color-hover: var(--color-click);
+    --field-border-color-disabled: var(--color-border);
+    --field-background-color-disabled: var(--color-shade-bg);
+    --field-color-disabled: var(--color-text-light);
+    --field-bg: var(--card-bg);
+  }
+}
+
+[data-theme="dark"] {
+  --field-border-color-default: var(--color-border);
+  --field-border-color-hover: var(--color-click);
+  --field-border-color-disabled: var(--color-border);
+  --field-background-color-disabled: var(--color-shade-bg);
+  --field-color-disabled: var(--color-text-light);
+  --field-bg: var(--card-bg);
+}
+
+[data-theme="light"] {
+  --field-bg: var(--color-white);
 }
 
 // Forms
@@ -58,7 +83,7 @@ label {
   display: block;
   margin-bottom: p.$spacing-sm;
   @include c.text-body-md;
-  color: var(--color-marketing-gray-07);
+  color: var(--color-text);
   font-weight: bold;
 
   .required {
@@ -217,8 +242,8 @@ textarea,
   height: 40px;
   border: 2px solid var(--field-border-color-default);
   border-radius: var(--global-radius);
-  background-color: var(--color-white);
-  color: #0c0c0d;
+  background-color: var(--field-bg);
+  color: var(--color-text);
   outline: 0;
   transition-duration: 150ms;
   transition-property: border-color;
@@ -293,7 +318,7 @@ select,
 .ts-select-trigger {
   position: relative;
   background-image: c.svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 10"><path fill="none" vector-effect="non-scaling-stroke" stroke="#42435A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M1 1l8 8 8-8"/></svg>');
-  background-color: var(--color-white);
+  background-color: var(--field-bg);
   @include p.bidi(((background-position, top 14px right 14px, top 14px left 14px),
       (padding-right, 40px, p.$spacing-sm),
       (padding-left, p.$spacing-sm, 40px),
@@ -476,7 +501,7 @@ label.required::after {
 }
 
 .field > label.disabled {
-  color: #d0d0d7;
+  color: var(--color-text-light);
 }
 
 #edit-document {

--- a/kitsune/sumo/static/sumo/scss/base/forms/_simple-search-form.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_simple-search-form.scss
@@ -60,6 +60,20 @@
   }
 }
 
+@media (prefers-color-scheme: dark) {
+  .search-button {
+    filter: invert(1);
+  }
+}
+
+[data-theme="dark"] .search-button {
+  filter: invert(1);
+}
+
+[data-theme="light"] .search-button {
+  filter: none;
+}
+
 .popular-searches {
   display: none;
 

--- a/kitsune/sumo/static/sumo/scss/base/forms/_toggles.scss
+++ b/kitsune/sumo/static/sumo/scss/base/forms/_toggles.scss
@@ -61,7 +61,7 @@
     width: calc(var(--switch-size) / 2 - 6px);
     height:  calc(var(--switch-size) / 2 - 6px);
     border-radius: calc(var(--switch-size) / 2 - #{p.$spacing-xs});
-    background: #fff;
+    background: var(--color-white);
     content: "";
     transition: 0.1s;
   }

--- a/kitsune/sumo/static/sumo/scss/components/_banner.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_banner.scss
@@ -96,7 +96,8 @@
 
 .sumo-banner-warning {
   background: var(--color-warning);
-  color: var(--color-heading);
+  // Yellow always needs dark text — do not inherit --color-heading which flips to light in dark mode.
+  color: var(--color-dark-gray-10);
 }
 
 .sumo-banner-no-close {

--- a/kitsune/sumo/static/sumo/scss/components/_card.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_card.scss
@@ -194,8 +194,8 @@
     flex-direction: column;
     justify-content: space-between;
     height: 100%;
-    background-color: p.$color-white;
-    border: 1px solid #ddd;
+    background-color: var(--card-bg);
+    border: 1px solid var(--color-border);
     border-radius: p.$border-radius-md;
     padding: p.$spacing-md;
     box-shadow: p.$box-shadow-sm;
@@ -245,7 +245,7 @@
         }
 
         a {
-          color: black;
+          color: var(--color-text);
           font-size: 14px;
           text-decoration: underline;
           display: -webkit-box;
@@ -262,12 +262,12 @@
     }
 
     .view-all-link {
-      border-top: 1px solid #ddd;
+      border-top: 1px solid var(--color-border);
       padding-top: 10px;
       margin-top: auto;
       display: block;
       font-size: 14px;
-      color: #000000;
+      color: var(--color-text);
       text-decoration: underline;
       font-weight: normal;
       white-space: nowrap;
@@ -533,3 +533,12 @@
 .elevation-03 {
   @include c.elevation-03;
 }
+
+// card--icon-sm: protocol SVGs with hardcoded dark fill/stroke, loaded as <img>.
+// Invert in dark mode so they're visible on dark backgrounds.
+@media (prefers-color-scheme: dark) {
+  .card--icon-sm { filter: invert(1); }
+}
+
+[data-theme="dark"] .card--icon-sm { filter: invert(1); }
+[data-theme="light"] .card--icon-sm { filter: none; }

--- a/kitsune/sumo/static/sumo/scss/components/_dashboards.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_dashboards.scss
@@ -144,6 +144,8 @@
 .dashboards td.status:has(.review),
 .dashboards td.status:has(.out-of-date){
     background-color: var(--color-warning);
+    // Yellow always needs dark text regardless of theme.
+    color: var(--color-dark-gray-10);
 }
 
 .dashboards td.status {
@@ -166,6 +168,36 @@
         color: #add575;
         margin-left: p.$spacing-xs;
     }
+}
+
+@media (prefers-color-scheme: dark) {
+  .dashboards td.status:has(.review),
+  .dashboards td.status:has(.out-of-date) {
+    background-color: rgba(255, 213, 0, 0.2);
+  }
+
+  .dashboards td.status .ok:after {
+    color: #6dbf6d;
+  }
+
+  .dashboards td.status .untranslated:after {
+    color: #ff6b6b;
+  }
+}
+
+[data-theme="dark"] {
+  .dashboards td.status:has(.review),
+  .dashboards td.status:has(.out-of-date) {
+    background-color: rgba(255, 213, 0, 0.2);
+  }
+
+  .dashboards td.status .ok:after {
+    color: #6dbf6d;
+  }
+
+  .dashboards td.status .untranslated:after {
+    color: #ff6b6b;
+  }
 }
 .dashboards td a {
     text-decoration:none;

--- a/kitsune/sumo/static/sumo/scss/components/_editor-tools.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_editor-tools.scss
@@ -73,6 +73,12 @@ button {
     }
   }
 
+  @media (prefers-color-scheme: dark) {
+    &.markup-toolbar-button {
+      filter: invert(1);
+    }
+  }
+
   &.btn-h2 {
     background-position: -34px 6px;
   }
@@ -108,6 +114,10 @@ button {
   &.btn-quote {
     background-position: -381px 6px;
   }
+}
+
+[data-theme="dark"] button.markup-toolbar-button {
+  filter: invert(1);
 }
 
 /* Modals */

--- a/kitsune/sumo/static/sumo/scss/components/_flaggit.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_flaggit.scss
@@ -9,7 +9,8 @@
         margin-bottom: p.$spacing-lg;
         border-radius: p.$border-radius-md;
         overflow: hidden;
-        background-color: p.$color-light-gray-20;
+        background-color: var(--card-bg);
+        border: 1px solid var(--color-border);
     }
 
     .wait {
@@ -50,22 +51,22 @@
 
 .flagged-content {
     padding: p.$spacing-md p.$spacing-lg;
-    background-color: p.$color-light-gray-10;
+    background-color: var(--color-shade-bg);
     border-radius: 5px;
-    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--elevation-shadow-01);
     margin-bottom: p.$spacing-md;
 
     &__heading,
     &__subheading {
         font-weight: bold;
         font-size: 1.25rem;
-        color: p.$color-dark-gray-80;
+        color: var(--color-heading);
     }
 
     &__title,
     &__text {
         font-size: 1.1rem;
-        color: p.$color-dark-gray-80;
+        color: var(--color-text);
     }
 
     .compact-info {
@@ -78,11 +79,11 @@
 
         .current-topic {
             display: inline-block;
-            color: p.$color-dark-gray-80;
+            color: var(--color-text);
             transition: color 0.3s ease-in-out;
 
             &.updated {
-                color: p.$color-green-80;
+                color: var(--color-success);
 
                 &::after {
                     content: ' ✔';

--- a/kitsune/sumo/static/sumo/scss/components/_groups.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_groups.scss
@@ -34,7 +34,7 @@ body:has(#group-profile) {
   @include c.elevation-01;
   margin-bottom: p.$spacing-lg;
   padding: p.$spacing-lg;
-  background: white;
+  background: var(--card-bg);
 
   &--avatar-section {
     text-align: center;
@@ -68,7 +68,7 @@ body:has(#group-profile) {
     @include c.text-body-md;
     font-weight: 700;
     margin-bottom: p.$spacing-md;
-    color: var(--color-ink-09);
+    color: var(--color-heading);
   }
 
   &--content {
@@ -230,8 +230,8 @@ body:has(#group-profile) {
     padding: p.$spacing-xl;
     background: linear-gradient(
       135deg,
-      var(--color-marketing-gray-01) 0%,
-      var(--color-white) 100%
+      var(--color-shade-bg) 0%,
+      var(--card-bg) 100%
     );
     border-left: 4px solid var(--color-link);
     margin-bottom: p.$spacing-2xl;
@@ -253,7 +253,7 @@ body:has(#group-profile) {
     @include c.elevation-01;
     padding: p.$spacing-xl;
     margin-bottom: p.$spacing-2xl;
-    background: white;
+    background: var(--card-bg);
   }
 
   .section-heading {
@@ -344,7 +344,7 @@ body:has(#group-profile) {
         background: linear-gradient(
           135deg,
           rgba(12, 175, 89, 0.03) 0%,
-          var(--color-white) 100%
+          var(--card-bg) 100%
         );
 
         &:hover {
@@ -527,7 +527,7 @@ body:has(#group-profile) {
         gap: p.$spacing-xs;
         padding: p.$spacing-sm p.$spacing-md;
         margin-top: p.$spacing-sm;
-        background: var(--color-white);
+        background: var(--card-bg);
         border: 2px solid var(--color-link);
         border-radius: p.$border-radius-sm;
         color: var(--color-link);
@@ -644,7 +644,7 @@ body:has(#group-profile) {
       @include c.text-body-lg;
       font-weight: 700;
       margin-bottom: p.$spacing-lg;
-      color: var(--color-ink-09);
+      color: var(--color-heading);
       text-align: center;
     }
 
@@ -703,7 +703,7 @@ body:has(#group-profile) {
       @include c.text-body-lg;
       font-weight: 700;
       margin-bottom: p.$spacing-lg;
-      color: var(--color-ink-09);
+      color: var(--color-heading);
     }
 
     .form-errors {
@@ -733,7 +733,7 @@ body:has(#group-profile) {
       @include c.text-body-md;
       font-weight: 600;
       margin-bottom: p.$spacing-sm;
-      color: var(--color-ink-09);
+      color: var(--color-heading);
 
       .required {
         color: var(--color-red-60);
@@ -872,5 +872,132 @@ body:has(#group-profile) {
       font-size: 0.5rem;
       text-align: center;
     }
+  }
+}
+
+// Dark mode overrides for group pages
+@mixin groups-dark {
+  #group-profile .card,
+  .sumo-l-two-col--sidebar .group-avatar-card,
+  .sumo-l-two-col--sidebar .group-hierarchy-card,
+  .sumo-l-two-col--sidebar .group-actions-card {
+    border-color: var(--color-border);
+
+    &--avatar-section {
+      border-bottom-color: var(--color-border);
+    }
+
+    &--actions {
+      border-bottom-color: var(--color-border);
+    }
+
+    &--title {
+      color: var(--color-heading);
+    }
+  }
+
+  #group-profile .group-avatar,
+  .sumo-l-two-col--sidebar .group-avatar {
+    border-color: var(--color-border);
+  }
+
+  #group-profile .group-stats {
+    .stat-item {
+      background: var(--color-shade-bg);
+    }
+
+    .stat-label {
+      color: var(--color-text-light);
+    }
+  }
+
+  #group-profile .group-hierarchy-card,
+  .sumo-l-two-col--sidebar .group-hierarchy-card {
+    .hierarchy-item label {
+      color: var(--color-text-light);
+    }
+  }
+
+  #group-profile {
+    .group-header {
+      border-bottom-color: var(--color-border);
+
+      .badge {
+        background: var(--color-shade-bg);
+        color: var(--color-text);
+
+        &--visibility {
+          background: var(--color-shade-bg);
+          color: var(--color-click);
+        }
+
+        &--count {
+          color: var(--color-text-light);
+        }
+      }
+    }
+
+    .section-heading {
+      border-bottom-color: var(--color-border);
+
+      .section-count {
+        color: var(--color-text-light);
+      }
+    }
+
+    .users {
+      .inactive-badge {
+        background: var(--color-shade-bg);
+        color: var(--color-text-light);
+      }
+    }
+  }
+
+  .sumo-l-two-col--sidebar .group-actions-card {
+    .action-button {
+      &:hover {
+        background: var(--color-shade-bg);
+      }
+    }
+
+    .action-toggle:checked ~ .action-button {
+      color: var(--page-bg);
+    }
+  }
+
+  #change-avatar {
+    .form-errors {
+      background: rgba(255, 0, 0, 0.1);
+      border-left-color: var(--color-error);
+
+      .error-message {
+        color: var(--color-error);
+      }
+    }
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  @include groups-dark;
+}
+
+[data-theme="dark"] {
+  @include groups-dark;
+}
+
+[data-theme="light"] {
+  #group-profile .card,
+  .sumo-l-two-col--sidebar .group-avatar-card,
+  .sumo-l-two-col--sidebar .group-hierarchy-card,
+  .sumo-l-two-col--sidebar .group-actions-card {
+    background: white;
+  }
+
+  #group-profile .group-section {
+    background: white;
+  }
+
+  .sumo-l-two-col--sidebar .group-actions-card .action-button {
+    background: var(--color-white);
   }
 }

--- a/kitsune/sumo/static/sumo/scss/components/_index.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_index.scss
@@ -28,3 +28,7 @@
 @forward 'jqueryui';
 @forward 'rickshaw';
 @forward 'rickshaw.sumo';
+
+// Dark mode bridge: overrides Protocol compile-time SCSS colors and remaps
+// Protocol CSS custom properties. Must be last so it wins the cascade.
+@forward 'protocol-dark-bridge';

--- a/kitsune/sumo/static/sumo/scss/components/_kbox--todo-remove.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_kbox--todo-remove.scss
@@ -12,7 +12,8 @@
 }
 
 .kbox-container {
-  background: #fff;
+  background: var(--card-bg);
+  color: var(--color-text);
   display: none;
   font-size: 14px;
   position: absolute;
@@ -30,6 +31,7 @@
 
 .kbox-close {
   font-size: 22px !important;
+  color: var(--color-heading);
   @include p.bidi(((margin, 0 p.$spacing-sm 0 0, 0 0 0 p.$spacing-sm),));
 
   &:link,

--- a/kitsune/sumo/static/sumo/scss/components/_messages.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_messages.scss
@@ -11,12 +11,12 @@
     display: flex;
     width: 100%;
     box-sizing: border-box; // Include padding and border in width calculations
-    background-color: #fff;
+    background-color: var(--page-bg);
 
     .email-cell {
         padding: 8px;
-        background-color: #fff;
-        border: 1px solid #ddd;
+        background-color: var(--page-bg);
+        border: 1px solid var(--color-border);
         box-sizing: border-box; // Include padding and border in width calculations
         overflow: hidden; // Hide overflow content
         text-overflow: ellipsis; // Add ellipsis for overflowing text
@@ -35,7 +35,7 @@
     &.header {
         .email-cell {
             font-weight: bold;
-            background-color: #eef;
+            background-color: var(--color-shade-bg);
         }
     }
 
@@ -43,6 +43,32 @@
         .email-cell {
             font-weight: bold; // Differentiate unread messages with a bold font
         }
+
+        // In dark mode bold alone isn't enough — add a left border accent and
+        // a slightly elevated background so unread rows are clearly distinct.
+        @media (prefers-color-scheme: dark) {
+            border-left: 3px solid var(--color-click);
+
+            .email-cell {
+                background-color: var(--color-callout-bg);
+            }
+        }
+    }
+}
+
+[data-theme="dark"] .email-row.unread {
+    border-left: 3px solid var(--color-click);
+
+    .email-cell {
+        background-color: var(--color-callout-bg);
+    }
+}
+
+[data-theme="light"] .email-row.unread {
+    border-left: none;
+
+    .email-cell {
+        background-color: var(--page-bg);
     }
 }
 

--- a/kitsune/sumo/static/sumo/scss/components/_modal.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_modal.scss
@@ -12,6 +12,18 @@
 
 .mzp-c-modal-close .mzp-c-modal-button-close {
   background: transparent url("protocol/img/icons/close.svg") center center no-repeat;
+
+  @media (prefers-color-scheme: dark) {
+    filter: invert(1);
+  }
+}
+
+[data-theme="dark"] .mzp-c-modal-close .mzp-c-modal-button-close {
+  filter: invert(1);
+}
+
+[data-theme="light"] .mzp-c-modal-close .mzp-c-modal-button-close {
+  filter: none;
 }
 
 

--- a/kitsune/sumo/static/sumo/scss/components/_product-picker-dropdown.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_product-picker-dropdown.scss
@@ -12,6 +12,10 @@
 
       &:after {
         background: url("data:image/svg+xml,%3Csvg width='24px' height='24px' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='none' stroke-width='1' fill='none' fill-rule='evenodd' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline stroke='%2320133A' stroke-width='2' points='5 9 12 16 19 9'%3E%3C/polyline%3E%3C/g%3E%3C/svg%3E") center center no-repeat;
+
+        @media (prefers-color-scheme: dark) {
+          filter: invert(1);
+        }
       }
 
       &:hover {
@@ -26,6 +30,15 @@
 
   a {
     @include c.text-body-lg;
+  }
+}
+
+[data-theme="dark"] {
+  .is-details.mzp-c-menu-list.featured-dropdown,
+  .is-details.mzp-c-menu-list.subheading-dropdown {
+    .mzp-c-menu-list-title button:after {
+      filter: invert(1);
+    }
   }
 }
 
@@ -77,7 +90,7 @@
     transition: none;
 
     &:hover:not(:disabled) {
-      background: var(--color-marketing-gray-02);
+      background: var(--color-shade-bg);
       color: inherit;
     }
   }

--- a/kitsune/sumo/static/sumo/scss/components/_progress-bar.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_progress-bar.scss
@@ -73,7 +73,7 @@
 
     &.is-complete {
       .progress--dot {
-        background-image: c.svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path stroke="#000" stroke-width="2" d="M20 6L9 17l-5-5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+        background-image: c.svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path stroke="#fff" stroke-width="2" d="M20 6L9 17l-5-5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"/></svg>');
         background-color: var(--color-green-06);
         background-position: center center;
         background-repeat: no-repeat;
@@ -110,7 +110,7 @@
       z-index: 1;
       width: 120%;
       height: 3px;
-      background: var(--color-marketing-gray-03);
+      background: var(--color-border);
       content: "";
     }
 
@@ -132,7 +132,7 @@
           (right, 0, auto),
           (left, auto, 0),
         ));
-        background: var(--color-marketing-gray-03);
+        background: var(--color-border);
         z-index: 2;
       }
 
@@ -142,7 +142,7 @@
 
       &:first-child {
         &:after {
-          background: var(--color-marketing-gray-03);
+          background: var(--color-border);
         }
       }
     }
@@ -194,7 +194,7 @@
     position: relative;
     z-index: 3;
     margin-bottom: 8px;
-    border: 4px solid var(--color-marketing-gray-03);
+    border: 4px solid var(--color-border);
     border-radius: 50%;
     background-color: var(--page-bg);
     font-size: 0;

--- a/kitsune/sumo/static/sumo/scss/components/_protocol-dark-bridge.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_protocol-dark-bridge.scss
@@ -1,0 +1,150 @@
+// Protocol Dark Mode Bridge
+//
+// Protocol components use two kinds of color references:
+//
+//   1. CSS custom properties (e.g. var(--background-color)) — these are
+//      remapped below via @mixin protocol-dark-vars so Protocol components
+//      that consume them adapt automatically.
+//
+//   2. Compile-time SCSS variables (e.g. $color-white) — these are baked
+//      into the compiled CSS and cannot be remapped. They require explicit
+//      selector overrides in @mixin protocol-dark-components.
+
+// -------------------------------------------------------------------------
+// 1. Protocol CSS custom property overrides
+//    Map Protocol's own tokens onto Kitsune's dark semantic tokens.
+// -------------------------------------------------------------------------
+@mixin protocol-dark-vars {
+  --background-color: var(--page-bg);
+  --background-color-secondary: var(--card-bg);
+  --background-color-tertiary: var(--color-callout-bg);
+  --body-text-color: var(--color-text);
+  --body-text-color-secondary: var(--color-text-light);
+  --title-text-color: var(--color-heading);
+  --link-color: var(--color-click);
+  --link-color-hover: var(--color-click);
+  --link-color-visited: var(--color-link-visited);
+}
+
+// -------------------------------------------------------------------------
+// 2. Explicit component overrides for hardcoded compile-time SCSS values
+// -------------------------------------------------------------------------
+@mixin protocol-dark-components {
+  // Navigation: Protocol's _navigation.scss hardcodes background: $color-white.
+  .mzp-c-navigation {
+    background-color: var(--page-bg);
+    color: var(--color-text);
+  }
+
+  // Sticky nav scroll shadow: replace ink-tinted rgba with dark-mode elevation token.
+  .mzp-c-navigation.mzp-is-sticky.mzp-is-scrolling {
+    box-shadow: var(--elevation-shadow-01);
+  }
+
+  // Menu panel (dropdown): Protocol's _menu.scss hardcodes background: $color-white.
+  .mzp-c-menu-panel {
+    background-color: var(--card-bg);
+    color: var(--color-text);
+  }
+
+  // Menu item separators: Protocol hardcodes $color-marketing-gray-30.
+  .mzp-c-menu-category-list > li,
+  .mzp-c-menu-item-list > li {
+    border-top-color: var(--color-border);
+  }
+
+  // Menu category titles (top-level nav items): hardcoded $color-black + border.
+  .mzp-c-menu-category .mzp-c-menu-title {
+    color: var(--color-text);
+    border-bottom-color: var(--color-border);
+
+    &:hover,
+    &:active,
+    &:focus {
+      color: var(--color-heading);
+    }
+  }
+
+  // The animated underline highlight on menu titles uses background: $color-black.
+  .mzp-c-menu-category .mzp-c-menu-title::after {
+    background: var(--color-heading);
+  }
+
+  // Menu item links in the dropdown panel: hardcoded $color-black.
+  .mzp-c-menu-item .mzp-c-menu-item-link {
+    color: var(--color-text);
+
+    &:hover,
+    &:active,
+    &:focus {
+      .mzp-c-menu-item-title {
+        color: var(--color-heading);
+        border-bottom-color: var(--color-heading);
+      }
+    }
+  }
+
+  // Menu item list links (sub-items inside a dropdown): hardcoded $color-black.
+  .mzp-c-menu-item .mzp-c-menu-item-list a {
+    color: var(--color-text);
+
+    &:hover,
+    &:active,
+    &:focus {
+      color: var(--color-heading);
+    }
+  }
+
+  // Hover box-shadow on menu items: $color-marketing-gray-20 (light gray, invisible on dark).
+  .mzp-c-menu-item:hover {
+    box-shadow: 0 0 0 4px var(--color-shade-bg);
+  }
+
+  // Menu button (mobile expand/collapse): hardcoded $color-black.
+  .mzp-c-menu-button {
+    color: var(--color-text);
+  }
+
+  // Menu panel close button: uses close.svg (dark icon), needs inversion.
+  .mzp-c-menu-button-close {
+    filter: invert(1);
+  }
+
+  // Nav section icons: SVGs use currentColor so they follow text colour.
+  .mzp-c-menu-item-icon {
+    color: var(--color-text);
+  }
+
+  // mzp-c-menu-list dropdown panel: hardcodes background-color: $color-white.
+  .mzp-c-menu-list-list {
+    background-color: var(--card-bg);
+    color: var(--color-text);
+  }
+
+  // mzp-c-menu-list item hover: hardcodes $color-marketing-gray-20 (light gray).
+  .mzp-c-menu-list-item a:hover,
+  .mzp-c-menu-list-item a:focus {
+    background: var(--color-shade-bg);
+    color: var(--color-heading);
+  }
+}
+
+// -------------------------------------------------------------------------
+// 3. Apply: OS-level automatic dark mode
+// -------------------------------------------------------------------------
+@media (prefers-color-scheme: dark) {
+  :root {
+    @include protocol-dark-vars;
+  }
+
+  @include protocol-dark-components;
+}
+
+// -------------------------------------------------------------------------
+// 4. Apply: Manual override via JS theme toggle (set in Phase 4)
+// -------------------------------------------------------------------------
+[data-theme="dark"] {
+  @include protocol-dark-vars;
+
+  @include protocol-dark-components;
+}

--- a/kitsune/sumo/static/sumo/scss/components/_sidebar-nav.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_sidebar-nav.scss
@@ -63,14 +63,23 @@
   .related-document,
   .related-question {
     @include c.text-body-md;
-    background-image: url("protocol/img/icons/blog.svg");
-    background-repeat: no-repeat;
-    background-position: 0px 6px;
-    background-size: p.$spacing-md p.$spacing-md;
+    position: relative;
     padding-left: p.$spacing-lg;
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 6px;
+      width: p.$spacing-md;
+      height: p.$spacing-md;
+      background-image: url("protocol/img/icons/blog.svg");
+      background-repeat: no-repeat;
+      background-size: contain;
+    }
   }
 
-  .related-document {
+  .related-document::before {
     background-image: url("protocol/img/icons/reader-mode.svg");
   }
 
@@ -120,7 +129,7 @@
         display: inline-flex;
         width: 12px;
         height: 10px;
-        background-image: c.svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 10"><path fill="none" vector-effect="non-scaling-stroke" stroke="#5E5E72" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M1 1l8 8 8-8"/></svg>');
+        background-image: c.svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 10"><path fill="none" vector-effect="non-scaling-stroke" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M1 1l8 8 8-8"/></svg>');
         background-size: contain;
         background-position: center center;
         background-repeat: no-repeat;
@@ -254,5 +263,28 @@
     &.is-accordion-heading {
       margin-top: p.$spacing-xl;
     }
+  }
+}
+
+// "See also" icons (blog.svg, reader-mode.svg) are dark-colored — invert in dark mode.
+// Filter is on ::before so the link text is unaffected.
+@media (prefers-color-scheme: dark) {
+  .sidebar-nav .related-document::before,
+  .sidebar-nav .related-question::before {
+    filter: invert(1);
+  }
+}
+
+[data-theme="dark"] {
+  .sidebar-nav .related-document::before,
+  .sidebar-nav .related-question::before {
+    filter: invert(1);
+  }
+}
+
+[data-theme="light"] {
+  .sidebar-nav .related-document::before,
+  .sidebar-nav .related-question::before {
+    filter: none;
   }
 }

--- a/kitsune/sumo/static/sumo/scss/components/_users.autocomplete.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_users.autocomplete.scss
@@ -17,8 +17,8 @@ ul.token-input-list-facebook {
   min-height: p.$spacing-2xl;
   border: 2px solid var(--field-border-color-default);
   border-radius: var(--global-radius);
-  background-color: var(--color-white);
-  color:#0c0c0d;
+  background-color: var(--field-bg);
+  color: var(--color-text);
   outline:0;
   transition-duration:150ms;
   transition-property:border-color;
@@ -49,7 +49,8 @@ ul.token-input-list-facebook li input {
     border: 0;
     width: 100px;
     padding: 3px p.$spacing-sm;
-    background: white;
+    background: var(--field-bg);
+    color: var(--color-text);
     margin: 2px 0;
     -webkit-appearance: caret;
 }
@@ -60,7 +61,7 @@ li.token-input-token-facebook {
     height: 15px;
     margin: 3px !important;
     padding: 1px 3px;
-    background-color: #eff2f7;
+    background-color: var(--color-shade-bg);
     color: var(--color-text);
     cursor: default;
     border: 1px solid var(--color-border);
@@ -98,7 +99,7 @@ div.token-input-dropdown-facebook {
     @include c.elevation-01;
     position: absolute;
     width: 400px;
-    background-color: var(--color-white);
+    background-color: var(--card-bg);
     overflow: hidden;
     border-radius: 0 0 var(--global-radius) var(--global-radius);
     cursor: default;

--- a/kitsune/sumo/static/sumo/scss/components/_wiki.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_wiki.scss
@@ -50,20 +50,20 @@ article {
 
 .sidebar-nav {
   &.topics {
-    background-color: #fff;
+    background-color: var(--page-bg);
     // margin-top: p.$spacing-md;
 
     >li {
-      background-color: #fff;
+      background-color: var(--page-bg);
 
       &.selected {
 
         >a,
         >a:visited {
-          background: #f3f3f3;
+          background: var(--color-shade-bg);
           border: none;
-          border-left: p.$spacing-xs solid #000;
-          color: #000;
+          border-left: p.$spacing-xs solid var(--color-heading);
+          color: var(--color-heading);
           font-weight: bold;
 
           &:before {
@@ -71,13 +71,13 @@ article {
           }
 
           &:hover {
-            color: #000;
+            color: var(--color-heading);
           }
         }
 
         &.has-subtopics {
           >a {
-            background: #fff;
+            background: var(--page-bg);
           }
         }
       }
@@ -85,10 +85,10 @@ article {
       >a,
       >a:visited,
       {
-      color: #000;
-      background: #fff;
+      color: var(--color-text);
+      background: var(--page-bg);
       border: none;
-      border-left: p.$spacing-xs solid #e7e7e7;
+      border-left: p.$spacing-xs solid var(--color-border);
       text-transform: none;
 
       &:before {
@@ -104,8 +104,8 @@ article {
 
       >a,
       >a:visited {
-        background: #fff;
-        border-left: p.$spacing-xs solid #000;
+        background: var(--page-bg);
+        border-left: p.$spacing-xs solid var(--color-heading);
       }
     }
 
@@ -119,9 +119,9 @@ article {
 
         >a,
         >a:visited {
-          background: #f3f3f3;
+          background: var(--color-shade-bg);
           border-left: none;
-          color: #000;
+          color: var(--color-text);
           display: block;
           padding: 12px 20px;
           text-decoration: none;
@@ -135,11 +135,11 @@ article {
 
           >a,
           >a:visited {
-            border-left: p.$spacing-xs solid #000;
+            border-left: p.$spacing-xs solid var(--color-heading);
             font-weight: bold;
 
             &:hover {
-              color: #000;
+              color: var(--color-heading);
             }
           }
         }
@@ -153,7 +153,7 @@ article {
       >a,
       >a:visited {
         border-left: none;
-        border-right: p.$spacing-xs solid #000;
+        border-right: p.$spacing-xs solid var(--color-heading);
       }
     }
 
@@ -161,7 +161,7 @@ article {
     >a:visited,
     {
     border-left: none;
-    border-right: p.$spacing-xs solid #e7e7e7;
+    border-right: p.$spacing-xs solid var(--color-border);
   }
 
   &.subtopic-selected {
@@ -169,7 +169,7 @@ article {
     >a,
     >a:visited {
       border-left: none;
-      border-right: p.$spacing-xs solid #000;
+      border-right: p.$spacing-xs solid var(--color-heading);
     }
   }
 }
@@ -319,27 +319,27 @@ article {
       }
 
       &:nth-child(odd) {
-        background: #f2f2f2;
+        background: var(--color-shade-bg);
       }
 
       &.current {
-        background: #daedf6;
-        border-bottom: solid 2px #a3b1b8;
-        border-top: solid 2px #a3b1b8;
+        background: var(--color-callout-bg);
+        border-bottom: solid 2px var(--color-border);
+        border-top: solid 2px var(--color-border);
 
         .status {
-          color: #223d61;
+          color: var(--color-heading);
           font-weight: bold;
         }
       }
 
       &.rejected *,
       &.rejected div.creator {
-        color: #999;
+        color: var(--color-text-light);
       }
 
       &.header {
-        color: #666 !important;
+        color: var(--color-text-light) !important;
         font-weight: bold;
       }
     }
@@ -420,10 +420,11 @@ article {
 
   .title {
     .locale {
-      background: #ddd;
+      background: var(--color-shade-bg);
+      color: var(--color-text);
       padding: 0 2px;
       font-size: 0.7em;
-      box-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.5);
+      box-shadow: 0 0 1px 0 var(--elevation-border);
       position: relative;
       bottom: 1px;
       margin-right: 5px;
@@ -528,6 +529,42 @@ article {
     display: none;
     height: 20px;
     width: 20px;
+  }
+}
+
+@mixin revision-list-icons-dark {
+  #revision-list {
+    .l10n a,
+    .edit a,
+    .delete a {
+      filter: invert(1);
+    }
+
+    .l10n span.not-approved,
+    .l10n span.trivial,
+    .l10n span.not-localizable,
+    .l10n span.translated {
+      filter: invert(1);
+    }
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  @include revision-list-icons-dark;
+}
+
+[data-theme="dark"] {
+  @include revision-list-icons-dark;
+}
+
+[data-theme="light"] {
+  #revision-list {
+    .l10n a,
+    .edit a,
+    .delete a,
+    .l10n span {
+      filter: none;
+    }
   }
 }
 
@@ -645,7 +682,8 @@ article {
 
 #preview {
   .showfor {
-    background: #fff;
+    background: var(--card-bg);
+    color: var(--color-text);
     border-radius: var(--global-radius);
     @include c.elevation-01;
     right: 10px;
@@ -671,7 +709,7 @@ article {
       z-index: 6;
 
       &:hover {
-        color: #999;
+        color: var(--color-text-light);
         cursor: pointer;
       }
     }
@@ -705,9 +743,10 @@ article {
   }
 
   .showfor {
-    background: #fff;
+    background: var(--card-bg);
+    color: var(--color-text);
     border-radius: 10px;
-    box-shadow: 0 p.$spacing-xs 10px #999;
+    box-shadow: var(--elevation-shadow-01);
     display: none;
     left: 10px;
     margin: -90px 0 0;
@@ -1315,5 +1354,133 @@ article {
 
   >h1:before {
     transform: rotate(0);
+  }
+}
+
+// -------------------------------------------------------------------------
+// Dark mode overrides for the wiki article editor
+// -------------------------------------------------------------------------
+@mixin wiki-editor-dark {
+  // #content-fields heading and border
+  #content-fields {
+    h3 {
+      color: var(--color-text);
+    }
+
+    div.val {
+      border-color: var(--color-border);
+    }
+  }
+
+  // CodeMirror editor area
+  .CodeMirror {
+    background: var(--field-bg);
+    color: var(--color-text);
+  }
+
+  .CodeMirror-gutters {
+    background-color: var(--color-shade-bg);
+    border-right-color: var(--color-border);
+  }
+
+  .CodeMirror-linenumber {
+    color: var(--color-text-light);
+  }
+
+  .CodeMirror-cursor {
+    border-left-color: var(--color-text);
+  }
+
+  #editor {
+    border-color: var(--color-border);
+  }
+
+  // Syntax token overrides
+  .cm-bold {
+    color: var(--color-heading) !important;
+  }
+
+  .cm-other.cm-link {
+    color: var(--color-click) !important;
+  }
+
+  .cm-editor .cm-identifier,
+  .cm-editor .cm-italic,
+  .cm-editor .cm-underline {
+    color: var(--color-text) !important;
+  }
+
+  .cm-comment {
+    color: #6dbf6d !important;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  @include wiki-editor-dark;
+}
+
+[data-theme="dark"] {
+  @include wiki-editor-dark;
+}
+
+[data-theme="light"] {
+  #content-fields h3 { color: #333; }
+}
+
+// Diff view dark mode
+@mixin diff-dark {
+  .diff-this {
+    table {
+      border-color: var(--color-border);
+      color: var(--color-text-light);
+    }
+
+    .output {
+      color: var(--color-text);
+    }
+
+    .fromLine {
+      background: #5c1a1a;
+    }
+
+    .toLine {
+      background: #1a3d1a;
+    }
+
+    .num {
+      background: var(--color-shade-bg);
+      border-right-color: var(--color-border);
+      color: var(--color-text-light);
+    }
+
+    ins {
+      background: #1a5c1a;
+      color: var(--color-text);
+    }
+
+    del {
+      background: #5c1a1a;
+      color: var(--color-text);
+    }
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  @include diff-dark;
+}
+
+[data-theme="dark"] {
+  @include diff-dark;
+}
+
+[data-theme="light"] {
+  .diff-this {
+    table { border-color: #ddd; color: #666; }
+    .output { color: #333; }
+    .fromLine { background: #ffdddd; }
+    .toLine { background: #ddffdd; }
+    .num { background: #ececec; border-right-color: #ddd; color: #aaa; }
+    ins { background: #aaffaa; color: #000; }
+    del { background: #ffaaaa; color: #000; }
   }
 }

--- a/kitsune/sumo/static/sumo/scss/config/_elevation.scss
+++ b/kitsune/sumo/static/sumo/scss/config/_elevation.scss
@@ -3,26 +3,17 @@
 // are reused in places other than cards.
 
 @mixin elevation-00() {
-  border: solid 1px rgba(21, 20, 26, 0.26);
+  border: solid 1px var(--elevation-border);
 }
 
 @mixin elevation-01() {
-  box-shadow:
-    0 5px 10px -3px rgba(14, 13, 26, 0.12),
-    0 3px 16px 2px rgba(7, 48, 114, 0.12),
-    0 8px 12px 1px rgba(34, 0, 51, 0.04);
+  box-shadow: var(--elevation-shadow-01);
 }
 
 @mixin elevation-02 {
-  box-shadow:
-    0 8px 12px -5px rgba(14, 13, 26, 0.12),
-    0 6px 32px 4px rgba(7, 48, 114, 0.12),
-    0 16px 24px 2px rgba(34, 0, 51, 0.04);
+  box-shadow: var(--elevation-shadow-02);
 }
 
 @mixin elevation-03 {
-  box-shadow:
-    0 12px 16px -6px rgba(14, 13, 26, 0.12),
-    0 10px 48px 8px rgba(7, 48, 114, 0.12),
-    0 24px 38px 3px rgba(34, 0, 51, 0.04);
+  box-shadow: var(--elevation-shadow-03);
 }

--- a/kitsune/sumo/static/sumo/scss/config/_project-theme.scss
+++ b/kitsune/sumo/static/sumo/scss/config/_project-theme.scss
@@ -30,9 +30,24 @@
   --color-link-inverse-active-bg: #{rgba(c.color('marketing-gray', '02'), 0.2)};
   --color-border: var(--color-marketing-gray-02);
   --color-callout-bg: var(--color-marketing-gray-02);
-  --color-moz-heading: #000000;
+  --color-moz-heading: var(--color-black);
   --color-moz-text: var(--color-moz-heading);
   --color-moz-inverse-bg: var(--color-ink-08);
+
+  // elevation
+  --elevation-border: rgba(21, 20, 26, 0.26);
+  --elevation-shadow-01:
+    0 5px 10px -3px rgba(14, 13, 26, 0.12),
+    0 3px 16px 2px rgba(7, 48, 114, 0.12),
+    0 8px 12px 1px rgba(34, 0, 51, 0.04);
+  --elevation-shadow-02:
+    0 8px 12px -5px rgba(14, 13, 26, 0.12),
+    0 6px 32px 4px rgba(7, 48, 114, 0.12),
+    0 16px 24px 2px rgba(34, 0, 51, 0.04);
+  --elevation-shadow-03:
+    0 12px 16px -6px rgba(14, 13, 26, 0.12),
+    0 10px 48px 8px rgba(7, 48, 114, 0.12),
+    0 24px 38px 3px rgba(34, 0, 51, 0.04);
 
   --base-font-size: 1rem;
   --heading-font-family: var(--title-font-family);
@@ -44,6 +59,64 @@
 
   // form fields
   --focus-shadow: 0 0 0 #{p.$spacing-xs} rgba(0, 96, 223, 0.3), 0 0 0 2px rgb(0, 138, 234);
+}
+
+@mixin dark-theme {
+  // Backgrounds
+  --page-bg: var(--color-dark-gray-09);
+  --card-bg: var(--color-dark-gray-08);
+  --color-shade-bg: var(--color-dark-gray-08);
+  --color-callout-bg: var(--color-dark-gray-07);
+
+  // Inverse (flipped: light sections on a dark page)
+  --color-inverse-bg: var(--color-light-gray-03);
+  --color-inverse: var(--color-dark-gray-09);
+
+  // Text
+  --color-heading: var(--color-light-gray-02);
+  --color-text: var(--color-marketing-gray-04);
+  --color-text-light: var(--color-marketing-gray-05);
+  --color-secondary: var(--color-marketing-gray-05);
+
+  // Links & interactive
+  --color-click: var(--color-blue-05);
+  --color-link-visited: var(--color-purple-03);
+  --color-link-active-bg: var(--color-dark-gray-07);
+
+  // Border
+  --color-border: var(--color-dark-gray-06);
+
+  // Mozilla branding
+  --color-moz-heading: var(--color-white);
+  --color-moz-inverse-bg: var(--color-dark-gray-07);
+
+  // Elevation (dark bg → lighter subtle borders, stronger black shadows)
+  --elevation-border: rgba(255, 255, 255, 0.1);
+  --elevation-shadow-01:
+    0 5px 10px -3px rgba(0, 0, 0, 0.4),
+    0 3px 16px 2px rgba(0, 0, 0, 0.3),
+    0 8px 12px 1px rgba(0, 0, 0, 0.2);
+  --elevation-shadow-02:
+    0 8px 12px -5px rgba(0, 0, 0, 0.4),
+    0 6px 32px 4px rgba(0, 0, 0, 0.3),
+    0 16px 24px 2px rgba(0, 0, 0, 0.2);
+  --elevation-shadow-03:
+    0 12px 16px -6px rgba(0, 0, 0, 0.4),
+    0 10px 48px 8px rgba(0, 0, 0, 0.3),
+    0 24px 38px 3px rgba(0, 0, 0, 0.2);
+}
+
+// Automatic dark mode: respects OS preference
+@media (prefers-color-scheme: dark) {
+  :root {
+    @include dark-theme;
+  }
+}
+
+// Manual override: set by JS theme toggle in Phase 4
+// [data-theme="light"] lets users opt back to light even on a dark-OS
+[data-theme="dark"] {
+  @include dark-theme;
 }
 
 // With locales where Mozilla Headline and Mozilla Text have partial character support,

--- a/kitsune/sumo/static/sumo/scss/layout/_aaq.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_aaq.scss
@@ -28,7 +28,7 @@
 
   .aaq-form-buttons {
     padding-top: p.$spacing-2xl;
-    border-top: 1px solid var(--color-marketing-gray-03);
+    border-top: 1px solid var(--color-border);
   }
 
   // Make the community card more compact
@@ -53,6 +53,20 @@
     margin-bottom: 0;
     vertical-align: middle;
   }
+}
+
+@media (prefers-color-scheme: dark) {
+  .support-type-switcher-widget .switcher-icon {
+    filter: invert(1);
+  }
+}
+
+[data-theme="dark"] .support-type-switcher-widget .switcher-icon {
+  filter: invert(1);
+}
+
+[data-theme="light"] .support-type-switcher-widget .switcher-icon {
+  filter: none;
 }
 
 aside .aaq-widget {
@@ -125,6 +139,10 @@ aside .aaq-widget {
     @media #{p.$mq-lg} {
       margin-right: 0;
       margin-bottom: p.$spacing-sm;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      filter: invert(1);
     }
 
     @keyframes pulse {

--- a/kitsune/sumo/static/sumo/scss/layout/_community.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_community.scss
@@ -71,7 +71,7 @@
     left: 0;
 }
 .ts-modal {
-    border: 1px solid #d4d4d4;
+    border: 1px solid var(--color-border);
     border-radius: 6px;
     min-width: 120%;
     max-height: 800%;
@@ -87,15 +87,14 @@
 }
 .options-filter input[type="text"] {
     padding: 5px 2%;
-    border: 1px solid #b2b2b2;
+    border: 1px solid var(--color-border);
     width: 100%;
     font-size: .8rem;
     border-radius: .2rem;
-    box-shadow: 0 1px rgba(255, 255, 255, 0.5);
 }
 .options-filter input[type="text"]:focus {
-    border: 1px solid #42a4e0;
-    box-shadow: 0 0 0 2px rgba(73, 173, 227, 0.4);
+    border: 1px solid var(--color-link);
+    box-shadow: var(--focus-shadow);
 }
 ul.ts-options {
     margin: 0;
@@ -104,17 +103,17 @@ ul.ts-options {
 }
 .ts-options a {
     display: block;
-    background-color: white;
-    color: black;
+    background-color: var(--page-bg);
+    color: var(--color-text);
     padding: .6rem .6rem .6rem 2rem;
     text-decoration: none;
 }
 .ts-options a:hover {
-    background-color: #005CB8;
-    color: #fff;
+    background-color: var(--color-link);
+    color: var(--color-inverse);
 }
 .ts-options li {
-    border-top: 1px solid #e0e0e0;
+    border-top: 1px solid var(--color-border);
     margin-bottom: 0;
 }
 .ts-options li:first-child {

--- a/kitsune/sumo/static/sumo/scss/layout/_document.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_document.scss
@@ -55,6 +55,8 @@
   border-radius: 36px;
   padding: p.$spacing-lg;
   min-width: 225px;
+  background-color: var(--card-bg);
+  color: var(--color-text);
 
   @at-root .hide-on-large & {
     padding: 20px;
@@ -72,7 +74,7 @@
   }
 
   .required-text {
-    color: red;
+    color: var(--color-error);
   }
 
   &.is-forum-answer {
@@ -159,6 +161,7 @@
     border: 0 none;
     appearance: none;
     background: transparent;
+    color: var(--color-text);
     will-change: transform;
     transition: transform 0.3s linear;
     cursor: pointer;
@@ -402,7 +405,7 @@
   }
 
   &.has-border-top {
-    border-top: 1px solid #EDEDF0;
+    border-top: 1px solid var(--color-border);
     margin-top: 12px;
     margin-bottom: 24px;
     padding-top: 12px;
@@ -421,6 +424,10 @@
       margin-right: 8px; // Optional, to add some space between the icon and text
     }
 
+    @media (prefers-color-scheme: dark) {
+      .pencil { filter: invert(1); }
+    }
+
     strong {
       font-weight: bold;
     }
@@ -437,6 +444,10 @@
 
     .thumbsup {
       margin-right: 8px; // Optional, to add some space between the icon and text
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .thumbsup { filter: invert(1); }
     }
 
     .helpful-count {
@@ -470,4 +481,14 @@
       }
     }
   }
+}
+
+[data-theme="dark"] {
+  .pencil { filter: invert(1); }
+  .thumbsup { filter: invert(1); }
+}
+
+[data-theme="light"] {
+  .pencil { filter: none; }
+  .thumbsup { filter: none; }
 }

--- a/kitsune/sumo/static/sumo/scss/layout/_forum.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_forum.scss
@@ -800,3 +800,119 @@
     color: rgb(255, 255, 255);
   }
 }
+
+// Thread type icons (lockbox.svg, pin.svg) are dark-colored SVGs —
+// invert them in dark mode so they're visible on dark backgrounds.
+@media (prefers-color-scheme: dark) {
+  td.type img {
+    filter: invert(1);
+  }
+}
+
+[data-theme="dark"] td.type img {
+  filter: invert(1);
+}
+
+// "Marked as spam" badge: --color-warning (#FFEA80) is a light yellow with no dark override.
+// In dark mode use a deeper amber background with dark text for legibility.
+@media (prefers-color-scheme: dark) {
+  .is-spam {
+    background-color: #b35c00;
+    color: #fff;
+  }
+}
+
+[data-theme="dark"] .is-spam {
+  background-color: #b35c00;
+  color: #fff;
+}
+
+[data-theme="light"] .is-spam {
+  background-color: var(--color-warning);
+  color: var(--color-heading);
+}
+
+// Tag sidebar dark mode fixes:
+// - search input uses var(--color-white) background (no dark override)
+// - tag count badge uses var(--color-light-gray-03) (#F0F0F4, light gray)
+// - hover background rgba(0,0,0,0.07) is near-invisible on dark backgrounds
+@mixin sidebar-tags-dark {
+  .sidebar-tags {
+    &--search {
+      background: var(--field-bg);
+      border-color: var(--color-border);
+    }
+
+    &--list a:hover {
+      background: rgba(255, 255, 255, 0.07);
+    }
+
+    &--count {
+      background: var(--color-shade-bg);
+      color: var(--color-text-light);
+    }
+  }
+
+  .sidebar-tag-chip {
+    background: var(--color-shade-bg);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  @include sidebar-tags-dark;
+}
+
+[data-theme="dark"] {
+  @include sidebar-tags-dark;
+}
+
+[data-theme="light"] {
+  .sidebar-tags {
+    &--search { background: var(--color-white); }
+    &--list a:hover { background: rgba(0, 0, 0, 0.07); }
+    &--count { background: var(--color-light-gray-03); }
+  }
+
+  .sidebar-tag-chip { background: var(--color-link-active-bg); }
+}
+
+// Tag pills in .tag-list and .tag-notification use --color-light-gray-03/04
+// which are hardcoded light grays with no dark mode override.
+@mixin tag-list-dark {
+  .tag-list {
+    li {
+      background-color: var(--color-shade-bg);
+
+      &:hover {
+        background: var(--color-link-active-bg);
+      }
+    }
+
+    &.no-hover li:hover {
+      background-color: var(--color-shade-bg);
+    }
+  }
+
+  .tag-notification--clear {
+    border-color: var(--color-border);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  @include tag-list-dark;
+}
+
+[data-theme="dark"] {
+  @include tag-list-dark;
+}
+
+[data-theme="light"] {
+  .tag-list li {
+    background-color: var(--color-light-gray-03);
+
+    &:hover { background: var(--color-light-gray-04); }
+  }
+
+  .tag-list.no-hover li:hover { background-color: var(--color-light-gray-03); }
+  .tag-notification--clear { border-color: var(--color-light-gray-04); }
+}

--- a/kitsune/sumo/static/sumo/scss/layout/_nav.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_nav.scss
@@ -234,6 +234,44 @@
     background-image: url('protocol/img/icons/search.svg');
   }
 
+  // Nav section icons use currentColor — set the colour via CSS.
+  .mzp-c-menu-item-icon {
+    color: var(--color-text);
+  }
+
+  // Theme toggle wrapper + button
+  &--theme-toggle {
+    display: flex;
+    align-items: center;
+    @include p.bidi(((margin, 0 0 0 10px, 0 10px 0 0), ));
+  }
+
+  &--theme-toggle-button {
+    appearance: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: p.$spacing-xl;
+    height: p.$spacing-xl;
+    border: none;
+    border-radius: p.$spacing-xs;
+    background-color: transparent;
+    color: var(--color-text);
+    cursor: pointer;
+    padding: 0;
+
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: var(--color-link-active-bg);
+      outline: none;
+    }
+
+    &:focus-visible {
+      box-shadow: var(--focus-shadow);
+    }
+  }
+
   .simple-search-form {
     display: none;
   }
@@ -362,7 +400,7 @@
   margin: 0;
   padding: 0;
   width: 100%;
-  background: #fff;
+  background: var(--page-bg);
 
   a {
     position: absolute;
@@ -371,7 +409,7 @@
     margin: 0;
     padding: 12px 10px;
     padding: 0;
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--page-bg);
     font-weight: bold;
     text-align: center;
 
@@ -434,3 +472,35 @@ html {
   @include p.bidi(((margin, 0 0 0 p.$spacing-sm, 0 p.$spacing-sm 0 0),));
   vertical-align: middle;
 }
+
+// Theme toggle icon visibility.
+// CSS-driven so icons are correct even before Alpine.js loads.
+// Default: light mode — show moon (click to go dark), hide sun.
+.theme-icon--sun { display: none; }
+.theme-icon--moon { display: inline-flex; }
+
+// OS dark mode (no data-theme attribute set yet)
+@media (prefers-color-scheme: dark) {
+  .theme-icon--sun  { display: inline-flex; }
+  .theme-icon--moon { display: none; }
+}
+
+// Manual override: dark
+[data-theme="dark"] {
+  .theme-icon--sun  { display: inline-flex; }
+  .theme-icon--moon { display: none; }
+}
+
+// Manual override: light (overrides OS dark preference)
+[data-theme="light"] {
+  .theme-icon--sun  { display: none; }
+  .theme-icon--moon { display: inline-flex; }
+}
+
+// Mozilla Support logo: fill="black" SVG loaded as <img>, needs inversion in dark mode
+@media (prefers-color-scheme: dark) {
+  .sumo-nav--logo img { filter: invert(1); }
+}
+
+[data-theme="dark"] .sumo-nav--logo img { filter: invert(1); }
+[data-theme="light"] .sumo-nav--logo img { filter: none; }

--- a/kitsune/sumo/static/sumo/scss/layout/_products.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_products.scss
@@ -127,7 +127,7 @@ body[data-product-slug="firefox-enterprise"] {
   h2 {
     font-size: 24px;
     margin-bottom: 0px;
-    color: #333;
+    color: var(--color-heading);
   }
 
   @media #{p.$mq-sm} {

--- a/kitsune/sumo/static/sumo/scss/layout/_topic-page.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_topic-page.scss
@@ -119,6 +119,15 @@
   }
 }
 
+// Search result type icons (reader-mode.svg, blog.svg, get-involved.svg) are dark-colored
+// <img> tags — invert them in dark mode so they're visible on dark backgrounds.
+@media (prefers-color-scheme: dark) {
+  .topic-article--icon { filter: invert(1); }
+}
+
+[data-theme="dark"] .topic-article--icon { filter: invert(1); }
+[data-theme="light"] .topic-article--icon { filter: none; }
+
 // pull search up inline with breadcrumbs on large
 @media #{p.$mq-md} {
   .breadcrumbs + .sumo-l-two-col {

--- a/svelte/contribute/Contribute.svelte
+++ b/svelte/contribute/Contribute.svelte
@@ -228,9 +228,9 @@
     @use "../../kitsune/sumo/static/sumo/scss/config/typography-mixins";
 
     :global(#svelte) {
-        --color: var(--color-dark-gray-10);
+        --color: var(--color-text);
         --header-bg: var(--color-shade-bg);
-        --tile-bg: var(--page-bg);
+        --tile-bg: var(--card-bg);
         --tile-shadow: 0px 2px 6px rgba(58, 57, 68, 0.2);
         --step-number-bg: #{p.$color-pink-50};
         --step-number-color: var(--color-white);


### PR DESCRIPTION
- Added CSS custom property tokens for dark mode in `_project-theme.scss`: page background, card backgrounds, text, borders, shadows, form fields, and interactive states
- All dark overrides follow a consistent three-rule pattern:
@media (prefers-color-scheme: dark) { ... }  ← OS preference
[data-theme="dark"] { ... }                  ← manual toggle
[data-theme="light"] { ... }                 ← override OS dark → light
-Added a theme toggle button to the top navbar via Alpine.js, with a cookie-backed preference that is pre-read server-side in base.html to eliminate the flash-of-wrong-theme on page load