### PR TITLE
eliminate extra whitespace below text in accouncements

### DIFF
--- a/kitsune/sumo/jinja2/base.html
+++ b/kitsune/sumo/jinja2/base.html
@@ -110,8 +110,8 @@
   {% call announcement_bar('geoip-suggestion', 'warning', close_memory="remember", close_type="remove") %}{% endcall %}
 
   {% for announ in get_announcements(request, product=announcement_product|default(None)) %}
-      {% call announcement_bar(announ.id, 'warning', close_memory="session") %}
-          {{ announ.content | wiki_to_html }}
+      {% call announcement_bar(announ.id, 'warning', close_memory="session", wrap_content=False) %}
+          {{ announ.content_parsed }}
       {% endcall %}
   {% endfor %}
   {% if settings.READ_ONLY %}

--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -884,8 +884,13 @@
   {% call announcement_bar('foo', 'info') %}
     This is the contents of the bar.
   {% endcall %}
+
+  Pass wrap_content=False when the caller already supplies block-level HTML
+  (e.g. paragraphs produced by wiki_to_html). Wrapping such content in a <p>
+  would nest block elements inside an inline paragraph, which browsers
+  recover from by inserting empty paragraphs (see mozilla/sumo#3065).
 #}
-{% macro announcement_bar(id, level, close_memory="", close_type="") -%}
+{% macro announcement_bar(id, level, close_memory="", close_type="", wrap_content=True) -%}
   {% set content = caller() %}
   {% if content %}
     <div id="announce-{{ id }}" class="mzp-c-notification-bar mzp-t-{{ level }}"
@@ -894,7 +899,7 @@
         {% if close_memory %}data-close-memory="{{ close_memory }}" {% endif %}
         {% if close_type %}data-close-type="{{ close_type }}" {% endif %}>
       </button>
-      <p>{{ content }}</p>
+      {% if wrap_content %}<p>{{ content }}</p>{% else %}{{ content }}{% endif %}
     </div>
   {% endif %}
 {% endmacro %}

--- a/kitsune/sumo/static/sumo/scss/components/_notifications.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_notifications.scss
@@ -61,6 +61,13 @@
   }
 }
 
+// Announcement bars hug their content. The shared 46px min-height leaves a
+// single line looking bottom-heavy (multi-line bars already exceed it). Scoped
+// to #announcements so other notification bars keep their minimum height.
+#announcements .mzp-c-notification-bar {
+  min-height: 0;
+}
+
 #announce-geoip-suggestion {
   display: none;
 

--- a/kitsune/sumo/tests/test_templates.py
+++ b/kitsune/sumo/tests/test_templates.py
@@ -5,6 +5,7 @@ from django.test.client import RequestFactory
 from django.utils import translation
 from pyquery import PyQuery as pq
 
+from kitsune.announcements.tests import AnnouncementFactory
 from kitsune.sumo.tests import TestCase
 from kitsune.users.tests import UserFactory
 
@@ -72,6 +73,21 @@ class BaseTemplateTests(MockRequestTests):
         html = render_to_string(self.template, request=self.request)
         doc = pq(html)
         self.assertEqual("false", doc("body")[0].attrib["data-readonly"])
+
+    def test_announcement_bar_no_empty_paragraphs(self):
+        """
+        Announcement content is already block-level HTML, so it must not be
+        re-wrapped in a <p>, and check that trailing blank lines in the source
+        are stripped.
+        """
+        self.request.user = UserFactory()
+        # Two real paragraphs plus a trailing blank line, exercising both the
+        # double-wrap and the trailing-empty-paragraph failure modes.
+        announcement = AnnouncementFactory(content="First line.\n\nSecond line.\n\n")
+        html = render_to_string(self.template, request=self.request)
+        paragraphs = pq(html)("#announce-{} p".format(announcement.id))
+        # Exactly the two authored paragraphs (no extra empty ones).
+        self.assertEqual(2, len(paragraphs))
 
     @override_settings(READ_ONLY=True)
     def test_readonly_login_link_disabled(self):


### PR DESCRIPTION
mozilla/sumo#3065

<img width="1383" height="408" alt="image" src="https://github.com/user-attachments/assets/93fd082b-2330-4aff-981a-3e8174239040" />
