### PR TITLE
Stack group profile Edit buttons so long locales do not break the header

### DIFF
--- a/kitsune/sumo/static/sumo/scss/components/_groups.scss
+++ b/kitsune/sumo/static/sumo/scss/components/_groups.scss
@@ -198,11 +198,15 @@ body:has(#group-profile) {
       flex-wrap: wrap;
     }
 
+    // Stack Edit Profile / Edit in admin so long locale labels do not
+    // force both buttons onto one line and break the header (sumo#3309).
     &--actions {
       flex-shrink: 0;
       display: flex;
+      flex-direction: column;
+      align-items: stretch;
       gap: p.$spacing-sm;
-      flex-wrap: wrap;
+      max-width: 100%;
 
       @media (max-width: 767px) {
         flex-basis: 100%;


### PR DESCRIPTION
## Summary
On the group profile page, Edit Profile and Edit in admin stayed side by side. In locales with longer labels that row broke the header.

This stacks those actions in a column so each button gets its own row and the header stays intact.

https://github.com/mozilla/sumo/issues/3309

## Test plan
1. Open a group profile as a user who can edit.
2. Confirm the Edit Profile and Edit in admin controls stack vertically.
3. Check a locale with longer button labels (for example Ukrainian) and confirm the header no longer overflows.