### PR TITLE
Enable l10n for contributor forums & L10n fixes

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -1,12 +1,9 @@
 [extractors]
 jinja2_custom = kitsune.lib.babel:extract_jinja 
 
-[ignore: kitsune/forums/**.py]
-[ignore: kitsune/forums/**.html]
 [ignore: kitsune/**/tests/**.py]
 [ignore: kitsune/**/management/**.py]
 [ignore: kitsune/**/templates/admin/**]
-[ignore: kitsune/forums/**.lhtml]
 [python: kitsune/**.py]
 [jinja2_custom: kitsune/**/templates/**.html]
 [jinja2_custom: kitsune/**/jinja2/**.html]

--- a/kitsune/forums/jinja2/forums/confirm_post_delete.html
+++ b/kitsune/forums/jinja2/forums/confirm_post_delete.html
@@ -1,10 +1,10 @@
 {% extends "forums/base.html" %}
 {# L10n: {t} is the title of the thread. {f} if the name of the forum. #}
-{% set title = _('Delete Post | {t} | {f} | Forums')|f(t=thread.title, f=forum.name) %}
-{% set crumbs = [(url('forums.forums'), _('Forums')),
+{% set title = _('Delete a post | {t} | {f} | Contributor Discussions')|f(t=thread.title, f=forum.name) %}
+{% set crumbs = [(url('forums.forums'), _('Contributor Discussions')),
                 (url('forums.threads', forum.slug), forum.name),
                 (url('forums.posts', forum.slug, thread.id), thread.title),
-                (None, _('Delete Post'))] %}
+                (None, _('Delete a post'))] %}
 {% set ga_content_group = "contributor-forum-post-delete" %}
 
 {% block content %}

--- a/kitsune/forums/jinja2/forums/confirm_thread_delete.html
+++ b/kitsune/forums/jinja2/forums/confirm_thread_delete.html
@@ -1,10 +1,10 @@
 {% extends "forums/base.html" %}
 {# L10n: {t} is the title of the thread. {f} if the name of the forum. #}
-{% set title = _('Delete Thread | {t} | {f} | Forums')|f(t=thread.title, f=forum.name) %}
-{% set crumbs = [(url('forums.forums'), _('Forums')),
+{% set title = _('Delete thread "{t}" | {f} | Contributor Discussions')|f(t=thread.title, f=forum.name) %}
+{% set crumbs = [(url('forums.forums'), _('Contributor Discussions')),
                 (url('forums.threads', forum.slug), forum.name),
                 (url('forums.posts', forum.slug, thread.id), thread.title),
-                (None, _('Delete Thread'))] %}
+                (None, _('Delete thread'))] %}
 {% set ga_content_group = "contributor-forum-thread-delete" %}
 
 {% block content %}

--- a/kitsune/forums/jinja2/forums/edit_post.html
+++ b/kitsune/forums/jinja2/forums/edit_post.html
@@ -2,8 +2,8 @@
 {% from "layout/errorlist.html" import errorlist %}
 {% from "includes/common_macros.html" import content_editor with context %}
 {# L10n: {f} if the name of the forum, {t} if the name of the thread. #}
-{% set title = _('Edit a post | {t} | {f} | Forums')|f(t=thread.title,f=forum.name) %}
-{% set crumbs = [(url('forums.forums'), _('Forums')),
+{% set title = _('Edit a post | {t} | {f} | Contributor Discussions')|f(t=thread.title,f=forum.name) %}
+{% set crumbs = [(url('forums.forums'), _('Contributor Discussions')),
 (url('forums.threads', forum.slug), forum.name),
 (url('forums.posts', forum.slug, thread.id), thread.title),
 (None, _('Edit a post'))] %}

--- a/kitsune/forums/jinja2/forums/edit_thread.html
+++ b/kitsune/forums/jinja2/forums/edit_thread.html
@@ -1,8 +1,8 @@
 {% extends "forums/base.html" %}
 {% from "layout/errorlist.html" import errorlist %}
 {# L10n: {f} is the name of the forum, {t} is the name of the thread. #}
-{% set title = _('Edit thread "{t}" | {f} | Forums')|f(t=thread.title, f=forum.name) %}
-{% set crumbs = [(url('forums.forums'), _('Forums')),
+{% set title = _('Edit thread "{t}" | {f} | Contributor Discussions')|f(t=thread.title, f=forum.name) %}
+{% set crumbs = [(url('forums.forums'), _('Contributor Discussions')),
 (url('forums.threads', forum.slug), forum.name),
 (url('forums.posts', forum.slug, thread.id), thread.title),
 (None, _('Edit thread'))] %}

--- a/kitsune/forums/jinja2/forums/forums.html
+++ b/kitsune/forums/jinja2/forums/forums.html
@@ -16,8 +16,11 @@
       <table>
         <thead>
           <tr class="forums-columns">
+            {# L10n: This is a header for a column, displayed when viewing the list of contributor forums on https://support.mozilla.org/forums/, which contains forum names. #}
             <th class="name">{{ _('Name') }}</th>
+            {# L10n: This is a header for a column, displayed when viewing the list of contributor forums on https://support.mozilla.org/forums/, which contains a number of threads for each forum. #}
             <th class="threads">{{ _('Threads') }}</th>
+            {# L10n: This is a header for a column, displayed when viewing contributor forums (such as https://support.mozilla.org/forums/contributors/), which contains info about the last post for each thread (date and author). #}
             <th class="last-post">{{ _('Last Post') }}</th>
           </tr>
         </thead>

--- a/kitsune/forums/jinja2/forums/includes/forum_macros.html
+++ b/kitsune/forums/jinja2/forums/includes/forum_macros.html
@@ -8,12 +8,18 @@
 <tr>
   <td class="type">
     {% if thread.is_locked %}
-    <img src="{{ webpack_static('protocol/img/icons/lockbox.svg') }}" alt="{{ pgettext('thread_type', 'Locked') }}"
-      title="{{ pgettext('thread_type', 'Locked') }}" />
+    <img src="{{ webpack_static('protocol/img/icons/lockbox.svg') }}"
+         {# L10n: This is a contributor forum thread status. #}
+         alt="{{ pgettext('thread_type', 'Locked') }}"
+         {# L10n: This is a contributor forum thread status. #}
+         title="{{ pgettext('thread_type', 'Locked') }}" />
     {% endif %}
     {% if thread.is_sticky %}
-    <img src="{{ webpack_static('protocol/img/icons/pin.svg') }}" alt="{{ pgettext('thread_type', 'Sticky') }}"
-      title="{{ pgettext('thread_type', 'Sticky') }}" />
+    <img src="{{ webpack_static('protocol/img/icons/pin.svg') }}"
+         {# L10n: This is a contributor forum thread status. #}
+         alt="{{ pgettext('thread_type', 'Sticky') }}"
+         {# L10n: This is a contributor forum thread status. #}
+         title="{{ pgettext('thread_type', 'Sticky') }}" />
     {% endif %}
   </td>
   <td class="title"><a

--- a/kitsune/forums/jinja2/forums/new_thread.html
+++ b/kitsune/forums/jinja2/forums/new_thread.html
@@ -2,8 +2,8 @@
 {% from "layout/errorlist.html" import errorlist %}
 {% from "includes/common_macros.html" import content_editor with context %}
 {# L10n: {f} if the name of the forum. #}
-{% set title = _('Create a new thread | {f} | Forums')|f(f=forum.name) %}
-{% set crumbs = [(url('forums.forums'), _('Forums')),
+{% set title = _('Create a new thread | {f} | Contributor Discussions')|f(f=forum.name) %}
+{% set crumbs = [(url('forums.forums'), _('Contributor Discussions')),
 (url('forums.threads', forum.slug), forum.name),
 (None, _('Create a new thread'))] %}
 {% set scripts = ('forums',) %}

--- a/kitsune/forums/jinja2/forums/posts.html
+++ b/kitsune/forums/jinja2/forums/posts.html
@@ -3,7 +3,7 @@
 {% from "includes/common_macros.html" import content_editor with context %}
 {% from "includes/common_macros.html" import for_contributors_sidebar %}
 {# L10n: {t} is the title of the thread. {f} is the name of the forum. #}
-{% set title = _('{t} | {f} | Forums')|f(t=thread.title, f=forum.name) %}
+{% set title = _('{t} | {f} | Contributor Discussions')|f(t=thread.title, f=forum.name) %}
 {% set crumbs = [(url('forums.forums'), _('Contributor Discussions')),
 (url('forums.threads', forum.slug), forum.name),
 (None, thread.title)] %}
@@ -21,10 +21,12 @@
     <h1 class="sumo-page-heading">{{ thread.title }}</h1>
 
     <ul class="topic-article--meta-list" id="thread-meta">
-      {% if count %}<li>{{ ngettext('{0} Reply', '{0} Replies', (count - 1))|f(count - 1) }}</li>{% endif %}
+      {% if count %}<li>{{ ngettext('1 reply', '{n} replies', (count - 1))|f(n=count - 1) }}</li>{% endif %}
       {% if last_post %}<li>{{ _('Last reply by') }} {{ display_name(last_post.author) }}</li>{% endif %}
-      {% if thread.is_sticky %}<li>{{ _('Sticky') }}</li>{% endif %}
-      {% if thread.is_locked %}<li>{{ _('Locked') }}</li>{% endif %}
+      {# L10n: This is a contributor forum thread status. #}
+      {% if thread.is_sticky %}<li>{{ pgettext('thread_type', 'Sticky') }}</li>{% endif %}
+      {# L10n: This is a contributor forum thread status. #}
+      {% if thread.is_locked %}<li>{{ pgettext('thread_type', 'Locked') }}</li>{% endif %}
     </ul>
     {% if user.is_authenticated %}
       <form action="{{ url('forums.watch_thread', forum_slug=forum.slug, thread_id=thread.id) }}" method="post">
@@ -96,7 +98,7 @@
   <ul id="thread-actions" class="sidebar-nav">
     {% if not thread.is_locked and
       (user == thread.creator or has_perm(user, 'forums.edit_forum_thread', forum)) %}
-      <li><a href="{{ url('forums.edit_thread', forum.slug, thread.id) }}">{{ _('Edit Thread Title') }}</a></li>
+      <li><a href="{{ url('forums.edit_thread', forum.slug, thread.id) }}">{{ _('Edit thread title') }}</a></li>
     {% endif %}
     {% if has_perm(user, 'forums.delete_forum_thread', forum) %}
       <li><a href="{{ url('forums.delete_thread', forum.slug, thread.id) }}">{{ _('Delete this thread') }}</a></li>
@@ -131,7 +133,8 @@
           {% endfor %}
         </select>
       </div>
-      <input type="submit" class="sumo-button primary-button button-sm" value="{{ _('Move Thread') }}" />
+      {# L10n: This is a button, displayed when viewing a thread on a contributor forum (for users with the corresponding permission), which moves the thread to a different forum. #}
+      <input type="submit" class="sumo-button primary-button button-sm" value="{{ _('Move thread') }}" />
       </form>
   {% endif %}
 

--- a/kitsune/forums/jinja2/forums/threads.html
+++ b/kitsune/forums/jinja2/forums/threads.html
@@ -2,7 +2,7 @@
 {% from 'includes/common_macros.html' import for_contributors_sidebar %}
 {% from "forums/includes/forum_macros.html" import thread_list with context %}
 {# L10n: {f} is the name of the forum. #}
-{% set title = _('{f} | Forums')|f(f=forum.name) %}
+{% set title = _('{f} | Contributor Discussions')|f(f=forum.name) %}
 {% set crumbs = [(url('forums.forums'), _('Contributor Discussions')), (None, forum.name)] %}
 {% set canonical_url = canonicalize(viewname='forums.threads', forum_slug=forum.slug) %}
 {% if threads.number > 1 %}
@@ -40,6 +40,7 @@
     <form name="find-thread" id="find-thread" class="simple-search-form"
       action="{{ url('forums.search', forum_slug=forum.slug) }}" method="get">
       <input type="search" name="q" id="search-q" class="searchbox" value="{{ q or '' }}"
+        {# L10n: A placeholder for the search field that appears when viewing contributor forums (e.g., on https://support.mozilla.org/forums/contributors/). #}
         placeholder="{{ _('Search this forum') }}" />
       <input type="submit" value="{{ _('Search') }}" class="search-button" />
     </form>
@@ -55,8 +56,10 @@
           <th class="author{% if sort == 3 %} sort{% endif %}"><a
               href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
           <th class="replies{% if sort == 4 %} sort{% endif %}"><a
-              href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
+              {# L10n: This is a header for the column with number of replies, displayed when viewing contributor forums (such as https://support.mozilla.org/forums/contributors). #}
+              href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ pgettext('counter column header', 'Replies') }}</a></th>
           <th class="last-post{% if sort == 5 %} sort{% endif %}"><a
+              {# L10n: This is a header for a column, displayed when viewing contributor forums (such as https://support.mozilla.org/forums/contributors/), which contains info about the last post for each thread (date and author). #}
               href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
         </tr>
       </thead>

--- a/kitsune/forums/tests/test_templates.py
+++ b/kitsune/forums/tests/test_templates.py
@@ -195,14 +195,14 @@ class PostsTemplateTests(TestCase):
 
         response = get(self.client, "forums.posts", args=[t.forum.slug, t.id])
         self.assertEqual(200, response.status_code)
-        assert b"0 Replies" in response.content
+        assert b"0 replies" in response.content
 
         PostFactory(thread=t)
         PostFactory(thread=t)
 
         response = get(self.client, "forums.posts", args=[t.forum.slug, t.id])
         self.assertEqual(200, response.status_code)
-        assert b"2 Replies" in response.content
+        assert b"2 replies" in response.content
 
     def test_num_posts(self):
         """Verify the number of posts in all threads for a given post's author."""

--- a/kitsune/forums/views.py
+++ b/kitsune/forums/views.py
@@ -541,6 +541,7 @@ def search(request, forum_slug=None):
     search_form = BaseSearchForm(request.GET, initial={"forum": forum})
     if not search_form.is_valid():
         messages.add_message(
+            # L10n: A message that appears when searching a contributor forum (such as https://support.mozilla.org/forums/contributors/) fails.
             request, messages.WARNING, _("Something went wrong. Cannot search this forum.")
         )
         return threads(request, forum_slug=forum_slug)

--- a/kitsune/kbforums/jinja2/kbforums/confirm_post_delete.html
+++ b/kitsune/kbforums/jinja2/kbforums/confirm_post_delete.html
@@ -1,11 +1,11 @@
 {% extends "kbforums/base.html" %}
 {% from "kbforums/includes/macros.html" import kbforums_warning with context %}
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
-{% set title = _('Delete Post | {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
+{% set title = _('Delete a post | {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss')),
                  ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc nofollow"'), thread.title),
-                 (None, _('Delete Post'))] %}
+                 (None, _('Delete a post'))] %}
 
 {% block content %}
 <div class="grid_9">

--- a/kitsune/kbforums/jinja2/kbforums/confirm_thread_delete.html
+++ b/kitsune/kbforums/jinja2/kbforums/confirm_thread_delete.html
@@ -1,11 +1,11 @@
 {% extends "kbforums/base.html" %}
 {% from "kbforums/includes/macros.html" import kbforums_warning with context %}
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
-{% set title = _('Delete Thread | {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
+{% set title = _('Delete thread "{t}" | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss')),
                  ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc nofollow"'), thread.title),
-                 (None, _('Delete Thread'))] %}
+                 (None, _('Delete thread'))] %}
 
 {% block content %}
 <div class="grid_9">

--- a/kitsune/kbforums/jinja2/kbforums/discussions.html
+++ b/kitsune/kbforums/jinja2/kbforums/discussions.html
@@ -33,7 +33,9 @@
               {% endif %}
               <th class="title">{{ _('Title') }}</th>
               <th class="author{% if sort == 3 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
-              <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
+              {# L10n: This is a header for the column with number of replies, displayed when viewing contributor forums (such as https://support.mozilla.org/forums/contributors). #}
+              <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ pgettext('counter column header', 'Replies') }}</a></th>
+              {# L10n: This is a header for a column, displayed when viewing contributor forums (such as https://support.mozilla.org/forums/contributors/), which contains info about the last post for each thread (date and author). #}
               <th class="last-post{% if sort == 5 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
             </tr>
           </thead>

--- a/kitsune/kbforums/jinja2/kbforums/edit_thread.html
+++ b/kitsune/kbforums/jinja2/kbforums/edit_thread.html
@@ -2,7 +2,7 @@
 {% from "layout/errorlist.html" import errorlist %}
 {% from "kbforums/includes/macros.html" import kbforums_warning with context %}
 {# L10n: {t} is the title of the thread. {d} is the name of the document. #}
-{% set title = _('Edit thread {t} | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
+{% set title = _('Edit thread "{t}" | {d} Discussion | Knowledge Base')|f(t=thread.title, d=document.title) %}
 {% set crumbs = [(document.get_absolute_url(), document.title),
                  ((url('wiki.discuss.threads', document.slug), 'rel="ugc nofollow"'), _('Discuss')),
                  ((url('wiki.discuss.posts', document.slug, thread.id), 'rel="ugc nofollow"'), thread.title),

--- a/kitsune/kbforums/jinja2/kbforums/posts.html
+++ b/kitsune/kbforums/jinja2/kbforums/posts.html
@@ -12,7 +12,7 @@
 {% block side_top_top %}
   <ul id="thread-actions" class="sidebar-nav">
     {% if perms.kbforums.change_thread or (thread.creator == request.user and not thread.is_locked) %}
-      <li><a rel="ugc nofollow" href="{{ url('wiki.discuss.edit_thread', document.slug, thread.id) }}">{{ _('Edit this thread') }}</a></li>
+      <li><a rel="ugc nofollow" href="{{ url('wiki.discuss.edit_thread', document.slug, thread.id) }}">{{ _('Edit thread title') }}</a></li>
     {% endif %}
     {% if perms.kbforums.delete_thread %}
       <li><a rel="ugc nofollow" href="{{ url('wiki.discuss.delete_thread', document.slug, thread.id) }}">{{ _('Delete this thread') }}</a></li>
@@ -44,7 +44,7 @@
 
       <h1 class="sumo-page-heading">{{ thread.title }}</h1>
       <ul class="topic-article--meta-list" id="thread-meta">
-        {% if count %}<li>{{ count - 1 }} {{ _('Replies') }}</li>{% endif %}
+        {% if count %}<li>{{ ngettext('1 reply', '{n} replies', (count - 1))|f(n=count - 1) }}</li>{% endif %}
         {% if last_post %}<li>{{ _('Last reply by') }} {{ display_name(last_post.creator) }}</li>{% endif %}
         {# L10n: This is a contributor forum thread status. #}
         {% if thread.is_sticky %}<li>{{ pgettext('thread_type', 'Sticky') }}</li>{% endif %}

--- a/kitsune/kbforums/jinja2/kbforums/threads.html
+++ b/kitsune/kbforums/jinja2/kbforums/threads.html
@@ -34,7 +34,9 @@
           <th class="type"><a rel="ugc nofollow" href="{{ url('wiki.discuss.threads', document.slug) }}">{{ _('Type') }}</a></th>
           <th class="title">{{ _('Title') }}</th>
           <th class="author{% if sort == 3 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=3, desc=desc_toggle) }}">{{ _('Author') }}</a></th>
-          <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ _('Replies') }}</a></th>
+          {# L10n: This is a header for the column with number of replies, displayed when viewing contributor forums (such as https://support.mozilla.org/forums/contributors). #}
+          <th class="replies{% if sort == 4 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=4, desc=desc_toggle) }}">{{ pgettext('counter column header', 'Replies') }}</a></th>
+          {# L10n: This is a header for a column, displayed when viewing contributor forums (such as https://support.mozilla.org/forums/contributors/), which contains info about the last post for each thread (date and author). #}
           <th class="last-post{% if sort == 5 %} sort{% endif %}"><a rel="ugc nofollow" href="{{ request.path|urlparams(sort=5, desc=desc_toggle) }}">{{ _('Last Post') }}</a></th>
         </tr>
         {% for thread in threads.object_list %}

--- a/kitsune/questions/views.py
+++ b/kitsune/questions/views.py
@@ -139,7 +139,7 @@ ORDER_BY = OrderedDict(
         # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
         ("votes", ("num_votes_past_week", _lazy("Votes"))),
         # L10n: This is a question sort option. It is a part of a drop-down menu with no heading.
-        ("replies", ("num_answers", _lazy("Replies"))),
+        ("replies", ("num_answers", pgettext_lazy("question-sort", "Replies"))),
     ]
 )
 


### PR DESCRIPTION
- Resolves https://github.com/mozilla/sumo/issues/3194.
- Resolves https://github.com/mozilla/sumo/issues/3190.
- Resolves https://github.com/mozilla/sumo/issues/3186.
- Unifies page title format on forums and kbforums.
- Switches to "Edit thread title" for kbforums to match forums (was "Edit this thread").
- Adds some l10n comments.

Here are the strings coming from forums:
- `Contributor Discussions`
- `Create a new thread | {f} | Contributor Discussions`
- `Delete a post | {t} | {f} | Contributor Discussions`
- `Delete thread "{t}" | {f} | Contributor Discussions`
- `Edit a post | {t} | {f} | Contributor Discussions`
- `Edit thread "{t}" | {f} | Contributor Discussions`
- `Move thread`
- `Name`
- `Recently updated threads in %s`
- `Search this forum`
- `Something went wrong. Cannot search this forum.`
- `Threads`
- `{f} | Contributor Discussions`
- `{t} | {f} | Contributor Discussions`

(Note that this PR also updates some other strings.)

