### PR TITLE
Playwright: Expand test coverage to admin user pages

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,6 +43,7 @@ on:
                     - userDeletion
                     - communityForums
                     - adminAnnouncementBanners
+                    - userAdminPages
                     - smokeTest
 
 env:
@@ -99,7 +100,7 @@ jobs:
         run: |
             source ../.venv/bin/activate
             declare dispatch_test_suite="${{inputs.TestSuite}}"
-            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productSupportPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics" "searchTests" "contributorForumSearch" "userGroupsTests" "antiSpamTests" "contributorDiscussions" "contributorDiscussionsThreads" "userDeletion" "communityForums" "adminAnnouncementBanners")
+            declare all_test_suites=("homePageTests" "topNavbarTests" "footerSectionTests" "contributePagesTests" "messagingSystem" "userContributionTests" "userProfile" "userSettings" "editUserProfileTests" "userQuestions" "contactSupportPage" "productSolutionsPage" "productSupportPage" "productTopicsPage" "aaqPage" "postedQuestions" "kbProductsPage" "kbArticleCreationAndAccess" "beforeThreadTests" "articleThreads" "afterThreadTests" "kbArticleShowHistory" "recentRevisionsDashboard" "kbDashboard" "kbRestrictedVisibility" "kbArticleTranslation" "exploreByTopics" "searchTests" "contributorForumSearch" "userGroupsTests" "antiSpamTests" "contributorDiscussions" "contributorDiscussionsThreads" "userDeletion" "communityForums" "adminAnnouncementBanners", "userAdminPages")
             if [ "$dispatch_test_suite" == "All" ] ; then
                 for test in "${all_test_suites[@]}"; do
                     if ! pytest -m ${test} --numprocesses 6 --browser ${BROWSER} --reruns 2 -v; then

--- a/playwright_tests/core/utilities.py
+++ b/playwright_tests/core/utilities.py
@@ -119,7 +119,8 @@ class Utilities:
                 print(f"Error clearing Gmail: {e}")
 
     def get_fxa_verification_code(self, max_attempts=5, poll_interval=5,
-                                  restmail_username: str = None, new_account: bool = False) -> str:
+                                  restmail_username: str = None, new_account: bool = False,
+                                  change_password: bool = False) -> str:
         """
         Polls Gmail for the FxA verification code.
         Args:
@@ -128,6 +129,7 @@ class Utilities:
             restmail_username (str): Optional. The restmail username (if we need/want to use
             restmail).
             new_account (bool): If we are creating a new fxa account.
+            change_password (bool): If we are fetching the fxa code for password change.
         Returns:
             str: The verification code
         """
@@ -140,6 +142,9 @@ class Utilities:
                     json_response = response.json()
                     if new_account:
                         fxa_verification_code = json_response[0]['headers']['x-verify-short-code']
+                    elif change_password:
+                        fxa_verification_code = (json_response[0]['headers']
+                        ['x-account-change-verify-code'])
                     else:
                         fxa_verification_code = json_response[0]['headers']['x-signin-verify-code']
                     self.clear_email(restmail_username=restmail_username)
@@ -488,6 +493,30 @@ class Utilities:
             session_file_name (str): The session file name
         """
         self.page.context.storage_state(path=f"core/sessions/.auth/{session_file_name}.json")
+
+    def create_new_context_page(self, **context_kwargs) -> Page:
+        """
+        This helper function opens a fresh, isolated browser context (its own cookie jar and
+        storage) and returns a new page within it. The context includes the FxA browser challenge
+        header and the standard user agent so that authentication flows work as expected.
+
+        The caller is responsible for closing the context (``page.context.close()``) once done.
+
+        Args:
+            **context_kwargs: Extra keyword arguments forwarded to ``browser.new_context()``.
+
+        Returns:
+            Page: A new page belonging to the freshly created, isolated context.
+        """
+        browser = self.page.context.browser
+        context = browser.new_context(
+            user_agent=self.user_agent,
+            extra_http_headers={
+                f"{self.fxa_browser_challenge_header}": f"{self.fxa_browser_challenge_value}"
+            },
+            **context_kwargs,
+        )
+        return context.new_page()
 
     def delete_cookies(self, tried_once=False, retries=3):
         """

