### PR TITLE
make the answer voting UI more prominent

### DIFF
--- a/kitsune/questions/jinja2/questions/includes/answer.html
+++ b/kitsune/questions/jinja2/questions/includes/answer.html
@@ -131,8 +131,8 @@
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                aria-hidden="true">
-            <path d="M14 9V5a3 3 0 0 0-3-3l-4 12v3h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3z"/>
-            <path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
+            <path d="M10 15v4a3 3 0 0 0 3 3l4-12V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3z"/>
+            <path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/>
           </svg>
           <strong class="answer-vote--count">{{ answer.num_helpful_votes }}</strong>
         </button>

--- a/kitsune/questions/jinja2/questions/question_details.html
+++ b/kitsune/questions/jinja2/questions/question_details.html
@@ -174,8 +174,8 @@
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
                  stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                  aria-hidden="true">
-              <path d="M14 9V5a3 3 0 0 0-3-3l-4 12v3h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3z"/>
-              <path d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
+              <path d="M10 15v4a3 3 0 0 0 3 3l4-12V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3z"/>
+              <path d="M17 2h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/>
             </svg>
             <strong>{{ question.solution.num_helpful_votes }}</strong>
             {{ _('helpful') }}

--- a/kitsune/sumo/static/sumo/scss/layout/_forum.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_forum.scss
@@ -714,11 +714,12 @@
 .answer-vote {
   display: flex;
   align-items: center;
-  gap: p.$spacing-xs;
+  gap: p.$spacing-sm;
 }
 
 .answer-vote--label {
   @include c.text-body-sm;
+  font-weight: 700;
   color: var(--color-text-light);
   margin-inline-end: p.$spacing-xs;
 }
@@ -726,19 +727,19 @@
 .answer-vote--btn {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 4px p.$spacing-sm;
+  gap: p.$spacing-xs;
+  padding: 0 p.$spacing-sm;
+  line-height: 1;
   border: 1px solid var(--color-light-gray-04);
   border-radius: 2em;
   background: transparent;
   cursor: pointer;
-  @include c.text-body-sm;
   color: var(--color-text-light);
   transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 20px;
+    height: 20px;
     flex-shrink: 0;
   }
 
@@ -752,6 +753,10 @@
     opacity: 0.65;
     cursor: default;
   }
+}
+
+.answer-vote--btn:not(.answer-vote--btn--down) svg {
+  transform: rotate(180deg);
 }
 
 .answer-vote--count {
@@ -838,8 +843,9 @@
     width: 14px;
     height: 14px;
     flex-shrink: 0;
-    color: var(--color-success);
-    stroke: var(--color-success);
+    color: var(--color-green-08);
+    stroke: var(--color-green-08);
+    transform: rotate(180deg);
   }
 
   strong {


### PR DESCRIPTION
mozilla/sumo#3026

- Fixed the thumbs-up SVG (including for the chosen solution)
- Increased the contrast-ratio of the thumbs-up SVG for the chosen solution, which was below the WCAG threshold of 3:1.

Before:

<img width="1303" height="579" alt="image" src="https://github.com/user-attachments/assets/3456c5c2-0d41-43e8-84a4-abfed55ae84b" />

After:

<img width="1300" height="571" alt="image" src="https://github.com/user-attachments/assets/5711b424-9744-4e43-b6e0-3941e8a17a59" />






