### PR TITLE
Playwright: Further expand media gallery test coverage

### DIFF
--- a/playwright_tests/core/utilities.py
+++ b/playwright_tests/core/utilities.py
@@ -1,28 +1,31 @@
-import os
-from urllib.error import HTTPError
-import requests
-import time
-import re
+import io
 import json
-import random
-import uuid
 import mimetypes
-from PIL import Image
-from PIL import ImageChops
-from typing import Any, Union
+import os
+import random
+import re
+import time
+import uuid
 from datetime import datetime
+from typing import Any, Union
+from urllib.error import HTTPError
+
+import requests
 from dateutil import parser
 from dateutil.tz import tz
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
 from nltk import SnowballStemmer, WordNetLemmatizer
-from playwright.sync_api import Page, Locator, Response, expect
+from PIL import Image, ImageChops
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Locator, Page, Response, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
 from playwright_tests.messages.auth_pages_messages.fxa_page_messages import FxAPageMessages
 from playwright_tests.messages.homepage_messages import HomepageMessages
 from playwright_tests.pages.top_navbar import TopNavbar
 from playwright_tests.test_data.search_synonym import SearchSynonyms
-from playwright.sync_api import TimeoutError as PlaywrightTimeoutError, Error as PlaywrightError
-from google.oauth2.credentials import Credentials
-from googleapiclient.discovery import build
-from google.auth.transport.requests import Request
 
 
 class Utilities:
@@ -407,19 +410,55 @@ class Utilities:
                 response = None
         return response
 
-    def upload_file(self, element: Locator, path_to_file: str, unique_name: bool = False):
+    def generate_in_memory_image(self, min_size_bytes: int = 0,
+                                 dimensions: tuple[int, int] = (50, 50)) -> bytes:
+        """Generate the bytes of a valid PNG image entirely in memory (no file on disk).
+
+        Used by upload tests so we don't have to commit fixed-size test images to the repo. The
+        returned bytes can be handed straight to ``upload_file`` via its ``file_buffer`` argument.
+
+        Args:
+            min_size_bytes (int): If the generated PNG is smaller than this, it is padded with
+                trailing null bytes until it reaches the requested size. Padding is appended after
+                the PNG's IEND marker, so the result is still a decodable image while letting us
+                exceed limits such as ``IMAGE_MAX_FILESIZE`` (10MB) for negative tests.
+            dimensions (tuple[int, int]): The (width, height) of the generated image.
+        """
+        buffer = io.BytesIO()
+        Image.new("RGB", dimensions, color=(120, 80, 200)).save(buffer, format="PNG")
+        image_bytes = buffer.getvalue()
+        if len(image_bytes) < min_size_bytes:
+            image_bytes += b"\x00" * (min_size_bytes - len(image_bytes))
+        return image_bytes
+
+    def upload_file(self, element: Locator, path_to_file: str = None,
+                    unique_name: bool = False, file_buffer: bytes = None,
+                    file_name: str = None):
         """This helper function uploads a file to a given file element chooser.
 
         Args:
             element (str): The element file chooser locator's xpath.
-            path_to_file (str): The path to the file to be uploaded.
+            path_to_file (str): The path to the file to be uploaded. Ignored when
+                ``file_buffer`` is provided.
             unique_name (bool): If True the file is uploaded under a randomized, unique filename
                 (preserving its extension) instead of its on-disk name. This avoids server-side
                 filename collisions when the same file is uploaded by tests running in parallel.
+            file_buffer (bytes): In-memory file contents to upload. When provided, no file is read
+                from disk; the bytes are uploaded directly under ``file_name``.
+            file_name (str): The filename to present to the page when uploading ``file_buffer``.
+                Defaults to a randomized ``.png`` name.
         """
         with self.page.expect_file_chooser() as file_chooser:
             element.click()
         file_chooser_value = file_chooser.value
+        if file_buffer is not None:
+            name = file_name or f"in-memory-{uuid.uuid4().hex}.png"
+            file_chooser_value.set_files(files={
+                "name": name,
+                "mimeType": mimetypes.guess_type(name)[0] or "image/png",
+                "buffer": file_buffer,
+            })
+            return
         absolute_path = os.path.abspath(path_to_file)
         if unique_name:
             root, extension = os.path.splitext(os.path.basename(absolute_path))

--- a/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_media_flow.py
+++ b/playwright_tests/flows/explore_articles_flows/article_flows/add_kb_media_flow.py
@@ -1,6 +1,4 @@
-import os
-
-from playwright.sync_api import Page, Locator
+from playwright.sync_api import Page
 
 from playwright_tests.core.utilities import Utilities
 from playwright_tests.pages.contribute.contributor_tools_pages.media_gallery import MediaGallery
