### PR TITLE
show tags async per question in list

### DIFF
--- a/kitsune/questions/jinja2/questions/includes/inline_tags.html
+++ b/kitsune/questions/jinja2/questions/includes/inline_tags.html
@@ -1,6 +1,6 @@
-{% for question_id, slugs in question_tags.items() %}
+{% for question_id, tags in question_tags.items() %}
 <div id="question-tags-{{ question_id }}" class="question-entry--tags" hx-swap-oob="innerHTML:#question-tags-{{ question_id }}">
-  {% for slug in slugs %}
+  {% for slug, name in tags %}
     {% set _tag_url = tag_base_url | urlparams(tagged=toggle_tag_slug(tagged, slug), page=None) %}
     <a class="question-entry--tag{% if tagged_set and slug in tagged_set %} is-active{% endif %}"
        href="{{ _tag_url }}"
@@ -9,7 +9,7 @@
        hx-select="#questions-list"
        hx-select-oob="#tagged,#owner-tabs"
        hx-swap="outerHTML"
-       hx-push-url="true">{{ slug }}</a>
+       hx-push-url="true">{{ name }}</a>
   {% endfor %}
 </div>
 {% endfor %}

--- a/kitsune/questions/jinja2/questions/includes/inline_tags.html
+++ b/kitsune/questions/jinja2/questions/includes/inline_tags.html
@@ -1,0 +1,15 @@
+{% for question_id, slugs in question_tags.items() %}
+<div id="question-tags-{{ question_id }}" class="question-entry--tags" hx-swap-oob="innerHTML:#question-tags-{{ question_id }}">
+  {% for slug in slugs %}
+    {% set _tag_url = tag_base_url | urlparams(tagged=toggle_tag_slug(tagged, slug), page=None) %}
+    <a class="question-entry--tag{% if tagged_set and slug in tagged_set %} is-active{% endif %}"
+       href="{{ _tag_url }}"
+       hx-get="{{ _tag_url }}"
+       hx-target="#questions-list"
+       hx-select="#questions-list"
+       hx-select-oob="#tagged,#owner-tabs"
+       hx-swap="outerHTML"
+       hx-push-url="true">{{ slug }}</a>
+  {% endfor %}
+</div>
+{% endfor %}

--- a/kitsune/questions/jinja2/questions/includes/tag_filter.html
+++ b/kitsune/questions/jinja2/questions/includes/tag_filter.html
@@ -53,12 +53,7 @@
     {% for tag in available_tags %}
       {% set slug = tag.slug %}
       {% set is_selected = slug in tagged_set %}
-      {% if is_selected %}
-        {% set _new_tagged = (tagged.split(',') | reject('equalto', slug) | list | join(',')) or None %}
-      {% else %}
-        {% set _new_tagged = (tagged + ',' + slug) if tagged else slug %}
-      {% endif %}
-      {% set _tag_url = base_list_url_with_params | urlparams(tagged=_new_tagged, page=None) %}
+      {% set _tag_url = base_list_url_with_params | urlparams(tagged=toggle_tag_slug(tagged, slug), page=None) %}
       <li data-rank="{{ loop.index0 }}"
           data-name="{{ tag.name | lower }}"
           class="{{ 'is-hidden ' if loop.index0 >= tags_initial_limit else '' }}{% if is_selected %}is-selected{% endif %}">

--- a/kitsune/questions/jinja2/questions/includes/tag_filter.html
+++ b/kitsune/questions/jinja2/questions/includes/tag_filter.html
@@ -54,12 +54,7 @@
     {% for tag in available_tags %}
       {% set slug = tag.slug %}
       {% set is_selected = slug in tagged_set %}
