### PR TITLE
adjust embedding headroom and provide token check command

### DIFF
--- a/kitsune/retrieval/embeddings.py
+++ b/kitsune/retrieval/embeddings.py
@@ -38,6 +38,8 @@ _NORMALIZATIONS = frozenset({"none", "l2"})
 _VERTEX_MAX_BATCH_SIZE = 250
 _VERTEX_MAX_INPUT_TOKENS = 2_048
 _VERTEX_MAX_REQUEST_TOKENS = 20_000
+# Pack requests to a fraction of the provider's own per-request ceiling.
+_REQUEST_TOKEN_TARGET = int(_VERTEX_MAX_REQUEST_TOKENS * 0.8)
 _RECIPE_FIELDS = frozenset(
     {
         "provider",
@@ -81,8 +83,10 @@ class EmbeddingRecipe:
 
 
 @dataclass
-class _ProviderStats:
+class ProviderStats:
     request_count: int = 0
+    estimated_token_count: int = 0
+    provider_token_count: int | None = 0
 
 
 def configured_embedding_recipe() -> EmbeddingRecipe:
@@ -154,8 +158,12 @@ def get_embeddings(
     *,
     task: Literal["document", "query"],
     recipe: EmbeddingRecipe,
+    stats: ProviderStats | None = None,
 ) -> list[list[float]]:
-    """Return validated embeddings in the same order as the input texts."""
+    """Return validated embeddings in the same order as the input texts.
+
+    Pass a stats object to read back the request and token counts this call reported.
+    """
     _validate_recipe(recipe)
     if task == "document":
         task_type = recipe.document_task
@@ -174,7 +182,7 @@ def get_embeddings(
 
     started = time.monotonic()
     character_count = sum(len(text) for text in inputs)
-    stats = _ProviderStats()
+    stats = ProviderStats() if stats is None else stats
     try:
         vectors = _EMBED_BACKENDS[recipe.provider](
             inputs,
@@ -200,6 +208,7 @@ def get_embeddings(
             text_count=len(inputs),
             character_count=character_count,
             request_count=stats.request_count,
+            estimated_token_count=stats.estimated_token_count,
             error_type=type(failure).__name__,
             duration_ms=_elapsed_ms(started),
         )
@@ -216,6 +225,8 @@ def get_embeddings(
         # A bounded measure of input size without recording the input itself.
         character_count=character_count,
         request_count=stats.request_count,
+        estimated_token_count=stats.estimated_token_count,
+        provider_token_count=stats.provider_token_count,
         duration_ms=_elapsed_ms(started),
     )
     return vectors
@@ -254,7 +265,7 @@ def _fake_embed(
     *,
     task_type: str,
     recipe: EmbeddingRecipe,
-    stats: _ProviderStats,
+    stats: ProviderStats,
 ) -> list[list[float]]:
     byte_count = recipe.dimensions * 4  # 4 bytes per float
     vectors = []
@@ -284,9 +295,10 @@ def _vertex_embed(
     *,
     task_type: str,
     recipe: EmbeddingRecipe,
-    stats: _ProviderStats,
+    stats: ProviderStats,
 ) -> list[list[float]]:
     input_tokens = [count_tokens(text) for text in texts]
+    stats.estimated_token_count = sum(input_tokens)
     if any(tokens > max_input_tokens() for tokens in input_tokens):
         raise InvalidEmbeddingResponse(
             "embedding input exceeds Vertex's estimated per-input token limit"
@@ -342,7 +354,7 @@ def provider_request_batch_lengths(input_tokens: Sequence[int]) -> tuple[int, ..
     batch_tokens = 0
     for tokens in input_tokens:
         if batch_inputs and (
-            batch_inputs >= max_inputs or batch_tokens + tokens > _VERTEX_MAX_REQUEST_TOKENS
+            batch_inputs >= max_inputs or batch_tokens + tokens > _REQUEST_TOKEN_TARGET
         ):
             batch_lengths.append(batch_inputs)
             batch_inputs = 0
@@ -369,7 +381,7 @@ def _embed_batch_with_retry(
     dimensions: int,
     timeout_ms: int,
     task: Literal["document", "query"],
-    stats: _ProviderStats,
+    stats: ProviderStats,
 ) -> list[list[float]]:
     # google-genai's transport is httpx: connection resets and timeouts both arrive as
     # HttpxTransportError subclasses and are as transient as a retryable status code.
@@ -379,7 +391,12 @@ def _embed_batch_with_retry(
         try:
             stats.request_count += 1
             return _request_vertex_embeddings(
-                client, batch, task_type=task_type, dimensions=dimensions, timeout_ms=timeout_ms
+                client,
+                batch,
+                task_type=task_type,
+                dimensions=dimensions,
+                timeout_ms=timeout_ms,
+                stats=stats,
             )
         except provider_errors as exc:
             # APIError.code can be None when the payload carries no status; treat that as
@@ -404,7 +421,13 @@ def _embed_batch_with_retry(
 
 
 def _request_vertex_embeddings(
-    client, batch: list[str], *, task_type: str, dimensions: int, timeout_ms: int
+    client,
+    batch: list[str],
+    *,
+    task_type: str,
+    dimensions: int,
+    timeout_ms: int,
+    stats: ProviderStats,
 ) -> list[list[float]]:
     """Call Google Gen AI directly so truncation cannot be hidden by the LangChain wrapper."""
     response = client.client.models.embed_content(
@@ -427,6 +450,10 @@ def _request_vertex_embeddings(
             )
         if embedding.values is None:
             raise InvalidEmbeddingResponse("Vertex embedding response has no vector values")
+        if statistics.token_count is None:
+            stats.provider_token_count = None
+        elif stats.provider_token_count is not None:
+            stats.provider_token_count += int(statistics.token_count)
         vectors.append(list(embedding.values))
     return vectors
 

--- a/kitsune/retrieval/management/commands/verify_token_estimate.py
+++ b/kitsune/retrieval/management/commands/verify_token_estimate.py
@@ -1,0 +1,140 @@
+"""Compare the local token estimate with the provider's own count, one locale at a time.
+
+A batch embedding call mixes locales, so its event cannot attribute tokens to a script. This
+samples each locale separately and at random, reporting the seed it used so the same sample can
+be measured again. It reads the database and writes nothing, but it does make real, paid
+embedding calls.
+"""
+
+import random
+
+from django.core.management.base import BaseCommand, CommandError
+
+from kitsune.retrieval.chunking import chunk
+from kitsune.retrieval.eligibility import eligible_documents
+from kitsune.retrieval.embeddings import (
+    ProviderStats,
+    configured_embedding_recipe,
+    get_embeddings,
+)
+from kitsune.retrieval.sync import CONTENT_TYPE
+
+DEFAULT_DOCUMENTS = 10
+DEFAULT_MAX_CHUNKS = 200
+
+
+def _count(value: int | None) -> str:
+    return "unknown" if value is None else f"{value:,}"
+
+
+def _ratio(estimated: int, provider: int | None) -> str:
+    if provider is None or not estimated:
+        return "n/a"
+    return f"{provider / estimated:.2f}"
+
+
+class Command(BaseCommand):
+    help = (
+        "Measure count_tokens against the provider's own token count, per locale. "
+        "Makes real embedding calls; writes nothing."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--locale",
+            action="append",
+            default=None,
+            metavar="LOCALE",
+            help="Restrict to these locales; repeatable. Absent means every eligible locale.",
+        )
+        parser.add_argument(
+            "--documents",
+            type=int,
+            default=DEFAULT_DOCUMENTS,
+            help="Documents to sample per locale.",
+        )
+        parser.add_argument(
+            "--max-chunks",
+            type=int,
+            default=DEFAULT_MAX_CHUNKS,
+            help="Ceiling on embedded chunks per locale, bounding what the sample costs.",
+        )
+        parser.add_argument(
+            "--seed",
+            type=int,
+            default=None,
+            help="Reuse a reported seed to measure the same sample again.",
+        )
+
+    def handle(self, *args, **options):
+        per_locale = options["documents"]
+        max_chunks = options["max_chunks"]
+        if per_locale < 1:
+            raise CommandError("--documents must be a positive integer.")
+        if max_chunks < 1:
+            raise CommandError("--max-chunks must be a positive integer.")
+        locales = list(dict.fromkeys(locale.strip() for locale in options["locale"] or ()))
+        if any(not locale for locale in locales):
+            raise CommandError("--locale must not be empty.")
+
+        # Fails before anything is sampled or paid for if the recipe is unusable.
+        recipe = configured_embedding_recipe()
+        documents = eligible_documents().select_related(None).prefetch_related(None)
+        if not locales:
+            locales = sorted(documents.order_by().values_list("locale", flat=True).distinct())
+
+        seed = random.randrange(2**32) if options["seed"] is None else options["seed"]
+        rows = []
+        for locale in locales:
+            ids = list(documents.order_by().filter(locale=locale).values_list("id", flat=True))
+            # Seeded per locale, so one locale's sample never depends on another's size.
+            random.Random(f"{seed}:{locale}").shuffle(ids)
+            chosen = ids[:per_locale]
+            by_id = documents.only("html", "title").in_bulk(chosen)
+
+            sampled = 0
+            texts: list[str] = []
+            for document_id in chosen:
+                if not (document := by_id.get(document_id)):
+                    continue
+                sampled += 1
+                texts.extend(
+                    item.text for item in chunk(CONTENT_TYPE, document.html, title=document.title)
+                )
+                if len(texts) >= max_chunks:
+                    break
+            del texts[max_chunks:]
+            if not texts:
+                continue
+
+            stats = ProviderStats()
+            get_embeddings(texts, task="document", recipe=recipe, stats=stats)
+            rows.append((locale, sampled, len(texts), stats))
+
+        if not rows:
+            self.stdout.write("No eligible documents in the selected locales; nothing measured.")
+            return
+
+        write = self.stdout.write
+        write(f"seed: {seed}")
+        write("")
+        write(
+            f"{'locale':<12}{'docs':>6}{'chunks':>8}"
+            f"{'estimated':>12}{'provider':>12}{'actual/est':>12}"
+        )
+        for locale, sampled, chunks, stats in rows:
+            write(
+                f"{locale:<12}{sampled:>6}{chunks:>8}"
+                f"{stats.estimated_token_count:>12,}"
+                f"{_count(stats.provider_token_count):>12}"
+                f"{_ratio(stats.estimated_token_count, stats.provider_token_count):>12}"
+            )
+
+        counts = [stats.provider_token_count for _, _, _, stats in rows]
+        estimated = sum(stats.estimated_token_count for _, _, _, stats in rows)
+        provider = None if any(count is None for count in counts) else sum(counts)
+        write("")
+        write(
+            f"{'total':<12}{sum(row[1] for row in rows):>6}{sum(row[2] for row in rows):>8}"
+            f"{estimated:>12,}{_count(provider):>12}{_ratio(estimated, provider):>12}"
+        )

--- a/kitsune/retrieval/tests/test_embeddings.py
+++ b/kitsune/retrieval/tests/test_embeddings.py
@@ -13,6 +13,8 @@ from httpx import ReadTimeout as HttpxReadTimeout
 
 from kitsune.retrieval.embeddings import (
     _MAX_ATTEMPTS,
+    _REQUEST_TOKEN_TARGET,
+    _VERTEX_MAX_REQUEST_TOKENS,
     FAKE_BACKEND,
     VERTEX_BACKEND,
     EmbeddingRecipe,
@@ -22,6 +24,7 @@ from kitsune.retrieval.embeddings import (
     _vertex_client,
     configured_embedding_recipe,
     get_embeddings,
+    provider_request_batch_lengths,
     recipe_from_payload,
     recipe_to_payload,
     validate_embeddings,
@@ -51,13 +54,13 @@ def _marker_vectors(batch, **kwargs):
     return [[float(ord(text[0])), *([0.0] * 7)] for text in batch]
 
 
-def _vertex_response(batch, *, truncated=False):
+def _vertex_response(batch, *, truncated=False, token_count=7.0):
     vectors = _marker_vectors(batch)
     return SimpleNamespace(
         embeddings=[
             SimpleNamespace(
                 values=vector,
-                statistics=SimpleNamespace(truncated=truncated),
+                statistics=SimpleNamespace(truncated=truncated, token_count=token_count),
             )
             for vector in vectors
         ]
@@ -151,8 +154,19 @@ class VertexBackendTests(SimpleTestCase):
 
         self.assertEqual(
             [len(call.kwargs["contents"]) for call in request.call_args_list],
-            [10, 1],
+            [8, 3],
         )
+
+    def test_packing_leaves_the_provider_ceiling_room_for_an_underestimate(self):
+        # count_tokens is an estimate, so a request filled to the provider's own limit could
+        # exceed it in real tokens, and Vertex refuses such a request rather than truncating.
+        self.assertLess(_REQUEST_TOKEN_TARGET, _VERTEX_MAX_REQUEST_TOKENS)
+
+        per_text = 1_000
+        lengths = provider_request_batch_lengths([per_text] * 60)
+
+        self.assertTrue(all(length * per_text <= _REQUEST_TOKEN_TARGET for length in lengths))
+        self.assertEqual(sum(lengths), 60)
 
     @override_settings(RETRIEVAL_EMBEDDING_TIMEOUT_SECONDS=12)
     def test_every_request_carries_an_explicit_deadline(self):

--- a/kitsune/retrieval/tests/test_observability.py
+++ b/kitsune/retrieval/tests/test_observability.py
@@ -113,6 +113,50 @@ class ProviderEventTests(SimpleTestCase):
         for field in _FORBIDDEN_FIELDS:
             self.assertNotIn(field, record.__dict__)
 
+    @override_settings(RETRIEVAL_EMBEDDING_BATCH_SIZE=1)
+    def test_a_completed_request_reports_the_estimate_beside_the_provider_count(self):
+        client, _ = _mock_vertex_client()
+        with (
+            mock.patch("kitsune.retrieval.embeddings._vertex_client", return_value=client),
+            self.assertLogs("k.retrieval", level="INFO") as logs,
+        ):
+            get_embeddings(["hello", "world!"], task="document", recipe=VERTEX)
+
+        record = _event(logs, "retrieval.embeddings.completed")
+        # Comparing the two is what keeps count_tokens honest and its packing margin justified.
+        self.assertEqual(record.estimated_token_count, 4)
+        self.assertEqual(record.provider_token_count, 14)  # the stub reports 7 tokens per text
+
+    @override_settings(RETRIEVAL_EMBEDDING_BATCH_SIZE=1)
+    def test_an_unreported_provider_count_is_unknown_rather_than_a_false_zero(self):
+        client, request = _mock_vertex_client()
+        request.side_effect = lambda **kwargs: _vertex_response(
+            kwargs["contents"], token_count=None
+        )
+        with (
+            mock.patch("kitsune.retrieval.embeddings._vertex_client", return_value=client),
+            self.assertLogs("k.retrieval", level="INFO") as logs,
+        ):
+            get_embeddings(["hello", "world!"], task="document", recipe=VERTEX)
+
+        record = _event(logs, "retrieval.embeddings.completed")
+        self.assertEqual(record.estimated_token_count, 4)
+        self.assertIsNone(record.provider_token_count)
+
+    def test_a_failure_reports_the_estimate_that_was_sent(self):
+        client, request = _mock_vertex_client()
+        request.side_effect = RuntimeError("boom")
+        with (
+            mock.patch("kitsune.retrieval.embeddings._vertex_client", return_value=client),
+            self.assertLogs("k.retrieval", level="ERROR") as logs,
+            self.assertRaises(RuntimeError),
+        ):
+            get_embeddings(["hello", "world!"], task="document", recipe=VERTEX)
+
+        # A refused request is the failure the packing margin exists to prevent, so its size
+        # has to be visible without the text.
+        self.assertEqual(_event(logs, "retrieval.embeddings.failed").estimated_token_count, 4)
+
     def test_a_retry_reports_the_error_type_and_not_its_message(self):
         client, request = _mock_vertex_client()
         request.side_effect = [

--- a/kitsune/retrieval/tests/test_verify_token_estimate.py
+++ b/kitsune/retrieval/tests/test_verify_token_estimate.py
@@ -1,0 +1,122 @@
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+
+from kitsune.retrieval.tests.test_embeddings import _mock_vertex_client, _vertex_response
+from kitsune.wiki.tests import ApprovedRevisionFactory, DocumentFactory
+
+VERTEX_RECIPE = {
+    "RETRIEVAL_EMBEDDING_BACKEND": "vertex",
+    "RETRIEVAL_EMBEDDING_MODEL": "text-embedding-005",
+    "RETRIEVAL_EMBEDDING_DIMENSIONS": 8,
+}
+
+
+def _document(locale="en-US", number=0):
+    document = DocumentFactory(
+        title=f"Guide {locale} {number}",
+        slug=f"guide-{locale}-{number}",
+        locale=locale,
+    )
+    ApprovedRevisionFactory(
+        document=document,
+        content="How to install and configure the browser.",
+    )
+    document.refresh_from_db()
+    return document
+
+
+@override_settings(**VERTEX_RECIPE)
+class VerifyTokenEstimateTests(TestCase):
+    def _run(self, response=None, **options):
+        client, request = _mock_vertex_client()
+        if response is not None:
+            request.side_effect = response
+        output = StringIO()
+        with mock.patch("kitsune.retrieval.embeddings._vertex_client", return_value=client):
+            call_command("verify_token_estimate", stdout=output, **options)
+        return output.getvalue(), request
+
+    def test_reports_each_locale_separately_so_scripts_are_not_averaged(self):
+        _document(locale="en-US")
+        _document(locale="ru")
+
+        rendered, _ = self._run()
+
+        # One row per locale is the whole point: a mixed batch hides an over- and under-count.
+        self.assertIn("en-US", rendered)
+        self.assertIn("ru", rendered)
+        self.assertIn("total", rendered)
+
+    def test_reports_the_provider_count_beside_the_estimate(self):
+        document = _document()
+
+        rendered, request = self._run()
+
+        # The stub reports 7 tokens per text, so the provider column is 7 per chunk.
+        [call] = request.call_args_list
+        chunks = len(call.kwargs["contents"])
+        self.assertIn(f"{7 * chunks:,}", rendered)
+        self.assertNotIn(document.title, rendered)
+
+    def test_reports_the_seed_it_sampled_with(self):
+        _document()
+
+        rendered, _ = self._run()
+
+        self.assertIn("seed:", rendered)
+
+    def test_the_same_seed_measures_the_same_sample(self):
+        for number in range(6):
+            _document(number=number)
+
+        _, first = self._run(documents=2, seed=7)
+        _, second = self._run(documents=2, seed=7)
+
+        self.assertEqual(
+            [call.kwargs["contents"] for call in first.call_args_list],
+            [call.kwargs["contents"] for call in second.call_args_list],
+        )
+
+    def test_a_locale_sample_does_not_depend_on_the_other_locales_asked_for(self):
+        for number in range(6):
+            _document(locale="de", number=number)
+
+        _, alone = self._run(documents=2, seed=7, locale=["de"])
+        _, alongside = self._run(documents=2, seed=7, locale=["de", "ru"])
+
+        self.assertEqual(
+            [call.kwargs["contents"] for call in alone.call_args_list],
+            [call.kwargs["contents"] for call in alongside.call_args_list],
+        )
+
+    def test_bounds_what_the_sample_costs(self):
+        for number in range(4):
+            _document(number=number)
+
+        _, request = self._run(**{"max_chunks": 1})
+
+        self.assertEqual([len(call.kwargs["contents"]) for call in request.call_args_list], [1])
+
+    def test_an_unreported_provider_count_reads_as_unknown(self):
+        _document()
+
+        rendered, _ = self._run(
+            response=lambda **kwargs: _vertex_response(kwargs["contents"], token_count=None)
+        )
+
+        self.assertIn("unknown", rendered)
+        self.assertIn("n/a", rendered)
+
+    def test_reports_nothing_rather_than_embedding_an_empty_sample(self):
+        rendered, request = self._run()
+
+        self.assertIn("nothing measured", rendered)
+        request.assert_not_called()
+
+    def test_rejects_a_non_positive_sample_size(self):
+        with self.assertRaisesMessage(CommandError, "--documents"):
+            call_command("verify_token_estimate", documents=0)


### PR DESCRIPTION
Provides more margin for error in the token count when performing embedding calls, and also provide a new `verify_token_estimate` management command for measuring the effectiveness of our token estimation by locale.