### PR TITLE
Fix question author name when quoting to reply

### DIFF
--- a/kitsune/sumo/static/sumo/js/questions.js
+++ b/kitsune/sumo/static/sumo/js/questions.js
@@ -379,9 +379,7 @@ function initReplyToAnswer() {
       var contentEl = document.getElementById(contentId);
       var rawEl = contentEl ? contentEl.querySelector('.content-raw') : null;
       var nameEl = contentEl ? contentEl.querySelector('.display-name') : null;
-      var authorEl = document.querySelector('.thread-post--author-name');
-      var author = authorEl ? authorEl.textContent.trim() : '';
-      var user = nameEl ? nameEl.textContent : author;
+      var user = nameEl ? nameEl.textContent : document.querySelector('.thread-post--author-name')?.textContent.trim();
       var text = rawEl ? rawEl.textContent : '';
       var reply_text = `''<p>${user} [[#${contentId}|${gettext('said')}]]</p>''\n<blockquote>${text}\n</blockquote>\n\n`;
       var textarea = document.getElementById('id_content');

--- a/kitsune/sumo/static/sumo/js/questions.js
+++ b/kitsune/sumo/static/sumo/js/questions.js
@@ -379,8 +379,10 @@ function initReplyToAnswer() {
       var contentEl = document.getElementById(contentId);
       var rawEl = contentEl ? contentEl.querySelector('.content-raw') : null;
       var nameEl = contentEl ? contentEl.querySelector('.display-name') : null;
+      var authorEl = document.querySelector('.thread-post--author-name');
+      var author = authorEl ? authorEl.textContent.trim() : '';
+      var user = nameEl ? nameEl.textContent : author;
       var text = rawEl ? rawEl.textContent : '';
-      var user = nameEl ? nameEl.textContent : '';
       var reply_text = `''<p>${user} [[#${contentId}|${gettext('said')}]]</p>''\n<blockquote>${text}\n</blockquote>\n\n`;
       var textarea = document.getElementById('id_content');
 


### PR DESCRIPTION
https://github.com/mozilla/sumo/issues/3034

Ryan noticed this has to cater for both selectors, the one within the dataset reply ID which contains the answer author (also done with the same link functinon), and the broken author quoting where the author's elements (question headers) are currently moved outside of its dataset question ID and don't follow the previous class naming anyway.

So this now attempts to reach both element selector possibilities in a failover fashion.