### PR TITLE
account for owner filter with tag counters

### DIFF
--- a/kitsune/questions/tests/test_views.py
+++ b/kitsune/questions/tests/test_views.py
@@ -530,11 +530,57 @@ class TestQuestionTags(ElasticTestCase):
         self._refresh_es()
 
         url = reverse("questions.tags")
-        response = self.client.get(
-            url, {"product_slug": "firefox", "show": "all", "q": "startup"}
-        )
+        response = self.client.get(url, {"product_slug": "firefox", "show": "all", "q": "startup"})
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Firefox Startup", response.content)
+
+    def test_owner_mine_filters_tag_counts_to_user_contributions(self):
+        """owner=mine narrows tag counts to questions the user created or answered."""
+        user = UserFactory()
+        other = UserFactory()
+        tag_authored = TagFactory(name="authored", slug="authored")
+        tag_answered = TagFactory(name="answered", slug="answered")
+        tag_unrelated = TagFactory(name="unrelated", slug="unrelated")
+
+        QuestionFactory(creator=user, product=self.product, tags=[tag_authored])
+        q_answered = QuestionFactory(creator=other, product=self.product, tags=[tag_answered])
+        AnswerFactory(question=q_answered, creator=user)
+        QuestionFactory(creator=other, product=self.product, tags=[tag_unrelated])
+        self._refresh_es()
+
+        # Anonymous: owner=mine is ignored, all three tags appear.
+        anon_tags = self._get_tags(product_slug="firefox", show="all", owner="mine")
+        self.assertIn("authored", anon_tags)
+        self.assertIn("answered", anon_tags)
+        self.assertIn("unrelated", anon_tags)
+
+        # Authenticated: only the user's contributions are counted.
+        self.client.force_login(user)
+        tags = self._get_tags(product_slug="firefox", show="all", owner="mine")
+        self.assertEqual(tags.get("authored"), 1)
+        self.assertEqual(tags.get("answered"), 1)
+        self.assertNotIn("unrelated", tags)
+
+    def test_owner_mine_with_no_contributions_returns_empty(self):
+        """A user with no contributions sees no tags when owner=mine."""
+        user = UserFactory()
+        QuestionFactory(product=self.product, tags=[self.tag])
+        self._refresh_es()
+
+        self.client.force_login(user)
+        tags = self._get_tags(product_slug="firefox", show="all", owner="mine")
+        self.assertEqual(tags, {})
+
+    def test_owner_mine_does_not_double_count(self):
+        """A question the user both created and answered counts once."""
+        user = UserFactory()
+        q = QuestionFactory(creator=user, product=self.product, tags=[self.tag])
+        AnswerFactory(question=q, creator=user)
+        self._refresh_es()
+
+        self.client.force_login(user)
+        tags = self._get_tags(product_slug="firefox", show="all", owner="mine")
+        self.assertEqual(tags.get("crash"), 1)
 
 
 class TestQuestionList(TestCase):

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -358,7 +358,7 @@ def question_list(request, product_slug=None, topic_slug=None):
 
     try:
         questions_page = simple_paginate(request, question_qs, per_page=config.QUESTIONS_PER_PAGE)
-    except (PageNotAnInteger, EmptyPage):
+    except PageNotAnInteger, EmptyPage:
         # If we aren't on page 1, redirect there.
         # TODO: Is 404 more appropriate?
         if request.GET.get("page", "1") != "1":
@@ -484,6 +484,7 @@ def question_tags(request):
     product_slug = request.GET.get("product_slug", "")
     topic_slug = request.GET.get("topic_slug", "")
     topic_navigation = request.GET.get("topic_navigation") == "1"
+    owner = request.GET.get("owner", "")
 
     product_ids = []
     if product_slug and product_slug != "all":
@@ -579,6 +580,12 @@ def question_tags(request):
             DSLQ("range", question_created={"lt": now - timedelta(days=90)})
             & DSLQ("term", question_has_answers=False)
         )
+        if owner == "mine" and request.user.is_authenticated:
+            user_id = str(request.user.id)
+            search = search.filter(
+                DSLQ("term", question_creator_id=user_id)
+                | DSLQ("term", question_answer_creator_ids=user_id)
+            )
         # Apply sub-filter if present, otherwise fall back to the show-level filter.
         if filter_ in FILTER_PRESETS:
             search = _apply_question_filters(search, **FILTER_PRESETS[filter_])
