### PR TITLE
update `django-csp` to version 4

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -8,6 +8,7 @@ import re
 
 import dj_database_url
 import django_cache_url
+from csp.constants import NONCE, NONE, SELF, UNSAFE_EVAL, UNSAFE_INLINE
 from decouple import Csv, config
 
 from kitsune.celery_beat import PERIODIC_TASKS_ALL, PERIODIC_TASKS_PRODUCTION_ONLY
@@ -489,6 +490,11 @@ MIDDLEWARE: tuple[str, ...] = (
     "kitsune.sumo.middleware.FilterByUserAgentMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    # CSPMiddleware must be above any middleware that renders templates
+    # using `request.csp_nonce` (e.g. Forbidden403Middleware), so that on
+    # the response phase (which runs in reverse) it is the last to write
+    # the CSP header. Otherwise `request.csp_nonce` raises CSPNonceError.
+    "csp.middleware.CSPMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "kitsune.sumo.middleware.SetRemoteAddr",
     "kitsune.sumo.middleware.EnforceHostIPMiddleware",
@@ -526,7 +532,6 @@ MIDDLEWARE: tuple[str, ...] = (
     "kitsune.sumo.middleware.InAAQMiddleware",
     "kitsune.users.middleware.LogoutDeactivatedUsersMiddleware",
     "kitsune.users.middleware.LogoutInvalidatedSessionsMiddleware",
-    "csp.middleware.CSPMiddleware",
     "dockerflow.django.middleware.DockerflowMiddleware",
 )
 
@@ -662,6 +667,7 @@ INSTALLED_APPS: tuple[str, ...] = (
     "graphene_django",
     "mozilla_django_oidc",
     "corsheaders",
+    "csp",
     "kitsune.users",
     "guardian",
     "waffle",
@@ -1245,81 +1251,73 @@ ZENDESK_WEBHOOK_API_KEY = config("ZENDESK_WEBHOOK_API_KEY", default="")
 LOGIN_EXCEPTIONS = frozenset(["mozilla-account"])
 
 # Django CSP configuration
-CSP_INCLUDE_NONCE_IN = ["script-src", "style-src"]
-
-CSP_DEFAULT_SRC = ("'none'",)
-
-CSP_SCRIPT_SRC: tuple[str, ...] = (
-    "'self'",
-    "https://*.mozilla.org",
-    "https://*.webservices.mozgcp.net",
-    "https://*.google-analytics.com",
-    "https://*.googletagmanager.com",
-    "https://pontoon.mozilla.org",
-    "https://*.jsdelivr.net",
-)
-
-CSP_IMG_SRC = (
-    "'self'",
-    "blob:",
-    "data:",
-    "https://*.mozaws.net",
-    "https://*.webservices.mozgcp.net",
-    "https://*.google-analytics.com",
-    "https://profile.accounts.firefox.com",
-    "https://firefoxusercontent.com",
-    "https://secure.gravatar.com",
-    "https://i1.wp.com",
-    "https://mozillausercontent.com",
-)
-
-CSP_MEDIA_SRC = (
-    "'self'",
-    "https://*.webservices.mozgcp.net",
-)
-
-CSP_FRAME_SRC = (
-    "'self'",
-    "https://*.youtube.com",
-)
-
-CSP_FONT_SRC = (
-    "'self'",
-    "https://*.webservices.mozgcp.net",
-)
-
-CSP_STYLE_SRC: tuple[str, ...] = (
-    "'self'",
-    "https://*.webservices.mozgcp.net",
-    "https://*.jsdelivr.net",
-)
-
-CSP_FORM_ACTION = (
-    "'self'",
-    "https://accounts.firefox.com",
-    "https://accounts.stage.mozaws.net",
-)
-
-CSP_MANIFEST_SRC = (
-    "https://support.allizom.org",
-    "https://support.mozilla.org",
-)
-
-CSP_CONNECT_SRC = (
-    "'self'",
-    "https://*.google-analytics.com",
-    "https://location.services.mozilla.com",
-    "https://accounts.firefox.com/metrics-flow",
-    "https://accounts.stage.mozaws.net/metrics-flow",
-    "https://basket.mozilla.org",
-)
+CONTENT_SECURITY_POLICY = {
+    "DIRECTIVES": {
+        "default-src": [NONE],
+        "script-src": [
+            SELF,
+            "https://*.mozilla.org",
+            "https://*.webservices.mozgcp.net",
+            "https://*.google-analytics.com",
+            "https://*.googletagmanager.com",
+            "https://pontoon.mozilla.org",
+            "https://*.jsdelivr.net",
+            NONCE,
+        ],
+        "img-src": [
+            SELF,
+            "blob:",
+            "data:",
+            "https://*.mozaws.net",
+            "https://*.webservices.mozgcp.net",
+            "https://*.google-analytics.com",
+            "https://profile.accounts.firefox.com",
+            "https://firefoxusercontent.com",
+            "https://secure.gravatar.com",
+            "https://i1.wp.com",
+            "https://mozillausercontent.com",
+        ],
+        "media-src": [
+            SELF,
+            "https://*.webservices.mozgcp.net",
+        ],
+        "frame-src": [
+            SELF,
+            "https://*.youtube.com",
+        ],
+        "font-src": [
+            SELF,
+            "https://*.webservices.mozgcp.net",
+        ],
+        "style-src": [
+            SELF,
+            "https://*.webservices.mozgcp.net",
+            "https://*.jsdelivr.net",
+            NONCE,
+        ],
+        "form-action": [
+            SELF,
+            "https://accounts.firefox.com",
+            "https://accounts.stage.mozaws.net",
+        ],
+        "manifest-src": [
+            "https://support.allizom.org",
+            "https://support.mozilla.org",
+        ],
+        "connect-src": [
+            SELF,
+            "https://*.google-analytics.com",
+            "https://location.services.mozilla.com",
+            "https://accounts.firefox.com/metrics-flow",
+            "https://accounts.stage.mozaws.net/metrics-flow",
+            "https://basket.mozilla.org",
+        ],
+    },
+}
 
 if DEBUG:
-    CSP_STYLE_SRC += ("'unsafe-inline'",)
-    CSP_SCRIPT_SRC += (
-        "'unsafe-inline'",
-        "'unsafe-eval'",
-    )
+    CONTENT_SECURITY_POLICY["DIRECTIVES"]["style-src"].append(UNSAFE_INLINE)
+    CONTENT_SECURITY_POLICY["DIRECTIVES"]["script-src"].extend([UNSAFE_INLINE, UNSAFE_EVAL])
 
 # Trusted Contributor Groups
 TRUSTED_GROUPS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "django-jsonfield-backport>=1.0.5,<2",
     "cffi>=2.0.0,<3",
     "django-mozilla-product-details>=1.0.3,<2",
-    "django-csp==3.8rc",
+    "django-csp==4.0",
     "oauthlib>=3.2.2,<4",
     "protobuf>=6.0.0,<8",
     "Babel>=2.14.0,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -823,14 +823,15 @@ wheels = [
 
 [[package]]
 name = "django-csp"
-version = "3.8rc0"
+version = "4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
+    { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/fb/8b58652b2e9e3d9a0a52fbe4bcbced0c0a5ee657bd586392d27bb5264e58/django_csp-3.8rc0.tar.gz", hash = "sha256:b2dd6b0d269a0ce0ff7148a23f4b15da2a45b41d0c20e0fd7477e80adec92b6f", size = 13551, upload-time = "2024-01-30T16:50:58.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/db/23567744dff2169aadb095f726088074476b24dfff5a759ffcf6389cf401/django_csp-4.0.tar.gz", hash = "sha256:b27010bb702eb20a3dad329178df2b61a2b82d338b70fbdc13c3a3bd28712833", size = 20028, upload-time = "2025-04-02T16:41:46.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/22/ba29fd0a1cb6e472713c761f74a7a47fa4fe101163170fc1e0181e23338a/django_csp-3.8rc0-py3-none-any.whl", hash = "sha256:7d4469e9828f53434d8b05f2226f5e5a4f91b8d05276382af7d47df7de7b4c8a", size = 17420, upload-time = "2024-01-30T16:50:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a4/736ab90ee527a23e194d1ce7358c6bcced66381ced83c28268b4aea236f7/django_csp-4.0-py3-none-any.whl", hash = "sha256:d5a0a05463a6b75a4f1fc1828c58c89af8db9364d09fc6e12f122b4d7f3d00dc", size = 25689, upload-time = "2025-04-02T16:41:45.689Z" },
 ]
 
 [[package]]
@@ -2172,7 +2173,7 @@ requires-dist = [
     { name = "django-cache-url", specifier = ">=3.4.5,<4" },
     { name = "django-celery-beat", specifier = ">=2.8.1,<3" },
     { name = "django-cors-headers", specifier = ">=3.14.0,<5" },
-    { name = "django-csp", specifier = "==3.8rc0" },
+    { name = "django-csp", specifier = "==4.0" },
     { name = "django-enforce-host", specifier = ">=1.1.0,<2" },
     { name = "django-extensions", specifier = ">=3.2.3,<4" },
     { name = "django-filter", specifier = "~=25.1" },


### PR DESCRIPTION
mozilla/sumo#3024

### Notes
- I added `csp` to the `INSTALLED_APPS` so we pick up the two CSP-related checks it includes when running `manage.py check`. That's all it does for us.
- I also moved the CSP middleware so that it runs after all other middleware that uses `request.csp_nonce`, avoiding `CSPNonceError` during the response phase (see https://django-csp.readthedocs.io/en/latest/nonce.html#using-the-generated-csp-nonce).