-      {% if is_selected %}
-        {% set _new_tagged = (tagged.split(',') | reject('equalto', slug) | list | join(',')) or None %}
-      {% else %}
-        {% set _new_tagged = (tagged + ',' + slug) if tagged else slug %}
-      {% endif %}
-      {% set _tag_url = base_list_url_with_params | urlparams(tagged=_new_tagged, page=None) %}
+      {% set _tag_url = base_list_url_with_params | urlparams(tagged=toggle_tag_slug(tagged, slug), page=None) %}
       <li data-rank="{{ loop.index0 }}"
           data-name="{{ tag.name | lower }}"
           class="{{ 'is-hidden ' if loop.index0 >= tags_initial_limit else '' }}{% if is_selected %}is-selected{% endif %}">

--- a/kitsune/questions/jinja2/questions/question_list.html
+++ b/kitsune/questions/jinja2/questions/question_list.html
@@ -198,10 +198,15 @@
 
       <div id="questions-list">
         {% if questions.object_list %}
-        <section class="forum--question-list questions">
+        <section class="forum--question-list questions"
+                 {% if show_inline_tags %}
+                 hx-get="{{ inline_tags_url }}"
+                 hx-trigger="load"
+                 hx-swap="none"
+                 {% endif %}>
           {% for question in questions.object_list %}
             <article id="question-{{ question.id }}" class="question-entry">
-              {{ question_entry(question, request=request, user_is_contributor=_user_is_contributor) }}
+              {{ question_entry(question, request=request, user_is_contributor=_user_is_contributor, show_tags=show_inline_tags) }}
             </article>
           {% endfor %}
         </section>

--- a/kitsune/questions/tests/test_views.py
+++ b/kitsune/questions/tests/test_views.py
@@ -35,7 +35,7 @@ from kitsune.sumo.tests import TestCase, eq_msg, get, template_used
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.tags.tests import TagFactory
 from kitsune.tidings.models import Watch
-from kitsune.users.tests import UserFactory, add_permission
+from kitsune.users.tests import ContributorFactory, UserFactory, add_permission
 
 
 class AAQSearchTests(ElasticTestCase):
@@ -1061,3 +1061,111 @@ class TestEditDetails(TestCase):
         response = self._request(data=data)
         # The French locale is not supported.
         self.assertEqual(400, response.status_code)
