### PR TITLE
avoid clipping on article dropdown for marky links

### DIFF
--- a/kitsune/sumo/static/sumo/js/markup.js
+++ b/kitsune/sumo/static/sumo/js/markup.js
@@ -199,6 +199,11 @@ function attachTypeahead(input, source, onSelect) {
   }
 
   function close() {
+    // Drop any search that hasn't started yet, and make sure the responses to
+    // the ones already out there don't get rendered. Otherwise a search from
+    // just before the modal closed can reopen the dropdown after it's gone.
+    clearTimeout(debounceTimer);
+    latestRequestId++;
     window.removeEventListener("scroll", reposition, true);
     window.removeEventListener("resize", reposition);
     if (repositionFrame) {

--- a/kitsune/sumo/static/sumo/js/markup.js
+++ b/kitsune/sumo/static/sumo/js/markup.js
@@ -61,39 +61,175 @@ function isVisible(el) {
   return !!(el && el.offsetParent !== null);
 }
 
+// Type-ahead dropdown sizes, in pixels. These live here rather than in the
+// stylesheet because we size the dropdown to the room around its input.
+var TYPEAHEAD_GAP = 4; // between the input and the dropdown
+var TYPEAHEAD_VIEWPORT_MARGIN = 8; // between the dropdown and the viewport edge
+var TYPEAHEAD_MAX_HEIGHT = 220;
+// How short we're willing to squeeze the dropdown when there's little room. A
+// dropdown that overhangs the viewport is better than one squeezed to nothing.
+var TYPEAHEAD_MIN_HEIGHT = 60;
+
+// Used to give each dropdown an id, so its input can point at it.
+var typeaheadCount = 0;
+
+// How much of the viewport `el` can actually be seen in, given any ancestors
+// that clip or scroll their content. The link modal scrolls its own content, so
+// the input can be scrolled out of sight while the dropdown, over on <body>,
+// knows nothing about it.
+function clipBounds(el) {
+  var top = 0;
+  var bottom = window.innerHeight;
+  var node = el.parentElement;
+  while (node && node !== document.body) {
+    if (window.getComputedStyle(node).overflowY !== "visible") {
+      var rect = node.getBoundingClientRect();
+      top = Math.max(top, rect.top);
+      bottom = Math.min(bottom, rect.bottom);
+    }
+    node = node.parentElement;
+  }
+  return { top: top, bottom: bottom };
+}
+
 // A small type-ahead for a text <input>: fetch suggestions via `source(term,
 // cb)`, show them in a dropdown with keyboard/mouse selection, and call
-// `onSelect(item)` when one is chosen. Replaces the old jQuery-UI autocomplete.
+// `onSelect(item)` when one is chosen. Returns a handle with a close() that the
+// owner of the input should call before removing it from the page (see open()).
 function attachTypeahead(input, source, onSelect) {
   if (!input) {
-    return;
+    // Same shape, so callers don't have to null-check the handle.
+    return { close: function () {} };
   }
   var list = document.createElement("ul");
   list.className = "marky-autocomplete";
+  list.id = "marky-autocomplete-" + ++typeaheadCount;
   list.hidden = true;
+  list.setAttribute("role", "listbox");
+  // We build the list next to the input, but it only shows up after we move it
+  // onto <body> (see open() and close()). The link modal is fixed, uses a
+  // transform, and scrolls its own content, so a dropdown left inside it gets
+  // cut off at the modal's edge. Moving it out to <body> lets it overlay the
+  // page freely instead.
   input.insertAdjacentElement("afterend", list);
+
+  // Once the list moves to <body> it's nowhere near the input in the document
+  // anymore, so these are all a screen reader has to go on.
+  input.setAttribute("role", "combobox");
+  input.setAttribute("aria-autocomplete", "list");
+  input.setAttribute("aria-expanded", "false");
+  input.setAttribute("aria-controls", list.id);
+  input.setAttribute("autocomplete", "off");
 
   var items = [];
   var activeIndex = -1;
   var debounceTimer;
+  var repositionFrame = null;
   // Monotonic request id. Debouncing throttles how often requests start, but
-  // several can still be in flight and finish out of order; only the newest
-  // request's response is rendered (jQuery UI guarded this with a request
-  // index).
+  // several can still be in flight and finish out of order, so we render only
+  // the newest request's response.
   var latestRequestId = 0;
 
+  // Place the dropdown against the article input. It lives on <body> while open,
+  // so we position it with viewport coordinates (position: fixed). We cap its
+  // height to the space available so it can't run off the screen, and open it
+  // above the input instead when there's more room up there (short or mobile
+  // viewports).
+  function positionList() {
+    var rect = input.getBoundingClientRect();
+    var bounds = clipBounds(input);
+    var spaceBelow =
+      window.innerHeight - rect.bottom - TYPEAHEAD_GAP - TYPEAHEAD_VIEWPORT_MARGIN;
+    var spaceAbove = rect.top - TYPEAHEAD_GAP - TYPEAHEAD_VIEWPORT_MARGIN;
+    var placeAbove =
+      spaceBelow < Math.min(TYPEAHEAD_MAX_HEIGHT, list.scrollHeight) &&
+      spaceAbove > spaceBelow;
+    var height = Math.min(
+      TYPEAHEAD_MAX_HEIGHT,
+      Math.max(TYPEAHEAD_MIN_HEIGHT, placeAbove ? spaceAbove : spaceBelow)
+    );
+    list.style.left = rect.left + "px";
+    list.style.width = rect.width + "px";
+    list.style.maxHeight = height + "px";
+    if (placeAbove) {
+      // Pin the bottom edge rather than the top, so a list with only a couple of
+      // results still sits right above the input instead of a gap away from it.
+      list.style.top = "auto";
+      list.style.bottom = window.innerHeight - rect.top + TYPEAHEAD_GAP + "px";
+    } else {
+      list.style.bottom = "auto";
+      list.style.top = rect.bottom + TYPEAHEAD_GAP + "px";
+    }
+    // If the input itself has been scrolled out of view, hide the dropdown too,
+    // rather than leave it hovering over the page by itself.
+    var offscreen = rect.bottom < bounds.top || rect.top > bounds.bottom;
+    list.style.visibility = offscreen ? "hidden" : "";
+  }
+
+  // Scroll and resize events fire much faster than we can paint, so measure at
+  // most once a frame, like kbox does when it repositions.
+  function reposition() {
+    if (list.hidden || repositionFrame) {
+      return;
+    }
+    repositionFrame = window.requestAnimationFrame(function () {
+      repositionFrame = null;
+      if (!list.hidden) {
+        positionList();
+      }
+    });
+  }
+
+  function open() {
+    if (list.hidden) {
+      // Move onto <body> so the modal's overflow can't clip the dropdown. That
+      // also takes it out of the modal, so the handle we return has to close it
+      // before the modal goes away.
+      document.body.appendChild(list);
+      list.hidden = false;
+      input.setAttribute("aria-expanded", "true");
+      // Follow the input if the modal or window scrolls or resizes while we're
+      // open.
+      window.addEventListener("scroll", reposition, true);
+      window.addEventListener("resize", reposition);
+    }
+    // Also reposition on later renders, since new results change how tall the
+    // dropdown wants to be.
+    positionList();
+  }
+
   function close() {
+    window.removeEventListener("scroll", reposition, true);
+    window.removeEventListener("resize", reposition);
+    if (repositionFrame) {
+      window.cancelAnimationFrame(repositionFrame);
+      repositionFrame = null;
+    }
     list.hidden = true;
     list.innerHTML = "";
+    list.style.visibility = "";
     items = [];
     activeIndex = -1;
+    input.setAttribute("aria-expanded", "false");
+    input.removeAttribute("aria-activedescendant");
+    // Put it back next to the input so it's torn down together with the modal
+    // (which uses destroy: true) instead of being left behind on <body>.
+    input.insertAdjacentElement("afterend", list);
   }
 
   function highlight(idx) {
     activeIndex = idx;
     Array.prototype.forEach.call(list.children, function (li, i) {
-      li.classList.toggle("active", i === idx);
+      var isActive = i === idx;
+      li.classList.toggle("active", isActive);
+      li.setAttribute("aria-selected", isActive ? "true" : "false");
     });
+    var active = list.children[idx];
+    if (active) {
+      input.setAttribute("aria-activedescendant", active.id);
+    } else {
+      input.removeAttribute("aria-activedescendant");
+    }
   }
 
   function pick(idx) {
@@ -114,6 +250,9 @@ function attachTypeahead(input, source, onSelect) {
     }
     items.forEach(function (item, i) {
       var li = document.createElement("li");
+      li.id = list.id + "-option-" + i;
+      li.setAttribute("role", "option");
+      li.setAttribute("aria-selected", "false");
       li.textContent = item.label;
       // mousedown (not click) so it fires before the input's blur closes the list.
       li.addEventListener("mousedown", function (e) {
@@ -123,7 +262,8 @@ function attachTypeahead(input, source, onSelect) {
       list.appendChild(li);
     });
     activeIndex = -1;
-    list.hidden = false;
+    input.removeAttribute("aria-activedescendant");
+    open();
   }
 
   input.addEventListener("input", function () {
@@ -169,6 +309,8 @@ function attachTypeahead(input, source, onSelect) {
   input.addEventListener("blur", function () {
     setTimeout(close, 150);
   });
+
+  return { close: close };
 }
 
 var Marky = {
@@ -498,7 +640,7 @@ Marky.LinkButton.prototype = Object.assign({}, Marky.SimpleButton.prototype, {
     };
 
     var internalInput = html.querySelector('input[name="internal"]');
-    attachTypeahead(
+    var typeahead = attachTypeahead(
       internalInput,
       function (term, response) {
         if (performSectionSearch(term)) {
@@ -592,6 +734,14 @@ Marky.LinkButton.prototype = Object.assign({}, Marky.SimpleButton.prototype, {
       id: "link-modal",
       container: document.body,
       position: "none",
+      preClose: function () {
+        // Close the dropdown ourselves instead of waiting for the input to lose
+        // focus. Not every way of dismissing this modal blurs the input, and the
+        // ones that do only close the dropdown after a short delay, so it can
+        // otherwise be left behind on the page once the modal is gone.
+        typeahead.close();
+        return true;
+      },
     });
     kbox.open();
 

--- a/kitsune/sumo/static/sumo/js/tests/markup-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/markup-tests.js
@@ -247,6 +247,38 @@ describe("markup: attachTypeahead", () => {
     expect(input.nextElementSibling).to.equal(list());
   });
 
+  it("drops a search that hasn't gone out yet when the list is closed", () => {
+    const source = sinon.spy();
+    const typeahead = attachTypeahead(input, source, () => {});
+    const clock = sinon.useFakeTimers();
+    input.value = "fire";
+    input.dispatchEvent(new window.Event("input"));
+    typeahead.close(); // still inside the debounce window
+    clock.tick(300);
+    clock.restore();
+    expect(source.called).to.equal(false);
+  });
+
+  it("ignores a response that lands after the list was closed", () => {
+    document.body.innerHTML = '<div id="modal"><input id="nested-input"></div>';
+    input = document.getElementById("nested-input");
+    const responses = [];
+    const typeahead = attachTypeahead(input, (term, cb) => responses.push(cb), () => {});
+    const clock = sinon.useFakeTimers();
+    input.value = "fire";
+    input.dispatchEvent(new window.Event("input"));
+    clock.tick(300); // the search goes out
+    clock.restore();
+
+    typeahead.close();
+    responses[0]([{ label: "Firefox" }]);
+
+    // Nothing rendered, and nothing back on <body> where the dropdown shows.
+    expect(list().hidden).to.equal(true);
+    expect(list().children.length).to.equal(0);
+    expect(list().parentNode.id).to.equal("modal");
+  });
+
   it("returns a usable handle even without an input", () => {
     expect(() => attachTypeahead(null, () => {}).close()).to.not.throw();
   });

--- a/kitsune/sumo/static/sumo/js/tests/markup-tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/markup-tests.js
@@ -97,11 +97,28 @@ describe("markup: attachTypeahead", () => {
 
   afterEach(() => {
     sinon.restore();
+    delete window.requestAnimationFrame;
+    delete window.cancelAnimationFrame;
     document.body.innerHTML = "";
   });
 
   function list() {
     return document.querySelector("ul.marky-autocomplete");
+  }
+
+  // jsdom has no requestAnimationFrame, and repositioning is throttled through
+  // it, so stand one in whose frames we can run when we want them.
+  function fakeFrames() {
+    let pending = [];
+    window.requestAnimationFrame = (cb) => pending.push(cb);
+    window.cancelAnimationFrame = () => {
+      pending = [];
+    };
+    return function runFrames() {
+      const frames = pending;
+      pending = [];
+      frames.forEach((cb) => cb());
+    };
   }
 
   // Type a term and let the 300ms debounce fire against fake timers.
@@ -200,6 +217,168 @@ describe("markup: attachTypeahead", () => {
 
     const labels = Array.prototype.map.call(list().children, (li) => li.textContent);
     expect(labels).to.deep.equal(["ab-result"]);
+  });
+
+  it("shows the list on <body> and puts it back by the input on close", () => {
+    // Nested so there's somewhere other than <body> for the list to return to,
+    // like the link modal it's really used in.
+    document.body.innerHTML = '<div id="modal"><input id="nested-input"></div>';
+    input = document.getElementById("nested-input");
+
+    type("f", (term, cb) => cb([{ label: "Firefox" }]));
+    expect(list().parentNode).to.equal(document.body);
+
+    key("Escape");
+    expect(list().parentNode.id).to.equal("modal");
+    expect(input.nextElementSibling).to.equal(list());
+  });
+
+  it("closes the list when its handle is closed, without waiting for a blur", () => {
+    const typeahead = attachTypeahead(input, (term, cb) => cb([{ label: "Firefox" }]));
+    const clock = sinon.useFakeTimers();
+    input.value = "f";
+    input.dispatchEvent(new window.Event("input"));
+    clock.tick(300);
+    clock.restore();
+    expect(list().parentNode).to.equal(document.body);
+
+    typeahead.close();
+    expect(list().hidden).to.equal(true);
+    expect(input.nextElementSibling).to.equal(list());
+  });
+
+  it("returns a usable handle even without an input", () => {
+    expect(() => attachTypeahead(null, () => {}).close()).to.not.throw();
+  });
+
+  it("follows the input while open and stops once closed", () => {
+    const runFrames = fakeFrames();
+    type("f", (term, cb) => cb([{ label: "Firefox" }]));
+    const ul = list();
+    const top = ul.style.top;
+
+    // Nudge the list off its measured position: a scroll should measure again
+    // and put it back.
+    ul.style.top = "999px";
+    window.dispatchEvent(new window.Event("scroll"));
+    runFrames();
+    expect(ul.style.top).to.equal(top);
+
+    key("Escape");
+    ul.style.top = "999px";
+    window.dispatchEvent(new window.Event("scroll"));
+    runFrames();
+    expect(ul.style.top).to.equal("999px");
+  });
+
+  it("opens above the input when it doesn't fit below, right up against it", () => {
+    // jsdom does no layout, so describe it ourselves: a 30px input near the
+    // bottom of the 768px viewport, and a dropdown 90px tall.
+    input.getBoundingClientRect = () => ({ top: 700, bottom: 730, left: 20, width: 200 });
+    attachTypeahead(input, (term, cb) => cb([{ label: "Firefox" }]), () => {});
+    Object.defineProperty(list(), "scrollHeight", { value: 90, configurable: true });
+
+    const clock = sinon.useFakeTimers();
+    input.value = "f";
+    input.dispatchEvent(new window.Event("input"));
+    clock.tick(300);
+    clock.restore();
+
+    // Pinned a gap above the input's top edge rather than a max-height above it.
+    expect(list().style.top).to.equal("auto");
+    expect(list().style.bottom).to.equal(window.innerHeight - 700 + 4 + "px");
+  });
+
+  it("hides the list while the input is scrolled out of its container", () => {
+    document.body.innerHTML = '<div id="scroller"><input id="nested-input"></div>';
+    input = document.getElementById("nested-input");
+    const scroller = document.getElementById("scroller");
+    // Again, jsdom won't lay this out: a container scrolled far enough that the
+    // input has gone off the top of it.
+    sinon
+      .stub(window, "getComputedStyle")
+      .callsFake((el) => ({ overflowY: el === scroller ? "auto" : "visible" }));
+    scroller.getBoundingClientRect = () => ({ top: 100, bottom: 300 });
+    input.getBoundingClientRect = () => ({ top: 40, bottom: 60, left: 0, width: 200 });
+
+    type("f", (term, cb) => cb([{ label: "Firefox" }]));
+    expect(list().hidden).to.equal(false);
+    expect(list().style.visibility).to.equal("hidden");
+  });
+
+  it("points the input at the list and its active option", () => {
+    type("f", (term, cb) => cb([{ label: "Firefox" }, { label: "Focus" }]));
+    expect(input.getAttribute("role")).to.equal("combobox");
+    expect(input.getAttribute("aria-controls")).to.equal(list().id);
+    expect(input.getAttribute("aria-expanded")).to.equal("true");
+    expect(list().getAttribute("role")).to.equal("listbox");
+    expect(list().children[0].getAttribute("role")).to.equal("option");
+
+    key("ArrowDown");
+    expect(input.getAttribute("aria-activedescendant")).to.equal(list().children[0].id);
+    expect(list().children[0].getAttribute("aria-selected")).to.equal("true");
+    expect(list().children[1].getAttribute("aria-selected")).to.equal("false");
+
+    key("Escape");
+    expect(input.getAttribute("aria-expanded")).to.equal("false");
+    expect(input.hasAttribute("aria-activedescendant")).to.equal(false);
+  });
+});
+
+describe("markup: LinkButton article dropdown", () => {
+  afterEach(() => {
+    sinon.restore();
+    document.body.innerHTML = "";
+  });
+
+  function jsonResponse(body) {
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      text: async () => JSON.stringify(body),
+    };
+  }
+
+  // Open the link modal and get the article dropdown showing.
+  async function openModalWithSuggestions() {
+    document.body.innerHTML = '<textarea id="id_content"></textarea>';
+    sinon
+      .stub(window, "fetch")
+      .resolves(jsonResponse({ results: [{ title: "Firefox", url: "/kb/firefox" }] }));
+
+    const btn = new Marky.LinkButton();
+    btn.bind(document.getElementById("id_content"));
+    btn.openModal({ preventDefault() {} });
+
+    const internal = document.querySelector('#link-modal input[name="internal"]');
+    const clock = sinon.useFakeTimers();
+    internal.value = "fire";
+    internal.dispatchEvent(new window.Event("input"));
+    clock.tick(300); // the search runs on the far side of the debounce
+    clock.restore();
+    // Back on real timers, let the search's promises settle before we look.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return internal;
+  }
+
+  it("shows suggestions outside the modal, where they won't be clipped", async () => {
+    await openModalWithSuggestions();
+
+    const list = document.querySelector("ul.marky-autocomplete");
+    expect(list.parentNode).to.equal(document.body);
+    expect(list.children[0].textContent).to.equal("Firefox");
+  });
+
+  it("takes the dropdown with it when the modal is dismissed", async () => {
+    await openModalWithSuggestions();
+
+    // Nothing here moves focus out of the input (jsdom won't, and neither will
+    // some browsers), so the dropdown's own blur handling never runs.
+    document.querySelector("#link-modal .kbox-cancel").click();
+
+    expect(document.querySelector("#link-modal")).to.equal(null);
+    expect(document.querySelector("ul.marky-autocomplete")).to.equal(null);
   });
 });
 

--- a/kitsune/sumo/static/sumo/scss/components/_editor-tools.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_editor-tools.scss
@@ -183,40 +183,36 @@ section.marky {
     max-width: none;
   }
 
-  // Anchor the type-ahead dropdown (inserted after the article <input>) to its
-  // list item, replacing the old jQuery-UI autocomplete menu.
-  ol li.field {
-    position: relative;
-  }
-
-  .marky-autocomplete {
-    position: absolute;
-    left: 0;
-    right: 0;
-    z-index: 10;
-    max-height: 220px;
-    margin: 0;
-    padding: 0;
-    overflow-y: auto;
-    list-style: none;
-    background: var(--color-white);
-    border: 1px solid var(--field-border-color-default);
-    border-radius: var(--global-radius);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-
-    li {
-      padding: p.$spacing-xs p.$spacing-sm;
-      cursor: pointer;
-
-      &.active,
-      &:hover {
-        background: var(--color-shade-bg);
-      }
-    }
-  }
-
   .kbox-cancel {
     margin-right: 0;
+  }
+}
+
+// While it's open, the article type-ahead dropdown lives on <body> rather than
+// inside #link-modal (see attachTypeahead in markup.js), so the modal can't clip
+// it. That's why it's styled here at the top level instead of under #link-modal.
+// The JavaScript sets its position and max-height. The z-index just needs to
+// keep it above the modal (99) and its overlay (98).
+.marky-autocomplete {
+  position: fixed;
+  z-index: 100;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+  background: var(--color-white);
+  border: 1px solid var(--field-border-color-default);
+  border-radius: var(--global-radius);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+
+  li {
+    padding: p.$spacing-xs p.$spacing-sm;
+    cursor: pointer;
+
+    &.active,
+    &:hover {
+      background: var(--color-shade-bg);
+    }
   }
 }
 


### PR DESCRIPTION
mozilla/sumo#3243

This one was surprisingly challenging. It turns out that the fix needs to do the same thing that `jquery` was doing "under the hood".

After:

<img width="497" height="686" alt="image" src="https://github.com/user-attachments/assets/cb74c316-9810-42fd-b674-330cd3c0be0c" />

<img width="899" height="611" alt="image" src="https://github.com/user-attachments/assets/7dd26a43-a819-4b53-a683-d1cf9f9c13d2" />

