### PR TITLE
Swap Article discussions with KB discussions

### DIFF
--- a/kitsune/sumo/jinja2/includes/common_macros.html
+++ b/kitsune/sumo/jinja2/includes/common_macros.html
@@ -689,10 +689,10 @@
   </a>
 </li>
 <li>
-  <a href="{{ url('wiki.locale_discussions') }}" {% if active == "article-discussions" %} class="selected" {% endif %}
+  <a href="{{ url('forums.threads', 'knowledge-base-articles') }}" {% if active == "knowledge-base-articles" %} class="selected" {% endif %}
     data-event-name="link_click"
-    data-event-parameters='{"link_name": "{{ context + '.article-discussions' }}"}'>
-    {{ _('Article discussions') }}
+    data-event-parameters='{"link_name": "{{ context + '.kb-discussions' }}"}'>
+    {{ _('Knowledge base discussions') }}
   </a>
 </li>
 <li>
@@ -722,10 +722,10 @@
 {% endif %}
 {% if context == "sidebar-menu" %}
   <li>
-    <a href="{{ url('forums.threads', 'knowledge-base-articles') }}" {% if active == "knowledge-base-articles" %} class="selected" {% endif %}
+    <a href="{{ url('wiki.locale_discussions') }}" {% if active == "article-discussions" %} class="selected" {% endif %}
       data-event-name="link_click"
-      data-event-parameters='{"link_name": "{{ context + '.kb-discussions' }}"}'>
-      {{ _('Knowledge base discussions') }}
+      data-event-parameters='{"link_name": "{{ context + '.article-discussions' }}"}'>
+      {{ _('Article discussions') }}
     </a>
   </li>
   <li>


### PR DESCRIPTION
- Resolves https://github.com/mozilla/sumo/issues/3334

This PR replaces the "Article discussions" entry in the top navbar with "Knowledge base discussions", and swaps those entries in the sidebar.