+
+
+class TestQuestionInlineTags(ElasticTestCase):
+    def setUp(self):
+        self.product = ProductFactory(slug="firefox")
+        TopicFactory(title="Fix problems", slug="fix-problems", products=[self.product])
+        ProductSupportConfigFactory(
+            product=self.product,
+            is_active=True,
+            forum_config=AAQConfigFactory(enabled_locales=QuestionLocale.objects.all()),
+            default_support_type=ProductSupportConfig.SUPPORT_TYPE_FORUM,
+        )
+        QuestionLocale.objects.get_or_create(locale=settings.LANGUAGE_CODE)
+
+        self.tag1 = TagFactory(name="crashes", slug="crashes")
+        self.tag2 = TagFactory(name="windows", slug="windows")
+
+        self.question = QuestionFactory(product=self.product)
+        self.question.tags.add(self.tag1, self.tag2)
+
+    def _url(self, **kwargs):
+        return urlparams(reverse("questions.inline_tags"), **kwargs)
+
+    def test_returns_tags_for_contributor(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("crashes", content)
+        self.assertIn("windows", content)
+        self.assertIn(f"question-tags-{self.question.id}", content)
+        self.assertIn("hx-swap-oob", content)
+
+    def test_returns_empty_for_non_contributor(self):
+        user = UserFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+
+    def test_returns_empty_for_anonymous_user(self):
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+
+    def test_returns_empty_for_missing_ids(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(self._url(product_slug=self.product.slug))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+
+    def test_caps_question_ids_at_50(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        ids = ",".join(str(i) for i in range(60))
+        response = self.client.get(self._url(ids=ids, product_slug=self.product.slug))
+        self.assertEqual(response.status_code, 200)
+
+    def test_active_tag_has_is_active_class(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+                tagged="crashes",
+            )
+        )
+        content = response.content.decode()
+        self.assertIn("is-active", content)
+
+    def test_reconstructs_tag_base_url_server_side(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+                show="all",
+            )
+        )
+        content = response.content.decode()
+        # The tag links should point to the questions list with preserved params
+        self.assertIn("/questions/firefox", content)
+        self.assertIn("show=all", content)

--- a/kitsune/questions/tests/test_views.py
+++ b/kitsune/questions/tests/test_views.py
@@ -35,7 +35,7 @@ from kitsune.sumo.tests import TestCase, eq_msg, get, template_used
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.tags.tests import TagFactory
 from kitsune.tidings.models import Watch
-from kitsune.users.tests import UserFactory, add_permission
+from kitsune.users.tests import ContributorFactory, UserFactory, add_permission
 
 
 class AAQSearchTests(ElasticTestCase):
@@ -997,3 +997,111 @@ class TestEditDetails(TestCase):
         response = self._request(data=data)
         # The French locale is not supported.
         self.assertEqual(400, response.status_code)
+
+
+class TestQuestionInlineTags(ElasticTestCase):
+    def setUp(self):
+        self.product = ProductFactory(slug="firefox")
+        TopicFactory(title="Fix problems", slug="fix-problems", products=[self.product])
+        ProductSupportConfigFactory(
+            product=self.product,
+            is_active=True,
+            forum_config=AAQConfigFactory(enabled_locales=QuestionLocale.objects.all()),
+            default_support_type=ProductSupportConfig.SUPPORT_TYPE_FORUM,
+        )
+        QuestionLocale.objects.get_or_create(locale=settings.LANGUAGE_CODE)
+
+        self.tag1 = TagFactory(name="crashes", slug="crashes")
+        self.tag2 = TagFactory(name="windows", slug="windows")
+
+        self.question = QuestionFactory(product=self.product)
+        self.question.tags.add(self.tag1, self.tag2)
+
+    def _url(self, **kwargs):
+        return urlparams(reverse("questions.inline_tags"), **kwargs)
+
+    def test_returns_tags_for_contributor(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("crashes", content)
+        self.assertIn("windows", content)
+        self.assertIn(f"question-tags-{self.question.id}", content)
+        self.assertIn("hx-swap-oob", content)
+
+    def test_returns_empty_for_non_contributor(self):
+        user = UserFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+
+    def test_returns_empty_for_anonymous_user(self):
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+
+    def test_returns_empty_for_missing_ids(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(self._url(product_slug=self.product.slug))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+
+    def test_caps_question_ids_at_50(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        ids = ",".join(str(i) for i in range(60))
+        response = self.client.get(self._url(ids=ids, product_slug=self.product.slug))
+        self.assertEqual(response.status_code, 200)
+
+    def test_active_tag_has_is_active_class(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+                tagged="crashes",
+            )
+        )
+        content = response.content.decode()
+        self.assertIn("is-active", content)
+
+    def test_reconstructs_tag_base_url_server_side(self):
+        user = ContributorFactory()
+        self.client.login(username=user.username, password="testpass")
+
+        response = self.client.get(
+            self._url(
+                ids=str(self.question.id),
+                product_slug=self.product.slug,
+                show="all",
+            )
+        )
+        content = response.content.decode()
+        # The tag links should point to the questions list with preserved params
+        self.assertIn("/questions/firefox", content)
+        self.assertIn("show=all", content)

--- a/kitsune/questions/urls.py
+++ b/kitsune/questions/urls.py
@@ -82,8 +82,9 @@ urlpatterns = [
         name="questions.remove_tag_async",
     ),
     # Tag filter (HTMX partial)
-    # Note: this needs to be above questions.list because "tags" matches the product slug regex.
+    # Note: these need to be above questions.list because the slugs match the product slug regex.
     path("tags/", views.question_tags, name="questions.tags"),
+    path("inline-tags/", views.question_inline_tags, name="questions.inline_tags"),
     # Feeds
     # Note: this needs to be above questions.list because "feed"
     # matches the product slug regex.

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -80,6 +80,7 @@ from kitsune.tidings.events import ActivationRequestFailed
 from kitsune.tidings.models import Watch
 from kitsune.upload.models import ImageAttachment
 from kitsune.users.models import Setting
+from kitsune.users.utils import user_is_contributor
 from kitsune.wiki.facets import topics_for
 from kitsune.wiki.utils import build_topics_data, get_featured_articles, get_kb_visited
 
@@ -423,6 +424,7 @@ def question_list(request, product_slug=None, topic_slug=None):
         "product_slug": product_slug,
         "topic_navigation": topic_navigation,
         "has_support_config": product_with_aaq,
+        "show_inline_tags": False,
     }
 
     if products:
@@ -439,6 +441,36 @@ def question_list(request, product_slug=None, topic_slug=None):
             tagged=tagged or None,
         )
         data["tags_url"] = tags_url
+
+        tag_base_url = urlparams(
+            reverse(
+                "questions.list_by_topic" if topic_navigation else "questions.list",
+                kwargs=(
+                    {"topic_slug": topic_slug}
+                    if topic_navigation
+                    else {"product_slug": product_slug}
+                ),
+            ),
+            **{k: v for k, v in request.GET.items() if k not in ("tagged", "page")},
+        )
+        data["tag_base_url"] = tag_base_url
+
+        data["show_inline_tags"] = user_is_contributor(request.user)
+
+        question_ids = ",".join(str(q.id) for q in questions_page)
+        data["inline_tags_url"] = urlparams(
+            reverse("questions.inline_tags"),
+            ids=question_ids,
+            product_slug=product_slug or None,
+            topic_slug=topic_slug or None,
+            topic_navigation="1" if topic_navigation else None,
+            tagged=tagged or None,
+            **{
+                k: v
+                for k, v in request.GET.items()
+                if k not in ("tagged", "page", "product_slug", "topic_slug", "topic_navigation")
+            },
+        )
 
     return render(request, "questions/question_list.html", data)
 
@@ -463,6 +495,69 @@ def _apply_question_filters(search, **kwargs):
         search = search.filter(filter_type, **{field_name: value})
 
     return search
+
+
+@require_GET
+@ratelimit("question-inline-tags", "30/m", method="GET")
+def question_inline_tags(request):
+    """Return per-question tag HTML via OOB swaps, populated from Elasticsearch."""
+    ids = request.GET.get("ids", "")
+    tagged = request.GET.get("tagged", "")
+    product_slug = request.GET.get("product_slug", "")
+    topic_slug = request.GET.get("topic_slug", "")
+    topic_navigation = request.GET.get("topic_navigation") == "1"
+
+    if not ids:
+        return HttpResponse("")
+
+    if not user_is_contributor(request.user):
+        return HttpResponse("")
+
+    # Reconstruct tag_base_url server-side (same pattern as question_tags view)
+    if topic_navigation and topic_slug:
+        base_list_url = reverse("questions.list_by_topic", kwargs={"topic_slug": topic_slug})
+    elif product_slug:
+        base_list_url = reverse("questions.list", kwargs={"product_slug": product_slug})
+    else:
+        base_list_url = reverse("questions.list", kwargs={"product_slug": "all"})
+
+    preserve_params = {
+        k: v
+        for k, v in request.GET.items()
+        if k not in ("ids", "product_slug", "topic_slug", "topic_navigation", "tagged", "page")
+    }
+    tag_base_url = urlparams(base_list_url, **preserve_params)
+
+    question_ids = ids.split(",")[: config.QUESTIONS_PER_PAGE]
+
+    question_tags = {}
+    try:
+        search = QuestionDocument.search()
+        search = search.filter("ids", values=question_ids)
+        search = search.source(includes=["question_tag_slugs"])
+        search = search.extra(size=len(question_ids))
+        for hit in search.execute():
+            slugs = list(hit.question_tag_slugs or [])
+            if slugs:
+                question_tags[hit.meta.id] = slugs
+    except Exception:
+        return HttpResponse("")
+
+    if not question_tags:
+        return HttpResponse("")
+
+    tagged_set = set(tagged.split(",")) if tagged else set()
+
+    return render(
+        request,
+        "questions/includes/inline_tags.html",
+        {
+            "question_tags": question_tags,
+            "tagged": tagged,
+            "tagged_set": tagged_set,
+            "tag_base_url": tag_base_url,
+        },
+    )
 
 
 @require_GET

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -442,19 +442,6 @@ def question_list(request, product_slug=None, topic_slug=None):
         )
         data["tags_url"] = tags_url
 