--- a/playwright_tests/flows/admin_flows/users/users_flows.py
+++ b/playwright_tests/flows/admin_flows/users/users_flows.py
@@ -1,0 +1,15 @@
+from playwright.sync_api import Page
+from playwright_tests.core.utilities import Utilities
+from playwright_tests.pages.admin_pages.users.admin_users_page import AdminUserPage
+
+
+class AdminUsersFlows:
+    def __init__(self, page: Page):
+        self.utilities = Utilities(page)
+        self.users_page = AdminUserPage(page)
+
+    def navigate_to_a_particular_user_profile_in_admin(self, username: str):
+        """Flow for navigating and accessing a user profile in admin."""
+        self.utilities.navigate_to_link(self.utilities.different_endpoints["admin_users_page"])
+        self.users_page.search_for_username(username)
+        self.users_page.click_on_a_user(username)

--- a/playwright_tests/flows/auth_flows/auth_flow.py
+++ b/playwright_tests/flows/auth_flows/auth_flow.py
@@ -104,3 +104,32 @@ class AuthFlowPage:
         self.auth_page.click_on_continue_deletion_button()
         self.auth_page.add_fxa_password(password)
         self.auth_page.click_on_the_delete_confirmation_button()
+
+    def change_test_account_password_flow(self, username: str, old_password: str,
+                                          new_password: str):
+        """Change FxA account password flow.
+
+        Args:
+            username (str): Targeted FxA username.
+            old_password (str): Old FxA account password.
+            new_password (str): New FxA account password.
+        """
+
+        self.page.goto(self.utilities.different_endpoints['fxa_stage'])
+        fxa_page = self.utilities.create_new_context_page()
+        auth_page = AuthPage(fxa_page)
+        utilities = Utilities(fxa_page)
+
+        auth_page.enter_your_email_input_field.wait_for(state="visible", timeout=3500)
+        auth_page.add_data_to_email_input_field(username)
+        auth_page.click_on_enter_your_email_submit_button()
+        auth_page.add_data_to_password_input_field(old_password)
+        auth_page.click_on_enter_your_password_submit_button()
+        auth_page.click_on_change_password_button()
+        confirmation_code = utilities.get_fxa_verification_code(restmail_username=username,
+                                                                change_password=True)
+        auth_page.add_password_change_confirmation_code(confirmation_code)
+        auth_page.change_fxa_password_form_completion(old_password, new_password)
+
+        fxa_page.context.close()
+

--- a/playwright_tests/messages/homepage_messages.py
+++ b/playwright_tests/messages/homepage_messages.py
@@ -10,3 +10,5 @@ class HomepageMessages:
     NEW_USER_REGISTRATION_MESSAGE = (
         "Welcome! You are now signed in using your Mozilla account. Edit your profile."
         "Already have a different Mozilla Support Account? Read more.")
+    USER_DEACTIVATED_MESSAGE = ("This account is not active. Please contact an administrator if "
+                                "you believe this is an error")

--- a/playwright_tests/messages/my_profile_pages_messages/my_profile_page_messages.py
+++ b/playwright_tests/messages/my_profile_pages_messages/my_profile_page_messages.py
@@ -3,6 +3,7 @@ class MyProfileMessages:
     TWITTER_REDIRECT_LINK = "https://x.com/"
     COMMUNITY_PORTAL_LINK = "https://community.mozilla.org"
     PEOPLE_DIRECTORY_LINK = "https://people.mozilla.org"
+    USER_DEACTIVATED_MESSAGE = "This user has been deactivated."
 
     @staticmethod
     def get_my_profile_stage_url(username: str) -> str:

--- a/playwright_tests/pages/admin_pages/users/admin_users_page.py
+++ b/playwright_tests/pages/admin_pages/users/admin_users_page.py
@@ -1,0 +1,37 @@
+from playwright.sync_api import Page
+from playwright_tests.core.basepage import BasePage
+
+
+class AdminUserPage(BasePage):
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+        """Locators belonging to the users listing page"""
+        self.users_page = page.locator("//th[@id='auth-user']/a")
+        self.searchbar = page.locator("//input[@id='searchbar']")
+        self.search_submit_button = page.locator("//input[@type='submit']")
+        self.user = lambda username: page.locator(
+            f"//th[@class='field-username']/a[text()='{username}']")
+        self.active_checkbox = page.locator("//input[@id='id_is_active']")
+        self.save_button = page.locator("//input[@value='Save']")
+
+    def click_on_users_page_option(self):
+        self._click(self.users_page)
+
+    def search_for_username(self, username: str):
+        """Search for a particular username inside the user admin page.
+        Args:
+            username (str): The username.
+        """
+        self._fill(self.searchbar, username)
+        self._click(self.search_submit_button)
+
+    def click_on_a_user(self, username: str):
+        """Click on a username from the User admin page table.
+        Args:
+            username (str): The username
+        """
+        self._click(self.user(username))
+
+    def click_on_save_changes_button(self):
+        self._click(self.save_button)

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -3,6 +3,7 @@ from functools import cached_property
 from playwright.sync_api import Page
 
 from playwright_tests.flows.admin_flows.announcement_banners.banner_flows import BannerFlows
