### PR TITLE
Add product version to question cards for contributors

### DIFF
--- a/kitsune/questions/models.py
+++ b/kitsune/questions/models.py
@@ -200,6 +200,9 @@ class Question(AAQBase):
             if update:
                 self.updated = timezone.now()
 
+        # Clear cached product_slug
+        self._product_slug = None
+
         super().save(*args, **kwargs)
 
         # Ensure that the metadata doesn't contain a "solver_id" if there's no solution.
@@ -214,7 +217,7 @@ class Question(AAQBase):
             if settings.QUESTION_CLASSIFIER_ENABLED:
                 question_classifier.delay(self.id)
 
-    def add_metadata(self, **kwargs):
+    def add_metadata(self, update=False, **kwargs):
         """Add (save to db) the passed in metadata.
 
         Usage:
@@ -223,7 +226,10 @@ class Question(AAQBase):
 
         """
         for key, value in list(kwargs.items()):
-            QuestionMetaData.objects.create(question=self, name=key, value=value)
+            if update:
+                QuestionMetaData.objects.update_or_create(question=self, name=key, defaults={"value": value})
+            else:
+                QuestionMetaData.objects.create(question=self, name=key, value=value)
         self._metadata = None
 
     def clear_mutable_metadata(self):
@@ -254,6 +260,18 @@ class Question(AAQBase):
         return self._metadata
 
     @property
+    def product_version(self):
+        metadata = self.metadata
+        if "sanitized_product_version" in metadata:
+            return metadata.get("sanitized_product_version")
+        elif self.product_slug in ("firefox", "mobile", "ios"):
+            return metadata.get("ff_version")
+        elif self.product_slug in ("thunderbird", "thunderbird-android"):
+            return metadata.get("tb_version")
+        else:
+            return None
+
+    @property
     def solver(self):
         """Get the user that solved the question."""
         solver_id = self.metadata.get("solver_id")
@@ -276,9 +294,7 @@ class Question(AAQBase):
 
     @property
     def product_slug(self):
-        """Return the product slug for this question.
-
-        It returns 'all' in the off chance that there are no products."""
+        """Return the product slug for this question."""
         if not hasattr(self, "_product_slug") or self._product_slug is None:
             self._product_slug = self.product.slug if self.product else None
 
@@ -319,6 +335,7 @@ class Question(AAQBase):
             # beta exists. A bare version is tagged only if it's a known
             # major/stability release.
             match = re.match(r"(\d+(?:\.\d+){0,2})([ab]\d*)?", raw_version)
+            sanitized_product_version = ""
             if match:
                 version, suffix = match.group(1), match.group(2)
                 if "." not in version:
@@ -327,14 +344,18 @@ class Question(AAQBase):
 
                 if suffix:
                     if any(key.startswith(f"{version}b") for key in development_releases):
+                        sanitized_product_version = f"{version}b"
                         tags.append(f"{product_name} {version}")
                         if tenths and tenths != version:
                             tags.append(f"{product_name} {tenths}")
                         tags.append("beta")
                 elif version in major_releases or version in stability_releases:
+                    sanitized_product_version = version
                     tags.append(f"{product_name} {version}")
                     if tenths and tenths != version:
                         tags.append(f"{product_name} {tenths}")
+            if action == "add":
+                self.add_metadata(update=True, sanitized_product_version=sanitized_product_version)
 
         # Add a tag for the OS but only if it already exists as a non-segmentation tag.
         if os := self.metadata.get("os"):

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -260,6 +260,7 @@ def question_list(request, product_slug=None, topic_slug=None):
         "topic",
         "product",
     )
+    question_qs = question_qs.prefetch_related("metadata_set")
     today = date.today()
     question_qs = (
         question_qs.exclude(

--- a/kitsune/sumo/jinja2/sumo/includes/question_entry.html
+++ b/kitsune/sumo/jinja2/sumo/includes/question_entry.html
@@ -188,6 +188,7 @@
   <div class="question-entry--meta">
     <div class="question-entry--meta-primary">
       {% if question.product and _product_url %}
+      <span class="question-entry--meta-item">
         <a class="question-entry--meta-item"
            href="{{ _product_url }}"
            title="{{ _('{product} questions')|f(product=question.product.title) }}">
@@ -199,6 +200,10 @@
           </svg>
           {{ question.product.title }}
         </a>
+        {% if question.channel != "direct_support" and user_is_contributor and question.product_version %}
+         {{ question.product_version }}
+        {% endif %}
+      </span>
       {% endif %}
       {% if question.topic and _topic_url %}
         <a class="question-entry--meta-item"

--- a/kitsune/sumo/static/sumo/scss/layout/_question-entry.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_question-entry.scss
@@ -105,12 +105,21 @@
     flex-shrink: 0;
   }
 
+  * {
+    position: relative;
+    z-index: 1;
+  }
 }
 
-a.question-entry--meta-item:hover {
-  color: var(--color-link);
-  text-decoration: underline;
-}
+  a.question-entry--meta-item,
+  .question-entry--meta-item a {
+    text-decoration: none;
+
+    &:hover {
+      color: var(--color-link);
+      text-decoration: underline;
+    }
+  }
 
 .question-entry--reply-count,
 .question-entry--vote-count {
@@ -137,16 +146,8 @@ a.question-entry--meta-item:hover {
 }
 
 .question-entry--meta-asked-by {
-  position: relative;
-  z-index: 1;
   color: var(--color-heading);
   font-weight: 600;
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-    color: var(--color-link);
-  }
 }
 
 .question-entry--last-reply {

--- a/kitsune/users/views.py
+++ b/kitsune/users/views.py
@@ -243,7 +243,7 @@ def questions_contributed(request, username):
     if channel != "direct_support":
         forum_questions = profile.user.questions.select_related(
             "solution", "product", "topic", "last_answer", "last_answer__creator"
-        ).order_by("-created")
+        ).prefetch_related("metadata_set").order_by("-created")
         if product_slug:
             forum_questions = forum_questions.filter(product__slug=product_slug)
         if topic_slug:


### PR DESCRIPTION
Resolves [#2958](https://github.com/mozilla/sumo/issues/2958).

To avoid fetching tags, we can use question metadata to get product versions (and display them). However, if we use raw data from the corresponding fields, this would expose us to all kinds of spam and UI breakages related to user input. In order to prevent that, this patch saves our validated version number (used to apply tags) into a separate question metadata field, and then displays it on question cards. For older questions, we fall back to the raw data from the version fields.

The SCSS changes do not represent any visual change, and are purely for clarity/future.