-        tag_base_url = urlparams(
-            reverse(
-                "questions.list_by_topic" if topic_navigation else "questions.list",
-                kwargs=(
-                    {"topic_slug": topic_slug}
-                    if topic_navigation
-                    else {"product_slug": product_slug}
-                ),
-            ),
-            **{k: v for k, v in request.GET.items() if k not in ("tagged", "page")},
-        )
-        data["tag_base_url"] = tag_base_url
-
         data["show_inline_tags"] = user_is_contributor(request.user)
 
         question_ids = ",".join(str(q.id) for q in questions_page)
@@ -521,6 +508,7 @@ def question_inline_tags(request):
 
     question_ids = ids.split(",")[: config.QUESTIONS_PER_PAGE]
 
+    all_slugs = set()
     question_tags = {}
     try:
         search = QuestionDocument.search()
@@ -530,12 +518,21 @@ def question_inline_tags(request):
         for hit in search.execute():
             slugs = list(hit.question_tag_slugs or [])
             if slugs:
+                all_slugs.update(slugs)
                 question_tags[hit.meta.id] = slugs
-    except Exception:
+    except TransportError:
         return HttpResponse("")
 
     if not question_tags:
         return HttpResponse("")
+
+    tag_name_map = dict(SumoTag.objects.filter(slug__in=all_slugs).values_list("slug", "name"))
+
+    # Replace raw slug lists with (slug, name) tuples
+    question_tags = {
+        qid: [(slug, tag_name_map.get(slug, slug)) for slug in slugs]
+        for qid, slugs in question_tags.items()
+    }
 
     tagged_set = set(tagged.split(",")) if tagged else set()
 

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -442,19 +442,6 @@ def question_list(request, product_slug=None, topic_slug=None):
         )
         data["tags_url"] = tags_url
 