@@ -802,7 +809,7 @@ def edit_details(request, question_id):
         # Ensure that questions are enabled for this product and locale.
         if not (locale and product.questions_enabled(locale)):
             raise ValueError
-    except (Product.DoesNotExist, Topic.DoesNotExist, ValueError):
+    except Product.DoesNotExist, Topic.DoesNotExist, ValueError:
         return HttpResponseBadRequest()
 
     question = get_object_or_404(Question, pk=question_id)

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -358,7 +358,7 @@ def question_list(request, product_slug=None, topic_slug=None):
 
     try:
         questions_page = simple_paginate(request, question_qs, per_page=config.QUESTIONS_PER_PAGE)
-    except PageNotAnInteger, EmptyPage:
+    except (PageNotAnInteger, EmptyPage):
         # If we aren't on page 1, redirect there.
         # TODO: Is 404 more appropriate?
         if request.GET.get("page", "1") != "1":
@@ -809,7 +809,7 @@ def edit_details(request, question_id):
         # Ensure that questions are enabled for this product and locale.
         if not (locale and product.questions_enabled(locale)):
             raise ValueError
-    except Product.DoesNotExist, Topic.DoesNotExist, ValueError:
+    except (Product.DoesNotExist, Topic.DoesNotExist, ValueError):
         return HttpResponseBadRequest()
 
     question = get_object_or_404(Question, pk=question_id)

--- a/kitsune/search/documents.py
+++ b/kitsune/search/documents.py
@@ -149,6 +149,7 @@ class QuestionDocument(SumoDocument):
     question_tags = field.Nested(doc_class=QuestionTagInnerDoc)
     question_has_answers = field.Boolean()
     question_last_answer_is_by_creator = field.Boolean()
+    question_answer_creator_ids = field.Keyword(multi=True)
     question_num_votes = field.Integer()
 
     # store answer content to optimise searching for AAQ threads as a unit
@@ -209,6 +210,14 @@ class QuestionDocument(SumoDocument):
                 else instance.answers.filter(is_spam=False)
             )
         ]
+
+    def prepare_question_answer_creator_ids(self, instance):
+        answers = (
+            instance.es_question_answers_not_spam
+            if hasattr(instance, "es_question_answers_not_spam")
+            else instance.answers.filter(is_spam=False)
+        )
+        return list({str(a.creator_id) for a in answers})
 
     def get_field_value(self, field, *args):
         if field.startswith("question_"):

--- a/kitsune/search/tests/signals/test_questions.py
+++ b/kitsune/search/tests/signals/test_questions.py
@@ -82,6 +82,33 @@ class QuestionDocumentSignalsTests(ElasticTestCase):
 
         self.assertEqual(self.get_doc().question_tag_ids, [])
 
+    def test_answer_creator_ids_populated_on_answer_save(self):
+        new_answer = AnswerFactory(question=self.question)
+
+        creator_ids = self.get_doc().question_answer_creator_ids
+        self.assertIn(str(self.answer.creator_id), creator_ids)
+        self.assertIn(str(new_answer.creator_id), creator_ids)
+
+    def test_answer_creator_ids_updated_on_answer_delete(self):
+        deleted_creator_id = self.answer.creator_id
+        self.answer.delete()
+
+        self.assertNotIn(str(deleted_creator_id), self.get_doc().question_answer_creator_ids)
+
+    def test_answer_creator_ids_excludes_spam(self):
+        spam_answer = AnswerFactory(question=self.question, is_spam=True)
+
+        self.assertNotIn(
+            str(spam_answer.creator_id),
+            self.get_doc().question_answer_creator_ids,
+        )
+
+    def test_answer_creator_ids_dedup(self):
+        AnswerFactory(question=self.question, creator=self.answer.creator)
+
+        creator_ids = self.get_doc().question_answer_creator_ids
+        self.assertEqual(creator_ids.count(str(self.answer.creator_id)), 1)
+
     @patch("kitsune.search.signals.questions.index_object.delay")
     def test_kb_tag(self, mock_index_object):
         # the tag m2m relation is shared across all models which use it


### PR DESCRIPTION
mozilla/sumo#3020

Requires a re-index after merging/deploying.