### PR TITLE
improve layout of question details

### DIFF
--- a/kitsune/sumo/static/sumo/scss/layout/_forum.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_forum.scss
@@ -701,7 +701,7 @@
   justify-content: space-between;
   gap: p.$spacing-md;
   padding-top: p.$spacing-md;
-  margin-top: p.$spacing-lg;
+  margin-top: p.$spacing-md;
   border-top: 1px solid var(--color-light-gray-04);
 }
 
@@ -761,13 +761,16 @@
 }
 
 .answer {
-  padding: p.$spacing-2xl 0;
-  border-bottom: 1px solid var(--color-border);
+  padding: p.$spacing-xl 0;
 
   @media #{p.$mq-md} {
     .main-content {
       padding-left: 55px;
     }
+  }
+
+  .user-meta {
+    margin-bottom: p.$spacing-md;
   }
 }
 
@@ -783,10 +786,10 @@
 }
 
 .question-reply-form {
-  padding-top: 20px;
+  padding-top: p.$spacing-md;
 
   @media #{p.$mq-md} {
-    padding-top: 40px;
+    padding-top: p.$spacing-xl;
   }
 }
 
@@ -809,9 +812,9 @@
 
 .thread-post--body .solution {
   position: relative;
-  margin-top: 60px;
-  padding-top: 36px;
-  padding-bottom: 36px;
+  margin-top: p.$spacing-xl;
+  padding-top: p.$spacing-lg;
+  padding-bottom: p.$spacing-lg;
 
   .is-solution {
     top: -12px;

--- a/kitsune/sumo/static/sumo/scss/layout/_thread-detail.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_thread-detail.scss
@@ -7,9 +7,7 @@
   flex-wrap: wrap;
   align-items: center;
   gap: p.$spacing-xs p.$spacing-sm;
-  padding-bottom: p.$spacing-lg;
-  border-bottom: 1px solid var(--color-light-gray-04);
-  margin-bottom: p.$spacing-xl;
+  margin-bottom: p.$spacing-md;
 }
 
 .thread-detail--title {
@@ -30,8 +28,7 @@
 
 // Single post component (question body / ticket description / comments)
 .thread-post {
-  padding: p.$spacing-xl 0;
-  border-bottom: 1px solid var(--color-light-gray-04);
+  padding: p.$spacing-md 0;
 
   &:first-child {
     padding-top: 0;
@@ -120,7 +117,7 @@
   gap: p.$spacing-sm;
   padding: p.$spacing-sm p.$spacing-md;
   border-radius: p.$border-radius-sm;
-  margin-bottom: p.$spacing-xl;
+  margin-bottom: p.$spacing-lg;
   @include c.text-body-sm;
 
   &--info {
@@ -137,8 +134,8 @@
 // Replies section heading row
 .thread-replies > h2,
 .thread-replies > h3 {
-  padding-top: p.$spacing-xl;
-  margin-bottom: p.$spacing-lg;
+  padding-top: p.$spacing-sm;
+  margin-bottom: p.$spacing-md;
 }
 
 // Loading state for async comment fetch


### PR DESCRIPTION
mozilla/sumo#3027

Thoughts? Too compact? Would you like to see any horizontal lines back?

Before:
<img width="934" height="846" alt="image" src="https://github.com/user-attachments/assets/1ae81c7d-c266-485a-94fe-37986e4ec7bc" />

After:
<img width="871" height="795" alt="image" src="https://github.com/user-attachments/assets/852225eb-beef-4fbc-b892-77eb9dd9600d" />