+from playwright_tests.flows.admin_flows.users.users_flows import AdminUsersFlows
 from playwright_tests.flows.ask_a_question_flows.aaq_flows.aaq_flow import AAQFlow
 from playwright_tests.flows.auth_flows.auth_flow import AuthFlowPage
 from playwright_tests.flows.contributor_threads_flows.contributor_threads_flows import (
@@ -34,6 +35,7 @@ from playwright_tests.flows.user_profile_flows.edit_profile_data_flow import Edi
 from playwright_tests.flows.user_profile_flows.user_profile_flow import UserProfileFlow
 from playwright_tests.pages.admin_pages.announcement_banners.announcement_banner_page import \
     AnnouncementBannerAdminPage
+from playwright_tests.pages.admin_pages.users.admin_users_page import AdminUserPage
 from playwright_tests.pages.ask_a_question.aaq_pages.aaq_form_page import AAQFormPage
 from playwright_tests.pages.ask_a_question.contact_support_pages.contact_support_page import (
     ContactSupportPage,
@@ -158,10 +160,18 @@ class SumoPages:
     def admin_banner_page(self):
         return AnnouncementBannerAdminPage(self._page)
 
+    @cached_property
+    def admin_users_page(self):
+        return AdminUserPage(self._page)
+
     # Admin Flows.
     @cached_property
     def admin_banner_flows(self):
         return BannerFlows(self._page)
+
+    @cached_property
+    def admin_users_flows(self):
+        return AdminUsersFlows(self._page)
 
     # Auth Page.
     @cached_property

--- a/playwright_tests/pages/user_pages/my_profile_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_page.py
@@ -15,6 +15,7 @@ class MyProfilePage(BasePage):
             "link").filter(has_text="Edit user profile")
         self.report_abuse_profile_option = page.locator("article#profile").get_by_role(
             "link").filter(has_text="Report Abuse")
+        self.this_user_was_deactivated_message = page.locator("//div[@id='deactivated-msg']")
         self.deactivate_this_user_button = page.locator("input[value='Deactivate this user']")
         self.deactivate_this_user_and_mark_all_content_as_spam = page.locator(
             "input[value='Deactivate this user and mark all content as spam']")
@@ -157,6 +158,13 @@ class MyProfilePage(BasePage):
     def click_on_report_abuse_option(self):
         """Click on the report abuse option."""
         self._click(self.report_abuse_profile_option)
+
+    def click_on_deactivate_this_user_button(self):
+        # The .deactivate form's submit handler calls window.confirm(...) — the
+        # dialog handler must be attached before the click, and it must call
+        # .accept() itself (otherwise confirm() blocks and the click hangs).
+        self.page.once("dialog", lambda dialog: dialog.accept())
+        self._click(self.deactivate_this_user_button)
 
     def click_deactivate_this_user_and_mark_all_content_as_spam(self):
         # The .deactivate form's submit handler calls window.confirm(...) — the

--- a/playwright_tests/pytest.ini
+++ b/playwright_tests/pytest.ini
@@ -36,4 +36,5 @@ markers =
     userDeletion: Tests belonging to the user deletion suite.
     communityForums: Tests belonging to the community forums suite.
     adminAnnouncementBanners: Tests belonging to announcement banners.
+    userAdminPages: Tests belonging to the admin user pages.
 addopts = --alluredir=./reports/allure_reports --video retain-on-failure --tb=no

--- a/playwright_tests/test_data/different_endpoints.json
+++ b/playwright_tests/test_data/different_endpoints.json
@@ -11,5 +11,6 @@
           },
   "fxa_stage": "https://accounts.stage.mozaws.net",
   "admin": "https://support.allizom.org/admin/",
-  "admin_announcement_page": "https://support.allizom.org/admin/announcements/announcement/"
+  "admin_announcement_page": "https://support.allizom.org/admin/announcements/announcement/",
+  "admin_users_page": "https://support.allizom.org/admin/auth/user/"
 }

--- a/playwright_tests/tests/admin/conftest.py
+++ b/playwright_tests/tests/admin/conftest.py
@@ -6,10 +6,10 @@ from playwright_tests.pages.sumo_pages import SumoPages
 
 
 @pytest.fixture()
-def create_admin_context(browser, request):
-    admin_context = browser.new_context(user_agent=f"{Utilities.user_agent}")
-    admin_page = admin_context.new_page
-    return admin_page
+def create_admin_context(page, request):
+    def _create_admin_context():
+        return Utilities(page).create_new_context_page()
+    return _create_admin_context
 
 @pytest.fixture()
 def create_announcement_banner(create_admin_context, request):
