### PR TITLE
Playwright: Further expand playwright coverage to user admin pages

### DIFF
--- a/playwright_tests/core/basepage.py
+++ b/playwright_tests/core/basepage.py
@@ -115,9 +115,10 @@ class BasePage:
                 self.wait_for_dom_to_load()
                 self._recover_if_on_error_page()
                 if expected_locator:
-                    self._wait_for_locator(expected_locator, timeout=3000)
+                    self._wait_for_locator(expected_locator, timeout=3000, raise_exception=True)
                 if expected_locator_to_be_hidden:
-                    self._wait_for_locator_to_be_hidden(expected_locator_to_be_hidden)
+                    self._wait_for_locator_to_be_hidden(
+                        expected_locator_to_be_hidden, raise_exception=True)
                 if expected_url:
                     self.page.wait_for_url(expected_url, timeout=10000)
                 break

--- a/playwright_tests/core/utilities.py
+++ b/playwright_tests/core/utilities.py
@@ -509,6 +509,17 @@ class Utilities:
             Page: A new page belonging to the freshly created, isolated context.
         """
         browser = self.page.context.browser
+        # Record this context's video into the same artifacts directory that
+        # pytest-playwright uses for the default page. pytest-playwright only
+        # wires up `record_video_dir` for the contexts it creates itself, so we
+        # mirror it here for manually-created contexts. This lets the failure
+        # hook attach the screencast of every window, not just the default page.
+        if "record_video_dir" not in context_kwargs and self.page.video:
+            try:
+                context_kwargs["record_video_dir"] = os.path.dirname(self.page.video.path())
+            except PlaywrightError as error:
+                print(f"Could not derive the video directory for the new context: {error}")
+
         context = browser.new_context(
             user_agent=self.user_agent,
             extra_http_headers={
@@ -516,7 +527,33 @@ class Utilities:
             },
             **context_kwargs,
         )
-        return context.new_page()
+        new_page = context.new_page()
+        new_page.set_default_navigation_timeout(30000)
+
+        # Wire up the same 502 nav-status tracking the autouse `navigate_to_homepage`
+        # fixture sets up for the default page. Without this, `_last_main_nav_status`
+        # is never set on manually-created windows (e.g. the admin page), so
+        # `BasePage._recover_if_on_error_page` can't detect a 502 and never reloads,
+        # leaving the window stuck on the error page.
+        new_page._last_main_nav_status = None
+
+        def _track_main_nav_status(response):
+            try:
+                if (response.request.is_navigation_request()
+                        and response.frame == new_page.main_frame):
+                    new_page._last_main_nav_status = response.status
+            except PlaywrightError as e:
+                print(f"Nav-status listener ignored error: {e}")
+
+        new_page.on("response", _track_main_nav_status)
+
+        # Register the page so the failure hook (pytest_runtest_makereport) can
+        # attach the screencasts of all windows opened during the test.
+        if not hasattr(self.page, "_extra_pages"):
+            self.page._extra_pages = []
+        self.page._extra_pages.append(new_page)
+
+        return new_page
 
     def delete_cookies(self, tried_once=False, retries=3):
         """

--- a/playwright_tests/flows/auth_flows/auth_flow.py
+++ b/playwright_tests/flows/auth_flows/auth_flow.py
@@ -1,5 +1,6 @@
 from playwright.sync_api import Page, TimeoutError as PlaywrightTimeoutError
 from playwright_tests.core.utilities import Utilities
+from playwright_tests.messages.homepage_messages import HomepageMessages
 from playwright_tests.pages.auth_page import AuthPage
 from playwright_tests.pages.top_navbar import TopNavbar
 
@@ -52,6 +53,16 @@ class AuthFlowPage:
             """If the 'Continue with Firefox Accounts' button is displayed, click on it."""
             self.auth_page.click_on_continue_with_firefox_accounts_button()
         self.auth_page.click_on_user_logged_in_sign_in_button()
