### PR TITLE
avoid flakiness from Redis clashes in tests

### DIFF
--- a/kitsune/dashboards/tests/test_cron.py
+++ b/kitsune/dashboards/tests/test_cron.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 
 from django.conf import settings
+from django.test import tag
 
 from kitsune.dashboards.models import (
     L10N_ALL_CODE,
@@ -131,6 +132,7 @@ class TopUnhelpfulArticlesTests(TestCase):
         self.assertEqual(5, result[r.document.id]["total"])
 
 
+@tag("no_parallel")
 class TopUnhelpfulArticlesCommandTests(TestCase):
     def setUp(self):
         super().setUp()
@@ -144,7 +146,7 @@ class TopUnhelpfulArticlesCommandTests(TestCase):
     def tearDown(self):
         try:
             self.redis.flushdb()
-        except (KeyError, AttributeError):
+        except KeyError, AttributeError:
             raise SkipTest
         super().tearDown()
 

--- a/kitsune/wiki/tests/test_views.py
+++ b/kitsune/wiki/tests/test_views.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.contrib.sites.models import Site
-from django.test import Client
+from django.test import Client, tag
 from pyquery import PyQuery as pq
 
 from kitsune.products.tests import ProductFactory, TopicFactory
@@ -2070,6 +2070,7 @@ class VoteTests(TestCase):
         self.assertEqual(10, HelpfulVote.objects.count())
 
 
+@tag("no_parallel")
 class TestDocumentLocking(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
While reviewing #7623, I discovered the possibility of Redis clashes causing flakiness in some tests run by `run-unit-tests-no-es.sh`, so this PR marks those tests as `no-parallel`.