### PR TITLE
ensure safe badges

### DIFF
--- a/kitsune/kbadge/admin.py
+++ b/kitsune/kbadge/admin.py
@@ -5,7 +5,7 @@ from django import forms
 from django.contrib import admin
 from django.db import models
 from django.urls import reverse
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 
 from kitsune.kbadge.models import Award, Badge
 
@@ -14,8 +14,10 @@ def show_image(obj):
     if not obj.image:
         return "None"
     img_url = obj.image.url
-    return mark_safe(
-        '<a href="{}" target="_new"><img src="{}" width="48" height="48" /></a>'.format(img_url, img_url)
+    return format_html(
+        '<a href="{}" target="_new"><img src="{}" width="48" height="48" /></a>',
+        img_url,
+        img_url,
     )
 
 
@@ -33,11 +35,13 @@ def build_related_link(self, model_name, name_single, name_plural, qs):
     )
     count = qs.count()
     what = ((count == 1) and name_single) or name_plural
-    return '<a href="{}">{} {}</a> (<a href="{}">new</a>)'.format(link, count, what, new_link)
+    return format_html(
+        '<a href="{}">{} {}</a> (<a href="{}">new</a>)', link, count, what, new_link
+    )
 
 
 def related_awards_link(self):
-    return mark_safe(build_related_link(self, "award", "award", "awards", self.award_set))
+    return build_related_link(self, "award", "award", "awards", self.award_set)
 
 
 related_awards_link.short_description = "Awards"  # type: ignore
@@ -76,7 +80,7 @@ class BadgeAdmin(admin.ModelAdmin):
 
 def badge_link(self):
     url = reverse("admin:kbadge_badge_change", args=[self.badge.id])
-    return mark_safe('<a href="{}">{}</a>'.format(url, self.badge))
+    return format_html('<a href="{}">{}</a>', url, self.badge)
 
 
 badge_link.short_description = "Badge"  # type: ignore
@@ -106,7 +110,7 @@ class AwardAdmin(admin.ModelAdmin):
 
 def award_link(self):
     url = reverse("admin:kbadge_award_change", args=[self.award.id])
-    return mark_safe('<a href="{}">{}</a>'.format(url, self.award))
+    return format_html('<a href="{}">{}</a>', url, self.award)
 
 
 award_link.short_description = "award"  # type: ignore

--- a/kitsune/kbadge/jinja2/badger/award_detail.html
+++ b/kitsune/kbadge/jinja2/badger/award_detail.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% set crumbs = [(url('kbadge.badges_list'), _('Badges')), (url('kbadge.awards_list'), _('Recently Awarded')), (None, pgettext('DB: badger.Badge.title', badge.title))] %}
+{% set crumbs = [(url('kbadge.badges_list'), _('Badges')), (url('kbadge.awards_list'), _('Recently Awarded')), (None, display_badge_title(badge.title))] %}
 
 {% block content %}
   <h1 class="sumo-page-heading">
-    {% trans badge_name=pgettext('DB: badger.Badge.title', badge.title) %}
+    {% trans badge_name=display_badge_title(badge.title) %}
       Awarded badge: {{ badge_name }}
     {% endtrans %}
   </h1>
@@ -14,7 +14,7 @@
       {% if badge.image %}
         <figure class="avatar-group--figure text-center">
           <a href="{{ badge.get_absolute_url() }}">
-            <img src="{{ badge.image.url }}" alt="{{ pgettext('DB: badger.Badge.title', badge.title) }}" width="160" height="160" />
+            <img src="{{ badge.image.url }}" alt="{{ display_badge_title(badge.title) }}" width="160" height="160" />
           </a>
         </figure>
       {% endif %}
@@ -23,7 +23,7 @@
         <dl class="sumo-dl">
           {% if badge.description %}
             <dt><strong>{{ _('Description:') }}</strong></dt>
