### PR TITLE
Improve the unreviewed machine translation warning

### DIFF
--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -79,8 +79,15 @@
       <div id="doc-unreviewed-machine-translation" class="mzp-c-notification-bar mzp-t-warning">
         <button class="mzp-c-notification-bar-button" type="button"></button>
         <div id="unreviewed-machine-translation-warning">
-          {% trans edit_link=url('wiki.edit_document', document.slug, locale=document.locale) %}
-            This is a machine-generated translation of the English content. It has not been
+          {% set deprecated_mt_warning %}
+            {% trans edit_link=url('wiki.edit_document', document.slug, locale=document.locale) %}
+              This is a machine-generated translation of the English content. It has not been
+              reviewed by a human, and may contain errors. If you would like to revise this
+              content, you can start <a href="{{ edit_link }}">here</a>.
+            {% endtrans %}
+          {% endset %}
+          {% trans original_link=document.parent.get_absolute_url(), edit_link=url('wiki.edit_document', document.slug, locale=document.locale) %}
+            This is a machine-generated translation of the <a href="{{ original_link }}">English article</a>. It has not been
             reviewed by a human, and may contain errors. If you would like to revise this
             content, you can start <a href="{{ edit_link }}">here</a>.
           {% endtrans %}


### PR DESCRIPTION
Resolves https://github.com/mozilla/sumo/issues/2980.

Add a link to the original article and replace "English content" with "English article".