### PR TITLE
Introduce emails to solution authors

### DIFF
--- a/kitsune/questions/events.py
+++ b/kitsune/questions/events.py
@@ -10,6 +10,7 @@ from kitsune.sumo import email_utils
 from kitsune.sumo.templatetags.jinja_helpers import add_utm, urlparams
 from kitsune.sumo.urlresolvers import reverse
 from kitsune.tidings.events import InstanceEvent
+from kitsune.users.models import Setting
 
 
 class QuestionEvent(InstanceEvent):
@@ -179,15 +180,27 @@ class QuestionSolvedEvent(QuestionEvent):
         # (bug 585029)
         question.solution = self.answer
         question.solution.question = question
+        answerer_id = question.solution.creator.id
 
         @email_utils.safe_translation
         def _make_mail(locale, user, context):
-            subject = _("Solution found to Firefox Help question")
+            is_answerer = answerer_id == user.id
+
+            if is_answerer:
+                subject = _('You have solved a question: "{question_title}"').format(
+                    question_title = question.title
+                )
+                text_template = "questions/email/solution_to_author.ltxt"
+                html_template = "questions/email/solution_to_author.html"
+            else:
+                subject = _("Solution found to Firefox Help question")
+                text_template = "questions/email/solution.ltxt"
+                html_template = "questions/email/solution.html"
 
             mail = email_utils.make_mail(
                 subject=subject,
-                text_template="questions/email/solution.ltxt",
-                html_template="questions/email/solution.html",
+                text_template=text_template,
+                html_template=html_template,
                 context_vars=context,
                 from_email=settings.TIDINGS_FROM_ADDRESS,
                 to_email=user.email,
@@ -196,6 +209,7 @@ class QuestionSolvedEvent(QuestionEvent):
             return mail
 
         solution_url = add_utm(question.solution.get_absolute_url(), "questions-solved")
+        question_url = add_utm(question.get_absolute_url(), "questions-solved")
 
         c = {
             "answerer": question.solution.creator,
@@ -203,7 +217,14 @@ class QuestionSolvedEvent(QuestionEvent):
             "question_title": question.title,
             "host": Site.objects.get_current().domain,
             "solution_url": solution_url,
+            "question_url":question_url,
         }
+
+        # Send the emails to users_and_watches and the solution creator.
+        # Since we only know that users_and_watches is an iterable,
+        # we can't check whether it already includes the solution creator.
+        # Thus we have to check that manually.
+        is_answerer_handled = False
 
         for u, w in users_and_watches:
             c["to_user"] = u  # '' if anonymous
@@ -218,6 +239,17 @@ class QuestionSolvedEvent(QuestionEvent):
                 locale = "en-US"
 
             yield _make_mail(locale, u, c)
+
+            if not is_answerer_handled and u.id == answerer_id:
+                is_answerer_handled = True
+
+        # If we haven't sent the email to the solution creator yet, send it now.
+        if not is_answerer_handled:
+            u = question.solution.creator
+            if Setting.get_for_user(u, "email_authored_solutions"):
+                c["to_user"] = u
+                locale = u.profile.locale
+                yield _make_mail(locale, u, c)
 
     @classmethod
     def description_of_watch(cls, watch):

--- a/kitsune/questions/jinja2/questions/email/solution_to_author.html
+++ b/kitsune/questions/jinja2/questions/email/solution_to_author.html
@@ -1,0 +1,31 @@
+{% extends 'email/base.html' %}
+
+{% block content %}
+  {% if display_name(to_user) %}
+    <p>{{ _('Hi {username},')|f(username=display_name(to_user)) }}</p>
+  {% endif %}
+
+  <p>
+    {% trans question_title=question_title %}
+      Great news! Your answer for the following question has just been marked as the solution: "{{ question_title }}"
+    {% endtrans %}
+  </p>
+
+  <p><a href="https://{{ host }}{{ question_url }}">{{ _('View the solved thread') }}</a></p>
+
+  <p>
+    {% trans %}
+      Thank you for taking the time to help another user in our forum.
+      Your knowledge and willingness to contribute make Mozilla Support
+      a welcoming and helpful community.
+    {% endtrans %}
+  </p>
+
+  <p>
+    {% trans %}
+      If you have time to help a few more people, take a look at our
+      <a href="https://{{ host }}/questions?filter=new">unanswered questions</a>.
+      Your next solution could be just a click away!
+    {% endtrans %}
+  </p>
+{% endblock %}

--- a/kitsune/questions/jinja2/questions/email/solution_to_author.ltxt
+++ b/kitsune/questions/jinja2/questions/email/solution_to_author.ltxt
@@ -1,0 +1,32 @@
+{%- from "includes/unsubscribe_text.ltxt" import unsubscribe_text with context -%}
+{%- autoescape false -%}
+{#- L10n: This is an email. Whitespace matters! -#}
+{%- if display_name(to_user) -%}
+    {{ _('Hi {username},')|f(username=display_name(to_user)) }}
+
+{% endif -%}
+
+{% trans question_title=question_title %}
+Great news! Your answer for the following question has just been marked as the solution: "{{ question_title }}"
+{% endtrans %}
+
+{{ _('You can view the solved question thread using the following link:') }}
+
+https://{{ host }}{{ question_url }}
+
+{% trans %}
+Thank you for taking the time to help another user in our forum.
+Your knowledge and willingness to contribute make Mozilla Support
+a welcoming and helpful community.
+{% endtrans %}
+
+{% trans %}
+If you have time to help a few more people, take a look at our unanswered questions. Your next solution could be just a click away!
+{% endtrans %}
+
+https://{{ host }}/questions?filter=new
+
+{% if watch -%}
+{{ unsubscribe_text(watch) }}
+{% endif %}
+{% endautoescape %}

--- a/kitsune/questions/tests/test_notifications.py
+++ b/kitsune/questions/tests/test_notifications.py
@@ -90,6 +90,24 @@ https://testserver/{locale}unsubscribe/"""
 
 SOLUTION_EMAIL = "Hi {to_user},\n\n" + SOLUTION_EMAIL_TO_ANONYMOUS
 
+SOLUTION_EMAIL_TO_AUTHOR = """Hi {to_user},
+
+Great news! Your answer for the following question has just been marked as the solution: "{title}"
+
+You can view the solved question thread using the following link:
+
+https://testserver/{locale}questions/{question_id}?utm_campaign=\
+questions-solved&utm_source=notification&utm_medium=email
+
+Thank you for taking the time to help another user in our forum. \
+Your knowledge and willingness to contribute make Mozilla Support \
+a welcoming and helpful community.
+
+If you have time to help a few more people, take a look at our unanswered questions. Your next solution could be just a click away!
+
+https://testserver/questions?filter=new
+"""
+
 
 class NotificationsTests(TestCase):
     """Test that notifications get sent."""
@@ -202,6 +220,50 @@ class NotificationsTests(TestCase):
             mail.outbox[1].alternatives[0][0],
             rf"{re.escape('https://example.com/mozilla-support.')}[0-9a-z]+\.png",
         )
+
+    @mock.patch.object(Site.objects, "get_current")
+    def test_solution_author_notification(self, get_current):
+        """Test emails to solution authors and the related setting."""
+        get_current.return_value.domain = "testserver"
+
+        # Create a user and opt in to email_authored_solutions.
+        u = UserFactory(email="alan@example.com")
+        u.settings.create(name="email_authored_solutions", value="True")
+
+        # Create a question and post an answer from `u`.
+        q = QuestionFactory()
+        a = AnswerFactory(question=q, creator=u)
+
+        # Mark `a` as a solution.
+        self.client.login(username=q.creator.username, password="testpass")
+        post(self.client, "questions.solve", args=[q.id, a.id])
+
+        self.assertEqual(len(mail.outbox), 1)
+
+        attrs_eq(
+            mail.outbox[0],
+            to=["alan@example.com"],
+            subject=f'You have solved a question: "{q.title}"',
+        )
+        starts_with(
+            mail.outbox[0].body,
+            SOLUTION_EMAIL_TO_AUTHOR.format(
+                to_user=display_name(u),
+                title=q.title,
+                question_id=q.id,
+                locale="en-US/",
+            ),
+        )
+
+        # Opt out of email_authored_solutions.
+        u.settings.filter(name="email_authored_solutions").update(value="False")
+
+        # Unmark `a` as a solution and mark it again.
+        post(self.client, "questions.unsolve", args=[q.id, a.id])
+        post(self.client, "questions.solve", args=[q.id, a.id])
+
+        # Assert that no new emails have been sent.
+        self.assertEqual(len(mail.outbox), 1)
 
     @mock.patch.object(Site.objects, "get_current")
     def test_autowatch_reply(self, get_current):

--- a/kitsune/users/forms.py
+++ b/kitsune/users/forms.py
@@ -57,6 +57,9 @@ class SettingsForm(forms.Form):
     questions_watch_after_reply = forms.BooleanField(
         required=False, label=_lazy("Watch Question threads I comment in")
     )
+    email_authored_solutions = forms.BooleanField(
+        required=False, label=_lazy("Send me an email when my reply is marked as a solution")
+    )
     email_private_messages = forms.BooleanField(
         required=False, label=_lazy("Send emails for private messages")
     )

--- a/playwright_tests/pages/user_pages/my_profile_edit_settings_page.py
+++ b/playwright_tests/pages/user_pages/my_profile_edit_settings_page.py
@@ -20,6 +20,8 @@ class MyProfileEditSettingsPage(BasePage):
             "//input[@id='id_kbforums_watch_after_reply']/following-sibling::label")
         self.watch_question_threads_I_comment_in_checkbox = page.locator(
             "//input[@id='id_questions_watch_after_reply']/following-sibling::label")