@@ -27,3 +27,20 @@ def create_announcement_banner(create_admin_context, request):
     yield _create_announcement_banner
 
     sumo_pages.admin_banner_flows.delete_new_banner_flow()
+
+
+@pytest.fixture()
+def navigate_to_users_admin_page(create_admin_context, request):
+    admin_page = create_admin_context()
+    utilities = Utilities(admin_page)
+    sumo_pages = SumoPages(admin_page)
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+
+    def _access_admin_users_page(username: str):
+        utilities.navigate_to_homepage()
+        utilities.start_existing_session(session_file_name=staff_user)
+        utilities.navigate_to_link(utilities.different_endpoints['admin_announcement_page'])
+        sumo_pages.admin_users_flows.navigate_to_a_particular_user_profile_in_admin(username)
+        return admin_page
+    yield _access_admin_users_page
+

--- a/playwright_tests/tests/admin/users/test_users_admin_page.py
+++ b/playwright_tests/tests/admin/users/test_users_admin_page.py
@@ -1,0 +1,85 @@
+import allure
+import pytest
+from playwright.sync_api import Page, expect
+from pytest_check import check
+
+from playwright_tests.core.utilities import Utilities
+from playwright_tests.messages.homepage_messages import HomepageMessages
+from playwright_tests.messages.my_profile_pages_messages.my_profile_page_messages import \
+    MyProfileMessages
+from playwright_tests.pages.sumo_pages import SumoPages
+from playwright_tests.tests.user_page_tests.test_my_questions import _submit_firefox_question
+
+
+@pytest.mark.userAdminPages
+def test_users_can_be_deactivated(page:Page, restmail_test_account_creation,
+                                  navigate_to_users_admin_page):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    email, _, _ = restmail_test_account_creation()
+    username = utilities.username_extraction_from_email(email)
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+    admin_page = navigate_to_users_admin_page(username)
+    admin_pages = SumoPages(admin_page)
+    admin_utilities = Utilities(admin_page)
+    moderator_page = utilities.create_new_context_page()
+    moderator_utilities = Utilities(moderator_page)
+    moderator_pages = SumoPages(moderator_page)
+
+    with allure.step("Signing in with an admin user account"):
+        moderator_utilities.navigate_to_link(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
+        moderator_utilities.start_existing_session(session_file_name=staff_user)
+
+    with allure.step("Submitting a question against the AAQ forum with the simple user"):
+        question_info = _submit_firefox_question(utilities, sumo_pages)
+
+    with allure.step("Navigating to the test user profile page"):
+        moderator_utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username))
+
+    with check, allure.step("Deactivating the user profile and verifying that the correct "
+                            "deactivation status is displayed."):
+        moderator_pages.my_profile_page.click_on_deactivate_this_user_button()
+        expect(moderator_pages.my_profile_page.this_user_was_deactivated_message).to_have_text(
+            MyProfileMessages.USER_DEACTIVATED_MESSAGE)
+
+    with check, allure.step("Verifying that the question was not deleted"):
+        moderator_utilities.navigate_to_link(question_info["question_page_url"])
+        expect(moderator_pages.question_page.question_author).to_have_text(username)
+        moderator_page.close()
+
+    with check, allure.step("Verifying that the after a page refresh the deactivated user was "
+                            "logged out"):
+        utilities.refresh_page()
+        expect(sumo_pages.top_navbar.signin_signup_button).to_be_visible()
+
+    with check, allure.step("Trying to manually sign in and verifying that the user is unable "
+                            "to and that the correct error message is displayed"):
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
+        sumo_pages.auth_flow_page.login_with_existing_session()
+        expect(sumo_pages.top_navbar.signin_signup_button).to_be_visible()
+        expect(sumo_pages.homepage.user_notification).to_have_text(
+            HomepageMessages.USER_DEACTIVATED_MESSAGE)
+
+    with check, allure.step("Verifying that the is active checkbox is unchecked in admin"):
+        admin_utilities.refresh_page()
+        expect(admin_pages.admin_users_page.active_checkbox).not_to_be_checked()
+
+    with allure.step("Checking the is active checkbox and saving the changes"):
+        admin_pages.admin_users_page.active_checkbox.check()
+        admin_pages.admin_users_page.click_on_save_changes_button()
+        admin_page.close()
+
+    with check, allure.step("Signing in with the test user and verify that the user successfully "
+                            "logs in"):
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
+        sumo_pages.auth_flow_page.login_with_existing_session()
+        expect(sumo_pages.top_navbar.signed_in_username).to_have_text(username)
+        expect(sumo_pages.homepage.user_notification).to_be_hidden()
+
+    with allure.step("Navigating to the test user profile page and verifying that the "
+                     "deactivation message is not displayed"):
+        utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username))
+        expect(sumo_pages.my_profile_page.this_user_was_deactivated_message).to_be_hidden()
+