-            <dd>{{ pgettext('DB: badger.Badge.description', badge.description) }}</dd>
+            <dd>{{ display_badge_description(badge.description) }}</dd>
           {% endif %}
 
           {% if badge.creator %}

--- a/kitsune/kbadge/jinja2/badger/awards_list.html
+++ b/kitsune/kbadge/jinja2/badger/awards_list.html
@@ -10,7 +10,7 @@
     {% endblock %}
     {% if badge %}
       <h1 class="sumo-page-heading">
-        {% trans badge_name=pgettext('DB: badger.Badge.title', badge.title) %}
+        {% trans badge_name=display_badge_title(badge.title) %}
           Recently awarded &quot;{{ badge_name }}&quot; badges
         {% endtrans %}
       </h1>
@@ -43,7 +43,7 @@
                 <td>
                   <a href="{{ award.get_absolute_url() }}">
                     <img src="{{ award_image }}" alt="" width="32" height="32">
-                    {{ pgettext('DB: badger.Badge.title', award.badge.title) }}
+                    {{ display_badge_title(award.badge.title) }}
                   </a>
                 </td>
                 <td>

--- a/kitsune/kbadge/jinja2/badger/badge_detail.html
+++ b/kitsune/kbadge/jinja2/badger/badge_detail.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% set crumbs = [(url('kbadge.badges_list'), _('Badges')), (None, pgettext('DB: badger.Badge.title', badge.title))] %}
+{% set crumbs = [(url('kbadge.badges_list'), _('Badges')), (None, display_badge_title(badge.title))] %}
 
 {% block content %}
   <h1 class="sumo-page-heading">
-    {% trans badge_name=pgettext('DB: badger.Badge.title', badge.title) %}
+    {% trans badge_name=display_badge_title(badge.title) %}
       Badge: {{ badge_name }}
     {% endtrans %}
   </h1>
@@ -14,7 +14,7 @@
       {% if badge.image %}
         <figure class="avatar-group--figure text-center">
           <a href="{{ badge.get_absolute_url() }}">
-            <img src="{{ badge.image.url }}" alt="{{ pgettext('DB: badger.Badge.title', badge.title) }}" width="160" height="160" />
+            <img src="{{ badge.image.url }}" alt="{{ display_badge_title(badge.title) }}" width="160" height="160" />
           </a>
         </figure>
       {% endif %}
@@ -23,7 +23,7 @@
         <dl class="sumo-dl">
           {% if badge.description %}
             <dt><strong>{{ _('Description:') }}</strong></dt>
-            <dd>{{ pgettext('DB: badger.Badge.description', badge.description) }}</dd>
+            <dd>{{ display_badge_description(badge.description) }}</dd>
           {% endif %}
 
           {% if badge.creator %}

--- a/kitsune/kbadge/jinja2/badger/badges_list.html
+++ b/kitsune/kbadge/jinja2/badger/badges_list.html
@@ -22,10 +22,10 @@
           {% endif %}
           <div class="card elevation-01 zoom-on-hover">
             <div class="card--horizontal">
-              <img class="card--img" src="{{ badge_image }}" alt="" title="{{ pgettext('DB: badger.Badge.title', badge.title) }}">
+              <img class="card--img" src="{{ badge_image }}" alt="" title="{{ display_badge_title(badge.title) }}">
               <h3 class="card--title">
                 <a class="expand-this-link" href="{{ badge.get_absolute_url() }}">
-                  {{ pgettext('DB: badger.Badge.title', badge.title) }}
+                  {{ display_badge_title(badge.title) }}
                 </a>
               </h3>
             </div>

--- a/kitsune/kbadge/jinja2/kbadge/email/award_notification.html
+++ b/kitsune/kbadge/jinja2/kbadge/email/award_notification.html
@@ -23,12 +23,12 @@
 
   <p>
     {% if award.creator %}