@@ -17,28 +15,44 @@ class AddKbMediaFlow:
         self.media_gallery_page.click_on_insert_media_button()
 
     def add_new_media_file_to_gallery(self, title: str, description:str, locale=None,
-                                      path_to_file=None, submit=True):
+                                      path_to_file=None, submit=True, image_bytes=None,
+                                      file_name=None):
         """
         Add a new media file to the Media Gallery.
+
+        By default the uploaded image is generated in memory, so no image fixture needs to be
+        committed to the project. Pass ``path_to_file`` to upload a specific on-disk image instead
+        (e.g. when a test depends on the actual image content).
         Args:
-            path_to_file (str): The path to the media item which is to be uploaded.
             title (str): The title given to the uploaded media item.
             description (str): The description given to the uploaded media item.
-            locale (str): The locale under which the media item is to be uploaded
-                          (defaults to en-US)
+            locale (str): The locale to select in the upload modal's locale dropdown. When omitted
+                          the image is uploaded under the gallery page's current locale.
+            path_to_file (str): Optional path to an on-disk image to upload instead of an in-memory
+                                generated one.
             submit (bool): If True the 'Upload' button from the Upload modal is clicked. If False
                            the 'Cancel' button from the Upload modal is clicked.
+            image_bytes (bytes): Optional in-memory image contents to upload (e.g. to control the
+                                 file size). Ignored when ``path_to_file`` is provided.
+            file_name (str): Optional filename to present when uploading in-memory bytes.
         """
         self.media_gallery_page.click_on_upload_a_new_media_file_button()
-        # Upload under a unique filename so parallel runs uploading the same test image don't
-        # collide on the server-generated storage path (RenameFileStorage derives the name from
-        # the upload's filename + a second-precision timestamp), which can otherwise wipe out a
-        # sibling upload's file and 500 the finalize step.
-        self.utilities.upload_file(
-            self.media_gallery_page.upload_modal_browse_button,
-            path_to_file or os.path.abspath("test_data/test-image.png"),
-            unique_name=True
-        )
+        if path_to_file is not None:
+            # Upload a specific on-disk file under a unique filename so parallel runs uploading the
+            # same image don't collide on the server-generated storage path (RenameFileStorage
+            # derives the name from the upload's filename + a second-precision timestamp), which
+            # can otherwise wipe out a sibling upload's file and 500 the finalize step.
+            self.utilities.upload_file(
+                self.media_gallery_page.upload_modal_browse_button, path_to_file, unique_name=True)
+        else:
+            # No fixture needed: generate the image in memory. upload_file falls back to a unique,
+            # uuid-based filename when none is given, which likewise avoids the storage-path
+            # collisions described above.
+            self.utilities.upload_file(
+                self.media_gallery_page.upload_modal_browse_button,
+                file_buffer=image_bytes if image_bytes is not None
+                else self.utilities.generate_in_memory_image(),
+                file_name=file_name)
 
         self.media_gallery_page.wait_for_image_preview()
         if locale:

--- a/playwright_tests/pages/contribute/contributor_tools_pages/media_gallery.py
+++ b/playwright_tests/pages/contribute/contributor_tools_pages/media_gallery.py
@@ -24,6 +24,7 @@ class MediaGallery(BasePage):
         self.upload_modal_upload_button = page.locator("//input[@value='Upload']")
         self.cancel_image_upload_during_upload_progress_button = page.locator(
             "//div[@class='field progress file off']//a[text()='Cancel']")
+        self.upload_modal_file_details = page.locator("div.upload-media.file div.details")
 
         """Locators belonging to the Edit Media description page."""
         self.edit_image_description_textarea = page.locator("//textarea[@id='id_description']")
@@ -44,7 +45,7 @@ class MediaGallery(BasePage):
         self.search_gallery_search_button_modal = page.locator("form#gallery-modal-search button")
         self.cancel_media_insert_button = page.locator("a[href='#cancel']")
         self.upload_media_button = page.locator("//form[@id='gallery-upload-image']//"
-                                                "input[@value='Upload']")
+                                                "input[@name='upload']")
         self.insert_media_button = page.get_by_role("button", name="Insert Media", exact=True)
         self.linked_in_document = lambda document_name: page.locator(
             "div[class='documents'] li").get_by_role("link", name=document_name, exact=True)

--- a/playwright_tests/tests/contribute_tests/test_media_gallery.py
+++ b/playwright_tests/tests/contribute_tests/test_media_gallery.py
@@ -156,6 +156,152 @@ def test_media_gallery_pagination(page: Page, create_user_factory):
         expect(sumo_pages.media_gallery.media_file(media_title)).to_be_visible()
 
 
