### PR TITLE
Remove the .showfor override when tranlsating

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_wiki.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_wiki.scss
@@ -690,23 +690,6 @@ article {
   }
 }
 
-.translate {
-  #preview {
-    .showfor {
-      border-radius: 0;
-      box-shadow: none;
-      float: none;
-      margin: 20px 0 40px 0;
-      padding: 0;
-      position: static;
-
-      .selectbox-wrapper {
-        margin-bottom: 8px;
-      }
-    }
-  }
-}
-
 #preview-bottom {
   display: none;
 }


### PR DESCRIPTION
Resolves https://github.com/mozilla/sumo/issues/3169.

Currently, we override CSS for the _Customize this article_ modal when in translation view. This PR removes the override.