### PR TITLE
Fix handling plurals for l10n of "{n} subgroups"

### DIFF
--- a/kitsune/groups/jinja2/groups/list.html
+++ b/kitsune/groups/jinja2/groups/list.html
@@ -26,7 +26,7 @@
 
           <a href="{{ profile.get_absolute_url() }}">{{ profile.group.name }}</a>
           {% if profile.visible_numchild > 0 %}
-            <span class="muted">({{ profile.visible_numchild }} {% if profile.visible_numchild == 1 %}{{ _('subgroup') }}{% else %}{{ _('subgroups') }}{% endif %})</span>
+            <span class="muted">({{ ngettext("{n} subgroup", "{n} subgroups", profile.visible_numchild)|f(n=profile.visible_numchild) }})</span>
           {% endif %}
         </li>
       {% endfor %}


### PR DESCRIPTION
Resolves https://github.com/mozilla/sumo/issues/3172.