### PR TITLE
Playwright expand test coverage to admin groups page

### DIFF
--- a/playwright_tests/flows/admin_flows/announcement_banners/banner_flows.py
+++ b/playwright_tests/flows/admin_flows/announcement_banners/banner_flows.py
@@ -18,8 +18,8 @@ class BannerFlows:
         field_map: Dict[str, Callable[[Any], None]] = {
             "start_display_date": self.banner_admin_page.set_start_displaying_date,
             "start_display_time": self.banner_admin_page.set_start_displaying_time,
-            "stop_display_date": self.banner_admin_page.stop_displaying_date,
-            "stop_display_time": self.banner_admin_page.stop_displaying_time,
+            "stop_display_date": self.banner_admin_page.set_stop_displaying_date,
+            "stop_display_time": self.banner_admin_page.set_stop_displaying_time,
             "target_groups": self.banner_admin_page.set_banner_target_groups,
             "target_locale": self.banner_admin_page.set_banner_target_locale,
             "target_platforms": self.banner_admin_page.set_banner_target_platforms,

--- a/playwright_tests/flows/admin_flows/groups/groups_flows.py
+++ b/playwright_tests/flows/admin_flows/groups/groups_flows.py
@@ -1,0 +1,51 @@
+from playwright.sync_api import Page
+
+from playwright_tests.core.utilities import Utilities
+from playwright_tests.pages.admin_pages.groups.admin_groups_page import AdminGroupsPage
+
+
+class AdminGroupsFlows:
+    def __init__(self, page: Page):
+        self.utilities = Utilities(page)
+        self.groups_page = AdminGroupsPage(page)
+
+    def create_group(self, group_name: str) -> str:
+        """Flow for creating a new user group via the groups admin page.
+
+        Args:
+            group_name (str): The name of the group to create.
+        """
+        self.utilities.navigate_to_link(
+            self.utilities.different_endpoints["admin_groups_page"] + "add/")
+        self.groups_page.add_text_to_name_field(group_name)
+        self.groups_page.click_on_save_button()
+        return group_name
+
+    def delete_group(self, group_name: str, ignore_missing: bool = False):
+        """Flow for deleting an existing user group via the groups admin page.
+
+        Args:
+            group_name (str): The name of the group to delete.
+            ignore_missing (bool): If True, a group which is no longer listed is skipped
+                instead of failing. Used by test teardown, which cannot know whether the
+                test itself already deleted the group.
+        """
+        self.utilities.navigate_to_link(self.utilities.different_endpoints["admin_groups_page"])
+        self.groups_page.search_for_group(group_name)
+
+        if ignore_missing and not self.groups_page.is_group_listed(group_name):
+            return
+
+        self.groups_page.click_on_a_group(group_name)
+        self.groups_page.click_on_delete_button()
+        self.groups_page.click_on_confirm_deletion_button()
+
+    def is_group_listed(self, group_name: str) -> bool:
+        """Search the groups admin page for a group and report whether it still exists.
+
+        Args:
+            group_name (str): The name of the group to search for.
+        """
+        self.utilities.navigate_to_link(self.utilities.different_endpoints["admin_groups_page"])
+        self.groups_page.search_for_group(group_name)
+        return self.groups_page.is_group_listed(group_name)

--- a/playwright_tests/pages/admin_pages/groups/admin_groups_page.py
+++ b/playwright_tests/pages/admin_pages/groups/admin_groups_page.py
@@ -1,0 +1,66 @@
+from playwright.sync_api import Page
+
+from playwright_tests.core.basepage import BasePage
+
+
+class AdminGroupsPage(BasePage):
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+        """Locators belonging to the groups listing page."""
+        self.searchbar = page.locator("input#searchbar")
+        self.search_submit_button = page.locator("input[type='submit']")
+        self.group = lambda group_name: page.locator(
+            f"//table[@id='result_list']//th//a[normalize-space(text())='{group_name}']")
+
+        """Locators belonging to the add/change group pages."""
+        self.name_input_field = page.locator("input#id_name")
+        self.save_button = page.locator("input[name='_save']")
+
+        """Locators belonging to the group deletion flow."""
+        self.delete_button = page.locator("a.deletelink")
+        self.confirm_deletion_button = page.locator(
+            "form:has(input[name='post'][value='yes']) input[type='submit']")
+
+    """Actions against the groups admin page locators."""
+    def search_for_group(self, group_name: str):
+        """Search for a particular group inside the groups admin page.
+
+        Args:
+            group_name (str): The group name.
+        """
+        self._fill(self.searchbar, group_name)
+        self._click(self.search_submit_button)
+
+    def click_on_a_group(self, group_name: str):
+        """Click on a group name from the groups admin page table.
+
+        Args:
+            group_name (str): The group name.
+        """
+        self._click(self.group(group_name))
+
+    def is_group_listed(self, group_name: str) -> bool:
+        """Check if a group is listed inside the groups admin page table.
+
+        Args:
+            group_name (str): The group name.
+        """
+        return self._is_element_visible(self.group(group_name))
+
+    def add_text_to_name_field(self, group_name: str):
+        """Fill the group name field.
+
+        Args:
+            group_name (str): The group name.
+        """
+        self._fill(self.name_input_field, group_name)
+
+    def click_on_save_button(self):
+        self._click(self.save_button)
+
+    def click_on_delete_button(self):
+        self._click(self.delete_button)
+
+    def click_on_confirm_deletion_button(self):
+        self._click(self.confirm_deletion_button)

--- a/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
+++ b/playwright_tests/pages/explore_help_articles/articles/kb_edit_article_meta.py
@@ -57,6 +57,8 @@ class KBArticleEditMetadata(BasePage):
 
     def add_and_select_restrict_visibility_group_metadata(self, group_name: str):
         self._fill(self.kb_article_restrict_visibility_field, group_name)
+        self._wait_for_locator(self.restrict_visibility_dropdown_option(group_name),
+                               raise_exception=True)
         self._click(self.restrict_visibility_dropdown_option(group_name))
 
     def search_for_a_restricted_visibility_group(self, group_name: str):

--- a/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
+++ b/playwright_tests/pages/explore_help_articles/articles/submit_kb_article_page.py
@@ -48,7 +48,8 @@ class SubmitKBArticlePage(BasePage):
             "//input[@id='id_slug']//preceding-sibling::ul[@class='errorlist']/li")
         self.all_kb_errors = page.locator("ul[class='errorlist'] li")
         self.restrict_visibility_to_group = lambda group_name: page.locator(
-            f"//div[@class='option active']/span[text()='{group_name}']")
+            "//div[@id='id_restrict_to_groups-ts-dropdown']"
+            f"//div[contains(@class,'option') and normalize-space(.)='{group_name}']")
         self.delete_group_restriction = lambda group_name: page.locator(
             f"//div[@class='item' and text()='{group_name}']/a")
         self.relevant_to_product_checkbox = lambda product_name: page.locator(
@@ -69,6 +70,7 @@ class SubmitKBArticlePage(BasePage):
     """Actions against the new KB form locators."""
     def add_and_select_restrict_visibility_group(self, group_name: str):
         self._fill(self.kb_article_restrict_visibility_field, group_name)
+        self._wait_for_locator(self.restrict_visibility_to_group(group_name), raise_exception=True)
         self._click(self.restrict_visibility_to_group(group_name))
 
     def delete_a_restricted_visibility_group(self, group_name: str):

--- a/playwright_tests/pages/messaging_system_pages/new_message.py
+++ b/playwright_tests/pages/messaging_system_pages/new_message.py
@@ -59,7 +59,7 @@ class NewMessagePage(BasePage):
                 username (str): The username to click on.
         """
         searched_user = self.searched_user(username)
-        self._wait_for_locator(searched_user, timeout=30000, raise_exception=True)
+        self._wait_for_locator(searched_user, timeout=60000, raise_exception=True)
         self._click(searched_user)
 
     def type_into_to_input_field(self, text: str):

--- a/playwright_tests/pages/sumo_pages.py
+++ b/playwright_tests/pages/sumo_pages.py
@@ -3,6 +3,7 @@ from functools import cached_property
 from playwright.sync_api import Page
 
 from playwright_tests.flows.admin_flows.announcement_banners.banner_flows import BannerFlows
+from playwright_tests.flows.admin_flows.groups.groups_flows import AdminGroupsFlows
 from playwright_tests.flows.admin_flows.users.users_flows import AdminUsersFlows
 from playwright_tests.flows.ask_a_question_flows.aaq_flows.aaq_flow import AAQFlow
 from playwright_tests.flows.auth_flows.auth_flow import AuthFlowPage
@@ -35,6 +36,7 @@ from playwright_tests.flows.user_profile_flows.edit_profile_data_flow import Edi
 from playwright_tests.flows.user_profile_flows.user_profile_flow import UserProfileFlow
 from playwright_tests.pages.admin_pages.announcement_banners.announcement_banner_page import \
     AnnouncementBannerAdminPage
+from playwright_tests.pages.admin_pages.groups.admin_groups_page import AdminGroupsPage
 from playwright_tests.pages.admin_pages.users.admin_users_page import AdminUserPage
 from playwright_tests.pages.ask_a_question.aaq_pages.aaq_form_page import AAQFormPage
 from playwright_tests.pages.ask_a_question.contact_support_pages.contact_support_page import (
@@ -165,6 +167,10 @@ class SumoPages:
     def admin_users_page(self):
         return AdminUserPage(self._page)
 
+    @cached_property
+    def admin_groups_page(self):
+        return AdminGroupsPage(self._page)
+
     # Admin Flows.
     @cached_property
     def admin_banner_flows(self):
@@ -173,6 +179,10 @@ class SumoPages:
     @cached_property
     def admin_users_flows(self):
         return AdminUsersFlows(self._page)
+
+    @cached_property
+    def admin_groups_flows(self):
+        return AdminGroupsFlows(self._page)
 
     # Auth Page.
     @cached_property

--- a/playwright_tests/test_data/different_endpoints.json
+++ b/playwright_tests/test_data/different_endpoints.json
@@ -13,5 +13,6 @@
   "admin": "https://support.allizom.org/admin/",
   "admin_announcement_page": "https://support.allizom.org/admin/announcements/announcement/",
   "admin_users_page": "https://support.allizom.org/admin/auth/user/",
+  "admin_groups_page": "https://support.allizom.org/admin/auth/group/",
   "media_gallery": "https://support.allizom.org/en-US/gallery/images"
 }

--- a/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
+++ b/playwright_tests/tests/explore_help_articles_tests/articles/test_kb_restricted_visibility.py
@@ -178,7 +178,7 @@ def test_restricted_visibility_in_search_results(page: Page, create_user_factory
         utilities.start_existing_session(cookies=test_user)
 
         article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
-            approve_first_revision=True, single_group=whitelisted_group[0]
+            approve_first_revision=True, single_group=whitelisted_group
         )
         utilities.reindex_document("WikiDocument", article_details["article_id"])
 
@@ -911,6 +911,170 @@ def test_kb_restricted_visibility_category_page(page: Page, is_template, create_
         utilities.delete_cookies()
         expect(sumo_pages.kb_category_page.article_from_list(article_details['article_title'])
                ).to_be_visible()
+
+
+@pytest.fixture
+def create_group_factory(page: Page):
+    """Create user groups through the groups admin page."""
+    utilities = Utilities(page)
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+    created_groups = []
+
+    def _admin_context() -> tuple[Page, SumoPages]:
+        """Open an isolated context already signed in with the admin account."""
+        admin_page = utilities.create_new_context_page()
+        admin_utilities = Utilities(admin_page)
+        admin_utilities.navigate_to_homepage()
+        admin_utilities.start_existing_session(session_file_name=staff_user)
+        return admin_page, SumoPages(admin_page)
+
+    admin_page, admin_sumo_pages = _admin_context()
+
+    def _create_group(group_name: str | None = None) -> str:
+        if group_name is None:
+            group_name = "test-group-" + ''.join(
+                random.choice(string.ascii_lowercase + string.digits) for _ in range(10))
+        admin_sumo_pages.admin_groups_flows.create_group(group_name)
+        created_groups.append(group_name)
+        return group_name
+
+    def _delete_group(group_name: str):
+        """Delete a group in the same admin context it was created in, leaving the test's own
+        session untouched.
+
+        Args:
+            group_name (str): The name of the group to delete.
+        """
+        admin_sumo_pages.admin_groups_flows.delete_group(group_name)
+        if group_name in created_groups:
+            created_groups.remove(group_name)
+
+    yield SimpleNamespace(create=_create_group, delete=_delete_group)
+
+    if created_groups:
+        if admin_page.is_closed():
+            admin_page, admin_sumo_pages = _admin_context()
+        for group_name in created_groups:
+            admin_sumo_pages.admin_groups_flows.delete_group(group_name, ignore_missing=True)
+
+    admin_page.context.close()
+
+
+# C4262690
+@pytest.mark.kbRestrictedVisibility
+def test_kb_restricted_visibility_group_deletion(page: Page, create_user_factory,
+                                                 create_group_factory):
+    utilities = Utilities(page)
+    sumo_pages = SumoPages(page)
+    staff_user = utilities.username_extraction_from_email(utilities.staff_user)
+
+    with allure.step("Creating two new user groups"):
+        first_group = create_group_factory.create()
+        second_group = create_group_factory.create()
+
+    test_user = create_user_factory(groups=["Knowledge Base Reviewers", "Staff"])
+    first_group_user = create_user_factory(groups=[first_group])
+    second_group_user = create_user_factory(groups=[second_group])
+
+    with allure.step("Creating a new kb article restricted to both of the new groups"):
+        utilities.start_existing_session(cookies=test_user)
+        article_details = sumo_pages.submit_kb_article_flow.submit_simple_kb_article(
+            approve_first_revision=True, restricted_to_groups=[first_group, second_group]
+        )
+
+    with check, allure.step("Verifying that a member of each group can view the restricted "
+                            "article"):
+        for user in (first_group_user, second_group_user):
+            utilities.start_existing_session(cookies=user)
+            with page.expect_navigation() as navigation_info:
+                utilities.navigate_to_link(article_details['article_url'])
+            response = navigation_info.value
+            assert response.status != 404
+
+            expect(sumo_pages.kb_article_page.kb_article_restricted_banner).to_contain_text(
+                [KBArticlePageMessages.KB_ARTICLE_RESTRICTED_BANNER])
+
+    with allure.step("Deleting the first group"):
+        create_group_factory.delete(first_group)
+
+    with allure.step("Navigating to the Edit Article Metadata page"):
+        utilities.start_existing_session(session_file_name=staff_user)
+        utilities.navigate_to_link(
+            article_details['article_url'] + KBArticleRevision.KB_EDIT_METADATA)
+
+    with check, allure.step("Verifying that the deleted group is no longer displayed inside the "
+                            "Edit Article Metadata section"):
+        expect(sumo_pages.kb_article_edit_article_metadata_page
+               .selected_restricted_visibility_groups).to_have_count(1)
+        expect(sumo_pages.kb_article_edit_article_metadata_page
+               .selected_restricted_visibility_group(first_group)).to_be_hidden()
+
+    with check, allure.step("Verifying that the group which was not deleted is still displayed "
+                            "inside the Edit Article Metadata section"):
+        expect(sumo_pages.kb_article_edit_article_metadata_page
+               .selected_restricted_visibility_group(second_group)).to_be_visible()
+
+    with check, allure.step("Verifying that the member of the deleted group can no longer view "
+                            "the article"):
+        utilities.start_existing_session(cookies=first_group_user)
+        with page.expect_navigation() as navigation_info:
+            utilities.navigate_to_link(article_details['article_url'])
+        response = navigation_info.value
+        assert response.status == 404
+
+    with check, allure.step("Verifying that the member of the remaining group can still view the "
+                            "article"):
+        utilities.start_existing_session(cookies=second_group_user)
+        with page.expect_navigation() as navigation_info:
+            utilities.navigate_to_link(article_details['article_url'])
+        response = navigation_info.value
+        assert response.status != 404
+
+        expect(sumo_pages.kb_article_page.kb_article_restricted_banner).to_contain_text(
+            [KBArticlePageMessages.KB_ARTICLE_RESTRICTED_BANNER])
+
+    with allure.step("Deleting the remaining group"):
+        create_group_factory.delete(second_group)
+
+    with check, allure.step("Navigating to the Edit Article Metadata page and verifying that the "
+                            "article is no longer restricted to any group"):
+        utilities.start_existing_session(session_file_name=staff_user)
+        utilities.navigate_to_link(
+            article_details['article_url'] + KBArticleRevision.KB_EDIT_METADATA)
+        expect(sumo_pages.kb_article_edit_article_metadata_page
+               .selected_restricted_visibility_groups).to_have_count(0)
+
+    with allure.step("Reindexing the article"):
+        utilities.reindex_document("WikiDocument", article_details['article_id'])
+
+    with check, allure.step("Verifying that the members of both deleted groups can view the "
+                            "unrestricted article"):
+        for user in (first_group_user, second_group_user):
+            utilities.start_existing_session(cookies=user)
+            with page.expect_navigation() as navigation_info:
+                utilities.navigate_to_link(article_details['article_url'])
+            response = navigation_info.value
+            assert response.status != 404
+
+            expect(sumo_pages.kb_article_page.kb_article_restricted_banner).to_be_hidden()
+
+    with allure.step("Signing out from SUMO"):
+        utilities.delete_cookies()
+
+    with check, allure.step("Verifying that signed out users can view the unrestricted article"):
+        with page.expect_navigation() as navigation_info:
+            utilities.navigate_to_link(article_details['article_url'])
+        response = navigation_info.value
+        assert response.status != 404
+
+        expect(sumo_pages.kb_article_page.kb_article_restricted_banner).to_be_hidden()
+
+    with check, allure.step("Verifying that the article is returned inside the search results "
+                            "for signed out users"):
+        sumo_pages.top_navbar.click_on_sumo_nav_logo()
+        sumo_pages.search_page.fill_into_searchbar(article_details['article_title'])
+        expect(sumo_pages.search_page.get_locator_of_a_particular_article(
+            article_details['article_title'])).to_be_visible()
 
 
 def _create_discussion_thread(page: Page) -> dict[str, Any]:

--- a/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
+++ b/playwright_tests/tests/messaging_system_tests/test_messaging_system.py
@@ -656,9 +656,9 @@ def test_group_messages_cannot_be_sent_by_non_staff_users(page: Page, create_use
 
     with allure.step("Verifying that the group is not returned inside the search results"):
         expect(sumo_pages.new_message_page.first_search_result_or_no_results).to_be_visible(
-            timeout=30000)
+            timeout=60000)
         expect(sumo_pages.new_message_page.searched_group(
-            utilities.user_message_test_data['test_groups'][0])).to_be_hidden(timeout=30000)
+            utilities.user_message_test_data['test_groups'][0])).to_be_hidden(timeout=60000)
 
     with allure.step("Navigating to the groups page"):
         utilities.navigate_to_link(utilities.general_test_data['groups'])
@@ -885,7 +885,7 @@ def test_unable_to_send_group_messages_to_profiless_groups(page: Page, create_us
 
     with allure.step("Verifying that no groups are returned"):
         expect(sumo_pages.new_message_page.no_user_search_results_text).to_be_visible(
-            timeout=20000)
+            timeout=60000)
 
 
 # C2083482

--- a/playwright_tests/tests/user_deletion_tests/messaging_system/test_user_deletion_in_messaging_system.py
+++ b/playwright_tests/tests/user_deletion_tests/messaging_system/test_user_deletion_in_messaging_system.py
@@ -90,4 +90,4 @@ def test_messages_cannot_be_sent_to_system_user(page: Page, create_user_factory)
         sumo_pages.new_message_page.type_into_to_input_field(
             utilities.general_test_data["system_account_name"])
         expect(sumo_pages.new_message_page.no_user_search_results_text).to_be_visible(
-            timeout=30000)
+            timeout=60000)


### PR DESCRIPTION
* stage seems slow in returning the username from the messaging system's "To" field. Increasing the timeout from 30 to 60 seconds.
* Creating page objects and flows for the admin group page. 
* Expanded the playwright test coverage by adding the test_kb_restricted_visibility_group_deletion which ensures that the visibility restriction is dropped in case of group deletion.