--- a/playwright_tests/tests/conftest.py
+++ b/playwright_tests/tests/conftest.py
@@ -157,7 +157,7 @@ def restmail_test_account_creation(page: Page, request):
     account is independently cleaned up.
     """
     sumo_pages = SumoPages(page)
-    browser = page.context.browser
+    utilities = Utilities(page)
 
     def _create(username: str = None, password: str = None):
         if username is None:
@@ -184,13 +184,7 @@ def restmail_test_account_creation(page: Page, request):
                 return
             already_cleaned = True
 
-            cleanup_context = browser.new_context(
-                extra_http_headers={
-                    f"{Utilities.fxa_browser_challenge_header}":
-                        f"{Utilities.fxa_browser_challenge_value}"
-                }
-            )
-            cleanup_page = cleanup_context.new_page()
+            cleanup_page = utilities.create_new_context_page()
             try:
                 cleanup_sumo_pages = SumoPages(cleanup_page)
                 cleanup_sumo_pages.auth_flow_page.delete_test_account_flow(
@@ -199,7 +193,7 @@ def restmail_test_account_creation(page: Page, request):
             except (TargetClosedError, Exception) as e:
                 print(f"Restmail test account cleanup failed: {e}")
             finally:
-                cleanup_context.close()
+                cleanup_page.context.close()
 
         request.addfinalizer(cleanup)
         return user, user_password, cleanup

--- a/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
+++ b/playwright_tests/tests/user_page_tests/test_edit_my_profile.py
@@ -602,7 +602,7 @@ def test_deactivate_this_user_buttons_are_displayed_only_for_admin_users(page: P
                ).to_be_visible()
 
 
-# C2778035
+# C2778035, C3081868
 @pytest.mark.editUserProfileTests
 def test_deactivate_this_user_and_mark_all_content_as_spam_kb_threads(page: Page,
                                                                       create_user_factory):
@@ -616,8 +616,14 @@ def test_deactivate_this_user_and_mark_all_content_as_spam_kb_threads(page: Page
         article = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
             approve_first_revision=True)
 
+    with allure.step("Creating a discussion thread"):
+        kb_article_discussion_1 = sumo_pages.kb_article_thread_flow.add_new_kb_discussion_thread()
+
     with allure.step("Signing in with a normal test user"):
         utilities.start_existing_session(cookies=test_user)
+
+    with allure.step("Leaving a reply to the thread posted by a different user"):
+        thread_reply = sumo_pages.kb_article_thread_flow.post_reply_to_thread("Test thread")
 
     with allure.step("Creating a new kb article discussion thread"):
         kb_article_discussion_2 = sumo_pages.kb_article_thread_flow.add_new_kb_discussion_thread()
@@ -638,7 +644,8 @@ def test_deactivate_this_user_and_mark_all_content_as_spam_kb_threads(page: Page
                             "1. The Kb discussion thread created by the deleted user and which "
                             "contained no replies was deleted."
                             "2. The kb discussion thread created by the deleted user and which"
-                            " contained a reply was deleted."):
+                            " contained a reply was deleted."
+                            "3. The kb discussion thread reply was successfully deleted."):
         with page.expect_navigation() as navigation_info:
             utilities.navigate_to_link(kb_article_discussion_2["thread_url"])
         response = navigation_info.value
@@ -648,6 +655,10 @@ def test_deactivate_this_user_and_mark_all_content_as_spam_kb_threads(page: Page
             utilities.navigate_to_link(kb_article_discussion_3["thread_url"])
         response = navigation_info.value
         assert response.status == 404
+
+        utilities.navigate_to_link(kb_article_discussion_1["thread_url"])
+        expect(sumo_pages.kb_article_discussion_page.article_thread_reply(thread_reply["reply_id"])
+               ).to_be_hidden()
 
     with allure.step("Deleting the kb article"):
         utilities.navigate_to_link(article["article_url"])


### PR DESCRIPTION
- Add page objects, locators and flows for the admin Users page.
- Added functionality for the fxa flow password change.
- Added a help function to easily create a new page context when needed.
- Adding test coverage for the https://github.com/mozilla/sumo/issues/3055 case.
- Adding test coverage for user deactivation/re-activation flow.