### PR TITLE
add periodic task for active support ticket sync

### DIFF
--- a/kitsune/celery_beat.py
+++ b/kitsune/celery_beat.py
@@ -64,6 +64,11 @@ PERIODIC_TASKS_ALL = {
         "task": "kitsune.customercare.tasks.process_failed_zendesk_tickets",
         "schedule": crontab(minute="0"),
     },
+    # Every hour at 15 minutes past. Backup reconciliation; webhook is primary.
+    "sync_active_support_tickets": {
+        "task": "kitsune.customercare.tasks.sync_active_support_tickets",
+        "schedule": crontab(minute="15"),
+    },
     # Questions Periodic Tasks
     # Daily at 04:00.
     "auto_archive_old_questions": {

--- a/kitsune/customercare/tasks.py
+++ b/kitsune/customercare/tasks.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import timedelta
 
-from celery import shared_task
+from celery import group, shared_task
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
@@ -9,7 +9,10 @@ from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from kitsune.customercare.models import SupportTicket
-from kitsune.customercare.utils import process_zendesk_classification_result
+from kitsune.customercare.utils import (
+    process_zendesk_classification_result,
+    sync_ticket_from_zendesk,
+)
 from kitsune.customercare.zendesk import ZendeskClient
 from kitsune.flagit.models import FlaggedObject
 from kitsune.llm.support.classifiers import classify_zendesk_submission
@@ -189,3 +192,50 @@ def process_zendesk_update(payload: dict) -> None:
             ticket.zd_updated_at = parse_datetime(updated_at)
             update_fields.append("zd_updated_at")
             ticket.save(update_fields=update_fields)
+
+
+@shared_task_with_retry
+def sync_support_ticket(ticket_id: int) -> None:
+    """Refresh a single SupportTicket from Zendesk.
+
+    Thin wrapper around `sync_ticket_from_zendesk`. Per-ticket task so a single
+    failing ticket doesn't stall the rest of the batch and gets isolated retries.
+    """
+    try:
+        ticket = (
+            SupportTicket.objects.filter(zendesk_ticket_id__isnull=False)
+            .exclude(zendesk_ticket_id="")
+            .get(id=ticket_id)
+        )
+    except SupportTicket.DoesNotExist:
+        return
+
+    sync_ticket_from_zendesk(ticket)
+
+
+@shared_task
+@skip_if_read_only_mode
+def sync_active_support_tickets() -> None:
+    """Dispatch sync sub-tasks for all locally-active Zendesk tickets.
+
+    Backup reconciliation path; the Zendesk webhook is the primary mechanism.
+    Zenpy handles Zendesk API rate limiting, so sub-tasks run as fast as the
+    worker pool allows.
+    """
+    active_statuses = [
+        SupportTicket.ZD_STATUS_OPEN,
+        SupportTicket.ZD_STATUS_PENDING,
+        SupportTicket.ZD_STATUS_WAITING,
+    ]
+    ticket_ids = (
+        SupportTicket.objects.filter(
+            zd_status__in=active_statuses,
+            zendesk_ticket_id__isnull=False,
+        )
+        .exclude(zendesk_ticket_id="")
+        .values_list("id", flat=True)
+    )
+
+    result = group(sync_support_ticket.s(ticket_id) for ticket_id in ticket_ids).delay()
+
+    log.info(f"Dispatched Zendesk sync for {len(result)} active tickets.")

--- a/kitsune/customercare/tests/test_tasks.py
+++ b/kitsune/customercare/tests/test_tasks.py
@@ -4,6 +4,8 @@ from kitsune.customercare.models import SupportTicket
 from kitsune.customercare.tasks import (
     process_failed_zendesk_tickets,
     process_zendesk_update,
+    sync_active_support_tickets,
+    sync_support_ticket,
     zendesk_submission_classifier,
 )
 from kitsune.llm.spam.classifier import ModerationAction
@@ -404,3 +406,100 @@ class ProcessZendeskUpdateTests(TestCase):
             )
         self.ticket.refresh_from_db()
         self.assertIsNone(self.ticket.zd_updated_at)
