### PR TITLE
add banner to built-in-vpn article

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_banner.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_banner.scss
@@ -94,6 +94,32 @@
   }
 }
 
+#built-in-vpn-banner {
+  margin: p.$spacing-md 0;
+
+  .heading {
+    margin: 0 p.$spacing-md;
+  }
+
+  .sumo-button {
+    margin: p.$spacing-md p.$spacing-md 0;
+  }
+
+  @media #{p.$mq-md} {
+    .heading {
+      margin: p.$spacing-md;
+    }
+
+    .sumo-button {
+      margin: p.$spacing-md p.$spacing-md p.$spacing-md 0;
+    }
+
+    .sumo-close-button {
+      margin-right: p.$spacing-md;
+    }
+  }
+}
+
 .sumo-banner-warning {
   background: var(--color-warning);
   color: var(--color-heading);

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -50,6 +50,14 @@
 {% endif %}
 
 {% block breadcrumbs %}
+  {% if document.slug == "built-in-vpn" %}
+    {{ sumo_banner(
+        id="built-in-vpn-banner",
+        text=_("Now through August 31, get unlimited bandwidth with more locations in built-in VPN. Head to Connect for more details."),
+        button_text=_('Details'),
+        button_link="https://connect.mozilla.org/t5/discussions/more-bandwidth-and-more-vpn-locations-in-firefox-this-summer/td-p/127583",
+    ) }}
+  {% endif %}
   {{ breadcrumbs(breadcrumb_items, id='main-breadcrumbs') }}
 {% endblock %}
 


### PR DESCRIPTION
mozilla/sumo#3098

<img width="1435" height="623" alt="image" src="https://github.com/user-attachments/assets/ddb9421d-9d56-4731-a8e6-8089ff83a07b" />