-        tag_base_url = urlparams(
-            reverse(
-                "questions.list_by_topic" if topic_navigation else "questions.list",
-                kwargs=(
-                    {"topic_slug": topic_slug}
-                    if topic_navigation
-                    else {"product_slug": product_slug}
-                ),
-            ),
-            **{k: v for k, v in request.GET.items() if k not in ("tagged", "page")},
-        )
-        data["tag_base_url"] = tag_base_url
-
         data["show_inline_tags"] = user_is_contributor(request.user)
 
         question_ids = ",".join(str(q.id) for q in questions_page)
@@ -530,6 +517,7 @@ def question_inline_tags(request):
 
     question_ids = ids.split(",")[: config.QUESTIONS_PER_PAGE]
 
+    all_slugs = set()
     question_tags = {}
     try:
         search = QuestionDocument.search()
@@ -539,12 +527,21 @@ def question_inline_tags(request):
         for hit in search.execute():
             slugs = list(hit.question_tag_slugs or [])
             if slugs:
+                all_slugs.update(slugs)
                 question_tags[hit.meta.id] = slugs
-    except Exception:
+    except TransportError:
         return HttpResponse("")
 
     if not question_tags:
         return HttpResponse("")
+
+    tag_name_map = dict(SumoTag.objects.filter(slug__in=all_slugs).values_list("slug", "name"))
+
+    # Replace raw slug lists with (slug, name) tuples
+    question_tags = {
+        qid: [(slug, tag_name_map.get(slug, slug)) for slug in slugs]
+        for qid, slugs in question_tags.items()
+    }
 
     tagged_set = set(tagged.split(",")) if tagged else set()
 

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -80,6 +80,7 @@ from kitsune.tidings.events import ActivationRequestFailed
 from kitsune.tidings.models import Watch
 from kitsune.upload.models import ImageAttachment
 from kitsune.users.models import Setting
