### PR TITLE
respect support config in search results AAQ widget

### DIFF
--- a/kitsune/search/tests/test_views.py
+++ b/kitsune/search/tests/test_views.py
@@ -1,7 +1,14 @@
 import json
 
+from django.test.utils import override_settings
 from pyquery import PyQuery as pq
 
+from kitsune.products.tests import (
+    ProductFactory,
+    ProductSupportConfigFactory,
+    ZendeskConfigFactory,
+)
+from kitsune.questions.tests import AAQConfigFactory, QuestionLocaleFactory
 from kitsune.search.tests import ElasticTestCase
 from kitsune.sumo.urlresolvers import reverse
 
@@ -53,3 +60,94 @@ class TestSearchSEO(ElasticTestCase):
         self.assertEqual(json.loads(response.content), {"error": "Invalid search data."})
         self.assertTrue("x-robots-tag" in response)
         self.assertEqual(response["x-robots-tag"], "noindex")
+
+
+class TestSearchSupportCard(ElasticTestCase):
+    """Test that the 'Still need help?' card respects product-support config."""
+
+    def _search_json(self, product_slug=None):
+        url = reverse("search", locale="en-US")
+        params = "format=json&q=zzzznotfound"
+        if product_slug:
+            params += f"&product={product_slug}"
+        response = self.client.get(f"{url}?{params}")
+        self.assertEqual(response.status_code, 200)
+        return json.loads(response.content)
+
+    def test_no_product_shows_support_url(self):
+        data = self._search_json()
+        self.assertEqual(data["support_aaq_url"], reverse("questions.aaq_step1", locale="en-US"))
+
+    def test_product_with_forum_support_shows_url(self):
+        product = ProductFactory(slug="test-product", visible=True)
+        locale = QuestionLocaleFactory(locale="en-US")
+        aaq_config = AAQConfigFactory(enabled_locales=[locale])
+        ProductSupportConfigFactory(
+            product=product,
+            forum_config=aaq_config,
+            is_active=True,
+        )
+        data = self._search_json(product_slug="test-product")
+        self.assertEqual(
+            data["support_aaq_url"],
+            reverse(
+                "questions.aaq_step3", locale="en-US", kwargs={"product_slug": "test-product"}
+            ),
+        )
+
+    def test_product_with_zendesk_support_shows_url(self):
+        product = ProductFactory(slug="test-zendesk", visible=True)
+        ProductSupportConfigFactory(
+            product=product,
+            zendesk_config=ZendeskConfigFactory(),
+            is_active=True,
+        )
+        data = self._search_json(product_slug="test-zendesk")
+        self.assertEqual(
+            data["support_aaq_url"],
+            reverse(
+                "questions.aaq_step3", locale="en-US", kwargs={"product_slug": "test-zendesk"}
+            ),
+        )
+
+    def test_subscription_only_redirect_shows_redirect_url(self):
+        redirect_product = ProductFactory(slug="test-redirect-target", visible=True)
+        product = ProductFactory(slug="test-redirect", visible=True)
+        ProductSupportConfigFactory(
+            product=product,
+            zendesk_config=ZendeskConfigFactory(),
+            is_active=True,
+            subscription_only=True,
+            unsubscribed_redirect_product=redirect_product,
+        )
+        data = self._search_json(product_slug="test-redirect")
+        self.assertEqual(
+            data["support_aaq_url"],
+            reverse(
+                "questions.aaq_step2",
+                locale="en-US",
+                kwargs={"product_slug": "test-redirect-target"},
+            ),
+        )
+
+    def test_subscription_only_hide_no_support_url(self):
+        product = ProductFactory(slug="test-sub", visible=True)
+        ProductSupportConfigFactory(
+            product=product,
+            zendesk_config=ZendeskConfigFactory(),
+            is_active=True,
+            subscription_only=True,
+            unsubscribed_redirect_product=None,
+        )
+        data = self._search_json(product_slug="test-sub")
+        self.assertIsNone(data["support_aaq_url"])
+
+    def test_no_support_config_no_support_url(self):
+        ProductFactory(slug="test-noconfig", visible=True)
+        data = self._search_json(product_slug="test-noconfig")
+        self.assertIsNone(data["support_aaq_url"])
+
+    @override_settings(READ_ONLY=True)
+    def test_read_only_mode_no_support_url(self):
+        data = self._search_json()
+        self.assertIsNone(data["support_aaq_url"])

