### PR TITLE
align caret icon with show-more button

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_sidebar-nav.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_sidebar-nav.scss
@@ -181,10 +181,10 @@
   }
 
   .show-more-btn {
+    display: inline-flex;
+    align-items: center;
 
     &:after {
-      position: relative;
-      top: 7px;
       margin-left: 5px;
       content: url('protocol/img/icons/caret-down.svg');
       filter: invert(27%) sepia(48%) saturate(3683%) hue-rotate(204deg) brightness(91%) contrast(106%);


### PR DESCRIPTION
mozilla/sumo#3199

After:
<img width="389" height="374" alt="image" src="https://github.com/user-attachments/assets/d28ba805-7fd8-433f-90d3-a6af607a65ad" />