+        self.send_me_an_email_when_my_reply_is_marked_as_a_solution_checkbox = page.locator(
+            "//input[@id='id_email_authored_solutions']/following-sibling::label")
         self.send_emails_for_private_messages_checkbox = page.locator(
             "//input[@id='id_email_private_messages']/following-sibling::label")
         self.edit_settings_update_button = page.locator(
@@ -62,6 +64,10 @@ class MyProfileEditSettingsPage(BasePage):
         """Click on watch question threads I comment in checkbox"""
         self._click(self.watch_question_threads_I_comment_in_checkbox)
 
+    def click_on_send_me_an_email_when_my_reply_is_marked_as_a_solution(self):
+        """Click on send me an email when my reply is marked as a solution checkbox"""
+        self._click(self.send_me_an_email_when_my_reply_is_marked_as_a_solution_checkbox)
+
     def click_on_send_emails_for_private_messages(self):
         """Click on send emails for private messages checkbox"""
         self._click(self.send_emails_for_private_messages_checkbox)
@@ -90,6 +96,10 @@ class MyProfileEditSettingsPage(BasePage):
         """Check if watch question threads I comment in checkbox is checked"""
         return self._is_checkbox_checked(self.watch_question_threads_I_comment_in_checkbox)
 
+    def is_send_me_an_email_when_my_reply_is_marked_as_a_solution_checkbox_checked(self) -> bool:
+        """Check if send me an email when my reply is marked as a solution checkbox is checked"""
+        return self._is_checkbox_checked(self.send_me_an_email_when_my_reply_is_marked_as_a_solution_checkbox)
+
     def is_send_emails_for_private_messages_checkbox_checked(self) -> bool:
         """Check if send emails for private messages checkbox is checked"""
         return self._is_checkbox_checked(self.send_emails_for_private_messages_checkbox)
@@ -102,5 +112,6 @@ class MyProfileEditSettingsPage(BasePage):
             self.is_watch_kb_discussion_threads_i_start_checkbox_checked(),
             self.is_watch_kb_discussion_threads_i_comment_checkbox_checked(),
             self.is_watch_question_threads_i_comment_checkbox_checked(),
+            self.is_send_me_an_email_when_my_reply_is_marked_as_a_solution_checkbox_checked(),
             self.is_send_emails_for_private_messages_checkbox_checked(),
         ])


### PR DESCRIPTION
- Resolves https://github.com/mozilla/sumo/issues/2875

Introduce emails to solution authors and a related setting. If a user has opted in to receive these emails or if they are subscribed to notifications about solutions for a particular question thread, send them the new email when their reply is marked as a solution.

Create a dedicated test for the new functionality and update a Playwright test for the profile settings page.