+from kitsune.users.utils import user_is_contributor
 from kitsune.wiki.facets import topics_for
 from kitsune.wiki.utils import build_topics_data, get_featured_articles, get_kb_visited
 
@@ -423,6 +424,7 @@ def question_list(request, product_slug=None, topic_slug=None):
         "product_slug": product_slug,
         "topic_navigation": topic_navigation,
         "has_support_config": product_with_aaq,
+        "show_inline_tags": False,
     }
 
     if products:
@@ -440,6 +442,36 @@ def question_list(request, product_slug=None, topic_slug=None):
         )
         data["tags_url"] = tags_url
 
+        tag_base_url = urlparams(
+            reverse(
+                "questions.list_by_topic" if topic_navigation else "questions.list",
+                kwargs=(
+                    {"topic_slug": topic_slug}
+                    if topic_navigation
+                    else {"product_slug": product_slug}
+                ),
+            ),
+            **{k: v for k, v in request.GET.items() if k not in ("tagged", "page")},
+        )
+        data["tag_base_url"] = tag_base_url
+
+        data["show_inline_tags"] = user_is_contributor(request.user)
+
+        question_ids = ",".join(str(q.id) for q in questions_page)
+        data["inline_tags_url"] = urlparams(
+            reverse("questions.inline_tags"),
+            ids=question_ids,
+            product_slug=product_slug or None,
+            topic_slug=topic_slug or None,
+            topic_navigation="1" if topic_navigation else None,
+            tagged=tagged or None,
+            **{
+                k: v
+                for k, v in request.GET.items()
+                if k not in ("tagged", "page", "product_slug", "topic_slug", "topic_navigation")
+            },
+        )
+
     return render(request, "questions/question_list.html", data)
 
 
@@ -455,6 +487,68 @@ def _apply_question_filters(search, **kwargs):
         search = search.filter(filter_type, **{field_name: value})
 
     return search
+
+
+@require_GET
+def question_inline_tags(request):
+    """Return per-question tag HTML via OOB swaps, populated from Elasticsearch."""
+    ids = request.GET.get("ids", "")
+    tagged = request.GET.get("tagged", "")
+    product_slug = request.GET.get("product_slug", "")
+    topic_slug = request.GET.get("topic_slug", "")
+    topic_navigation = request.GET.get("topic_navigation") == "1"
+
+    if not ids:
+        return HttpResponse("")
+
+    if not user_is_contributor(request.user):
+        return HttpResponse("")
+
+    # Reconstruct tag_base_url server-side (same pattern as question_tags view)
+    if topic_navigation and topic_slug:
+        base_list_url = reverse("questions.list_by_topic", kwargs={"topic_slug": topic_slug})
+    elif product_slug:
+        base_list_url = reverse("questions.list", kwargs={"product_slug": product_slug})
+    else:
+        base_list_url = reverse("questions.list", kwargs={"product_slug": "all"})
+
+    preserve_params = {
+        k: v
+        for k, v in request.GET.items()
+        if k not in ("ids", "product_slug", "topic_slug", "topic_navigation", "tagged", "page")
+    }
+    tag_base_url = urlparams(base_list_url, **preserve_params)
+
+    question_ids = ids.split(",")[: config.QUESTIONS_PER_PAGE]
+
+    question_tags = {}
+    try:
+        search = QuestionDocument.search()
+        search = search.filter("ids", values=question_ids)
+        search = search.source(includes=["question_tag_slugs"])
+        search = search.extra(size=len(question_ids))
+        for hit in search.execute():
+            slugs = list(hit.question_tag_slugs or [])
+            if slugs:
+                question_tags[hit.meta.id] = slugs
+    except Exception:
+        return HttpResponse("")
+
+    if not question_tags:
+        return HttpResponse("")
+
+    tagged_set = set(tagged.split(",")) if tagged else set()
+
+    return render(
+        request,
+        "questions/includes/inline_tags.html",
+        {
+            "question_tags": question_tags,
+            "tagged": tagged,
+            "tagged_set": tagged_set,
+            "tag_base_url": tag_base_url,
+        },
+    )
 
 
 @require_GET

