### PR TITLE
Remove notification link spacing moved to Protocol

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_notifications.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_notifications.scss
@@ -34,7 +34,6 @@
   a:visited,
   a:active {
     color: inherit;
-    margin: 0;
   }
 
   @media #{p.$mq-sm} {


### PR DESCRIPTION
Cleans up https://github.com/mozilla/sumo/issues/1927#issuecomment-2541316672 now being set on the upstream component by default.

Superfluous since last Protocol upgrade.