+
+
+class SyncSupportTicketTests(TestCase):
+    """Tests for the sync_support_ticket per-ticket task."""
+
+    def setUp(self):
+        self.product = ProductFactory(slug="firefox", title="Firefox")
+
+    def _make_ticket(self, **overrides):
+        defaults = {
+            "subject": "Help",
+            "description": "Need help",
+            "category": "general",
+            "email": "user@example.com",
+            "product": self.product,
+            "zendesk_ticket_id": "12345",
+            "zd_status": SupportTicket.ZD_STATUS_OPEN,
+        }
+        defaults.update(overrides)
+        return SupportTicket.objects.create(**defaults)
+
+    @patch("kitsune.customercare.tasks.sync_ticket_from_zendesk")
+    def test_calls_helper_with_loaded_ticket(self, mock_helper):
+        ticket = self._make_ticket()
+
+        sync_support_ticket(ticket.id)
+
+        mock_helper.assert_called_once()
+        called_ticket = mock_helper.call_args[0][0]
+        self.assertEqual(called_ticket.id, ticket.id)
+
+    @patch("kitsune.customercare.tasks.sync_ticket_from_zendesk")
+    def test_missing_ticket_returns_silently(self, mock_helper):
+        sync_support_ticket(999999)
+
+        mock_helper.assert_not_called()
+
+    @patch("kitsune.customercare.tasks.sync_ticket_from_zendesk")
+    def test_null_or_blank_zendesk_ticket_id_skips_helper(self, mock_helper):
+        null_ticket = self._make_ticket(zendesk_ticket_id=None)
+        blank_ticket = self._make_ticket(zendesk_ticket_id="")
+
+        sync_support_ticket(null_ticket.id)
+        sync_support_ticket(blank_ticket.id)
+
+        mock_helper.assert_not_called()
+
+    @patch("kitsune.customercare.tasks.sync_ticket_from_zendesk")
+    def test_helper_exception_propagates(self, mock_helper):
+        mock_helper.side_effect = RuntimeError("Zendesk down")
+        ticket = self._make_ticket()
+
+        with self.assertRaises(RuntimeError):
+            sync_support_ticket(ticket.id)
+
+
+class SyncActiveSupportTicketsTests(TestCase):
+    """Tests for the sync_active_support_tickets orchestrator task."""
+
+    def setUp(self):
+        self.product = ProductFactory(slug="firefox", title="Firefox")
+
+    def _make_ticket(self, zd_status, zendesk_ticket_id="12345"):
+        return SupportTicket.objects.create(
+            product=self.product,
+            zendesk_ticket_id=zendesk_ticket_id,
+            zd_status=zd_status,
+        )
+
+    @patch("kitsune.customercare.tasks.sync_ticket_from_zendesk")
+    def test_dispatches_only_active_tickets_with_zendesk_ids(self, mock_sync):
+        active_open = self._make_ticket(SupportTicket.ZD_STATUS_OPEN)
+        active_pending = self._make_ticket(SupportTicket.ZD_STATUS_PENDING)
+        active_waiting = self._make_ticket(SupportTicket.ZD_STATUS_WAITING)
+        # Inactive statuses — should not be dispatched.
+        self._make_ticket(SupportTicket.ZD_STATUS_SOLVED)
+        self._make_ticket(SupportTicket.ZD_STATUS_CLOSED)
+        # Active status but no Zendesk id — should not be dispatched.
+        self._make_ticket(SupportTicket.ZD_STATUS_OPEN, zendesk_ticket_id="")
+
+        sync_active_support_tickets()
+
+        self.assertEqual(mock_sync.call_count, 3)
+        dispatched_ids = {call.args[0].id for call in mock_sync.call_args_list}
+        self.assertEqual(
+            dispatched_ids,
+            {active_open.id, active_pending.id, active_waiting.id},
+        )
+
+    @patch("kitsune.customercare.tasks.sync_ticket_from_zendesk")
+    def test_no_active_tickets_dispatches_nothing(self, mock_sync):
+        self._make_ticket(SupportTicket.ZD_STATUS_SOLVED)
+        self._make_ticket(SupportTicket.ZD_STATUS_CLOSED)
+
+        sync_active_support_tickets()
+
+        mock_sync.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <3.15"
+requires-python = "==3.14.*"
 
 [[package]]
 name = "allure-pytest"


### PR DESCRIPTION
mozilla/sumo#2857

### Assumptions
- Rate-limiting is handled by `zenpy`. We're using `zenpy`'s default reactive handling that occurs when we receive a 429 from Zendesk (sleep for second, check if budget allows, repeat). This is probably not an issue as long as we only have 10's/100's of active tickets at any moment in time rather than thousands.