--- a/kitsune/sumo/jinja2/sumo/includes/question_entry.html
+++ b/kitsune/sumo/jinja2/sumo/includes/question_entry.html
@@ -74,7 +74,7 @@
   {% endif %}
 {% endmacro %}
 
-{% macro question_entry(question, profile_username=None, request=None, user_is_contributor=False) %}
+{% macro question_entry(question, profile_username=None, request=None, user_is_contributor=False, show_tags=None) %}
   {% set _base_url = url('users.questions', username=profile_username) if (question.channel == "direct_support" and profile_username) else None %}
   {% if _base_url %}
     {% set _product_url = (_base_url + '?channel=direct_support&product=' + question.product.slug) if question.product else None %}
@@ -208,4 +208,7 @@
       </span>
     {% endif %}
   </div>
+  {% if show_tags %}
+    <div id="question-tags-{{ question.id }}" class="question-entry--tags"></div>
+  {% endif %}
 {% endmacro %}

--- a/kitsune/sumo/static/sumo/scss/layout/_question-entry.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_question-entry.scss
@@ -197,6 +197,47 @@
   }
 }
 
+.question-entry--tags {
+  position: relative;
+  z-index: 1;
+  grid-column: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: p.$spacing-xs;
+  margin-top: p.$spacing-md;
+
+  &:empty {
+    display: none;
+  }
+}
+
+.question-entry--tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px p.$spacing-sm;
+  background: var(--color-light-gray-03);
+  color: var(--color-text);
+  border-radius: 20px;
+  @include c.text-body-xs;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:hover {
+    background: var(--color-light-gray-04);
+    color: var(--color-heading);
+  }
+
+  &.is-active {
+    background: var(--color-link-active-bg);
+    color: var(--color-link);
+    font-weight: 600;
+
+    &:hover {
+      background: var(--color-light-gray-04);
+    }
+  }
+}
+
 .question-entry--meta {
   grid-column: 2;
   display: flex;

--- a/kitsune/tags/templatetags/jinja_helpers.py
+++ b/kitsune/tags/templatetags/jinja_helpers.py
@@ -12,8 +12,20 @@ def tags_to_text(tags):
 
 
 @library.global_function
+def toggle_tag_slug(tagged_csv, slug):
+    """Toggle a tag slug in a comma-separated slug string.
+
+    Returns the updated string, or None if the result is empty.
+    """
+    slugs = [s for s in tagged_csv.split(",") if s] if tagged_csv else []
+    if slug in slugs:
+        slugs = [s for s in slugs if s != slug]
+    else:
+        slugs.append(slug)
+    return ",".join(slugs) or None
+
+
+@library.global_function
 def tag_vocab():
     """Returns the tag vocabulary as a JSON object."""
-    return json.dumps(
-        {t[0]: t[1] for t in SumoTag.objects.active().values_list("name", "slug")}
-    )
+    return json.dumps({t[0]: t[1] for t in SumoTag.objects.active().values_list("name", "slug")})


### PR DESCRIPTION
mozilla/sumo#2975

- Asynchronously loads each question's tags in the question list view, and uses ES to get each question's tags.
- The tags are only shown to contributors.