### PR TITLE
ensure visited links purple in questions/cards

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_card.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_card.scss
@@ -159,6 +159,12 @@
       a {
         white-space: pre-line;
         word-wrap: break-word;
+
+        // Surface the visited state so users can tell which featured articles
+        // they've already read (issue #7459).
+        &:visited {
+          color: var(--color-link-visited);
+        }
       }
     }
 
@@ -262,6 +268,12 @@
           line-clamp: 2;
           -webkit-box-orient: vertical;
           overflow: hidden;
+
+          // Surface the visited state so users can tell which articles they've
+          // already read (issue #7459).
+          &:visited {
+            color: var(--color-link-visited);
+          }
 
           &:hover {
             text-decoration: underline;

--- a/kitsune/sumo/static/sumo/scss/layout/_question-entry.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_question-entry.scss
@@ -37,6 +37,12 @@
     inset: 0;
   }
 
+  // Surface the visited state so users can tell which questions they've already
+  // read (issue #7459). Before :hover so hover still wins (CSS LVHA order).
+  &:visited {
+    color: var(--color-link-visited);
+  }
+
   &:hover {
     text-decoration: underline;
     color: var(--color-click);


### PR DESCRIPTION
mozilla/kitsune#7459

Shows visited links as purple in the question list, and also in the topic and featured-article cards.