### PR TITLE
Sync *_ESR_NEXT & Make only supported ESRs visible

### DIFF
--- a/kitsune/products/management/commands/sync_product_versions.py
+++ b/kitsune/products/management/commands/sync_product_versions.py
@@ -67,8 +67,6 @@ class Command(BaseCommand):
                 "alpha_version_key": "FIREFOX_NIGHTLY",
                 "history_data": product_details.firefox_history_major_releases,
                 "esr_keys": ["FIREFOX_ESR"],
-                "esr_major_versions": [52, 60, 68, 78, 91, 102, 115, 128, 140],
-                "esr_only": False,
             },
             "mobile": {
                 "name": "Firefox for Android",
@@ -79,7 +77,6 @@ class Command(BaseCommand):
                 "alpha_version_key": "nightly_version",
                 "history_data": product_details.firefox_history_major_releases,
                 "esr_keys": [],
-                "esr_only": False,
             },
             "ios": {
                 "name": "Firefox for iOS",
@@ -90,7 +87,6 @@ class Command(BaseCommand):
                 "alpha_version_key": "FIREFOX_NIGHTLY",
                 "history_data": product_details.firefox_history_major_releases,
                 "esr_keys": [],
-                "esr_only": False,
             },
             "thunderbird": {
                 "name": "Thunderbird",
@@ -101,7 +97,6 @@ class Command(BaseCommand):
                 "alpha_version_key": "LATEST_THUNDERBIRD_NIGHTLY_VERSION",
                 "history_data": product_details.thunderbird_history_major_releases,
                 "esr_keys": ["THUNDERBIRD_ESR"],
-                "esr_only": False,
             },
         }
 
@@ -118,30 +113,26 @@ class Command(BaseCommand):
         if verbosity >= 1:
             self.stdout.write(f"\nSyncing {product.title} (latest release: {latest_version})...")
 
-        esr_only = config.get("esr_only", False)
-
         # Use transaction only if not dry-run
         context = transaction.atomic() if not dry_run else nullcontext()
 
         with context:
-            # Only sync regular versions if not ESR-only
-            if not esr_only:
-                history_data = config["history_data"]
-                available_versions = self._get_available_versions(history_data, latest_major)
+            history_data = config["history_data"]
+            available_versions = self._get_available_versions(history_data, latest_major)
 
-                beta_version = config["version_data"].get(config["beta_version_key"])
-                beta_major = self._parse_major_version(beta_version) if beta_version else None
-                if beta_major:
-                    available_versions.append(beta_major)
+            beta_version = config["version_data"].get(config["beta_version_key"])
+            beta_major = self._parse_major_version(beta_version) if beta_version else None
+            if beta_major:
+                available_versions.append(beta_major)
 
-                alpha_version = config["version_data"].get(config["alpha_version_key"])
-                alpha_major = self._parse_major_version(alpha_version) if alpha_version else None
-                if alpha_major:
-                    available_versions.append(alpha_major)
+            alpha_version = config["version_data"].get(config["alpha_version_key"])
+            alpha_major = self._parse_major_version(alpha_version) if alpha_version else None
+            if alpha_major:
+                available_versions.append(alpha_major)
 
-                self._create_or_update_versions(
-                    product, config, available_versions, dry_run, verbosity
-                )
+            self._create_or_update_versions(
+                product, config, available_versions, dry_run, verbosity
+            )
             self._handle_esr_versions(product, config, dry_run, verbosity)
             self._update_visibility(product, latest_major, dry_run, verbosity)
 
@@ -213,10 +204,8 @@ class Command(BaseCommand):
     def _handle_esr_versions(self, product: Product, config: dict, dry_run: bool, verbosity: int):
         """Create or update ESR versions."""
         esr_keys = config.get("esr_keys", [])
-        esr_major_versions = config.get("esr_major_versions", [])
 
-        # Collect ESR major versions from keys
-        esr_majors_from_keys = set()
+        esr_majors = set()
         if esr_keys:
             version_data = config["version_data"]
             for esr_key in esr_keys:
@@ -224,17 +213,14 @@ class Command(BaseCommand):
                 if esr_version_str:
                     esr_major = self._parse_major_version(esr_version_str)
                     if esr_major is not None:
-                        esr_majors_from_keys.add(esr_major)
+                        esr_majors.add(esr_major)
 
-        # Combine with explicit esr_major_versions
-        all_esr_majors = esr_majors_from_keys | set(esr_major_versions)
-
-        if not all_esr_majors:
+        if not esr_majors:
             return
 
         slug_prefix = config["slug_prefix"]
 
-        for esr_major in sorted(all_esr_majors):
+        for esr_major in sorted(esr_majors):
             slug = f"{slug_prefix}{esr_major}-esr"
             name = f"Version {esr_major} ESR"
             min_version = float(esr_major)

