### PR TITLE
Fix "watch" style inside the /kb/all/discussions page

### DIFF
--- a/kitsune/sumo/static/sumo/scss/layout/_contributors.scss
+++ b/kitsune/sumo/static/sumo/scss/layout/_contributors.scss
@@ -96,7 +96,25 @@
   }
 }
 
+th.watch,
+td.watch {
+  text-align: center;
+}
+
 .watch-form {
+  display: inline-block;
+
+  a {
+    display: flex;
+    cursor: pointer;
+    border-radius: p.$border-radius-sm;
+    transition: background-color 150ms ease;
+  }
+
+  &:hover a {
+    background-color: var(--color-link-active-bg);
+  }
+
   svg {
     width: p.$spacing-lg;
     height: p.$spacing-lg;


### PR DESCRIPTION
On kb/all/discussions page each row has a small checkmark or cross in the `Watch` column that turns email notifications for that thread on or off. The functionality works but the UI doesn't let the user know that the option is clickable (the mouse pointer stays as a normal arrow and nothing changes when you mouse-over it)

The problem is that the icon is wrapped in a link tag with no address in it.

The proposed fix:
1. The icon gets the finger pointer on hover.
2. Applied a soft grey rounded square which fades in behind the icon on hover.
3. The invisible clickable area was shrunk down to match the icon itself.