### PR TITLE
wrap long usernames on rev history page

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_wiki.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_wiki.scss
@@ -386,7 +386,6 @@ article {
 
     .creator {
       width: 300px;
-      overflow: auto;
     }
 
     .comment {
@@ -400,6 +399,14 @@ article {
 
   .creator {
     color: #333;
+    // Long display names/usernames without spaces would otherwise expand this
+    // column and force the whole table to overflow horizontally, so allow them
+    // to wrap within the column. Keep room for a minimum number of characters
+    // too, otherwise on narrow screens the column collapses to the width of a
+    // single character.
+    min-width: 16ch;
+    overflow-wrap: break-word;
+    word-break: break-word;
   }
 
 


### PR DESCRIPTION
mozilla/sumo#3023

Before:

<img width="1389" height="831" alt="Screenshot 2026-06-23 at 11 44 10 AM" src="https://github.com/user-attachments/assets/2241c5fa-c64e-4016-87c1-e390db1c9630" />

After:

<img width="1322" height="808" alt="image" src="https://github.com/user-attachments/assets/bf078353-6e41-4075-87e1-765f8b713763" />
