### PR TITLE
Sort group leaders and members alphabetically by displayed name

### DIFF
--- a/kitsune/groups/tests/test_views.py
+++ b/kitsune/groups/tests/test_views.py
@@ -411,6 +411,44 @@ class DeactivatedMemberVisibilityTests(TestCase):
         self.assertEqual(self._group_count(doc, "Members"), 4)
 
 
+class MemberOrderingTests(TestCase):
+    """Leaders and members are listed in alphabetical order of their displayed name."""
+
+    def setUp(self):
+        super().setUp()
+        self.group_profile = GroupProfileFactory()
+
+        # Added in reverse of the expected order, and usernames sort differently
+        # from displayed names, so sorting by the wrong thing fails here.
+        users = {
+            "Carol": None,
+            "alice": "carla",
+            "Bob": "",
+            "zoe": "Aaron",
+        }
+        for username, display_name in users.items():
+            user = UserFactory(username=username, profile__name=display_name)
+            self.group_profile.group.user_set.add(user)
+            if username in ("zoe", "Bob", "alice"):
+                self.group_profile.leaders.add(user)
+
+        # No profile row at all: must fall back to the username, not be dropped.
+        self.group_profile.group.user_set.add(UserFactory(username="quinn", profile=None))
+
+        self.url = reverse("groups.profile", args=[self.group_profile.slug])
+
+    def _names(self, section):
+        r = self.client.get(self.url)
+        self.assertEqual(200, r.status_code)
+        return [pq(el).text() for el in pq(r.content)(f"ul.users.{section} .user-name")]
+
+    def test_members_sorted_by_displayed_name(self):
+        self.assertEqual(self._names("members"), ["Aaron", "Bob", "carla", "Carol", "quinn"])
+
+    def test_leaders_sorted_by_displayed_name(self):
+        self.assertEqual(self._names("leaders"), ["Aaron", "Bob", "carla"])
+
+
 class GroupTicketsViewTests(TestCase):
     """Tests for the groups.tickets view."""
 

--- a/kitsune/groups/views.py
+++ b/kitsune/groups/views.py
@@ -5,6 +5,8 @@ from django.contrib import messages
 from django.contrib.auth.models import Group, User
 from django.core.exceptions import PermissionDenied
 from django.core.files.storage import default_storage
+from django.db.models import Value
+from django.db.models.functions import Coalesce, Lower, NullIf
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.utils.translation import gettext as _
@@ -19,6 +21,9 @@ from kitsune.sumo.utils import get_next_url, paginate
 from kitsune.upload.utils import create_image_thumbnail
 
 TICKET_STATUS_FILTERS = {"active", "all", "solved"}
+
+# Mirrors Profile.display_name, which treats a blank name as unset.
+DISPLAY_NAME_ORDER = Lower(Coalesce(NullIf("profile__name", Value("")), "username"))
 
 
 def _remove_group_member(profile, user, request, remove_from_group=True):
@@ -80,8 +85,8 @@ def list(request):
 
 def profile(request, group_slug, member_form=None, leader_form=None):
     prof = _get_group_profile_or_404(request.user, group_slug)
-    leaders = prof.leaders.all().select_related("profile")
-    members_qs = prof.group.user_set.all().select_related("profile")
+    leaders = prof.leaders.all().select_related("profile").order_by(DISPLAY_NAME_ORDER)
+    members_qs = prof.group.user_set.all().select_related("profile").order_by(DISPLAY_NAME_ORDER)
 
     if not prof.can_view_inactive_members(request.user):
         leaders = leaders.filter(is_active=True)


### PR DESCRIPTION
The group profile page listed leaders and members in whatever order the database returned, which also made member pagination unstable across pages. Order both lists case-insensitively by the name the page actually renders: the profile's display name when set, falling back to the username, mirroring Profile.display_name.

Fixes #7270