### PR TITLE
Redirect the user to the profile page on edit profile cancel

### DIFF
--- a/kitsune/users/jinja2/users/edit_profile.html
+++ b/kitsune/users/jinja2/users/edit_profile.html
@@ -87,7 +87,7 @@
 
     <div class="sumo-button-wrap reverse-on-desktop">
       <button class="sumo-button primary-button" type="submit">{{ _('Update My Profile') }}</button>
-      <button class="sumo-button secondary-button push-right" type="reset">{{ _('Cancel') }}</button>
+      <a class="sumo-button secondary-button push-right" href="{{ url('users.profile', profile.user.username) }}">{{ _('Cancel') }}</a>
     </div>
   </form>
   {% if request.user == profile.user %}


### PR DESCRIPTION
Proposed fix: 
* Clicking on the "Cancel" button navigates away (back to the profile page) without submitting the form.

I used profile.user.username because profile (the user_profile) is the object in the template context, and this correctly handles an admin editing another user's profile