### PR TITLE
Make question/answer API profile serialization read-only (#7591)

### DIFF
--- a/kitsune/questions/api.py
+++ b/kitsune/questions/api.py
@@ -36,23 +36,27 @@ from kitsune.users.api import ProfileFKSerializer
 from kitsune.users.models import Profile
 
 
-def get_or_create_profile(user):
+def get_profile(user):
     """
-    Get or create a Profile for a User.
+    Return the Profile for a User without creating one.
 
-    This helper ensures Users without Profiles don't cause serialization failures.
-    Follows Django's get_or_create naming pattern.
+    Serialization happens on read-only (GET) requests, so it must never
+    write. Users without a Profile serialize gracefully as ``None`` (mirroring
+    the read-only fallback already used by ``profile_avatar`` and
+    ``display_name``) rather than triggering a ``get_or_create`` write. That
+    per-row write was an N+1 write-on-read which intermittently timed out
+    (HTTP 500) on large, ordered list queries such as
+    ``?ordering=updated&updated__gt=`` (mozilla/kitsune#7591).
 
     Args:
         user: User instance (can be None for optional fields)
 
     Returns:
-        Profile instance if user is provided, None otherwise
+        Profile instance if the user has one, None otherwise.
     """
     if user is None:
         return None
-    profile, _ = Profile.objects.get_or_create(user=user)
-    return profile
+    return Profile.objects.filter(user=user).first()
 
 
 class QuestionMetaDataSerializer(serializers.ModelSerializer):
@@ -120,12 +124,13 @@ class QuestionSerializer(serializers.ModelSerializer):
 
     def get_involved(self, obj):
         involved_profiles = []
-        creator_profile = get_or_create_profile(obj.creator)
-        involved_profiles.append(creator_profile)
+        creator_profile = get_profile(obj.creator)
+        if creator_profile:
+            involved_profiles.append(creator_profile)
 
         for answer in obj.answers.all():
-            answer_profile = get_or_create_profile(answer.creator)
-            if answer_profile not in involved_profiles:
+            answer_profile = get_profile(answer.creator)
+            if answer_profile and answer_profile not in involved_profiles:
                 involved_profiles.append(answer_profile)
 
         return ProfileFKSerializer(involved_profiles, many=True).data
@@ -133,19 +138,19 @@ class QuestionSerializer(serializers.ModelSerializer):
     def get_solved_by(self, obj):
         if not obj.solution:
             return None
-        profile = get_or_create_profile(obj.solution.creator)
-        return ProfileFKSerializer(profile).data
+        profile = get_profile(obj.solution.creator)
+        return ProfileFKSerializer(profile).data if profile else None
 
     def get_creator(self, obj):
-        profile = get_or_create_profile(obj.creator)
-        return ProfileFKSerializer(profile).data
+        profile = get_profile(obj.creator)
+        return ProfileFKSerializer(profile).data if profile else None
 
     def get_taken_by(self, obj):
-        profile = get_or_create_profile(obj.taken_by)
+        profile = get_profile(obj.taken_by)
         return ProfileFKSerializer(profile).data if profile else None
 
     def get_updated_by(self, obj):
-        profile = get_or_create_profile(obj.updated_by)
+        profile = get_profile(obj.updated_by)
         return ProfileFKSerializer(profile).data if profile else None
 
     def get_tags(self, obj):
@@ -471,11 +476,11 @@ class AnswerSerializer(serializers.ModelSerializer):
         )
 
     def get_creator(self, obj):
-        profile = get_or_create_profile(obj.creator)
-        return ProfileFKSerializer(profile).data
+        profile = get_profile(obj.creator)
+        return ProfileFKSerializer(profile).data if profile else None
 
     def get_updated_by(self, obj):
-        profile = get_or_create_profile(obj.updated_by)
+        profile = get_profile(obj.updated_by)
         return ProfileFKSerializer(profile).data if profile else None
 
     def validate(self, data):

--- a/kitsune/questions/tests/test_api.py
+++ b/kitsune/questions/tests/test_api.py
@@ -187,6 +187,22 @@ class TestQuestionSerializerSerialization(TestCase):
             },
         )
 
+    def test_creator_without_profile_serializes_as_none(self):
+        """Regression test for #7591.
+
+        Serializing a Question is a read-only operation, so a creator who
+        has no Profile must serialize as None rather than triggering a
+        write (``get_or_create``) during serialization.
+        """
+        self.question.creator.profile.delete()
+        profiles_before = Profile.objects.count()
+
+        serializer = api.QuestionSerializer(instance=self.question)
+
+        self.assertIsNone(serializer.data["creator"])
+        # Serialization must not create a Profile for the profile-less creator.
+        self.assertEqual(Profile.objects.count(), profiles_before)
+
     def test_with_tags(self):
         self.question.tags.add("tag1")
         self.question.tags.add("tag2")
