### PR TITLE
Revert "Fix question OP author name when quoting to reply"

### DIFF
--- a/kitsune/sumo/static/sumo/js/forums.js
+++ b/kitsune/sumo/static/sumo/js/forums.js
@@ -21,7 +21,7 @@ import Marky from "sumo/js/markup";
       var post = $(this).data('post'),
         $post = $('#post-' + post),
         text = $post.find('div.content-raw').text(),
-        user = $post.closest('.thread-post').find('.thread-post--author-name').text().trim(),
+        user = $post.find('.display-name').text(),
         reply_text = `''${user} [[#post-${post}|${gettext('said')}]]''\n<blockquote>\n${text}\n</blockquote>\n\n`,
         $textarea = $('#id_content'),
         oldtext = $textarea.val();


### PR DESCRIPTION
Reverts mozilla/kitsune#7732

That PR actually breaks forum quoting and doesn't fix AAQ quoting which belongs in `question.js`, so reverting. Also, I think I'll fix this once #7718 lands.