-      {% trans awarder=display_name(award.creator), title=pgettext('DB: badger.Badge.title', badge.title) %}
+      {% trans awarder=display_name(award.creator), title=display_badge_title(badge.title) %}
         <strong>{{ awarder }}</strong> has awarded you the
         <strong>{{ title }}</strong> badge!
       {% endtrans %}
     {% else %}
-      {% trans title=pgettext('DB: badger.Badge.title', badge.title) %}
+      {% trans title=display_badge_title(badge.title) %}
         You have been awarded the <strong>{{ title }}</strong> badge!
       {% endtrans %}
     {% endif %}

--- a/kitsune/kbadge/jinja2/kbadge/includes/macros.html
+++ b/kitsune/kbadge/jinja2/kbadge/includes/macros.html
@@ -9,8 +9,8 @@
         {% set award_image = webpack_static('kbadge/img/default-badge.png') %}
       {% endif %}
       <li>
-        <a href="{{ award.get_absolute_url() }}" title="{{ pgettext('DB: badger.Badge.title', award.badge.title) }}">
-          <img src="{{ award_image }}" alt="{{ pgettext('DB: badger.Badge.title', award.badge.title) }}" />
+        <a href="{{ award.get_absolute_url() }}" title="{{ display_badge_title(award.badge.title) }}">
+          <img src="{{ award_image }}" alt="{{ display_badge_title(award.badge.title) }}" />
         </a>
       </li>
     {% endfor %}

--- a/kitsune/kbadge/templatetags/jinja_helpers.py
+++ b/kitsune/kbadge/templatetags/jinja_helpers.py
@@ -1,0 +1,26 @@
+from django.utils.translation import pgettext
+from django_jinja import library
+from markupsafe import escape
+
+
+def _display_db_string(value, context):
+    """Return a localized DB string, HTML-escaped for safe rendering.
+
+    Badge titles and descriptions are plain-text labels, but they're localized
+    via pgettext, whose newstyle return value is marked safe (Markup) under
+    autoescape. That bypasses Jinja's autoescaping, so a value containing markup
+    would render unescaped. Escaping the translated value here treats it as the
+    plain text it is, keeping it safe in both element-text and quoted-attribute
+    contexts.
+    """
+    return escape(pgettext(context, str(value)))
+
+
+@library.global_function
+def display_badge_title(title):
+    return _display_db_string(title, "DB: badger.Badge.title")
+
+
+@library.global_function
+def display_badge_description(description):
+    return _display_db_string(description, "DB: badger.Badge.description")

--- a/kitsune/kbadge/tests/test_admin.py
+++ b/kitsune/kbadge/tests/test_admin.py
@@ -1,0 +1,46 @@
+import time
+
+from django.urls import reverse
+
+from kitsune.kbadge.tests import AwardFactory, BadgeFactory
+from kitsune.sumo.tests import TestCase
+from kitsune.users.tests import UserFactory
+
+XSS_TITLE = '<script>alert("kbadge-xss")</script>'
+RAW_PAYLOAD = '<script>alert("kbadge-xss")'
+ESCAPED_PAYLOAD = "&lt;script&gt;alert("
+
+
+class BadgeAdminEscapingTests(TestCase):
+    def setUp(self):
+        self.superuser = UserFactory(is_staff=True, is_superuser=True)
+        # Admin requests pass through SUMORefreshIDTokenAdminMiddleware, which forces OIDC
+        # re-authentication (a 302) unless the session was created by the OIDC backend and
+        # carries an unexpired ID token. Build a session that satisfies both conditions.
+        self.client.force_login(self.superuser, backend="kitsune.users.auth.SumoOIDCAuthBackend")
+        session = self.client.session
+        session["oidc_id_token_expiration"] = time.time() + 3600
+        session.save()
+
+    def test_badge_changelist_escapes_title(self):
+        # Exercises the title column and the related_awards_link callable.
+        badge = BadgeFactory(title=XSS_TITLE)
+        AwardFactory(badge=badge)
+
+        resp = self.client.get(reverse("admin:kbadge_badge_changelist"))
+
+        self.assertEqual(200, resp.status_code)
+        self.assertNotContains(resp, RAW_PAYLOAD)
+        self.assertContains(resp, ESCAPED_PAYLOAD)
+
+    def test_award_changelist_escapes_badge_title(self):
+        # Exercises the Award __str__ column and the badge_link callable, both of
+        # which embed the (attacker-controlled) badge title.
+        badge = BadgeFactory(title=XSS_TITLE)
+        AwardFactory(badge=badge)
+
+        resp = self.client.get(reverse("admin:kbadge_award_changelist"))
+
+        self.assertEqual(200, resp.status_code)
+        self.assertNotContains(resp, RAW_PAYLOAD)
+        self.assertContains(resp, ESCAPED_PAYLOAD)

