### PR TITLE
Playwright: Expand test coverage

### DIFF
--- a/playwright_tests/flows/user_profile_flows/user_profile_flow.py
+++ b/playwright_tests/flows/user_profile_flows/user_profile_flow.py
@@ -1,0 +1,33 @@
+from typing import Literal
+
+from playwright.sync_api import Page
+from playwright_tests.core.utilities import Utilities
+from playwright_tests.pages.user_pages.my_profile_page import MyProfilePage
+
+
+class UserProfileFlow:
+    def __init__(self, page: Page):
+        self.page = page
+        self.utilities = Utilities(page)
+        self.my_profile_page = MyProfilePage(page)
+
+    REPORT_REASON = Literal[
+        "Spam or other unrelated content",
+        "Inappropriate language/dialog",
+        "Abusive content",
+        "Other (please specify)",
+    ]
+
+    _REPORT_REASON_ACTIONS = {
+        "Spam or other unrelated content": "click_on_spam_content_option",
+        "Inappropriate language/dialog": "click_on_inappropriate_language_option",
+        "Abusive content": "click_on_abusive_content_option",
+        "Other (please specify)": "click_on_other_content_option",
+    }
+
+    def report_user_profile(self, report_reason: REPORT_REASON, report_details: str = ""):
+        self.my_profile_page.click_on_report_abuse_option()
+        getattr(self.my_profile_page, self._REPORT_REASON_ACTIONS[report_reason])()
+        if report_details:
+            self.my_profile_page.fill_have_more_to_say_textarea(report_details)
+        self.my_profile_page.click_on_report_submit_button()

--- a/playwright_tests/pages/contribute/contributor_tools_pages/moderate_forum_content.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/moderate_forum_content.py
@@ -40,6 +40,17 @@ class ModerateForumContent(BasePage):
         self.paginator_section = page.locator("//ol[@class='pagination cf']")
         self.last_paginator_option = page.locator("//ol[@class='pagination cf']/li/a").last
 
+        """Locators belonging to the flagged profile tickets"""
+        self.profile_flagged_ticket = lambda username: page.locator(
+            f"//h2[@class='sumo-page-subheading' and text()='{username}']")
+        self.profile_flagged_reason = lambda username: page.locator(
+            f"//h2[@class='sumo-page-subheading' and text()='{username}']/../../../hgroup/h2"
+            f"[@class='sumo-card-heading']")
+        self.profile_flagged_additional_notes = lambda username: page.locator(
+            f"//h2[@class='sumo-page-subheading' and text()='{username}']/../../../hgroup/"
+            f"p[@class='notes']")
+
+
     def click_created_by_link(self, question_info: str):
         self._click(self.created_by_link_text(question_info))
 

--- a/playwright_tests/pages/explore_help_articles/articles/kb_article_discussion_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_article_discussion_page.py
@@ -60,6 +60,10 @@ class KBArticleDiscussionPage(BasePage):
 
         """Locators belonging to the article discussions content section."""
         self.all_article_threads_titles = page.locator("td[class='title'] a")
+        self.article_thread_author_by_id = lambda thread_id: page.locator(
+            f"//li[@id='{thread_id}']//span[@class='display-name']")
+        self.article_thread_reply = lambda thread_id: page.locator(
+            f"//li[@id='{thread_id}']")
         self.all_article_threads_authors = page.locator("td[class='author'] a")
         self.all_article_thread_replies = page.locator("td[class='replies']")
         self.discussions_thread_counter = lambda thread_id: page.locator(

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -31,6 +31,7 @@ from playwright_tests.flows.messaging_system_flows.messaging_system_flow import 
 )
 from playwright_tests.flows.user_groups_flows.user_group_flow import UserGroupFlow
 from playwright_tests.flows.user_profile_flows.edit_profile_data_flow import EditProfileDataFlow
+from playwright_tests.flows.user_profile_flows.user_profile_flow import UserProfileFlow
 from playwright_tests.pages.admin_pages.announcement_banners.announcement_banner_page import \
     AnnouncementBannerAdminPage
 from playwright_tests.pages.ask_a_question.aaq_pages.aaq_form_page import AAQFormPage
@@ -429,6 +430,11 @@ class SumoPages:
     @cached_property
     def messaging_system_flow(self):
         return MessagingSystemFlows(self._page)
+
+    # User profile flow
+    @cached_property
+    def user_profile_flow(self):
+        return UserProfileFlow(self._page)
 
     # Edit profile flow
     @cached_property

