### PR TITLE
Resolve URL mismatch on response preview

### DIFF
--- a/kitsune/sumo/static/sumo/js/markup.js
+++ b/kitsune/sumo/static/sumo/js/markup.js
@@ -840,7 +840,11 @@ Marky.CannedResponsesButton.prototype = Object.assign({}, Marky.SimpleButton.pro
     var kbox;
 
     var cannedResponsesUrl = "/kb/common-forum-responses";
-    var previewUrl = "answer-preview-async";
+    var previewBtn = document.getElementById("preview");
+    var siteLanguage = window.location.pathname.split("/")[1];
+    var previewUrl = previewBtn
+      ? previewBtn.dataset.previewUrl
+      : "/" + siteLanguage + "/questions/answer-preview-async";
 
     function updatePreview() {
       var response = html.querySelector("#response-content").value;


### PR DESCRIPTION
[#2805](https://github.com/mozilla/sumo/issues/2805) Resolve URL mismatch bug on response preview defaulting to relative path and instead fixed it to use absolute path.