+# The server-side limit (settings.IMAGE_MAX_FILESIZE) and the client-side check in gallery.js.
+IMAGE_MAX_FILESIZE = 10485760  # 10MB, in bytes
+IMAGE_TOO_LARGE_MESSAGE = "Image too large. Please select a smaller image file."
+
+
+# C1811690
+@pytest.mark.mediaGalleryTests
+def test_image_under_size_limit_can_be_uploaded(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(groups=["forum-contributors"])
+    media_title = utilities.generate_unique_title()
+    media_description = f"Automation test description{utilities.generate_random_number(1, 1000)}"
+
+    with allure.step("Signing in with a contributor account and navigating to the media gallery"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.top_navbar.click_on_media_gallery_option()
+
+    with allure.step("Generating a small (well under 10MB) in-memory image and uploading it to "
+                     "the media gallery"):
+        small_image = utilities.generate_in_memory_image()
+        assert len(small_image) < IMAGE_MAX_FILESIZE
+        sumo_pages.add_kb_media_flow.add_new_media_file_to_gallery(
+            title=media_title, description=media_description, image_bytes=small_image)
+
+    with check, allure.step("Verifying that the upload succeeded and landed on the image preview "
+                            "page for the newly uploaded image"):
+        expect(sumo_pages.media_gallery.image_heading).to_have_text(media_title)
+
+    with check, allure.step("Searching for the uploaded image in the gallery and verifying that "
+                            "it is listed"):
+        sumo_pages.top_navbar.click_on_media_gallery_option()
+        sumo_pages.media_gallery.fill_search_media_gallery_searchbox_input_field(media_title)
+        sumo_pages.media_gallery.click_on_media_gallery_searchbox_search_button()
+        expect(sumo_pages.media_gallery.media_file(media_title)).to_be_visible()
+
+
+# C1811691
+@pytest.mark.mediaGalleryTests
+def test_image_over_size_limit_cannot_be_uploaded(page: Page, create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(groups=["forum-contributors"])
+    media_title = utilities.generate_unique_title()
+
+    with allure.step("Signing in with a contributor account and navigating to the media gallery"):
+        utilities.start_existing_session(cookies=test_user)
+        sumo_pages.top_navbar.click_on_media_gallery_option()
+
+    with allure.step("Opening the 'Upload a New Media File' panel and selecting an in-memory "
+                     "image that exceeds the 10MB limit"):
+        oversized_image = utilities.generate_in_memory_image(
+            min_size_bytes=IMAGE_MAX_FILESIZE + 1024)
+        assert len(oversized_image) > IMAGE_MAX_FILESIZE
+        sumo_pages.media_gallery.click_on_upload_a_new_media_file_button()
+        utilities.upload_file(
+            sumo_pages.media_gallery.upload_modal_browse_button,
+            file_buffer=oversized_image,
+            file_name=f"{media_title}.png")
+
+    with check, allure.step("Verifying that the 'Image too large' error message is displayed and "
+                            "that no image preview is rendered"):
+        expect(sumo_pages.media_gallery.upload_modal_file_details).to_contain_text(
+            IMAGE_TOO_LARGE_MESSAGE)
+        expect(sumo_pages.media_gallery.upload_modal_image_preview).to_be_hidden()
+
+
+# C2266244
+@pytest.mark.mediaGalleryTests
+@pytest.mark.parametrize("upload_origin", ["en-US", "de"])
+def test_image_is_only_displayed_in_the_locale_it_was_uploaded_in(
+        page: Page, create_user_factory, upload_origin):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(groups=["forum-contributors"])
+    media_title = utilities.generate_unique_title()
+    media_description = f"Automation test description{utilities.generate_random_number(1, 1000)}"
+    en_us_gallery = utilities.different_endpoints["media_gallery"]
+    de_gallery = en_us_gallery.replace("/en-US/", "/de/")
+
+    with allure.step("Signing in with a contributor account"):
+        utilities.start_existing_session(cookies=test_user)
+
+    if upload_origin == "en-US":
+        with allure.step("From the en-US media gallery, uploading an image and assigning it the "
+                         "German (de) locale via the upload modal's locale dropdown"):
+            utilities.navigate_to_link(en_us_gallery)
+            sumo_pages.add_kb_media_flow.add_new_media_file_to_gallery(
+                title=media_title, description=media_description, locale="de")
+    else:
+        with allure.step("Uploading an image directly from the German (de) media gallery, which "
+                         "defaults the image locale to German"):
+            utilities.navigate_to_link(de_gallery)
+            sumo_pages.add_kb_media_flow.add_new_media_file_to_gallery(
+                title=media_title, description=media_description)
+
+    with check, allure.step("Searching the German media gallery and verifying that the image is "
+                            "displayed there"):
+        utilities.navigate_to_link(de_gallery)
+        sumo_pages.media_gallery.fill_search_media_gallery_searchbox_input_field(media_title)
+        sumo_pages.media_gallery.click_on_media_gallery_searchbox_search_button()
+        expect(sumo_pages.media_gallery.media_file(media_title)).to_be_visible()
+
+    with check, allure.step("Searching the en-US media gallery and verifying that the image is "
+                            "not displayed there"):
+        utilities.navigate_to_link(en_us_gallery)
+        sumo_pages.media_gallery.fill_search_media_gallery_searchbox_input_field(media_title)
+        sumo_pages.media_gallery.click_on_media_gallery_searchbox_search_button()
+        expect(sumo_pages.media_gallery.media_file(media_title)).to_be_hidden()
+
+
+# C2266244
+@pytest.mark.mediaGalleryTests
+def test_en_us_image_is_not_displayed_in_a_non_en_us_locale_gallery(page: Page,
+                                                                    create_user_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    test_user = create_user_factory(groups=["forum-contributors"])
+    media_title = utilities.generate_unique_title()
+    media_description = f"Automation test description{utilities.generate_random_number(1, 1000)}"
+    en_us_gallery = utilities.different_endpoints["media_gallery"]
+    de_gallery = en_us_gallery.replace("/en-US/", "/de/")
+
+    with allure.step("Signing in with a contributor account and uploading an image from the "
+                     "en-US media gallery (the image defaults to the en-US locale)"):
+        utilities.start_existing_session(cookies=test_user)
+        utilities.navigate_to_link(en_us_gallery)
+        sumo_pages.add_kb_media_flow.add_new_media_file_to_gallery(
+            title=media_title, description=media_description)
+
+    with check, allure.step("Searching the en-US media gallery and verifying that the image is "
+                            "displayed there"):
+        utilities.navigate_to_link(en_us_gallery)
+        sumo_pages.media_gallery.fill_search_media_gallery_searchbox_input_field(media_title)
+        sumo_pages.media_gallery.click_on_media_gallery_searchbox_search_button()
+        expect(sumo_pages.media_gallery.media_file(media_title)).to_be_visible()
+
+    with check, allure.step("Searching the German (non en-US) media gallery and verifying that "
+                            "the image is not displayed there"):
+        utilities.navigate_to_link(de_gallery)
+        sumo_pages.media_gallery.fill_search_media_gallery_searchbox_input_field(media_title)
+        sumo_pages.media_gallery.click_on_media_gallery_searchbox_search_button()
+        expect(sumo_pages.media_gallery.media_file(media_title)).to_be_hidden()
+
+
+# C2663905
 @pytest.mark.mediaGalleryTests
 @pytest.mark.parametrize("user", ["forum_contributor", "non_contributor", None])
 def test_contributor_tools_side_navbar(page: Page, create_user_factory, user):
@@ -163,9 +309,6 @@ def test_contributor_tools_side_navbar(page: Page, create_user_factory, user):
     sumo_pages = SumoPages(page)
     common_web_elements = sumo_pages.common_web_elements
     media_gallery_url = utilities.different_endpoints["media_gallery"]
-    # All 'Contributor tools' side navbar options available to a signed-in non-moderator. The
-    # last three are revealed by the 'Show More' toggle. ('Moderate forum content' is excluded
-    # since it requires moderation permissions.)
     contributor_tools = ["Knowledge base dashboards", "Guides", "Templates", "Media gallery",
                          "Recent revisions", "Community hub", "Locales", "Locale metrics",
                          "Aggregated metrics"]
@@ -203,16 +346,12 @@ def test_contributor_tools_side_navbar(page: Page, create_user_factory, user):
             expect(common_web_elements.contributor_tools_side_navbar_option(option)
                    ).to_be_visible()
 
-    # The side navbar options are identical for every signed-in user, so we only verify the
-    # redirects once, using the forum contributor account.
     if user == "forum_contributor":
         for option in contributor_tools:
             with check, allure.step(f"Clicking on the '{option}' option and verifying that it "
                                     f"successfully navigates to its page (status < 400)"):
                 utilities.navigate_to_link(media_gallery_url)
                 common_web_elements.click_on_contributor_tools_side_navbar_show_more_button()
-                # click_and_wait_for_navigation reloads the destination on a 502 and returns the
-                # final response, so transient gateway errors are retried instead of failing.
                 response = utilities.click_and_wait_for_navigation(
                     lambda: common_web_elements
                     .click_on_a_contributor_tools_side_navbar_option(option))


### PR DESCRIPTION
- Implement in memory image generation for media gallery tests.
- Expand test coverage to cover both image size upload limits & the restricted visibility of locale-specific gallery media uploads.