--- a/playwright_tests/pages/user_pages/my_profile_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_page.py
@@ -26,13 +26,15 @@ class MyProfilePage(BasePage):
             has_text="Spam or other unrelated content")
         self.inappropriate_language_or_dialog_option = page.locator("label").filter(
             has_text="Inappropriate language/dialog")
+        self.abusive_content = page.locator("label").filter(
+            has_text="Abusive content")
         self.other_please_specify_option = page.locator("label").filter(
             has_text="Other (please specify)")
         self.have_more_to_say_textarea = page.locator("textarea[name='other']")
         self.report_abuse_close_panel_button = page.locator(
             "div[class='mzp-c-modal-close'] button")
         self.report_abuse_submit_button = page.locator(
-            "section#report-abuse- button[type='submit']")
+            "//section[@data-modal-id='report-abuse-']//button[@type='submit']")
         self.reported_user_confirmation_message = page.locator("span[class='message']")
 
         """Locators belonging to the contributions section."""
@@ -156,9 +158,43 @@ class MyProfilePage(BasePage):
         """Click on the report abuse option."""
         self._click(self.report_abuse_profile_option)
 
+    def click_deactivate_this_user_and_mark_all_content_as_spam(self):
+        # The .deactivate form's submit handler calls window.confirm(...) — the
+        # dialog handler must be attached before the click, and it must call
+        # .accept() itself (otherwise confirm() blocks and the click hangs).
+        self.page.once("dialog", lambda dialog: dialog.accept())
+        self._click(self.deactivate_this_user_and_mark_all_content_as_spam)
+
+    def click_on_spam_content_option(self):
+        """Select the 'Spam or other unrelated content' report reason radio button."""
+        self._click(self.spam_or_other_unrelated_content_option)
+
+    def click_on_inappropriate_language_option(self):
+        """Select the 'Inappropriate language/dialog' report reason radio button."""
+        self._click(self.inappropriate_language_or_dialog_option)
+
+    def click_on_abusive_content_option(self):
+        """Select the 'Abusive content' report reason radio button."""
+        self._click(self.abusive_content)
+
+    def click_on_other_content_option(self):
+        """Select the 'Other (please specify)' report reason radio button."""
+        self._click(self.other_please_specify_option)
+
+    def fill_have_more_to_say_textarea(self, text: str):
+        """"Fills the 'Have more to say?' textarea
+        Args:
+            text(): Text to be filled inside the textarea field
+        """
+        self._fill(self.have_more_to_say_textarea, text)
+
     def click_on_report_abuse_close_button(self):
         """Click on the report abuse close button."""
         self._click(self.report_abuse_close_panel_button)