--- a/kitsune/products/management/commands/sync_product_versions.py
+++ b/kitsune/products/management/commands/sync_product_versions.py
@@ -66,7 +66,7 @@ class Command(BaseCommand):
                 "beta_version_key": "LATEST_FIREFOX_RELEASED_DEVEL_VERSION",
                 "alpha_version_key": "FIREFOX_NIGHTLY",
                 "history_data": product_details.firefox_history_major_releases,
-                "esr_keys": ["FIREFOX_ESR"],
+                "esr_keys": ["FIREFOX_ESR", "FIREFOX_ESR_NEXT"],
             },
             "mobile": {
                 "name": "Firefox for Android",
@@ -96,7 +96,7 @@ class Command(BaseCommand):
                 "beta_version_key": "LATEST_THUNDERBIRD_DEVEL_VERSION",
                 "alpha_version_key": "LATEST_THUNDERBIRD_NIGHTLY_VERSION",
                 "history_data": product_details.thunderbird_history_major_releases,
-                "esr_keys": ["THUNDERBIRD_ESR"],
+                "esr_keys": ["THUNDERBIRD_ESR", "THUNDERBIRD_ESR_NEXT"],
             },
         }
 
@@ -133,8 +133,8 @@ class Command(BaseCommand):
             self._create_or_update_versions(
                 product, config, available_versions, dry_run, verbosity
             )
-            self._handle_esr_versions(product, config, dry_run, verbosity)
-            self._update_visibility(product, latest_major, dry_run, verbosity)
+            supported_esr_majors = self._handle_esr_versions(product, config, dry_run, verbosity)
+            self._update_visibility(product, latest_major, supported_esr_majors, dry_run, verbosity)
 
     def _get_available_versions(self, history_data: dict, latest_major: int) -> list:
         """Get list of available major version numbers from history."""
@@ -201,7 +201,7 @@ class Command(BaseCommand):
                     if verbosity >= 1:
                         self.stdout.write(f"  Created {slug}")
 
-    def _handle_esr_versions(self, product: Product, config: dict, dry_run: bool, verbosity: int):
+    def _handle_esr_versions(self, product: Product, config: dict, dry_run: bool, verbosity: int) -> set:
         """Create or update ESR versions."""
         esr_keys = config.get("esr_keys", [])
 
@@ -214,9 +214,6 @@ class Command(BaseCommand):
                     esr_major = self._parse_major_version(esr_version_str)
                     if esr_major is not None:
                         esr_majors.add(esr_major)
-
-        if not esr_majors:
-            return
 
         slug_prefix = config["slug_prefix"]
 
@@ -265,19 +262,21 @@ class Command(BaseCommand):
                     if verbosity >= 1:
                         self.stdout.write(f"  Created ESR {slug}")
 
-    def _update_visibility(self, product: Product, latest_major: int, dry_run: bool, verbosity: int):
+        return esr_majors
+
+    def _update_visibility(self, product: Product, latest_major: int, supported_esr_majors: set, dry_run: bool, verbosity: int):
         """Update visibility and default flags for all versions of a product."""
         all_versions = list(Version.objects.filter(product=product).order_by("-max_version"))
         if not all_versions:
             return
 
-        esr_versions = [v for v in all_versions if v.slug.endswith("-esr")]
+        supported_esr_versions = [v for v in all_versions if v.slug.endswith("-esr") and v.min_version in supported_esr_majors]
         regular_versions = [v for v in all_versions if not v.slug.endswith("-esr") and v.min_version <= latest_major]
         prerelease_versions = [v for v in all_versions if not v.slug.endswith("-esr") and v.min_version > latest_major]
         top_10 = regular_versions[:10]
 
         for version in all_versions:
-            should_be_visible = version in top_10 or version in esr_versions or version in prerelease_versions
+            should_be_visible = version in top_10 or version in supported_esr_versions or version in prerelease_versions
             should_be_default = bool(regular_versions) and version == regular_versions[0]
 
             if version.visible != should_be_visible or version.default != should_be_default:

--- a/kitsune/products/tests/test_sync_product_versions.py
+++ b/kitsune/products/tests/test_sync_product_versions.py
@@ -29,6 +29,7 @@ class SyncProductVersionsTests(TestCase):
             "LATEST_FIREFOX_RELEASED_DEVEL_VERSION": "144.0b7",
             "FIREFOX_NIGHTLY": "145.0a2",
             "FIREFOX_ESR": "140.3.1esr",
+            "FIREFOX_ESR_NEXT": "153.0.1esr",
         }
 
         # Firefox history data (major releases)
@@ -52,6 +53,7 @@ class SyncProductVersionsTests(TestCase):
             "LATEST_THUNDERBIRD_DEVEL_VERSION": "129.0b2",
             "LATEST_THUNDERBIRD_NIGHTLY_VERSION": "130.0a1",
             "THUNDERBIRD_ESR": "128.5.0esr",
