### PR TITLE
Remove Escape Spam Filtering from TRUSTED_GROUPS

### DIFF
--- a/kitsune/settings.py
+++ b/kitsune/settings.py
@@ -1424,8 +1424,6 @@ TRUSTED_GROUPS = [
     "SUMO Locale Leaders",
     "Knowledge Base Reviewers",
     "Reviewers",
-    # Temporary workaround to exempt individual users if needed
-    "Escape Spam Filtering",
     "trusted contributors",
     "kb-contributors",
     "l10n-contributors",


### PR DESCRIPTION
The "Escape Spam Filtering" group no longer exists in both `stage` and `prod` 