@@ -375,6 +391,34 @@ class TestQuestionViewSet(TestCase):
         self.assertEqual(res.data["results"][0]["id"], q1.id)
         self.assertEqual(res.data["results"][1]["id"], q2.id)
         self.assertEqual(res.data["results"][2]["id"], q3.id)
+
+    def test_list_ordering_by_updated_does_not_write_profiles(self):
+        """Regression test for #7591.
+
+        ``GET /api/2/question/?ordering=updated&updated__gt=`` is a
+        read-only request and must never create Profile rows. Accounts
+        without a Profile (common for old or imported users) previously
+        triggered a per-row ``Profile.objects.get_or_create`` write while
+        serializing the question's creator and involved users -- an N+1
+        write-on-read that intermittently timed out (HTTP 500) on large,
+        ordered result sets.
+        """
+        asker = UserFactory()
+        answerer = UserFactory()
+        question = QuestionFactory(creator=asker)
+        AnswerFactory(question=question, creator=answerer)
+
+        # Simulate accounts that have no Profile.
+        Profile.objects.all().delete()
+        self.assertEqual(Profile.objects.count(), 0)
+
+        url = reverse("question-list") + "?ordering=updated&updated__gt=2000-01-01T00:00:00"
+        res = self.client.get(url)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["count"], 1)
+        # The GET must not have created any Profile rows.
+        self.assertEqual(Profile.objects.count(), 0)
 
     def test_filter_product_with_slug(self):
         p1 = ProductFactory()


### PR DESCRIPTION
## Who we are

We're [Thunderbird](https://www.thunderbird.net/) (MZLA). We run a [GrimoireLab/Bitergia](https://github.com/chaoss/grimoirelab) analytics instance at **https://bitergia.thunderbird.net** that ingests SUMO/Kitsune data via the `/api/2/question/` endpoint, which is how we hit this issue (#7591) in production.

## Summary

Fixes the write-on-read N+1 in the question/answer API serializers that is the most likely cause of the intermittent `HTTP 500` on `GET /api/2/question/?ordering=updated&updated__gt=<date>` reported in mozilla/sumo#3124.

`QuestionSerializer` and `AnswerSerializer` resolve each row's `creator`, `updated_by`, `taken_by`, `solution.creator` and every involved answer author through `get_or_create_profile()`, which calls `Profile.objects.get_or_create(user=...)`. `get_or_create` is a **write**, executed here during a **read-only `GET`**, once per related user per row.

## Why this surfaces as an intermittent 500 on the ordered query

- For accounts that already have a `Profile`, `get_or_create` is just a `SELECT`. For accounts **without** one (common for old/imported users), it does an `INSERT` inside a savepoint.
- `?ordering=updated&updated__gt=` walks a window of older questions whose authors are more likely to be profile-less, so a single page can fan out into a burst of per-row writes plus the existing N+1 `SELECT`s.
- The first request that hits such a page does the writes (slow/contended under load → times out → `500`); a retry finds the now-created `Profile`s and succeeds (`200`). That matches the intermittent **500-then-200** behaviour in the issue.

I was not able to reproduce the production `500` directly (it's load/scale dependent), but eliminating writes during `GET` removes a clear timeout/contention source and is correct regardless: **read requests should never write.**

## Change

- `get_or_create_profile()` → `get_profile()`: returns the user's `Profile` or `None`, **never creating one**.
- Serializer methods treat a missing `Profile` as `None`.

This mirrors the read-only graceful fallback the codebase already uses for missing profiles in `profile_avatar()` and `display_name()` (both `try/except` → default, no write), so it preserves the intent of the original *"Gracefully handle missing profiles"* change without the side effect.

### Behaviour change

For the rare profile-less user, the affected fields (`creator`, `updated_by`, `taken_by`, `solved_by`, and entries in `involved`) now serialize as `null`/are omitted, instead of the previous behaviour of silently creating a `Profile` row mid-request. If you'd prefer profiles be guaranteed to exist via a different mechanism (e.g. a signal on user creation / a backfill) rather than returning `null`, I'm happy to adjust — opening early per CONTRIBUTING for discussion.

## Tests

Added regression tests in `kitsune/questions/tests/test_api.py`:

- `test_creator_without_profile_serializes_as_none` — serializing a question whose creator has no `Profile` returns `None` and creates **zero** `Profile` rows.
- `test_list_ordering_by_updated_does_not_write_profiles` — `GET /api/2/question/?ordering=updated&updated__gt=` over profile-less authors returns `200` and creates **zero** `Profile` rows.

Both fail on `main` (the old code re-creates the profile and then errors serializing it) and pass with this change. Full `kitsune.questions.tests.test_api` suite (70 tests) passes locally, `ruff check`/`ruff format` clean.

Refs mozilla/sumo#3124