+            "THUNDERBIRD_ESR_NEXT": "140.0.1esr",
         }
 
         # Thunderbird history data
@@ -107,6 +109,10 @@ class SyncProductVersionsTests(TestCase):
         esr140 = Version.objects.get(product=self.firefox, slug="fx140-esr")
         self.assertEqual(esr140.name, "Version 140 ESR")
         self.assertTrue(esr140.visible)
+
+        esr153 = Version.objects.get(product=self.firefox, slug="fx153-esr")
+        self.assertEqual(esr153.name, "Version 153 ESR")
+        self.assertTrue(esr153.visible)
 
     @mock.patch("kitsune.products.management.commands.sync_product_versions.product_details")
     def test_sync_mobile_versions(self, mock_product_details):
@@ -194,6 +200,10 @@ class SyncProductVersionsTests(TestCase):
         self.assertEqual(esr128.name, "Version 128 ESR")
         self.assertTrue(esr128.visible)
 
+        esr140 = Version.objects.get(product=self.thunderbird, slug="tb140-esr")
+        self.assertEqual(esr140.name, "Version 140 ESR")
+        self.assertTrue(esr140.visible)
+
     @mock.patch("kitsune.products.management.commands.sync_product_versions.product_details")
     def test_visibility_rules(self, mock_product_details):
         """Test that only top 10 versions + ESR + beta/alpha are visible."""
@@ -217,10 +227,14 @@ class SyncProductVersionsTests(TestCase):
         nightly = Version.objects.get(product=self.firefox, slug="fx145")
         self.assertTrue(nightly.visible)
 
-        # ESR versions should always be visible
+        # Only supported ESR versions should be visible (but we don't create others)
         esr_versions = Version.objects.filter(product=self.firefox, slug__endswith="-esr")
-        for esr in esr_versions:
+        supported_esr_versions = [v for v in esr_versions if v.slug in ["fx140-esr", "fx153-esr"]]
+        unsupported_esr_versions = [v for v in esr_versions if v.slug not in ["fx140-esr", "fx153-esr"]] # empty
+        for esr in supported_esr_versions:
             self.assertTrue(esr.visible)
+        for esr in unsupported_esr_versions:
+            self.assertFalse(esr.visible)
 
     @mock.patch("kitsune.products.management.commands.sync_product_versions.product_details")
     def test_default_version_is_latest(self, mock_product_details):

--- a/kitsune/products/tests/test_sync_product_versions.py
+++ b/kitsune/products/tests/test_sync_product_versions.py
@@ -29,7 +29,6 @@ class SyncProductVersionsTests(TestCase):
             "LATEST_FIREFOX_RELEASED_DEVEL_VERSION": "144.0b7",
             "FIREFOX_NIGHTLY": "145.0a2",
             "FIREFOX_ESR": "140.3.1esr",
-            "FIREFOX_ESR115": "115.20.0esr",
         }
 
         # Firefox history data (major releases)
@@ -104,18 +103,10 @@ class SyncProductVersionsTests(TestCase):
         self.assertEqual(v145.max_version, 146.0)
         self.assertFalse(v145.default)
 
-        # ESR versions should be created under Firefox product
+        # Check ESR
         esr140 = Version.objects.get(product=self.firefox, slug="fx140-esr")
         self.assertEqual(esr140.name, "Version 140 ESR")
         self.assertTrue(esr140.visible)
-
-        esr115 = Version.objects.get(product=self.firefox, slug="fx115-esr")
-        self.assertEqual(esr115.name, "Version 115 ESR")
-        self.assertTrue(esr115.visible)
-
-        # Historical ESR versions from esr_major_versions should all exist
-        esr_versions = Version.objects.filter(product=self.firefox, slug__endswith="-esr")
-        self.assertGreaterEqual(esr_versions.count(), 9)
 
     @mock.patch("kitsune.products.management.commands.sync_product_versions.product_details")
     def test_sync_mobile_versions(self, mock_product_details):


### PR DESCRIPTION
This PR consists of two patches:
- The first one cleans up some leftovers after #7517, particularly:
  - Remove the hardcoded `esr_major_versions` array. Old ESR versions are never deleted, so we don't need to recreate them, and new ones are synced and created automatically.
  - Remove the `esr_only` property. This was something exclusive for the Enterprise product, and with it removed, it's no longer needed.
- The second patch adds `"FIREFOX_ESR_NEXT"`/`"THUNDERBIRD_ESR_NEXT"` to `esr_keys` and updates ESR visibility, so that only supported ESRs (`*_ESR` and `*_ESR_NEXT`) are visible. Resolves [#3054](https://github.com/mozilla/sumo/issues/3054).