### PR TITLE
Prevent external images in private message emails

### DIFF
--- a/kitsune/messages/tasks.py
+++ b/kitsune/messages/tasks.py
@@ -31,12 +31,12 @@ def email_private_message(inbox_message_id):
         msg_url = reverse("messages.read", kwargs={"msgid": inbox_message.id})
         settings_url = reverse("users.edit_settings")
 
-        from kitsune.sumo.templatetags.jinja_helpers import add_utm
+        from kitsune.sumo.templatetags.jinja_helpers import add_utm, wiki_to_safe_html
 
         context = {
             "sender": inbox_message.sender,
             "message": inbox_message.message,
-            "message_html": inbox_message.content_parsed,
+            "message_html": wiki_to_safe_html(inbox_message.message),
             "message_url": add_utm(msg_url, "messages-new"),
             "unsubscribe_url": add_utm(settings_url, "messages-new"),
             "host": Site.objects.get_current().domain,

--- a/kitsune/messages/tests/test_notifications.py
+++ b/kitsune/messages/tests/test_notifications.py
@@ -2,7 +2,10 @@ from unittest import mock
 
 from django.contrib.sites.models import Site
 from django.core import mail
+from pyquery import PyQuery as pq
 
+from kitsune.messages.models import InboxMessage
+from kitsune.messages.tasks import email_private_message
 from kitsune.sumo.tests import TestCase, attrs_eq, post, starts_with
 from kitsune.users.models import Setting
 from kitsune.users.tests import UserFactory
@@ -50,6 +53,21 @@ class NotificationsTests(TestCase):
         starts_with(
             mail.outbox[0].body, PRIVATE_MESSAGE_EMAIL.format(sender=self.sender.profile.name)
         )
+
+    @mock.patch.object(Site.objects, "get_current")
+    def test_private_message_email_excludes_images(self, get_current):
+        get_current.return_value.domain = "testserver"
+        inbox_message = InboxMessage.objects.create(
+            sender=self.sender,
+            to=self.to,
+            message=('<strong>Keep this formatting</strong><img src="https://picsum.photos/200">'),
+        )
+        email_private_message(inbox_message.id)
+
+        html = pq(mail.outbox[0].alternatives[0][0])
+        message = html(".quote")
+        assert message("strong").text() == "Keep this formatting"
+        assert not message("img")
 
     @mock.patch.object(Site.objects, "get_current")
     def test_private_message_not_sends_email(self, get_current):


### PR DESCRIPTION
## Summary

- render private-message notification content with the existing restricted wiki renderer
- remove user-supplied media from the HTML email while preserving text formatting and links
- add regression coverage for the email boundary

## Why

The web message view relies on CSP to block disallowed image sources, but email clients do not inherit that policy. Passing InboxMessage.content_parsed directly into the HTML email therefore lets a remote image load.

Sanitizing when building the email avoids duplicating the CSP host allowlist and leaves stored messages and the web view unchanged.

## Tests

- python manage.py test kitsune.messages.tests.test_notifications
- ruff check kitsune/messages/tasks.py kitsune/messages/tests/test_notifications.py
- ruff format --check kitsune/messages/tasks.py kitsune/messages/tests/test_notifications.py

Closes mozilla/sumo#3303