### PR TITLE
Improve search result headers

### DIFF
--- a/kitsune/search/jinja2/search/results.html
+++ b/kitsune/search/jinja2/search/results.html
@@ -24,15 +24,29 @@
       {% if num_results > 0 %}
         <p class="sumo-page-intro">
           {% if total_is_approximate %}
-            {# L10n: Hybrid search shows a bounded ranking; {n} approximates all potential matches, not pageable results. #}
-            {{ ngettext('Showing the most relevant result for <strong>{q}</strong> in <strong>{product}</strong> from about <strong>{n}</strong> potential match',
-                        'Showing the most relevant results for <strong>{q}</strong> in <strong>{product}</strong> from about <strong>{n}</strong> potential matches',
-                        num_results)|fe(n=num_results, q=q, product=product_titles) }}
+            {% if product_titles != _("All Products") %}
+              {# L10n: Hybrid search shows a bounded ranking; {n} approximates all potential matches, not pageable results. #}
+              {{ ngettext('Showing the most relevant result for ‘<strong>{q}</strong>’ in <strong>{product}</strong> from about <strong>{n}</strong> potential match',
+                          'Showing the most relevant results for ‘<strong>{q}</strong>’ in <strong>{product}</strong> from about <strong>{n}</strong> potential matches',
+                          num_results)|fe(n=num_results, q=q, product=product_titles) }}
+            {% else %}
+              {# L10n: Hybrid search shows a bounded ranking; {n} approximates all potential matches, not pageable results. #}
+              {{ ngettext('Showing the most relevant result for ‘<strong>{q}</strong>’ from about <strong>{n}</strong> potential match',
+                          'Showing the most relevant results for ‘<strong>{q}</strong>’ from about <strong>{n}</strong> potential matches',
+                          num_results)|fe(n=num_results, q=q) }}
+            {% endif %}
           {% else %}
-            {# L10n: {n} is the number of search results, {q} is the search query, {product} is the product. #}
-            {{ ngettext('Found <strong>{n}</strong> result for <strong>{q}</strong> for <strong>{product}</strong>',
-                        'Found <strong>{n}</strong> results for <strong>{q}</strong> for <strong>{product}</strong>',
-                        num_results)|fe(n=num_results, q=q, product=product_titles) }}
+            {% if product_titles != _("All Products") %}
+              {# L10n: {n} is the number of search results, {q} is the search query, {product} is the product. #}
+              {{ ngettext('Found <strong>{n}</strong> result for ‘<strong>{q}</strong>’ in <strong>{product}</strong>',
+                          'Found <strong>{n}</strong> results for ‘<strong>{q}</strong>’ in <strong>{product}</strong>',
+                          num_results)|fe(n=num_results, q=q, product=product_titles) }}
+            {% else %}
+              {# L10n: {n} is the number of search results, {q} is the search query. #}
+              {{ ngettext('Found <strong>{n}</strong> result for ‘<strong>{q}</strong>’',
+                          'Found <strong>{n}</strong> results for ‘<strong>{q}</strong>’',
+                          num_results)|fe(n=num_results, q=q, product=product_titles) }}
+            {% endif %}
           {% endif %}
         </p>
 

--- a/kitsune/search/jinja2/search/search-results.html
+++ b/kitsune/search/jinja2/search/search-results.html
@@ -9,9 +9,9 @@
   {% if num_results > 0 %}
   <p class="sumo-page-intro">
     {# L10n: {n} is the number of search results, {q} is the search query. #}
-    {{ ngettext('Found <strong>{n}</strong> result for <strong>{q}</strong>',
-                      'Found <strong>{n}</strong> results for <strong>{q}</strong>',
-                      num_results)|fe(n=num_results, q=q) }}
+    {{ ngettext('Found <strong>{n}</strong> result for ‘<strong>{q}</strong>’',
+                'Found <strong>{n}</strong> results for ‘<strong>{q}</strong>’',
+                num_results)|fe(n=num_results, q=q) }}
   </p>
 
   <div class="content-box">
@@ -23,7 +23,7 @@
   {{ pages|paginator }}
   {% else %}
   <p class="sumo-page-intro">
-    {{ _("Sorry! 0 results found for <strong>‘{q}’</strong>.")|fe(q=q) }}
+    {{ _("Sorry! 0 results found for ‘<strong>{q}</strong>’.")|fe(q=q) }}
   </p>
 
   <p>{{ _("Try searching again with different keywords.") }}</p>

--- a/kitsune/search/tests/test_views.py
+++ b/kitsune/search/tests/test_views.py
@@ -237,7 +237,7 @@ class TestHybridSearchSwitch(TestCase):
 
         doc = pq(response.content)
         self.assertIn(
-            "Showing the most relevant results for firefox in All Products "
+            "Showing the most relevant results for ‘firefox’ "
             "from about 23 potential matches",
             doc(".sumo-page-intro").text(),
         )

--- a/kitsune/sumo/static/sumo/tpl/search-results-list.njk
+++ b/kitsune/sumo/static/sumo/tpl/search-results-list.njk
@@ -3,24 +3,48 @@
 <h2 class="sumo-card-heading search-results-heading mb-0">
   {% if num_results > 0 %}
     {% if total_is_approximate %}
-      {# L10n: Hybrid search shows a bounded ranking; {n} approximates all potential matches, not pageable results. #}
-      {{ ngettext('Showing the most relevant result for ‘<span>%(q)s</span>’ in ‘<span>%(product)s</span>’ from about %(n)s potential match',
-                  'Showing the most relevant results for ‘<span>%(q)s</span>’ in ‘<span>%(product)s</span>’ from about %(n)s potential matches',
-                  num_results)
-          | f({n: num_results, q: q, product: product_titles}, true)
-          | safe }}
+      {% if product_titles != _("All Products") %}
+        {# L10n: Hybrid search shows a bounded ranking; {n} approximates all potential matches, not pageable results. #}
+        {{ ngettext('Showing the most relevant result for ‘<span>%(q)s</span>’ in <span>%(product)s</span> from about %(n)s potential match',
+                    'Showing the most relevant results for ‘<span>%(q)s</span>’ in <span>%(product)s</span> from about %(n)s potential matches',
+                    num_results)
+            | f({n: num_results, q: q, product: product_titles}, true)
+            | safe }}
+      {% else %}
+        {# L10n: Hybrid search shows a bounded ranking; {n} approximates all potential matches, not pageable results. #}
+        {{ ngettext('Showing the most relevant result for ‘<span>%(q)s</span>’ from about %(n)s potential match',
+                    'Showing the most relevant results for ‘<span>%(q)s</span>’ from about %(n)s potential matches',
+                    num_results)
+            | f({n: num_results, q: q}, true)
+            | safe }}
+      {% endif %}
     {% else %}
-      {# L10n: {n} is the number of search results, {q} is the search query, {product} is the product. #}
-      {{ ngettext('Found %(n)s result for ‘<span>%(q)s</span>’ for ‘<span>%(product)s</span>’',
-                  'Found %(n)s results for ‘<span>%(q)s</span>’ for ‘<span>%(product)s</span>’',
-                  num_results)
-          | f({n: num_results, q: q, product: product_titles}, true)
-          | safe }}
+      {% if product_titles != _("All Products") %}
+        {# L10n: {n} is the number of search results, {q} is the search query, {product} is the product. #}
+        {{ ngettext('Found %(n)s result for ‘<span>%(q)s</span>’ in <span>%(product)s</span>',
+                    'Found %(n)s results for ‘<span>%(q)s</span>’ in <span>%(product)s</span>',
+                    num_results)
+            | f({n: num_results, q: q, product: product_titles}, true)
+            | safe }}
+      {% else %}
+        {# L10n: {n} is the number of search results, {q} is the search query. #}
+        {{ ngettext('Found %(n)s result for ‘<span>%(q)s</span>’',
+                    'Found %(n)s results for ‘<span>%(q)s</span>’',
+                    num_results)
+            | f({n: num_results, q: q}, true)
+            | safe }}
+      {% endif %}
     {% endif %}
   {% else %}
-    {{ _("Sorry! 0 results found for ‘<span>%(q)s</span>’ for ‘<span>%(product)s</span>’")
-        | f({q: q, product: product_titles}, true)
-        | safe }}
+    {% if product_titles != _("All Products") %}
+      {{ _("Sorry! 0 results found for ‘<span>%(q)s</span>’ in <span>%(product)s</span>")
+          | f({q: q, product: product_titles}, true)
+          | safe }}
+    {% else %}
+      {{ _("Sorry! 0 results found for ‘<span>%(q)s</span>’")
+          | f({q: q}, true)
+          | safe }}
+    {% endif %}
   {% endif %}
 </h2>
 <nav class="tabs">


### PR DESCRIPTION
Don't specify a product when "All products" is selected; otherwise, don't put the product name in quotes. Always put the search query in quotes. Use "in" when referring to a product.