### PR TITLE
fix overlap of long email headers

### DIFF
--- a/kitsune/sumo/jinja2/email/base.html
+++ b/kitsune/sumo/jinja2/email/base.html
@@ -100,6 +100,7 @@
     h5,
     h6 {
       color: #333 !important;
+      line-height: 1.2;
     }
 
     h1 a,


### PR DESCRIPTION
mozilla/sumo#2999

After this fix:

<img width="1142" height="875" alt="image" src="https://github.com/user-attachments/assets/b9d0ae27-f901-4249-a9e0-6e692d542c3c" />
