### PR TITLE
fix hover highlight on tags

### DIFF
--- a/kitsune/sumo/static/sumo/scss/layout/_forum.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_forum.scss
@@ -152,11 +152,17 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+      gap: p.$spacing-xs;
       padding: p.$spacing-xs p.$spacing-sm;
       border-radius: var(--global-radius);
       @include c.text-body-sm;
       color: var(--color-text);
       text-decoration: none;
+
+      > span:first-child {
+        min-width: 0;
+        overflow-wrap: anywhere;
+      }
 
       &:hover {
         background: rgba(0, 0, 0, 0.07);


### PR DESCRIPTION
mozilla/sumo#2986

<img width="1334" height="672" alt="image" src="https://github.com/user-attachments/assets/42fba21f-62ac-45da-b419-df6a9e5c900c" />

