### PR TITLE
update pre-commit packages via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,16 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+
+  # Updates the hook versions in .pre-commit-config.yaml, plus the packages
+  # pinned under additional_dependencies. Grouped into one PR because some tools
+  # are pinned in both places and should move together.
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
I noticed that we can have `dependabot` also handle our `pre-commit` package updates.