--- a/kitsune/search/views.py
+++ b/kitsune/search/views.py
@@ -11,14 +11,16 @@ from django.utils.translation import pgettext
 from django.views.decorators.cache import cache_page
 
 from kitsune import search as constants
-from kitsune.products.models import Product
+from kitsune.products.managers import ProductSupportConfigManager
+from kitsune.products.models import Product, ProductSupportConfig
 from kitsune.search.base import SumoSearchPaginator
 from kitsune.search.forms import SimpleSearchForm
 from kitsune.search.search import CompoundSearch, QuestionSearch, WikiSearch
 from kitsune.search.utils import locale_or_default
 from kitsune.sumo.api_utils import JSONRenderer
 from kitsune.sumo.templatetags.jinja_helpers import Paginator as PaginatorRenderer
-from kitsune.sumo.utils import paginate
+from kitsune.sumo.urlresolvers import reverse
+from kitsune.sumo.utils import get_aaq_context, get_aaq_url, paginate
 from kitsune.wiki.facets import documents_for
 
 log = logging.getLogger("k.search")
@@ -156,6 +158,22 @@ def simple_search(request):
         data["product"] = product.slug
     if not results:
         data["message"] = constants.NO_MATCH
+
+    # Compute the support AAQ URL for the "Still need help?" card.
+    # Its presence/absence controls whether the card is shown.
+    is_ticketed = False
+    support_aaq_url = None
+    if not settings.READ_ONLY:
+        if product:
+            aaq_context = get_aaq_context(request, product)
+            support_type = aaq_context.get("current_support_type")
+            if support_type and support_type != ProductSupportConfigManager.SUPPORT_TYPE_HIDE:
+                support_aaq_url = get_aaq_url(aaq_context)
+                is_ticketed = support_type == ProductSupportConfig.SUPPORT_TYPE_ZENDESK
+        else:
+            support_aaq_url = reverse("questions.aaq_step1")
+    data["support_aaq_url"] = support_aaq_url
+    data["is_ticketed"] = is_ticketed
 
     json_data = JSONRenderer().render(data)
     return HttpResponse(

--- a/kitsune/sumo/static/sumo/tpl/search-results-list.njk
+++ b/kitsune/sumo/static/sumo/tpl/search-results-list.njk
@@ -120,7 +120,7 @@
 {% endif %}
 
 
-{% if num_results == 0 and product != 'firefox-enterprise' %}
+{% if num_results == 0 and support_aaq_url and (product != 'firefox-enterprise') %}
 <div class="sumo-page-section--inner">
   <div class="card card--ribbon is-inverse">
     <div class="card--details">
@@ -133,19 +133,27 @@
             </g>
           </g>
         </svg>
-        {{ _('Still need help?') }}
+        {{ _("Still need help?") }}
       </h3>
 
       <p class="card--desc">
-        {{ _('We’re here for you. Get support from our contributors or staff members.') }}
+        {% if is_ticketed %}
+          {{ _("We’re here for you! If you haven’t found a solution after exploring our help articles, you can get in touch with our support team.") }}
+        {% else %}
+          {{ _("We’re here for you. Post a question to our support forums and get answers from our community of experts.") }}
+        {% endif %}
       </p>
       <a
         id="search-results-aaq-link"
         class="sumo-button primary-button button-lg"
-        href="{% if product %}/questions/new/{{ product }}/form{% else %}/questions/new{% endif %}"
+        href="{{ support_aaq_url }}"
         data-event-name="link_click"
-        data-event-parameters='{"link_name": "search-results.aaq-step-3.get-support"}'>
-        {{ _('Get Support') }}
+        data-event-parameters=’{"link_name": "search-results.aaq-step-3.get-support"}’>
+        {% if is_ticketed %}
+          {{ _("Contact Support") }}
+        {% else %}
+          {{ _("Ask the Community") }}
+        {% endif %}
       </a>
     </div>
   </div>


### PR DESCRIPTION
mozilla/sumo#2853

I also updated the widget's text to match the text in our other AAQ widgets for ticketed vs. not-ticketed -- I'm still excluding the search-results AAQ widget when the product is `Firefox for Enterprise`.