+        # Clicking "Sign in" kicks off the FxA -> /fxa/callback/?code=... -> SUMO redirect
+        # chain. Block until it lands back on the SUMO origin and off the callback page,
+        # otherwise callers race the redirect and assert against the still-loading callback
+        # page (e.g. the signed-in username hasn't rendered yet, so to_have_text times out).
+        base = HomepageMessages.STAGE_HOMEPAGE_URL
+        self.page.wait_for_url(
+            lambda url: url.startswith(base) and "/fxa/callback" not in url,
+            timeout=30000,
+        )
+        self.utilities.wait_for_dom_to_load()
 
     # Sign in flow.
     def sign_in_flow(self, username: str, account_password: str, via_top_navbar: bool = False,

--- a/playwright_tests/pages/admin_pages/users/admin_users_page.py
+++ b/playwright_tests/pages/admin_pages/users/admin_users_page.py
@@ -13,7 +13,10 @@ class AdminUserPage(BasePage):
         self.user = lambda username: page.locator(
             f"//th[@class='field-username']/a[text()='{username}']")
         self.active_checkbox = page.locator("//input[@id='id_is_active']")
+        self.superuser_checkbox = page.locator("//input[@id='id_is_superuser']")
         self.save_button = page.locator("//input[@value='Save']")
+        self.save_and_continue_editing_button = page.locator(
+            "//input[@value='Save and continue editing']")
 
     def click_on_users_page_option(self):
         self._click(self.users_page)
@@ -35,3 +38,6 @@ class AdminUserPage(BasePage):
 
     def click_on_save_changes_button(self):
         self._click(self.save_button)
+
+    def click_on_save_and_continue_editing_button(self):
+        self._click(self.save_and_continue_editing_button)

--- a/playwright_tests/pages/user_pages/my_profile_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_page.py
@@ -160,18 +160,30 @@ class MyProfilePage(BasePage):
         self._click(self.report_abuse_profile_option)
 
     def click_on_deactivate_this_user_button(self):
-        # The .deactivate form's submit handler calls window.confirm(...) — the
-        # dialog handler must be attached before the click, and it must call
-        # .accept() itself (otherwise confirm() blocks and the click hangs).
-        self.page.once("dialog", lambda dialog: dialog.accept())
-        self._click(self.deactivate_this_user_button)
+        # The .deactivate form's submit handler calls window.confirm(...), so a dialog
+        # handler that calls .accept() must be attached before the click (otherwise
+        # confirm() blocks and the click hangs). Use a persistent `on` listener rather
+        # than `once`: _click retries the click on failure, and a one-shot handler would
+        # be consumed by the first attempt, leaving retries to hit an auto-dismissed
+        # dialog. Remove it afterwards so it can't accept unrelated dialogs.
+        handler = lambda dialog: dialog.accept()  # noqa: E731
+        self.page.on("dialog", handler)
+        try:
+            self._click(self.deactivate_this_user_button,
+                        expected_locator=self.this_user_was_deactivated_message)
+        finally:
+            self.page.remove_listener("dialog", handler)
 
     def click_deactivate_this_user_and_mark_all_content_as_spam(self):
-        # The .deactivate form's submit handler calls window.confirm(...) — the
-        # dialog handler must be attached before the click, and it must call
-        # .accept() itself (otherwise confirm() blocks and the click hangs).
-        self.page.once("dialog", lambda dialog: dialog.accept())
-        self._click(self.deactivate_this_user_and_mark_all_content_as_spam)
+        # See click_on_deactivate_this_user_button for why a persistent dialog handler
+        # is attached and removed around the click.
+        handler = lambda dialog: dialog.accept()  # noqa: E731
+        self.page.on("dialog", handler)
+        try:
+            self._click(self.deactivate_this_user_and_mark_all_content_as_spam,
+                        expected_locator=self.this_user_was_deactivated_message)
+        finally:
+            self.page.remove_listener("dialog", handler)
 
     def click_on_spam_content_option(self):
         """Select the 'Spam or other unrelated content' report reason radio button."""

--- a/playwright_tests/tests/admin/users/test_users_admin_page.py
+++ b/playwright_tests/tests/admin/users/test_users_admin_page.py
@@ -11,6 +11,7 @@ from playwright_tests.pages.sumo_pages import SumoPages
 from playwright_tests.tests.user_page_tests.test_my_questions import _submit_firefox_question
 
 
+# C916054
 @pytest.mark.userAdminPages
 def test_users_can_be_deactivated(page:Page, restmail_test_account_creation,
                                   navigate_to_users_admin_page):
@@ -45,7 +46,6 @@ def test_users_can_be_deactivated(page:Page, restmail_test_account_creation,
     with check, allure.step("Verifying that the question was not deleted"):
         moderator_utilities.navigate_to_link(question_info["question_page_url"])
         expect(moderator_pages.question_page.question_author).to_have_text(username)
-        moderator_page.close()
 
     with check, allure.step("Verifying that the after a page refresh the deactivated user was "
                             "logged out"):
@@ -83,3 +83,122 @@ def test_users_can_be_deactivated(page:Page, restmail_test_account_creation,
         utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username))
         expect(sumo_pages.my_profile_page.this_user_was_deactivated_message).to_be_hidden()
 
+
+# C916055
+@pytest.mark.userAdminPages
+def test_deactivation_via_deactivate_and_mark_content_as_spam(page: Page,
+                                                              navigate_to_users_admin_page,
+                                                              restmail_test_account_creation):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    email, _, _ = restmail_test_account_creation()
+    username = utilities.username_extraction_from_email(email)
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+    admin_page = navigate_to_users_admin_page(username)
+    admin_pages = SumoPages(admin_page)
+    admin_utilities = Utilities(admin_page)
+    moderator_page = utilities.create_new_context_page()
+    moderator_utilities = Utilities(moderator_page)
+    moderator_pages = SumoPages(moderator_page)
+
+    with allure.step("Submitting a question against the AAQ forum with the simple user"):
+        question_info = _submit_firefox_question(utilities, sumo_pages)
+
+    with allure.step("Signing in with an admin user account"):
+        moderator_utilities.navigate_to_link(HomepageMessages.STAGE_HOMEPAGE_URL_EN_US)
+        moderator_utilities.start_existing_session(session_file_name=staff_user)
+
+    with allure.step("Navigating to the test user profile page"):
+        moderator_utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username))
+
+    with check, allure.step("Deactivating the user profile via deactivate this user and mark "
+                            "all content as spam button and verifying that the correct "
+                            "deactivation status is displayed."):
+        moderator_pages.my_profile_page.click_deactivate_this_user_and_mark_all_content_as_spam()
+        expect(moderator_pages.my_profile_page.this_user_was_deactivated_message).to_have_text(
+            MyProfileMessages.USER_DEACTIVATED_MESSAGE)
+
+    with allure.step("Verifying that the question was marked as spam"):
+        moderator_utilities.navigate_to_link(question_info["question_page_url"])
+        expect(moderator_pages.question_page.marked_as_spam_banner).to_be_visible()
+
+    with check, allure.step("Verifying that the after a page refresh the deactivated user was "
+                            "logged out"):
+        utilities.refresh_page()
+        expect(sumo_pages.top_navbar.signin_signup_button).to_be_visible()
+
+    with check, allure.step("Trying to manually sign in and verifying that the user is unable "
+                            "to and that the correct error message is displayed"):
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
+        sumo_pages.auth_flow_page.login_with_existing_session()
+        expect(sumo_pages.top_navbar.signin_signup_button).to_be_visible()
+        expect(sumo_pages.homepage.user_notification).to_have_text(
+            HomepageMessages.USER_DEACTIVATED_MESSAGE)
+
+    with check, allure.step("Verifying that the is active checkbox is unchecked in admin"):
+        admin_utilities.refresh_page()
+        expect(admin_pages.admin_users_page.active_checkbox).not_to_be_checked()
+
+    with allure.step("Checking the is active checkbox and saving the changes"):
+        admin_pages.admin_users_page.active_checkbox.check()
+        admin_pages.admin_users_page.click_on_save_changes_button()
+        admin_page.close()
+
+    with check, allure.step("Signing in with the test user and verify that the user successfully "
+                            "logs in"):
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
+        sumo_pages.top_navbar.click_on_signin_signup_button()
+        sumo_pages.auth_flow_page.login_with_existing_session()
+        expect(sumo_pages.top_navbar.signed_in_username).to_have_text(username)
+        expect(sumo_pages.homepage.user_notification).to_be_hidden()
+
+    with allure.step("Navigating to the test user profile page and verifying that the "
+                     "deactivation message is not displayed"):
+        utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(username))
+        expect(sumo_pages.my_profile_page.this_user_was_deactivated_message).to_be_hidden()
+
+    with allure.step("Verifying that the question is still marked as spam"):
+        moderator_utilities.refresh_page()
+        expect(moderator_pages.question_page.marked_as_spam_banner).to_be_visible()
+
+
+# C3293157
+@pytest.mark.userAdminPages
+def test_superusers_cannot_be_deactivated_via_ui(page: Page, navigate_to_users_admin_page,
+                                                 create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory()
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+    admin_page = navigate_to_users_admin_page(test_user["username"])
+    admin_pages = SumoPages(admin_page)
+
+    with allure.step("Making the newly created user a superuser"):
+        admin_pages.admin_users_page.superuser_checkbox.check()
+        admin_pages.admin_users_page.click_on_save_and_continue_editing_button()
+
+    with allure.step("Signing in with the staff user"):
+        utilities.start_existing_session(session_file_name=staff_user)
+
+    with allure.step("Navigating to the superuser profile page and verifying that the user cannot "
+                     "be deactivated via UI"):
+        utilities.navigate_to_link(MyProfileMessages.get_my_profile_stage_url(
+            test_user["username"]))
+        expect(sumo_pages.my_profile_page.deactivate_this_user_button).to_be_hidden()
+        expect(sumo_pages.my_profile_page.deactivate_this_user_and_mark_all_content_as_spam
+               ).to_be_hidden()
+
+    with allure.step("Stripping the user from having superuser permissions"):
+        admin_pages.admin_users_page.superuser_checkbox.uncheck()
+        admin_pages.admin_users_page.click_on_save_and_continue_editing_button()
+        admin_page.close()
+
+    with allure.step("Verifying that the user can be deactivated"):
+        utilities.refresh_page()
+        expect(sumo_pages.my_profile_page.deactivate_this_user_button).to_be_visible()
+        expect(sumo_pages.my_profile_page.deactivate_this_user_and_mark_all_content_as_spam
+               ).to_be_visible()
+        sumo_pages.my_profile_page.click_on_deactivate_this_user_button()
+        expect(sumo_pages.my_profile_page.this_user_was_deactivated_message).to_have_text(
+            MyProfileMessages.USER_DEACTIVATED_MESSAGE)

--- a/playwright_tests/tests/conftest.py
+++ b/playwright_tests/tests/conftest.py
@@ -56,15 +56,49 @@ def pytest_runtest_makereport(item, call) -> None:
         # Ensure the test has failed and involves Playwright automation.
         if report.failed and "page" in item.funcargs:
             page: Page = item.funcargs["page"]  # Retrieve the page object from the test args.
-            video_path = page.video.path()  # Retrieve the path to the recorded video.
-            page.context.close()  # Close the browser context to ensure the video is saved.
 
-            # Attaching the video to the Allure report:
-            allure.attach(
-                open(video_path, 'rb').read(),
-                name=f"{slugify(item.nodeid)}.webm",
-                attachment_type=allure.attachment_type.WEBM
-            )
+            # Gather the default page plus any extra windows opened during the
+            # test. Each extra window lives in its own browser context (created
+            # via Utilities.create_new_context_page) with its own video.
+            pages = [page] + list(getattr(page, "_extra_pages", []))
+
+            # Snapshot each window's video, then close its context so the video
+            # file is flushed to disk before we read it. A context shared by
+            # several pages is only closed once.
+            windows = []
+            closed_contexts = set()
+            for index, current_page in enumerate(pages):
+                try:
+                    video = current_page.video
+                except Exception as error:  # page may already be closed by the test
+                    print(f"Could not access video for window {index + 1}: {error}")
+                    video = None
+                windows.append(video)
+                try:
+                    context = current_page.context
+                    if id(context) not in closed_contexts:
+                        closed_contexts.add(id(context))
+                        context.close()  # Close to ensure the video is saved.
+                except Exception as error:
+                    print(f"Could not close context for window {index + 1}: {error}")
+
+            # Attach each window's screencast to the Allure report. For
+            # single-window tests the name is unchanged; multi-window tests get
+            # a per-window suffix so all screencasts are distinguishable.
+            multiple_windows = len([v for v in windows if v]) > 1
+            for index, video in enumerate(windows):
+                if not video:
+                    continue
+                try:
+                    video_path = video.path()
+                    suffix = f"-window-{index + 1}" if multiple_windows else ""
+                    allure.attach(
+                        open(video_path, 'rb').read(),
+                        name=f"{slugify(item.nodeid)}{suffix}.webm",
+                        attachment_type=allure.attachment_type.WEBM
+                    )
+                except Exception as error:
+                    print(f"Could not attach screencast for window {index + 1}: {error}")
 
 
 @pytest.fixture()


### PR DESCRIPTION
* Expand screencast on test failure to all opened browser contexts.
* Verify that users which were deactivated via the "Deactivate this user and mark all content as spam" are successfully logged out and are unable to log back in only after re-activation.
* Verify that superusers cannot be deactivated from the UI