### PR TITLE
select default show filter based on contributor status

### DIFF
--- a/kitsune/questions/tests/test_templates.py
+++ b/kitsune/questions/tests/test_templates.py
@@ -23,7 +23,7 @@ from kitsune.tags.models import SumoTag
 from kitsune.tags.tests import TagFactory
 from kitsune.tidings.models import Watch
 from kitsune.upload.models import ImageAttachment
-from kitsune.users.tests import UserFactory, add_permission
+from kitsune.users.tests import ContributorFactory, UserFactory, add_permission
 
 
 class AnswersTemplateTestCase(TestCase):
@@ -1203,6 +1203,30 @@ class QuestionsTemplateTestCase(TestCase):
         QuestionFactory()
         response = self.client.get(urlparams(reverse("questions.list", args=["all"]), show=""))
         self.assertEqual(200, response.status_code)
+
+    def test_default_show_depends_on_contributor_status(self):
+        QuestionFactory()
+        list_url = reverse("questions.list", args=["all"])
+
+        # Anonymous user → default "all".
+        response = self.client.get(list_url)
+        doc = pq(response.content)
+        self.assertEqual(1, len(doc('#owner-tabs a.selected[href*="show=all"]')))
+
+        # Authenticated non-contributor → default "all".
+        non_contributor = UserFactory()
+        self.client.login(username=non_contributor.username, password="testpass")
+        response = self.client.get(list_url)
+        doc = pq(response.content)
+        self.assertEqual(1, len(doc('#owner-tabs a.selected[href*="show=all"]')))
+        self.client.logout()
+
+        # Contributor → default "needs-attention".
+        contributor = ContributorFactory()
+        self.client.login(username=contributor.username, password="testpass")
+        response = self.client.get(list_url)
+        doc = pq(response.content)
+        self.assertEqual(1, len(doc('#owner-tabs a.selected[href*="show=needs-attention"]')))
 
 
 class QuestionsTemplateTestCaseNoFixtures(TestCase):

--- a/kitsune/questions/tests/test_templates.py
+++ b/kitsune/questions/tests/test_templates.py
@@ -1238,7 +1238,7 @@ class QuestionsTemplateTestCaseNoFixtures(TestCase):
         QuestionFactory(product=p, is_locked=True)
 
         url = reverse("questions.list", args=["all"])
-        url = urlparams(url, filter="no-replies")
+        url = urlparams(url, filter="recently-unanswered")
         response = self.client.get(url)
         doc = pq(response.content)
         self.assertEqual(2, len(doc(".question-entry")))

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -80,6 +80,7 @@ from kitsune.tidings.events import ActivationRequestFailed
 from kitsune.tidings.models import Watch
 from kitsune.upload.models import ImageAttachment
 from kitsune.users.models import Setting
+from kitsune.users.utils import user_is_contributor
 from kitsune.wiki.facets import topics_for
 from kitsune.wiki.utils import build_topics_data, get_featured_articles, get_kb_visited
 
@@ -173,9 +174,8 @@ def question_list(request, product_slug=None, topic_slug=None):
     filter_ = request.GET.get("filter")
     owner = request.GET.get("owner", request.session.get("questions_owner", "all"))
     show = request.GET.get("show")
-    # Show defaults to NEEDS ATTENTION
     if show not in FILTER_GROUPS:
-        show = "needs-attention"
+        show = "needs-attention" if user_is_contributor(request.user) else "all"
 
     tagged = request.GET.get("tagged")
     tags = None


### PR DESCRIPTION
mozilla/sumo#3013

This PR doesn't change the default order of the questions. That remains at `updated`. If we'd prefer to change that to `views`, that's left for a separate PR.