--- a/kitsune/kbadge/tests/test_views.py
+++ b/kitsune/kbadge/tests/test_views.py
@@ -1,3 +1,5 @@
+from markupsafe import escape
+
 from kitsune.kbadge.tests import AwardFactory, BadgeFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.sumo.urlresolvers import reverse
@@ -31,3 +33,57 @@ class AwardDetailsTests(TestCase):
 
         resp = self.client.get(a1.get_absolute_url(), follow=True)
         self.assertEqual(200, resp.status_code)
+
+
+class BadgeFieldEscapingTests(TestCase):
+    XSS_TITLE = "<img src=x onerror=alert(1)>"
+    XSS_DESCRIPTION = "<img src=y onerror=alert(2)>"
+
+    def _assert_escaped(self, resp, payload):
+        self.assertEqual(200, resp.status_code)
+        # The raw payload must be absent (it would execute), and its escaped
+        # form present (confirming the value rendered, just safely).
+        self.assertNotContains(resp, payload)
+        self.assertContains(resp, escape(payload))
+
+    def test_badges_list_escapes_title(self):
+        BadgeFactory(title=self.XSS_TITLE)
+        resp = self.client.get(reverse("kbadge.badges_list"), follow=True)
+        self._assert_escaped(resp, self.XSS_TITLE)
+
+    def test_badge_detail_escapes_title(self):
+        badge = BadgeFactory(title=self.XSS_TITLE)
+        self._assert_escaped(
+            self.client.get(badge.get_absolute_url(), follow=True), self.XSS_TITLE
+        )
+
+    def test_awards_list_escapes_title(self):
+        AwardFactory(badge=BadgeFactory(title=self.XSS_TITLE))
+        resp = self.client.get(reverse("kbadge.awards_list"), follow=True)
+        self._assert_escaped(resp, self.XSS_TITLE)
+
+    def test_award_detail_escapes_title(self):
+        award = AwardFactory(badge=BadgeFactory(title=self.XSS_TITLE))
+        self._assert_escaped(
+            self.client.get(award.get_absolute_url(), follow=True), self.XSS_TITLE
+        )
+
+    def test_badge_detail_escapes_description(self):
+        badge = BadgeFactory(description=self.XSS_DESCRIPTION)
+        self._assert_escaped(
+            self.client.get(badge.get_absolute_url(), follow=True), self.XSS_DESCRIPTION
+        )
+
+    def test_award_detail_escapes_description(self):
+        award = AwardFactory(badge=BadgeFactory(description=self.XSS_DESCRIPTION))
+        self._assert_escaped(
+            self.client.get(award.get_absolute_url(), follow=True), self.XSS_DESCRIPTION
+        )
+
+    def test_title_escaped_in_attribute_context(self):
+        # The title also renders inside title="..." attributes, where a double
+        # quote would break out without any tag.
+        payload = '" onmouseover=alert(1) x="'
+        BadgeFactory(title=payload)
+        resp = self.client.get(reverse("kbadge.badges_list"), follow=True)
+        self._assert_escaped(resp, payload)


### PR DESCRIPTION
mozilla/sumo#3068

Addresses the vulnerability in the `description` field of badges as well.