### PR TITLE
Fix mobile instant search product filter label on article pages

### DIFF
--- a/kitsune/sumo/static/sumo/js/protocol-details-init.js
+++ b/kitsune/sumo/static/sumo/js/protocol-details-init.js
@@ -16,45 +16,47 @@ export default function detailsInit() {
   'use strict';
   var _mqWide = matchMedia('(max-width: 1055px)');
 
-  var sidebarList = document.querySelector('.details-heading');
-
-  function swapMobileSubnavText(){
-    var button = document.querySelector('.details-heading button');
-    var activeLink = document.querySelector('.sidebar-nav .selected a') ||
-      document.querySelector('.sidebar-nav a.selected') ||
-      document.querySelector('.sidebar-nav .sidebar-subheading');
-
-    if (activeLink) {
-      var mobileButtonText = activeLink.innerHTML;
-    } else {
-      var mobileButtonText = 'Sidebar';
+  function swapMobileSubnavText(heading) {
+    var button = heading.querySelector('button');
+    if (!button) {
+      return;
     }
+    var sidebar = heading.closest('.sidebar-nav') || heading.parentNode;
+    var activeLink = sidebar.querySelector('.selected a') ||
+      sidebar.querySelector('a.selected') ||
+      sidebar.querySelector('select option:checked') ||
+      sidebar.querySelector('.sidebar-subheading');
 
-    button.innerHTML = mobileButtonText;
+    button.innerHTML = activeLink ? activeLink.innerHTML : 'Sidebar';
   }
 
   function initializeMobileDetails() {
+    var sidebarHeadings = document.querySelectorAll('.details-heading');
+    if (!sidebarHeadings.length) {
+      return;
+    }
     Details.init('.details-heading');
-    if (document.body.classList.contains('document')
-      && (document.querySelector('#doc-tools')?.textContent ?? "").trim() === "") {
+    var aside = document.querySelector('#aside');
+    var hideAside = aside && document.body.classList.contains('document')
+      && (document.querySelector('#doc-tools')?.textContent ?? "").trim() === "";
+    if (hideAside) {
       // The only potential section of a mobile article sidebar is empty, so there's no sense in displaying the sidebar.
       // This isn't relevant for the large version, where the sidebar will always include the helpfulness survey at least.
       // Note that we can't check #aside directly, since the helpfulness survey has not been moved from it yet.
-      let aside = document.querySelector('#aside');
-      if (aside) {
-        aside.hidden = true;
+      aside.hidden = true;
+    }
+    sidebarHeadings.forEach(function(heading) {
+      if (!(hideAside && aside.contains(heading))) {
+        swapMobileSubnavText(heading);
       }
-    }
-    else {
-      swapMobileSubnavText();
-    }
+    });
   }
 
-  if (sidebarList && _mqWide.matches) {
+  if (_mqWide.matches) {
     initializeMobileDetails();
   }
   _mqWide.addListener(function(mq) {
-    if (sidebarList && mq.matches) {
+    if (mq.matches) {
       initializeMobileDetails();
     } else {
       Details.destroy('.details-heading');

--- a/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
+++ b/kitsune/sumo/static/sumo/js/tests/instant_search_tests.js
@@ -171,3 +171,78 @@ describe('instant search', () => {
     });
   });
 });
+
+describe('instant search on a KB article page', () => {
+  let clock;
+  let cxhrMock;
+  let originalMatchMedia;
+
+  function loadArticlePage(sidebarItems) {
+    document.body.className = 'document';
+    document.body.innerHTML = `
+      <div>
+        <div id="main-content">
+          <aside id="aside">
+            <nav id="doc-tools">
+              <ul class="sidebar-nav sidebar-folding">
+                <li id="editing-tools-sidebar">
+                  <span class="details-heading"></span>
+                  <ul class="sidebar-nav--list">${sidebarItems}</ul>
+                </li>
+              </ul>
+            </nav>
+          </aside>
+        </div>
+        <form data-instant-search="form" action="" method="get" class="simple-search-form">
+          <input type="search" name="q" class="searchbox" id="search-q">
+        </form>
+      </div>`;
+  }
+
+  function searchFor(query) {
+    const searchInput = document.getElementById('search-q');
+    searchInput.value = query;
+    fireInput(searchInput);
+    clock.tick(600);
+    cxhrMock.firstCall.args[1].success({
+      num_results: 0,
+      q: query,
+      products: [{ slug: 'firefox', title: 'Firefox' }],
+    });
+  }
+
+  function filterHeadingText() {
+    return document.querySelector('#instant-search-content .details-heading button').textContent.trim();
+  }
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    cxhrMock = sinon.fake();
+    sinon.replace(CachedXHR.prototype, "request", cxhrMock);
+    originalMatchMedia = global.matchMedia;
+    global.matchMedia = () => ({ matches: true, addListener() {} });
+  });
+
+  afterEach(() => {
+    clock.restore();
+    sinon.restore();
+    global.matchMedia = originalMatchMedia;
+    document.body.className = '';
+    document.body.innerHTML = '';
+  });
+
+  it('labels the product filter heading with the selected product', () => {
+    loadArticlePage('<li><a href="/kb/article">Article</a></li>');
+    searchFor('reader view');
+
+    expect(filterHeadingText()).to.equal('All Products');
+  });
+
+  it('labels the product filter heading while hiding the empty article sidebar', () => {
+    loadArticlePage('');
+    searchFor('private browsing');
+
+    expect(document.getElementById('aside').hidden).to.equal(true);
+    expect(filterHeadingText()).to.equal('All Products');
+  });
+});


### PR DESCRIPTION
Resolves [#3356](https://github.com/mozilla/sumo/issues/3356)

## Summary

Scopes each mobile sidebar heading to its own sidebar and refreshes headings after instant search re-renders the product filter.

## Test plan

- [x] `npm run webpack:test` under Node 22: 274 passing. Five existing upload tests fail locally because Node rejects jsdom `File` values in `FormData`.
- [ ] Below 1056px, open a KB article, search, and confirm the product filter shows `All Products`.
- [ ] Repeat with an empty article sidebar and confirm it stays hidden while the product filter remains labelled.