### PR TITLE
reduce space after text in question cards

### DIFF
--- a/kitsune/sumo/static/sumo/scss/layout/_question-entry.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_question-entry.scss
@@ -77,6 +77,11 @@
   color: var(--color-text-light);
   margin: 0;
 
+  p:last-child,
+  .short-text {
+    margin-bottom: 0;
+  }
+
   .show-more-link {
     position: relative;
     z-index: 1;


### PR DESCRIPTION
mozilla/sumo#2977

<img width="482" height="284" alt="image" src="https://github.com/user-attachments/assets/ac45eb38-9994-4c4d-b4eb-e0b56063574f" />