+
+    def click_on_report_submit_button(self):
+        """Click on the report submit button"""
+        self._click(self.report_abuse_submit_button)
 
     def click_on_private_message_button(self, expected_url=None):
         """Click on the private message button.

--- a/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/popular_topics_page_tests/test_popular_topics_page.py
@@ -66,6 +66,7 @@ def test_learn_more_redirect(page: Page):
 def test_aaq_redirect(page: Page, restmail_test_account_creation):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
+    restmail_test_account_creation()
     utilities.delete_cookies()
 
     with (allure.step("Navigating to product topics pages")):

--- a/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
+++ b/playwright_tests/tests/ask_a_question_tests/product_solutions_page_tests/test_product_solutions_page.py
@@ -101,6 +101,7 @@ def test_popular_topics_redirect(page: Page):
 def test_ask_now_widget_redirect(page: Page, restmail_test_account_creation):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
+    restmail_test_account_creation()
 
     with allure.step("Accessing the contact support page via the top navbar Get Help > "
                      "Browse All products"):
@@ -141,6 +142,7 @@ def test_ask_now_widget_redirect(page: Page, restmail_test_account_creation):
 def test_contact_support_widget_redirect(page: Page, restmail_test_account_creation):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
+    restmail_test_account_creation()
 
     with allure.step("Accessing the contact support page via the top navbar Get Help > "
                      "Browse All products"):

--- a/playwright_tests/tests/conftest.py
+++ b/playwright_tests/tests/conftest.py
@@ -146,38 +146,62 @@ def create_user_factory(page: Page, request):
 
 @pytest.fixture()
 def restmail_test_account_creation(page: Page, request):
+    """Factory for creating a restmail test account.
+
+    Call with no args to get auto-generated credentials, or pass ``username``
+    and/or ``password`` to override either one. Returns
+    ``(username, password, cleanup)``. ``cleanup`` deletes the FxA account
+    immediately and is also registered as a finalizer, so a test that doesn't
+    need early teardown can ignore it. Calling ``cleanup()`` more than once is
+    a no-op. The factory may be invoked multiple times in one test — each
+    account is independently cleaned up.
+    """
     sumo_pages = SumoPages(page)
-    """Creates and deletes a restmail test account on teardown."""
-    username = 'Test'.join(random.choice(
-        string.ascii_lowercase + string.digits) for _ in range(3)) + "@restmail.net"
-    password = 'Test'.join(random.choice(
-        string.ascii_lowercase + string.digits) for _ in range(3))
-
-    user, user_password = sumo_pages.auth_flow_page.sign_in_flow(
-        username=username, account_password=password, via_top_navbar=True, is_restmail=True,
-        new_account=True
-    )
-
     browser = page.context.browser
 
-    def _cleanup():
-        try:
-            sumo_pages.auth_flow_page.delete_test_account_flow(username, password)
-        except TargetClosedError as e:
+    def _create(username: str = None, password: str = None):
+        if username is None:
+            username = 'Test'.join(random.choice(
+                string.ascii_lowercase + string.digits) for _ in range(3)) + "@restmail.net"
+        if password is None:
+            password = 'Test'.join(random.choice(
+                string.ascii_lowercase + string.digits) for _ in range(3))
+
+        user, user_password = sumo_pages.auth_flow_page.sign_in_flow(
+            username=username, account_password=password, via_top_navbar=True,
+            is_restmail=True, new_account=True
+        )
+
+        already_cleaned = False
+
+        def cleanup():
+            # Always delete in a fresh, cookieless context so the FxA
+            # email/password form is shown — reusing the test's page hits the
+            # "already-signed-in" path and pays the full locator timeout
+            # before falling back.
+            nonlocal already_cleaned
+            if already_cleaned:
+                return
+            already_cleaned = True
+
             cleanup_context = browser.new_context(
                 extra_http_headers={
-                f"{Utilities.fxa_browser_challenge_header}":
-                    f"{Utilities.fxa_browser_challenge_value}"
+                    f"{Utilities.fxa_browser_challenge_header}":
+                        f"{Utilities.fxa_browser_challenge_value}"
                 }
             )
             cleanup_page = cleanup_context.new_page()
             try:
                 cleanup_sumo_pages = SumoPages(cleanup_page)
-                cleanup_sumo_pages.auth_flow_page.delete_test_account_flow(username, password)
-            except Exception as e:
+                cleanup_sumo_pages.auth_flow_page.delete_test_account_flow(
+                    user, user_password
+                )
+            except (TargetClosedError, Exception) as e:
                 print(f"Restmail test account cleanup failed: {e}")
             finally:
                 cleanup_context.close()
 
-    request.addfinalizer(_cleanup)
-    return user, user_password
+        request.addfinalizer(cleanup)
+        return user, user_password, cleanup
+
+    return _create

--- a/playwright_tests/tests/test_prerequisites_login.py
+++ b/playwright_tests/tests/test_prerequisites_login.py
@@ -27,7 +27,7 @@ def test_create_user_sessions_for_test_accounts(page: Page):
 def test_new_account_creation(page: Page, restmail_test_account_creation):
     utilities = Utilities(page)
     sumo_pages = SumoPages(page)
-    username, password = restmail_test_account_creation
+    username, password, _ = restmail_test_account_creation()
 
     with check, allure.step("Verifying that the correct username is displayed inside the"
                             " top-navbar and the correct user message banner is displayed"):

--- a/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
@@ -1,5 +1,7 @@
 import datetime
+import random
 import re
+import string
 
 import allure
 import pytest
@@ -9,6 +11,7 @@ from pytest_check import check
 
 from playwright_tests.core.utilities import Utilities
 from playwright_tests.messages.auth_pages_messages.fxa_page_messages import FxAPageMessages
+from playwright_tests.messages.homepage_messages import HomepageMessages
 from playwright_tests.messages.my_profile_pages_messages.edit_my_profile_page_messages import (
     EditMyProfilePageMessages,
 )
@@ -29,7 +32,7 @@ def _submit_firefox_question(utilities: Utilities, sumo_pages: SumoPages) -> dic
     )
 
 
-# C891529
+# C891529, C1491020
 @pytest.mark.editUserProfileTests
 def test_username_field_is_automatically_populated(page: Page, create_user_factory):
     utilities = Utilities(page)
@@ -47,7 +50,7 @@ def test_username_field_is_automatically_populated(page: Page, create_user_facto
             sumo_pages.top_navbar.get_text_of_logged_in_username())
 
 
-# C1491017, C1491019
+# C1491017, C1491019, C1491022
 @pytest.mark.editUserProfileTests
 def test_edit_profile_field_validation_with_symbols(page: Page, create_user_factory):
     utilities = Utilities(page)
@@ -557,60 +560,6 @@ def test_edit_user_profile_button_is_not_displayed_for_non_admin_users(page: Pag
         expect(sumo_pages.edit_my_profile_page.edit_my_profile_edit_input_form).to_be_hidden()
 
 
-# T5697928
-@pytest.mark.smokeTest
-@pytest.mark.editUserProfileTests
-def test_report_user_is_displayed_and_accessible_for_signed_in_users_only(page: Page,
-                                                                          create_user_factory):
-    utilities = Utilities(page)
-    sumo_pages = SumoPages(page)
-    test_user = create_user_factory()
-    test_user_two = create_user_factory()
-
-    with allure.step(f"Signing in with {test_user['username']} user account"):
-        utilities.start_existing_session(cookies=test_user)
-
-    with check, allure.step("Accessing another user profile and verifying that the 'Report Abuse' "
-                            "option is displayed"):
-        utilities.navigate_to_link(
-            MyProfileMessages.get_my_profile_stage_url(test_user_two["username"])
-        )
-        expect(sumo_pages.my_profile_page.report_abuse_profile_option).to_be_visible()
-
-    with check, allure.step("Clicking on the 'Report Abuse' option and verifying that the report "
-                            "abuse panel is displayed"):
-        sumo_pages.my_profile_page.click_on_report_abuse_option()
-        expect(sumo_pages.my_profile_page.report_abuse_panel).to_be_visible()
-
-    with check, allure.step("Closing the report abuse panel and verifying that the report user "
-                            "panel is no longer displayed"):
-        sumo_pages.my_profile_page.click_on_report_abuse_close_button()
-        expect(sumo_pages.my_profile_page.report_abuse_panel).to_be_hidden()
-
-    with allure.step("Signing out and verifying that the 'Report Abuse' option is not "
-                     "displayed on user profiles"):
-        utilities.delete_cookies()
-        expect(sumo_pages.my_profile_page.report_abuse_profile_option).to_be_hidden()
-
-
-# T5697930
-@pytest.mark.editUserProfileTests
-def test_private_message_button_redirects_signed_out_users_to_fxa_login_flow(page: Page,
-                                                                             create_user_factory):
-    utilities = Utilities(page)
-    sumo_pages = SumoPages(page)
-    test_user = create_user_factory()
-
-    with allure.step("Accessing a user profile"):
-        utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(
-            test_user["username"]))
-
-    with allure.step("Clicking on the 'Private Message' button and verifying that the non-signed "
-                     "in user is redirected to the fxa page"):
-        sumo_pages.my_profile_page.click_on_private_message_button()
-        expect(sumo_pages.auth_page.continue_with_firefox_accounts_button).to_be_visible()
-
-
 # C916055, C916054
 @pytest.mark.smokeTest
 @pytest.mark.editUserProfileTests
@@ -651,6 +600,59 @@ def test_deactivate_this_user_buttons_are_displayed_only_for_admin_users(page: P
         expect(sumo_pages.my_profile_page.deactivate_this_user_button).to_be_visible()
         expect(sumo_pages.my_profile_page.deactivate_this_user_and_mark_all_content_as_spam
                ).to_be_visible()
+
+
+# C2778035
+@pytest.mark.editUserProfileTests
+def test_deactivate_this_user_and_mark_all_content_as_spam_kb_threads(page: Page,
+                                                                      create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+
+    with allure.step("Signing in with an admin user and creating a new kb article"):
+        utilities.start_existing_session(session_file_name=staff_user)
+        article = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+            approve_first_revision=True)
+
+    with allure.step("Signing in with a normal test user"):
+        utilities.start_existing_session(cookies=test_user)
+
+    with allure.step("Creating a new kb article discussion thread"):
+        kb_article_discussion_2 = sumo_pages.kb_article_thread_flow.add_new_kb_discussion_thread()
+
+    with allure.step("Creating a new kb article discussion thread and leaving a reply to the "
+                     "thread with a different user"):
+        kb_article_discussion_3 = sumo_pages.kb_article_thread_flow.add_new_kb_discussion_thread()
+        utilities.start_existing_session(session_file_name=staff_user)
+        sumo_pages.kb_article_thread_flow.post_reply_to_thread("Test thread reply")
+
+    with allure.step("Navigating to the normal user account and deactivating the user via the "
+                     "'deactivate this user and mark all content as spam' option"):
+        utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(
+            test_user["username"]))
+        sumo_pages.my_profile_page.click_deactivate_this_user_and_mark_all_content_as_spam()
+
+    with check, allure.step("Navigating to the kb article discussions page and verifying that:"
+                            "1. The Kb discussion thread created by the deleted user and which "
+                            "contained no replies was deleted."
+                            "2. The kb discussion thread created by the deleted user and which"
+                            " contained a reply was deleted."):
+        with page.expect_navigation() as navigation_info:
+            utilities.navigate_to_link(kb_article_discussion_2["thread_url"])
+        response = navigation_info.value
+        assert response.status == 404
+
+        with page.expect_navigation() as navigation_info:
+            utilities.navigate_to_link(kb_article_discussion_3["thread_url"])
+        response = navigation_info.value
+        assert response.status == 404
+
+    with allure.step("Deleting the kb article"):
+        utilities.navigate_to_link(article["article_url"])
+        sumo_pages.kb_article_deletion_flow.delete_kb_article()
+
 
 
 # C2189013
@@ -762,3 +764,57 @@ def test_close_account_and_delete_profile_information(page:Page, create_user_fac
         expect(page).to_have_url(re.compile(r".*close_account.*"))
         utilities.navigate_to_homepage()
         expect(sumo_pages.top_navbar.signin_signup_button).to_be_visible()
+
+# C2189014
+@pytest.mark.editUserProfileTests
+def test_preferred_language_can_be_set(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+
+    with allure.step("Signing in to SUMO"):
+        utilities.start_existing_session(cookies=test_user)
+
+    with allure.step("Navigating to the Edit Profile page and changing the preferred language"):
+        sumo_pages.top_navbar.click_on_edit_profile_option()
+        sumo_pages.edit_my_profile_page.select_preferred_language_dropdown_option_by_value("ro")
+        sumo_pages.edit_my_profile_page.click_update_my_profile_button()
+
+    with allure.step("Navigating to the SUMO homepage without including the locale inside the "
+                     "request and verifying that the user is automatically redirected to the 'ro' "
+                     "locale."):
+        utilities.navigate_to_link(HomepageMessages.STAGE_HOMEPAGE_URL)
+        expect(page).to_have_url(re.compile(".*/ro.*"))
+
+
+# C1491460
+@pytest.mark.editUserProfileTests
+def test_username_can_be_reused_after_sumo_account_deletion(page: Page,
+                                                            restmail_test_account_creation):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    username = 'Test'.join(random.choice(
+        string.ascii_lowercase + string.digits) for _ in range(3)) + "@restmail.net"
+
+    username, password, _ = restmail_test_account_creation(username=username)
+
+    with allure.step("Verify that we are signed in with the correct user"):
+        utilities.wait_for_url_to_be(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US, 20000)
+        expect(sumo_pages.top_navbar.signed_in_username).to_have_text(
+            utilities.username_extraction_from_email(username)
+        )
+
+    with allure.step("Deleting the sumo account"):
+        sumo_pages.edit_profile_flow.close_account()
+
+    with allure.step("Signing back to SUMO using the same FxA account and verifying that the "
+                     "username can be reused"):
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
+        sumo_pages.auth_flow_page.login_with_existing_session()
+
+        utilities.wait_for_url_to_be(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US, 20000)
+        expect(sumo_pages.top_navbar.signed_in_username).to_have_text(
+            utilities.username_extraction_from_email(username)
+        )
+

--- a/playwright_tests/tests/user_page_tests/test_my_profile_page.py
+++ b/playwright_tests/tests/user_page_tests/test_my_profile_page.py
@@ -306,3 +306,94 @@ def test_accounts_with_symbols_are_getting_a_corresponding_valid_username(page: 
         sumo_pages.top_navbar.click_on_edit_profile_option()
         expect(sumo_pages.edit_my_profile_page.username_input_field).to_have_value(
             test_user["username"])
+
+
+# C2094290, C916053
+@pytest.mark.userProfile
+@pytest.mark.parametrize("report_type", ['Spam or other unrelated content',
+                                         'Inappropriate language/dialog', 'Abusive content',
+                                         'Other (please specify)'])
+def test_report_user_functionality(page: Page, create_user_factory, report_type):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory()
+    test_user_three = create_user_factory(groups=["Forum Moderators", "forum-contributors"])
+    report_details = 'This is just a test report'
+
+    with allure.step(f"Signing in with {test_user['username']} user account"):
+        utilities.start_existing_session(cookies=test_user)
+
+    with allure.step(f"Navigating to the second user and reporting the user as {report_type}"):
+        utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(
+            test_user_two["username"]))
+        sumo_pages.user_profile_flow.report_user_profile(report_reason=report_type,
+                                                         report_details=report_details)
+
+    with allure.step("Signing in with the forum moderator and navigating to the /flagged page"):
+        utilities.start_existing_session(cookies=test_user_three)
+        sumo_pages.top_navbar.click_on_moderate_forum_content_option()
+
+    with check, allure.step("Verifying that the correct flagg information is displayed"):
+        expect(sumo_pages.moderate_forum_content_page.profile_flagged_ticket(
+            test_user_two["username"])).to_be_visible()
+        expect(sumo_pages.moderate_forum_content_page.profile_flagged_reason(
+            test_user_two["username"])).to_have_text(
+            f"Flagged Users | profile (Reason: {report_type})")
+        expect(sumo_pages.moderate_forum_content_page.profile_flagged_additional_notes(
+            test_user_two["username"])).to_have_text(
+            f"Additional notes: {report_details}")
+
+
+# C2094290
+@pytest.mark.smokeTest
+@pytest.mark.userProfile
+def test_report_user_is_displayed_and_accessible_for_signed_in_users_only(page: Page,
+                                                                          create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    test_user_two = create_user_factory()
+
+    with allure.step(f"Signing in with {test_user['username']} user account"):
+        utilities.start_existing_session(cookies=test_user)
+
+    with check, allure.step("Accessing another user profile and verifying that the 'Report Abuse' "
+                            "option is displayed"):
+        utilities.navigate_to_link(
+            MyProfileMessages.get_my_profile_stage_url(test_user_two["username"])
+        )
+        expect(sumo_pages.my_profile_page.report_abuse_profile_option).to_be_visible()
+
+    with check, allure.step("Clicking on the 'Report Abuse' option and verifying that the report "
+                            "abuse panel is displayed"):
+        sumo_pages.my_profile_page.click_on_report_abuse_option()
+        expect(sumo_pages.my_profile_page.report_abuse_panel).to_be_visible()
+
+    with check, allure.step("Closing the report abuse panel and verifying that the report user "
+                            "panel is no longer displayed"):
+        sumo_pages.my_profile_page.click_on_report_abuse_close_button()
+        expect(sumo_pages.my_profile_page.report_abuse_panel).to_be_hidden()
+
+    with allure.step("Signing out and verifying that the 'Report Abuse' option is not "
+                     "displayed on user profiles"):
+        utilities.delete_cookies()
+        expect(sumo_pages.my_profile_page.report_abuse_profile_option).to_be_hidden()
+
+
+# C2108841
+@pytest.mark.userProfile
+def test_private_message_button_redirects_signed_out_users_to_fxa_login_flow(page: Page,
+                                                                             create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+
+    with allure.step("Accessing a user profile"):
+        utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(
+            test_user["username"]))
+
+    with allure.step("Clicking on the 'Private Message' button and verifying that the non-signed "
+                     "in user is redirected to the fxa page"):
+        sumo_pages.my_profile_page.click_on_private_message_button()
+        expect(sumo_pages.auth_page.continue_with_firefox_accounts_button).to_be_visible()


### PR DESCRIPTION
* Expand test coverage to: user deactivation, user profile preferred language, username re-usability & user reporting functionality.
* Added test flow for flagging a user profile.
* Added new locators.
* Updated the restmail_test_account_creation fixture/factory so custom usernames and passwords can be set & also return the cleanup function so that test functions can invoke it earlier (while also keeping it registered as a finalizer for other tests)