### PR TITLE
Fix featured article and topics card on reduced window widths

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_card-grid.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_card-grid.scss
@@ -96,6 +96,34 @@
     --cg-card-width: 40vw;
   }
 
+  @media (max-width: #{p.$screen-lg}) and (hover: hover) and (pointer: fine) {
+    overflow: visible;
+    scroll-snap-type: none;
+
+    .scroll-wrap {
+      width: auto;
+      flex-wrap: wrap;
+    }
+    &.is-product-wrap .scroll-wrap,
+    &.is-four-wide .scroll-wrap {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      grid-auto-rows: 1fr;
+      column-gap: var(--cg-gutter);
+      row-gap: 20px;
+    }
+
+    &.is-product-wrap .card,
+    &.is-four-wide .card,
+    &.is-product-wrap .card:first-child,
+    &.is-four-wide .card:first-child,
+    &.is-product-wrap .card:last-child,
+    &.is-four-wide .card:last-child {
+      width: auto;
+      margin: 0;
+    }
+  }
+
   @media #{p.$mq-lg} {
     --cg-gutter: #{c.$gutter-width};
     margin: 0;
@@ -109,7 +137,22 @@
     }
 
     &.is-product-wrap {
-      margin-bottom: -40px;
+      margin-bottom: 0;
+      .scroll-wrap {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        grid-auto-rows: 1fr;
+        column-gap: c.$gutter-width;
+        row-gap: p.$spacing-lg;
+        margin: 0;
+      }
+
+      .card,
+      .card:first-child,
+      .card:last-child {
+        width: auto;
+        margin: 0;
+      }
     }
 
     .card {
@@ -127,15 +170,27 @@
       @include c.col(1, 3); // This should be an 8 col grid, and it should use a 10-col grid at XL
     }
 
-    &.is-four-wide, &.extra-padding {
+    &.extra-padding {
       margin-bottom: -1 * p.$spacing-lg;
     }
 
     &.is-four-wide {
+      margin-bottom: 0;
+
+      .scroll-wrap {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        grid-auto-rows: 1fr;
+        column-gap: c.$gutter-width;
+        row-gap: p.$spacing-lg;
+        margin: 0;
+      }
+
       .card,
       .card:first-child,
       .card:last-child {
-        @include c.col(1, 4);
+        width: auto;
+        margin: 0;
       }
     }
   }

--- a/kitsune/sumo/static/sumo/scss/components/_card.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_card.scss
@@ -187,6 +187,15 @@
     display: flex;
     flex-direction: column;
     min-height: 144px;
+
+    // Clamp the description so a single verbose product can't stretch every
+    // card in the uniform grid into a tall box full of empty space.
+    .card--desc {
+      display: -webkit-box;
+      overflow: hidden;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+    }
   }
 
   &--topic {
@@ -478,7 +487,11 @@
   @media #{p.$mq-lg} {
     &--product {
       flex-direction: row;
-      align-items: center;
+      // Top-align the icon and text rather than centering them. When cards wrap
+      // into rows, each card stretches to the tallest card in its row; centering
+      // would float the shorter cards' content in the middle so titles wouldn't
+      // line up across the row. flex-start keeps every card's title aligned.
+      align-items: flex-start;
     }
 
     &--icon {

--- a/kitsune/sumo/static/sumo/scss/layout/_products.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_products.scss
@@ -168,4 +168,19 @@ body[data-product-slug="firefox-enterprise"] {
       }
     }
   }
+
+  // Below the large breakpoint the cards become a single-row horizontal
+  // scroller with a hidden scrollbar. Touch devices can swipe through it, but
+  // on a narrow desktop window (fine pointer) there's no scrollbar and the
+  // wheel scrolls vertically, so the cards are unreachable. For non-touch
+  // pointers, let the cards wrap into rows that scroll with the page instead.
+  @media (max-width: #{p.$screen-lg}) and (hover: hover) and (pointer: fine) {
+    flex-wrap: wrap;
+    overflow-x: visible;
+    scroll-snap-type: none;
+
+    >.card--topic {
+      height: auto;
+    }
+  }
 }


### PR DESCRIPTION
The proposed fix is to let cards to wrap into rows on reduced window widths.

<img width="1458" height="879" alt="FeaturedArticlesTopicsFix" src="https://github.com/user-attachments/assets/2fd369dc-bff5-486c-b29b-faeee16ed359" />
